### PR TITLE
feat: search page with filters, sort, and autocomplete

### DIFF
--- a/actions/search.ts
+++ b/actions/search.ts
@@ -1,0 +1,21 @@
+"use server";
+
+import { query } from "@/lib/db";
+import type { SearchSuggestion } from "@/lib/db/types";
+
+export async function getSearchSuggestions(
+  term: string
+): Promise<SearchSuggestion[]> {
+  if (!term || term.length < 2) return [];
+
+  const like = `%${term}%`;
+  return query<SearchSuggestion>(
+    `SELECT p.slug, p.name, p.brand, p.base_price,
+       (SELECT pi.url FROM product_images pi WHERE pi.product_id = p.id AND pi.is_primary = 1 LIMIT 1) as image_url
+     FROM products p
+     WHERE p.is_active = 1 AND (p.name LIKE ? OR p.brand LIKE ?)
+     ORDER BY p.is_featured DESC, p.created_at DESC
+     LIMIT 5`,
+    [like, like]
+  );
+}

--- a/app/(storefront)/search/active-filters.tsx
+++ b/app/(storefront)/search/active-filters.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { formatPrice } from "@/lib/utils/format";
+import { useFilterData } from "./filter-context";
+
+export function ActiveFilters() {
+  const { categories } = useFilterData();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const activeCategory = searchParams.get("category");
+  const activeBrands = searchParams.get("brand")?.split(",").filter(Boolean) ?? [];
+  const minPrice = searchParams.get("min_price");
+  const maxPrice = searchParams.get("max_price");
+
+  const hasFilters = activeCategory || activeBrands.length > 0 || minPrice || maxPrice;
+  if (!hasFilters) return null;
+
+  const removeParam = (key: string, value?: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (key === "brand" && value) {
+      const remaining = activeBrands.filter((b) => b !== value);
+      if (remaining.length > 0) {
+        params.set("brand", remaining.join(","));
+      } else {
+        params.delete("brand");
+      }
+    } else {
+      params.delete(key);
+    }
+    params.delete("page");
+    router.push(`/search?${params.toString()}`);
+  };
+
+  const clearAll = () => {
+    const params = new URLSearchParams();
+    const q = searchParams.get("q");
+    const sort = searchParams.get("sort");
+    if (q) params.set("q", q);
+    if (sort) params.set("sort", sort);
+    router.push(`/search?${params.toString()}`);
+  };
+
+  const categoryName = activeCategory
+    ? categories.find((c) => c.slug === activeCategory)?.name
+    : null;
+
+  return (
+    <>
+      {categoryName && (
+        <FilterChip label={categoryName} onRemove={() => removeParam("category")} />
+      )}
+      {activeBrands.map((brand) => (
+        <FilterChip key={brand} label={brand} onRemove={() => removeParam("brand", brand)} />
+      ))}
+      {minPrice && (
+        <FilterChip
+          label={`Min: ${formatPrice(parseInt(minPrice, 10))}`}
+          onRemove={() => removeParam("min_price")}
+        />
+      )}
+      {maxPrice && (
+        <FilterChip
+          label={`Max: ${formatPrice(parseInt(maxPrice, 10))}`}
+          onRemove={() => removeParam("max_price")}
+        />
+      )}
+      <button
+        onClick={clearAll}
+        className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none"
+      >
+        Tout effacer
+      </button>
+    </>
+  );
+}
+
+function FilterChip({ label, onRemove }: { label: string; onRemove: () => void }) {
+  return (
+    <button
+      onClick={onRemove}
+      aria-label={`Retirer ${label}`}
+      className="inline-flex h-5 items-center gap-1 rounded-full border px-2 text-[0.625rem] font-medium transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none"
+    >
+      {label}
+      <span aria-hidden="true" className="ml-0.5 text-muted-foreground">&times;</span>
+    </button>
+  );
+}

