### PR TITLE
feat: add filters to category pages

### DIFF
--- a/app/(storefront)/c/[slug]/load-more-button.tsx
+++ b/app/(storefront)/c/[slug]/load-more-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 export function LoadMoreButton({
   slug,
@@ -10,13 +10,20 @@ export function LoadMoreButton({
   nextPage: number;
 }) {
   const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const handleClick = () => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("page", String(nextPage));
+    router.push(`/c/${slug}?${params.toString()}`);
+  };
 
   return (
     <button
-      onClick={() => router.push(`/c/${slug}?page=${nextPage}`)}
-      className="rounded-xl border px-6 py-2.5 text-sm font-medium transition-colors hover:bg-muted"
+      onClick={handleClick}
+      className="rounded-xl border px-6 py-2.5 text-sm font-medium transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none"
     >
-      Page suivante
+      Charger plus
     </button>
   );
 }

--- a/app/(storefront)/c/[slug]/page.tsx
+++ b/app/(storefront)/c/[slug]/page.tsx
@@ -3,10 +3,18 @@ import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import { getCategoryBySlug } from "@/lib/db/categories";
 import {
-  getProductsByCategory,
-  getProductCountByCategory,
-} from "@/lib/db/products";
+  searchProducts,
+  countSearchResults,
+  getBrandsInCategory,
+  getPriceRangeInCategory,
+} from "@/lib/db/search";
+import type { SearchOptions } from "@/lib/db/types";
 import { ProductGrid } from "@/components/storefront/product-grid";
+import { FilterProvider } from "@/app/(storefront)/search/filter-context";
+import { SearchFilters } from "@/app/(storefront)/search/search-filters";
+import { SearchSort } from "@/app/(storefront)/search/search-sort";
+import { ActiveFilters } from "@/app/(storefront)/search/active-filters";
+import { MobileFilterSheet } from "@/app/(storefront)/search/mobile-filter-sheet";
 import { LoadMoreButton } from "./load-more-button";
 import { SITE_NAME } from "@/lib/utils/constants";
 
