### PR TITLE
fix: rename middleware to proxy for Next.js 16

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -6,7 +6,7 @@ const PROTECTED_PATHS = ["/account", "/checkout"];
 const AUTH_PATHS = ["/auth/"];
 const SESSION_COOKIE = "better-auth.session_token";
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const isAuthPath = AUTH_PATHS.some((p) => pathname.startsWith(p));
   const isProtectedPath = PROTECTED_PATHS.some((p) => pathname.startsWith(p));


### PR DESCRIPTION
## Summary
- Renamed `middleware.ts` → `proxy.ts` and exported function `middleware()` → `proxy()` to follow the Next.js 16 convention

## Test plan
- [ ] Verify no deprecation warning on `npm run dev`
- [ ] Verify auth redirects still work (protected routes, auth pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)