--- a/app/(storefront)/search/filter-context.tsx
+++ b/app/(storefront)/search/filter-context.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import type { Category, PriceRange } from "@/lib/db/types";
+
+interface FilterData {
+  categories: Category[];
+  brands: string[];
+  priceRange: PriceRange;
+}
+
+const FilterContext = createContext<FilterData | null>(null);
+
+export function FilterProvider({
+  children,
+  ...data
+}: FilterData & { children: React.ReactNode }) {
+  return (
+    <FilterContext value={data}>
+      {children}
+    </FilterContext>
+  );
+}
+
+export function useFilterData() {
+  const ctx = useContext(FilterContext);
+  if (!ctx) throw new Error("useFilterData must be used within FilterProvider");
+  return ctx;
+}

--- a/app/(storefront)/search/load-more-search.tsx
+++ b/app/(storefront)/search/load-more-search.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+
+export function LoadMoreSearch({ nextPage }: { nextPage: number }) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const handleClick = () => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("page", String(nextPage));
+    router.push(`/search?${params.toString()}`);
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className="rounded-xl border px-6 py-2.5 text-sm font-medium transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none"
+    >
+      Charger plus
+    </button>
+  );
+}

--- a/app/(storefront)/search/loading.tsx
+++ b/app/(storefront)/search/loading.tsx
@@ -1,0 +1,37 @@
+export default function SearchLoading() {
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-6" role="status" aria-label="Chargement…">
+      <div className="mb-6">
+        <div className="h-8 w-64 animate-pulse rounded-md bg-muted" />
+        <div className="mt-2 h-4 w-24 animate-pulse rounded-md bg-muted" />
+      </div>
+
+      <div className="flex gap-8">
+        {/* Sidebar skeleton */}
+        <aside className="hidden w-60 shrink-0 lg:block" aria-hidden="true">
+          <div className="space-y-4">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="h-6 animate-pulse rounded-md bg-muted" />
+            ))}
+          </div>
+        </aside>
+
+        {/* Grid skeleton */}
+        <div className="min-w-0 flex-1" aria-hidden="true">
+          <div className="grid grid-cols-2 gap-3 sm:gap-4 md:grid-cols-3 lg:grid-cols-4">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div key={i} className="overflow-hidden rounded-xl border">
+                <div className="aspect-square animate-pulse bg-muted" />
+                <div className="space-y-2 p-3">
+                  <div className="h-3 w-16 animate-pulse rounded bg-muted" />
+                  <div className="h-4 animate-pulse rounded bg-muted" />
+                  <div className="h-4 w-20 animate-pulse rounded bg-muted" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(storefront)/search/mobile-filter-sheet.tsx
+++ b/app/(storefront)/search/mobile-filter-sheet.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Cancel, FilterIcon } from "@hugeicons/core-free-icons";
+import { SearchFilters } from "./search-filters";
+
+export function MobileFilterSheet() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    document.body.classList.toggle("overflow-hidden", open);
+    return () => {
+      document.body.classList.remove("overflow-hidden");
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  return (
+    <>
+      {/* Trigger — visible only on mobile */}
+      <button
+        onClick={() => setOpen(true)}
+        className="flex h-8 items-center gap-1.5 rounded-lg border px-3 text-xs font-medium hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none lg:hidden"
+      >
+        <HugeiconsIcon icon={FilterIcon} size={14} aria-hidden="true" />
+        Filtres
+      </button>
+
+      {/* Backdrop */}
+      <div
+        className={`fixed inset-0 z-[60] bg-black/40 transition-opacity duration-300 ${
+          open ? "opacity-100" : "pointer-events-none opacity-0"
+        }`}
+        onClick={() => setOpen(false)}
+        aria-hidden="true"
+      />
+
+      {/* Sheet — slides up from bottom */}
+      <div
+        role="dialog"
+        aria-modal={open}
+        aria-label="Filtres"
+        className={`fixed inset-x-0 bottom-0 z-[61] flex max-h-[85vh] flex-col rounded-t-2xl bg-background shadow-xl transition-transform duration-300 ease-out ${
+          open ? "translate-y-0" : "translate-y-full"
+        }`}
+      >
+        <div className="flex items-center justify-between border-b px-4 py-3">
+          <h2 className="text-lg font-semibold">Filtres</h2>
+          <button
+            onClick={() => setOpen(false)}
+            className="flex h-9 w-9 items-center justify-center rounded-full hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none"
+            aria-label="Fermer"
+          >
+            <HugeiconsIcon icon={Cancel} size={20} aria-hidden="true" />
+          </button>
+        </div>
+        <div className="flex-1 overflow-y-auto overscroll-contain p-4 touch-manipulation">
+          <SearchFilters />
+        </div>
+        <div className="border-t p-4">
+          <button
+            onClick={() => setOpen(false)}
+            className="w-full rounded-xl bg-primary py-2.5 text-center text-sm font-semibold text-primary-foreground hover:bg-primary/90 focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none"
+          >
+            Appliquer
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/(storefront)/search/page.tsx
+++ b/app/(storefront)/search/page.tsx
@@ -1,0 +1,105 @@
+import type { Metadata } from "next";
+import { searchProducts, countSearchResults, getBrandsInUse, getPriceRange } from "@/lib/db/search";
+import { getCategories } from "@/lib/db/categories";
+import { ProductGrid } from "@/components/storefront/product-grid";
+import { SITE_NAME } from "@/lib/utils/constants";
+import type { SearchOptions } from "@/lib/db/types";
+import { FilterProvider } from "./filter-context";
+import { SearchFilters } from "./search-filters";
+import { SearchSort } from "./search-sort";
+import { ActiveFilters } from "./active-filters";
+import { MobileFilterSheet } from "./mobile-filter-sheet";
+import { LoadMoreSearch } from "./load-more-search";
+
+interface Props {
+  searchParams: Promise<{
+    q?: string;
+    category?: string;
+    brand?: string;
+    min_price?: string;
+    max_price?: string;
+    sort?: string;
+    page?: string;
+  }>;
+}
+
+export async function generateMetadata({ searchParams }: Props): Promise<Metadata> {
+  const { q } = await searchParams;
+  const title = q ? `Résultats pour "${q}"` : "Recherche";
+  return {
+    title: `${title} | ${SITE_NAME}`,
+  };
+}
+
+export default async function SearchPage({ searchParams }: Props) {
+  const sp = await searchParams;
+  const currentPage = Math.max(1, parseInt(sp.page ?? "1", 10) || 1);
+  const limit = 20;
+
+  const opts: SearchOptions = {
+    query: sp.q || undefined,
+    category: sp.category || undefined,
+    brands: sp.brand ? sp.brand.split(",").filter(Boolean) : undefined,
+    minPrice: sp.min_price ? parseInt(sp.min_price, 10) : undefined,
+    maxPrice: sp.max_price ? parseInt(sp.max_price, 10) : undefined,
+    sort: (sp.sort as SearchOptions["sort"]) || "relevance",
+    limit,
+    offset: (currentPage - 1) * limit,
+  };
+
+  const [products, total, brands, categories, priceRange] = await Promise.all([
+    searchProducts(opts),
+    countSearchResults(opts),
+    getBrandsInUse(),
+    getCategories(),
+    getPriceRange(),
+  ]);
+
+  const hasMore = (currentPage - 1) * limit + products.length < total;
+
+  return (
+    <FilterProvider categories={categories} brands={brands} priceRange={priceRange}>
+      <div className="mx-auto max-w-7xl px-4 py-6">
+        {/* Header */}
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold">
+            {sp.q ? `Résultats pour "${sp.q}"` : "Tous les produits"}
+          </h1>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {total} produit{total !== 1 ? "s" : ""}
+          </p>
+        </div>
+
+        {/* Active filters + sort */}
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+          <div className="flex flex-1 flex-wrap items-center gap-2">
+            <ActiveFilters />
+            <MobileFilterSheet />
+          </div>
+          <SearchSort />
+        </div>
+
+        {/* Main layout */}
+        <div className="flex gap-8">
+          {/* Desktop sidebar */}
+          <aside className="hidden w-60 shrink-0 lg:block">
+            <div className="sticky top-24">
+              <SearchFilters />
+            </div>
+          </aside>
+
+          {/* Results */}
+          <div className="min-w-0 flex-1">
+            <ProductGrid products={products} />
+
+            {hasMore && (
+              <div className="mt-8 flex justify-center">
+                <LoadMoreSearch nextPage={currentPage + 1} />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </FilterProvider>
+  );
+}

--- a/app/(storefront)/search/search-filters.tsx
+++ b/app/(storefront)/search/search-filters.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useRef, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { formatPrice } from "@/lib/utils/format";
+import { useFilterData } from "./filter-context";
+
+export function SearchFilters() {
+  const { categories, brands, priceRange } = useFilterData();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const activeCategory = searchParams.get("category") ?? "";
+  const activeBrands = searchParams.get("brand")?.split(",").filter(Boolean) ?? [];
+  const activeMinPrice = searchParams.get("min_price") ?? "";
+  const activeMaxPrice = searchParams.get("max_price") ?? "";
+
+  const [priceState, setPriceState] = useState({ min: activeMinPrice, max: activeMaxPrice, urlMin: activeMinPrice, urlMax: activeMaxPrice });
+  const priceTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  // Sync local price state when URL changes externally (e.g. "Tout effacer")
+  let { min: minPrice, max: maxPrice } = priceState;
+  if (priceState.urlMin !== activeMinPrice || priceState.urlMax !== activeMaxPrice) {
+    minPrice = activeMinPrice;
+    maxPrice = activeMaxPrice;
+    setPriceState({ min: activeMinPrice, max: activeMaxPrice, urlMin: activeMinPrice, urlMax: activeMaxPrice });
+  }
+
+  const updateParams = useCallback(
+    (updates: Record<string, string | null>) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete("page");
+      for (const [key, value] of Object.entries(updates)) {
+        if (value === null || value === "") {
+          params.delete(key);
+        } else {
+          params.set(key, value);
+        }
+      }
+      router.push(`/search?${params.toString()}`);
+    },
+    [router, searchParams]
+  );
+
+  const handleCategoryChange = (slug: string) => {
+    updateParams({ category: slug === activeCategory ? null : slug });
+  };
+
+  const handleBrandToggle = (brand: string) => {
+    const next = activeBrands.includes(brand)
+      ? activeBrands.filter((b) => b !== brand)
+      : [...activeBrands, brand];
+    updateParams({ brand: next.length > 0 ? next.join(",") : null });
+  };
+
+  const handlePriceChange = (field: "min_price" | "max_price", value: string) => {
+    setPriceState((prev) => ({
+      ...prev,
+      [field === "min_price" ? "min" : "max"]: value,
+    }));
+
+    clearTimeout(priceTimerRef.current);
+    priceTimerRef.current = setTimeout(() => {
+      updateParams({ [field]: value || null });
+    }, 500);
+  };
+
+  const handleReset = () => {
+    const params = new URLSearchParams();
+    const q = searchParams.get("q");
+    if (q) params.set("q", q);
+    router.push(`/search?${params.toString()}`);
+  };
+
+  const hasFilters = activeCategory || activeBrands.length > 0 || activeMinPrice || activeMaxPrice;
+
+  return (
+    <div className="space-y-6">
+      {/* Categories */}
+      <fieldset>
+        <legend className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          Catégorie
+        </legend>
+        <div className="space-y-1">
+          {categories.map((cat) => (
+            <button
+              key={cat.id}
+              onClick={() => handleCategoryChange(cat.slug)}
+              className={`block w-full rounded-md px-2 py-1.5 text-left text-sm transition-colors focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none ${
+                cat.slug === activeCategory
+                  ? "bg-primary/10 font-medium text-primary"
+                  : "text-foreground hover:bg-muted"
+              }`}
+            >
+              {cat.name}
+            </button>
+          ))}
+        </div>
+      </fieldset>
+
+      {/* Brands */}
+      {brands.length > 0 && (
+        <fieldset>
+          <legend className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            Marque
+          </legend>
+          <div className="space-y-1">
+            {brands.map((brand) => (
+              <label
+                key={brand}
+                className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted"
+              >
+                <input
+                  type="checkbox"
+                  checked={activeBrands.includes(brand)}
+                  onChange={() => handleBrandToggle(brand)}
+                  className="size-3.5 rounded border-input accent-primary"
+                />
+                {brand}
+              </label>
+            ))}
+          </div>
+        </fieldset>
+      )}
+
+      {/* Price range */}
+      <fieldset>
+        <legend className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          Prix
+        </legend>
+        <p className="mb-2 text-[10px] text-muted-foreground">
+          {formatPrice(priceRange.min)} — {formatPrice(priceRange.max)}
+        </p>
+        <div className="flex items-center gap-2">
+          <Input
+            type="number"
+            placeholder="Min…"
+            aria-label="Prix minimum"
+            value={minPrice}
+            onChange={(e) => handlePriceChange("min_price", e.target.value)}
+            className="h-8 text-xs"
+          />
+          <span className="text-muted-foreground" aria-hidden="true">—</span>
+          <Input
+            type="number"
+            placeholder="Max…"
+            aria-label="Prix maximum"
+            value={maxPrice}
+            onChange={(e) => handlePriceChange("max_price", e.target.value)}
+            className="h-8 text-xs"
+          />
+        </div>
+      </fieldset>
+
+      {/* Reset */}
+      {hasFilters && (
+        <button
+          onClick={handleReset}
+          className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none"
+        >
+          Réinitialiser les filtres
+        </button>
+      )}
+    </div>
+  );
+}

--- a/app/(storefront)/search/search-sort.tsx
+++ b/app/(storefront)/search/search-sort.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const SORT_OPTIONS = [
+  { value: "relevance", label: "Pertinence" },
+  { value: "price_asc", label: "Prix croissant" },
+  { value: "price_desc", label: "Prix décroissant" },
+  { value: "newest", label: "Nouveautés" },
+] as const;
+
+export function SearchSort() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const current = searchParams.get("sort") ?? "relevance";
+
+  const handleChange = (value: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value === "relevance") {
+      params.delete("sort");
+    } else {
+      params.set("sort", value);
+    }
+    params.delete("page");
+    router.push(`/search?${params.toString()}`);
+  };
+
+  return (
+    <Select value={current} onValueChange={handleChange}>
+      <SelectTrigger className="w-auto" aria-label="Trier par">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {SORT_OPTIONS.map((opt) => (
+          <SelectItem key={opt.value} value={opt.value}>
+            {opt.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/components/storefront/header.tsx
+++ b/components/storefront/header.tsx
@@ -1,28 +1,21 @@
 import Link from "next/link";
-import { HugeiconsIcon } from "@hugeicons/react";
-import { Search } from "@hugeicons/core-free-icons";
 import { SITE_NAME } from "@/lib/utils/constants";
 import { getOptionalSession } from "@/lib/auth/guards";
 import { HeaderUserMenu } from "@/components/storefront/header-user-menu";
 import { CartIcon } from "@/components/storefront/cart-icon";
+import { SearchAutocomplete } from "@/components/storefront/search-autocomplete";
 
 export async function Header() {
   const session = await getOptionalSession();
 
   return (
     <header className="sticky top-0 z-50 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4">
+      <div className="relative mx-auto flex h-16 max-w-7xl items-center justify-between px-4">
         <Link href="/" className="text-xl font-bold tracking-tight">
           {SITE_NAME}
         </Link>
         <nav className="flex items-center gap-1">
-          <Link
-            href="/search"
-            className="flex h-10 w-10 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-            aria-label="Rechercher"
-          >
-            <HugeiconsIcon icon={Search} size={20} />
-          </Link>
+          <SearchAutocomplete />
           <CartIcon />
           <HeaderUserMenu user={session?.user ?? null} />
         </nav>

--- a/components/storefront/search-autocomplete.tsx
+++ b/components/storefront/search-autocomplete.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Search, Cancel } from "@hugeicons/core-free-icons";
+import { getSearchSuggestions } from "@/actions/search";
+import { formatPrice } from "@/lib/utils/format";
+import { getImageUrl } from "@/lib/utils/images";
+import type { SearchSuggestion } from "@/lib/db/types";
+
+export function SearchAutocomplete() {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const [suggestions, setSuggestions] = useState<SearchSuggestion[]>([]);
+  const [open, setOpen] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const fetchSuggestions = useCallback(async (term: string) => {
+    if (term.length < 2) {
+      setSuggestions([]);
+      setOpen(false);
+      return;
+    }
+    const results = await getSearchSuggestions(term);
+    setSuggestions(results);
+    setOpen(results.length > 0);
+  }, []);
+
+  const handleChange = (value: string) => {
+    setQuery(value);
+    clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => fetchSuggestions(value), 300);
+  };
+
+  const handleSubmit = (e?: React.FormEvent) => {
+    e?.preventDefault();
+    if (!query.trim()) return;
+    setOpen(false);
+    setExpanded(false);
+    router.push(`/search?q=${encodeURIComponent(query.trim())}`);
+  };
+
+  const handleSelect = (slug: string) => {
+    setOpen(false);
+    setExpanded(false);
+    setQuery("");
+    router.push(`/p/${slug}`);
+  };
+
+  // Clean up debounce timer on unmount
+  useEffect(() => {
+    return () => clearTimeout(timerRef.current);
+  }, []);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    function onClick(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+        setExpanded(false);
+      }
+    }
+    document.addEventListener("mousedown", onClick, { passive: true });
+    return () => document.removeEventListener("mousedown", onClick);
+  }, []);
+
+  return (
+    <div ref={containerRef} className="relative">
+      {/* Desktop: inline search */}
+      <form onSubmit={handleSubmit} className="hidden md:block">
+        <div className="relative">
+          <HugeiconsIcon
+            icon={Search}
+            size={16}
+            aria-hidden="true"
+            className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground"
+          />
+          <input
+            ref={inputRef}
+            type="search"
+            name="q"
+            value={query}
+            onChange={(e) => handleChange(e.target.value)}
+            onFocus={() => { if (suggestions.length > 0) setOpen(true); }}
+            placeholder="Rechercher…"
+            aria-label="Rechercher"
+            autoComplete="off"
+            spellCheck={false}
+            className="h-9 w-56 rounded-lg border bg-muted/50 pl-8 pr-3 text-sm transition-all placeholder:text-muted-foreground focus-visible:w-72 focus-visible:border-ring focus-visible:bg-background focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none"
+          />
+        </div>
+      </form>
+
+      {/* Mobile: icon → full-width overlay */}
+      <div className="md:hidden">
+        <button
+          onClick={() => { setExpanded(true); }}
+          className={`flex h-10 w-10 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none ${expanded ? "invisible" : ""}`}
+          aria-label="Rechercher"
+        >
+          <HugeiconsIcon icon={Search} size={20} aria-hidden="true" />
+        </button>
+      </div>
+      {expanded && (
+        <form
+          onSubmit={handleSubmit}
+          className="fixed inset-x-0 top-0 z-50 flex h-16 items-center gap-2 border-b bg-background px-4 md:hidden"
+        >
+          <input
+            autoFocus
+            type="search"
+            name="q"
+            value={query}
+            onChange={(e) => handleChange(e.target.value)}
+            placeholder="Rechercher…"
+            aria-label="Rechercher"
+            autoComplete="off"
+            spellCheck={false}
+            className="h-9 min-w-0 flex-1 rounded-lg border bg-background px-3 text-sm focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none"
+          />
+          <button
+            type="button"
+            onClick={() => { setExpanded(false); setOpen(false); setQuery(""); }}
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none"
+            aria-label="Fermer"
+          >
+            <HugeiconsIcon icon={Cancel} size={18} aria-hidden="true" />
+          </button>
+        </form>
+      )}
+
+      {/* Suggestions dropdown */}
+      {open && (
+        <div
+          role="listbox"
+          aria-label="Suggestions"
+          aria-live="polite"
+          className="fixed inset-x-0 top-16 z-50 overflow-hidden border-b bg-background shadow-lg md:absolute md:inset-x-auto md:left-0 md:right-0 md:top-full md:mt-1 md:w-72 md:rounded-lg md:border md:shadow-lg"
+        >
+          {suggestions.map((s) => (
+            <button
+              key={s.slug}
+              role="option"
+              aria-selected={false}
+              onClick={() => handleSelect(s.slug)}
+              className="flex w-full items-center gap-3 px-3 py-2 text-left hover:bg-muted focus-visible:bg-muted focus-visible:outline-none"
+            >
+              <div className="relative size-10 shrink-0 overflow-hidden rounded-md bg-muted">
+                <Image
+                  src={getImageUrl(s.image_url)}
+                  alt={s.name}
+                  fill
+                  className="object-contain p-1"
+                  sizes="40px"
+                />
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm">{s.name}</p>
+                <p className="text-xs font-medium text-foreground">
+                  {formatPrice(s.base_price)}
+                </p>
+              </div>
+            </button>
+          ))}
+          <button
+            onClick={() => handleSubmit()}
+            className="w-full border-t px-3 py-2 text-left text-xs text-muted-foreground hover:bg-muted focus-visible:bg-muted focus-visible:outline-none"
+          >
+            Voir tous les résultats pour &ldquo;{query}&rdquo;
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/db/search.ts
+++ b/lib/db/search.ts
@@ -1,0 +1,91 @@
+import { query, queryFirst } from "@/lib/db";
+import type { Product, SearchOptions, PriceRange } from "@/lib/db/types";
+
+const BASE_SELECT = `SELECT p.*,
+  (SELECT pi.url FROM product_images pi WHERE pi.product_id = p.id AND pi.is_primary = 1 LIMIT 1) as image_url,
+  (SELECT COUNT(*) FROM product_variants pv WHERE pv.product_id = p.id AND pv.is_active = 1) as variant_count,
+  c.name as category_name, c.slug as category_slug
+FROM products p
+JOIN categories c ON c.id = p.category_id`;
+
+function buildWhere(opts: SearchOptions): { clause: string; params: unknown[] } {
+  const conditions: string[] = ["p.is_active = 1"];
+  const params: unknown[] = [];
+
+  if (opts.query) {
+    const like = `%${opts.query}%`;
+    conditions.push("(p.name LIKE ? OR p.brand LIKE ? OR p.description LIKE ?)");
+    params.push(like, like, like);
+  }
+
+  if (opts.category) {
+    conditions.push("c.slug = ?");
+    params.push(opts.category);
+  }
+
+  if (opts.brands && opts.brands.length > 0) {
+    const placeholders = opts.brands.map(() => "?").join(", ");
+    conditions.push(`p.brand IN (${placeholders})`);
+    params.push(...opts.brands);
+  }
+
+  if (opts.minPrice != null) {
+    conditions.push("p.base_price >= ?");
+    params.push(opts.minPrice);
+  }
+
+  if (opts.maxPrice != null) {
+    conditions.push("p.base_price <= ?");
+    params.push(opts.maxPrice);
+  }
+
+  return { clause: conditions.join(" AND "), params };
+}
+
+function buildOrderBy(sort?: string): string {
+  switch (sort) {
+    case "price_asc":
+      return "ORDER BY p.base_price ASC";
+    case "price_desc":
+      return "ORDER BY p.base_price DESC";
+    case "newest":
+      return "ORDER BY p.created_at DESC";
+    default:
+      return "ORDER BY p.is_featured DESC, p.created_at DESC";
+  }
+}
+
+export async function searchProducts(opts: SearchOptions): Promise<Product[]> {
+  const { clause, params } = buildWhere(opts);
+  const orderBy = buildOrderBy(opts.sort);
+  const limit = opts.limit ?? 20;
+  const offset = opts.offset ?? 0;
+
+  return query<Product>(
+    `${BASE_SELECT} WHERE ${clause} ${orderBy} LIMIT ? OFFSET ?`,
+    [...params, limit, offset]
+  );
+}
+
+export async function countSearchResults(opts: SearchOptions): Promise<number> {
+  const { clause, params } = buildWhere(opts);
+  const result = await queryFirst<{ count: number }>(
+    `SELECT COUNT(*) as count FROM products p JOIN categories c ON c.id = p.category_id WHERE ${clause}`,
+    params
+  );
+  return result?.count ?? 0;
+}
+
+export async function getBrandsInUse(): Promise<string[]> {
+  const rows = await query<{ brand: string }>(
+    "SELECT DISTINCT brand FROM products WHERE is_active = 1 AND brand IS NOT NULL ORDER BY brand"
+  );
+  return rows.map((r) => r.brand);
+}
+
+export async function getPriceRange(): Promise<PriceRange> {
+  const result = await queryFirst<{ min_price: number; max_price: number }>(
+    "SELECT MIN(base_price) as min_price, MAX(base_price) as max_price FROM products WHERE is_active = 1"
+  );
+  return { min: result?.min_price ?? 0, max: result?.max_price ?? 0 };
+}

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -125,6 +125,30 @@ export interface OrderItem {
   total_price: number;
 }
 
+export interface SearchOptions {
+  query?: string;
+  category?: string; // category slug
+  brands?: string[]; // brand names
+  minPrice?: number;
+  maxPrice?: number;
+  sort?: "relevance" | "price_asc" | "price_desc" | "newest";
+  limit?: number;
+  offset?: number;
+}
+
+export interface SearchSuggestion {
+  slug: string;
+  name: string;
+  brand: string | null;
+  base_price: number;
+  image_url: string | null;
+}
+
+export interface PriceRange {
+  min: number;
+  max: number;
+}
+
 export interface PromoCode {
   id: string;
   code: string;


### PR DESCRIPTION
## Summary
- Add `/search` page with LIKE-based full-text search across product name, brand, and description
- URL-driven filters: category (single), brand (multi), price range (min/max), sort (relevance, price asc/desc, newest)
- Header autocomplete with debounced suggestions (300ms, top 5 results with thumbnails and prices)
- Mobile-optimized: full-width search overlay, bottom sheet for filters, responsive 2-col grid
- "Charger plus" pagination preserving all active filters

## New files
- `lib/db/search.ts` — Dynamic SQL builder for search queries
- `actions/search.ts` — Server action for autocomplete suggestions
- `app/(storefront)/search/` — Page, filters, sort, active filter chips, mobile sheet, loading skeleton
- `components/storefront/search-autocomplete.tsx` — Header search with autocomplete

## Modified files
- `lib/db/types.ts` — Added `SearchOptions`, `SearchSuggestion`, `PriceRange` types
- `components/storefront/header.tsx` — Replaced search link with `SearchAutocomplete` component

## Test plan
- [ ] Search "iPhone" → 8 results displayed
- [ ] Filter by category "Smartphones" → results filtered
- [ ] Filter by brands "Apple" + "Samsung" → combined filter works
- [ ] Set price range → products within range shown
- [ ] Sort by price ascending → correct order
- [ ] Active filter chips appear, can be removed individually
- [ ] "Charger plus" loads next page preserving filters
- [ ] Mobile: search overlay covers full header, suggestions full-width
- [ ] Mobile: filter button opens bottom sheet
- [ ] Autocomplete: type "Sam" → Samsung products suggested
- [ ] Share URL with filters → same results on load

🤖 Generated with [Claude Code](https://claude.com/claude-code)