### PR TITLE
fix: auth CAPTCHA, D1 adapter et Turnstile sign-in

### DIFF
--- a/app/(storefront)/auth/forgot-password/page.tsx
+++ b/app/(storefront)/auth/forgot-password/page.tsx
@@ -26,7 +26,7 @@ export default function ForgotPasswordPage() {
         email,
         redirectTo: "/auth/reset-password",
         fetchOptions: captchaToken
-          ? { headers: { "x-captcha-token": captchaToken } }
+          ? { headers: { "x-captcha-response": captchaToken } }
           : undefined,
       });
 

--- a/app/(storefront)/auth/sign-in/page.tsx
+++ b/app/(storefront)/auth/sign-in/page.tsx
@@ -10,6 +10,7 @@ import { Separator } from "@/components/ui/separator";
 import { AuthCard } from "@/components/storefront/auth/auth-card";
 import { PasswordInput } from "@/components/storefront/auth/password-input";
 import { SocialLoginButtons } from "@/components/storefront/auth/social-login-buttons";
+import { TurnstileCaptcha } from "@/components/storefront/auth/turnstile-captcha";
 import { authClient } from "@/lib/auth/client";
 
 const errorMessages: Record<string, string> = {
@@ -23,6 +24,7 @@ export default function SignInPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
+  const [captchaToken, setCaptchaToken] = useState("");
   const [loading, setLoading] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -35,6 +37,9 @@ export default function SignInPage() {
         email,
         password,
         callbackURL: "/",
+        fetchOptions: captchaToken
+          ? { headers: { "x-captcha-response": captchaToken } }
+          : undefined,
       });
 
       if (error) {
@@ -95,6 +100,8 @@ export default function SignInPage() {
             onChange={(e) => setPassword(e.target.value)}
           />
         </div>
+
+        <TurnstileCaptcha onVerify={setCaptchaToken} />
 
         {error && (
           <p className="text-sm text-destructive">{error}</p>

--- a/app/(storefront)/auth/sign-up/page.tsx
+++ b/app/(storefront)/auth/sign-up/page.tsx
@@ -52,7 +52,7 @@ export default function SignUpPage() {
         phone,
         callbackURL: "/",
         fetchOptions: captchaToken
-          ? { headers: { "x-captcha-token": captchaToken } }
+          ? { headers: { "x-captcha-response": captchaToken } }
           : undefined,
       });
 

--- a/components/storefront/auth/turnstile-captcha.tsx
+++ b/components/storefront/auth/turnstile-captcha.tsx
@@ -23,14 +23,18 @@ declare global {
 export function TurnstileCaptcha({ onVerify, onError }: TurnstileCaptchaProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const widgetIdRef = useRef<string | null>(null);
+  const onVerifyRef = useRef(onVerify);
+  const onErrorRef = useRef(onError);
+  onVerifyRef.current = onVerify;
+  onErrorRef.current = onError;
 
   const renderWidget = () => {
     if (!containerRef.current || !window.turnstile || widgetIdRef.current)
       return;
     widgetIdRef.current = window.turnstile.render(containerRef.current, {
       sitekey: process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY!,
-      callback: onVerify,
-      "error-callback": onError,
+      callback: (token: string) => onVerifyRef.current(token),
+      "error-callback": () => onErrorRef.current?.(),
       theme: "auto",
     });
   };

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -1,17 +1,23 @@
 import { betterAuth } from "better-auth";
 import { captcha } from "better-auth/plugins";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { Kysely } from "kysely";
+import { D1Dialect } from "kysely-d1";
 
 export async function initAuth() {
   const { env } = await getCloudflareContext();
   const cfEnv = env as CloudflareEnv;
 
+  const db = new Kysely({
+    dialect: new D1Dialect({ database: cfEnv.DB }),
+  });
+
   return betterAuth({
     baseURL: cfEnv.SITE_URL,
     secret: cfEnv.BETTER_AUTH_SECRET,
     database: {
+      db,
       type: "sqlite",
-      db: cfEnv.DB,
     },
     emailAndPassword: {
       enabled: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "better-auth": "^1.4.18",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "kysely-d1": "^0.4.0",
         "nanoid": "^5.1.6",
         "next": "16.1.6",
         "nuqs": "^2.8.7",
@@ -19268,6 +19269,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/kysely-d1": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/kysely-d1/-/kysely-d1-0.4.0.tgz",
+      "integrity": "sha512-wUcVvQNtm30OTfuo7Ad5vYJ1qHqPXOCZc+zWchVKNyuvqY3u8OuGw4gmUx1Ypdx2wRVFLHVQC9I7v0pTmF7Nkw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "kysely": "*"
       }
     },
     "node_modules/language-subtag-registry": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "better-auth": "^1.4.18",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "kysely": "^0.28.11",
         "kysely-d1": "^0.4.0",
         "nanoid": "^5.1.6",
         "next": "16.1.6",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "better-auth": "^1.4.18",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "kysely-d1": "^0.4.0",
     "nanoid": "^5.1.6",
     "next": "16.1.6",
     "nuqs": "^2.8.7",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "better-auth": "^1.4.18",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "kysely": "^0.28.11",
     "kysely-d1": "^0.4.0",
     "nanoid": "^5.1.6",
     "next": "16.1.6",


### PR DESCRIPTION
## Summary
- Fix CAPTCHA header name from `x-captcha-token` to `x-captcha-response` (sign-up, forgot-password)
- Replace raw D1 binding with `Kysely` + `D1Dialect` via `kysely-d1` to fix `selectFrom is not a function` error
- Add Turnstile CAPTCHA widget to sign-in page (required by Better Auth default config)
- Fix stale callback reference in `TurnstileCaptcha` component using `useRef`

## Test plan
- [x] Sign-up with email/password: creates account and redirects to home
- [x] Sign-out: clears session and shows "Connexion" button
- [x] Sign-in with email/password: authenticates and redirects to home
- [ ] Forgot password flow (needs email provider configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)