@@ -14,7 +22,13 @@ const getCategoryCached = cache(getCategoryBySlug);
 
 interface Props {
   params: Promise<{ slug: string }>;
-  searchParams: Promise<{ page?: string }>;
+  searchParams: Promise<{
+    brand?: string;
+    min_price?: string;
+    max_price?: string;
+    sort?: string;
+    page?: string;
+  }>;
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -29,42 +43,84 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function CategoryPage({ params, searchParams }: Props) {
   const { slug } = await params;
-  const { page } = await searchParams;
+  const sp = await searchParams;
   const category = await getCategoryCached(slug);
   if (!category) notFound();
 
-  const currentPage = Math.max(1, parseInt(page ?? "1", 10) || 1);
+  const currentPage = Math.max(1, parseInt(sp.page ?? "1", 10) || 1);
   const limit = 20;
-  const offset = (currentPage - 1) * limit;
 
-  const [products, total] = await Promise.all([
-    getProductsByCategory(category.id, { limit, offset }),
-    getProductCountByCategory(category.id),
+  const opts: SearchOptions = {
+    category: slug,
+    brands: sp.brand ? sp.brand.split(",").filter(Boolean) : undefined,
+    minPrice: sp.min_price ? parseInt(sp.min_price, 10) : undefined,
+    maxPrice: sp.max_price ? parseInt(sp.max_price, 10) : undefined,
+    sort: (sp.sort as SearchOptions["sort"]) || "relevance",
+    limit,
+    offset: (currentPage - 1) * limit,
+  };
+
+  const [products, total, brands, priceRange] = await Promise.all([
+    searchProducts(opts),
+    countSearchResults(opts),
+    getBrandsInCategory(category.id),
+    getPriceRangeInCategory(category.id),
   ]);
 
-  const hasMore = offset + products.length < total;
+  const hasMore = (currentPage - 1) * limit + products.length < total;
 
   return (
-    <div className="mx-auto max-w-7xl px-4 py-6">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold">{category.name}</h1>
-        {category.description && (
-          <p className="mt-1 text-sm text-muted-foreground">
-            {category.description}
+    <FilterProvider
+      categories={[]}
+      brands={brands}
+      priceRange={priceRange}
+      basePath={`/c/${slug}`}
+      hideCategory
+    >
+      <div className="mx-auto max-w-7xl px-4 py-6">
+        {/* Header */}
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold">{category.name}</h1>
+          {category.description && (
+            <p className="mt-1 text-sm text-muted-foreground">
+              {category.description}
+            </p>
+          )}
+          <p className="mt-1 text-xs text-muted-foreground">
+            {total} produit{total !== 1 ? "s" : ""}
           </p>
-        )}
-        <p className="mt-1 text-xs text-muted-foreground">
-          {total} produit{total > 1 ? "s" : ""}
-        </p>
-      </div>
-
-      <ProductGrid products={products} />
-
-      {hasMore && (
-        <div className="mt-8 flex justify-center">
-          <LoadMoreButton slug={slug} nextPage={currentPage + 1} />
         </div>
-      )}
-    </div>
+
+        {/* Active filters + sort */}
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+          <div className="flex flex-1 flex-wrap items-center gap-2">
+            <ActiveFilters />
+            <MobileFilterSheet />
+          </div>
+          <SearchSort />
+        </div>
+
+        {/* Main layout */}
+        <div className="flex gap-8">
+          {/* Desktop sidebar */}
+          <aside className="hidden w-60 shrink-0 lg:block">
+            <div className="sticky top-24">
+              <SearchFilters />
+            </div>
+          </aside>
+
+          {/* Results */}
+          <div className="min-w-0 flex-1">
+            <ProductGrid products={products} />
+
+            {hasMore && (
+              <div className="mt-8 flex justify-center">
+                <LoadMoreButton slug={slug} nextPage={currentPage + 1} />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </FilterProvider>
   );
 }

--- a/app/(storefront)/search/active-filters.tsx
+++ b/app/(storefront)/search/active-filters.tsx
@@ -5,7 +5,7 @@ import { formatPrice } from "@/lib/utils/format";
 import { useFilterData } from "./filter-context";
 
 export function ActiveFilters() {
-  const { categories } = useFilterData();
+  const { categories, basePath } = useFilterData();
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -30,7 +30,7 @@ export function ActiveFilters() {
       params.delete(key);
     }
     params.delete("page");
-    router.push(`/search?${params.toString()}`);
+    router.push(`${basePath}?${params.toString()}`);
   };
 
   const clearAll = () => {
@@ -39,7 +39,7 @@ export function ActiveFilters() {
     const sort = searchParams.get("sort");
     if (q) params.set("q", q);
     if (sort) params.set("sort", sort);
-    router.push(`/search?${params.toString()}`);
+    router.push(`${basePath}?${params.toString()}`);
   };
 
   const categoryName = activeCategory

--- a/app/(storefront)/search/filter-context.tsx
+++ b/app/(storefront)/search/filter-context.tsx
@@ -7,16 +7,19 @@ interface FilterData {
   categories: Category[];
   brands: string[];
   priceRange: PriceRange;
+  basePath: string;
+  hideCategory?: boolean;
 }
 
 const FilterContext = createContext<FilterData | null>(null);
 
 export function FilterProvider({
   children,
+  basePath = "/search",
   ...data
-}: FilterData & { children: React.ReactNode }) {
+}: Omit<FilterData, "basePath"> & { basePath?: string; children: React.ReactNode }) {
   return (
-    <FilterContext value={data}>
+    <FilterContext value={{ ...data, basePath }}>
       {children}
     </FilterContext>
   );

--- a/app/(storefront)/search/search-filters.tsx
+++ b/app/(storefront)/search/search-filters.tsx
@@ -7,7 +7,7 @@ import { formatPrice } from "@/lib/utils/format";
 import { useFilterData } from "./filter-context";
 
 export function SearchFilters() {
-  const { categories, brands, priceRange } = useFilterData();
+  const { categories, brands, priceRange, basePath, hideCategory } = useFilterData();
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -38,9 +38,9 @@ export function SearchFilters() {
           params.set(key, value);
         }
       }
-      router.push(`/search?${params.toString()}`);
+      router.push(`${basePath}?${params.toString()}`);
     },
-    [router, searchParams]
+    [router, searchParams, basePath]
   );
 
   const handleCategoryChange = (slug: string) => {
@@ -70,7 +70,7 @@ export function SearchFilters() {
     const params = new URLSearchParams();
     const q = searchParams.get("q");
     if (q) params.set("q", q);
-    router.push(`/search?${params.toString()}`);
+    router.push(`${basePath}?${params.toString()}`);
   };
 
   const hasFilters = activeCategory || activeBrands.length > 0 || activeMinPrice || activeMaxPrice;
@@ -78,26 +78,28 @@ export function SearchFilters() {
   return (
     <div className="space-y-6">
       {/* Categories */}
-      <fieldset>
-        <legend className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-          Catégorie
-        </legend>
-        <div className="space-y-1">
-          {categories.map((cat) => (
-            <button
-              key={cat.id}
-              onClick={() => handleCategoryChange(cat.slug)}
-              className={`block w-full rounded-md px-2 py-1.5 text-left text-sm transition-colors focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none ${
-                cat.slug === activeCategory
-                  ? "bg-primary/10 font-medium text-primary"
-                  : "text-foreground hover:bg-muted"
-              }`}
-            >
-              {cat.name}
-            </button>
-          ))}
-        </div>
-      </fieldset>
+      {!hideCategory && (
+        <fieldset>
+          <legend className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            Catégorie
+          </legend>
+          <div className="space-y-1">
+            {categories.map((cat) => (
+              <button
+                key={cat.id}
+                onClick={() => handleCategoryChange(cat.slug)}
+                className={`block w-full rounded-md px-2 py-1.5 text-left text-sm transition-colors focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none ${
+                  cat.slug === activeCategory
+                    ? "bg-primary/10 font-medium text-primary"
+                    : "text-foreground hover:bg-muted"
+                }`}
+              >
+                {cat.name}
+              </button>
+            ))}
+          </div>
+        </fieldset>
+      )}
 
       {/* Brands */}
       {brands.length > 0 && (

--- a/app/(storefront)/search/search-sort.tsx
+++ b/app/(storefront)/search/search-sort.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
+import { useFilterData } from "./filter-context";
 import {
   Select,
   SelectContent,
@@ -17,6 +18,7 @@ const SORT_OPTIONS = [
 ] as const;
 
 export function SearchSort() {
+  const { basePath } = useFilterData();
   const router = useRouter();
   const searchParams = useSearchParams();
   const current = searchParams.get("sort") ?? "relevance";
@@ -29,7 +31,7 @@ export function SearchSort() {
       params.set("sort", value);
     }
     params.delete("page");
-    router.push(`/search?${params.toString()}`);
+    router.push(`${basePath}?${params.toString()}`);
   };
 
   return (

--- a/lib/db/search.ts
+++ b/lib/db/search.ts
@@ -76,6 +76,22 @@ export async function countSearchResults(opts: SearchOptions): Promise<number> {
   return result?.count ?? 0;
 }
 
+export async function getBrandsInCategory(categoryId: string): Promise<string[]> {
+  const rows = await query<{ brand: string }>(
+    "SELECT DISTINCT brand FROM products WHERE is_active = 1 AND brand IS NOT NULL AND category_id = ? ORDER BY brand",
+    [categoryId]
+  );
+  return rows.map((r) => r.brand);
+}
+
+export async function getPriceRangeInCategory(categoryId: string): Promise<PriceRange> {
+  const result = await queryFirst<{ min_price: number; max_price: number }>(
+    "SELECT MIN(base_price) as min_price, MAX(base_price) as max_price FROM products WHERE is_active = 1 AND category_id = ?",
+    [categoryId]
+  );
+  return { min: result?.min_price ?? 0, max: result?.max_price ?? 0 };
+}
+
 export async function getBrandsInUse(): Promise<string[]> {
   const rows = await query<{ brand: string }>(
     "SELECT DISTINCT brand FROM products WHERE is_active = 1 AND brand IS NOT NULL ORDER BY brand"


### PR DESCRIPTION
## Summary
- Reuse search filter components (brand, price range, sort) on `/c/[slug]` category pages
- Add `basePath` and `hideCategory` to `FilterProvider` so filter components work on any page
- Add `getBrandsInCategory()` and `getPriceRangeInCategory()` DB helpers for category-scoped filter data
- Update `LoadMoreButton` to preserve filter query params when paginating

## Test plan
- [ ] Visit a category page (`/c/smartphones`) and verify brand, price, and sort filters appear
- [ ] Apply filters and confirm products update correctly
- [ ] Test mobile filter sheet on small viewports
- [ ] Verify search page (`/search`) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)