### PR TITLE
fix: enable horizontal scroll with drag and nav buttons

### DIFF
--- a/components/storefront/category-nav.tsx
+++ b/components/storefront/category-nav.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
@@ -12,6 +14,8 @@ import {
   Projector,
 } from "@hugeicons/core-free-icons";
 import type { Category } from "@/lib/db/types";
+import { useHorizontalScroll } from "@/hooks/use-horizontal-scroll";
+import { ScrollButtons } from "@/components/storefront/scroll-buttons";
 
 const CATEGORY_ICONS: Record<string, typeof Smartphone> = {
   smartphones: Smartphone,
@@ -26,23 +30,35 @@ const CATEGORY_ICONS: Record<string, typeof Smartphone> = {
 };
 
 export function CategoryNav({ categories }: { categories: Category[] }) {
+  const { scrollRef, canScrollLeft, canScrollRight, scroll, dragProps } =
+    useHorizontalScroll();
+
   return (
-    <div className="flex gap-3 overflow-x-auto pb-2 scrollbar-none">
-      {categories.map((cat) => {
-        const icon = CATEGORY_ICONS[cat.slug];
-        return (
-          <Link
-            key={cat.id}
-            href={`/c/${cat.slug}`}
-            className="flex shrink-0 items-center gap-2 rounded-full border bg-card px-4 py-2 text-sm font-medium transition-colors hover:bg-primary hover:text-primary-foreground"
-          >
-            {icon && (
-              <HugeiconsIcon icon={icon} size={16} />
-            )}
-            {cat.name}
-          </Link>
-        );
-      })}
+    <div className="group relative">
+      <ScrollButtons
+        canScrollLeft={canScrollLeft}
+        canScrollRight={canScrollRight}
+        onScroll={scroll}
+      />
+      <div
+        ref={scrollRef}
+        {...dragProps}
+        className="flex cursor-grab gap-3 overflow-x-auto scrollbar-none active:cursor-grabbing"
+      >
+        {categories.map((cat) => {
+          const icon = CATEGORY_ICONS[cat.slug];
+          return (
+            <Link
+              key={cat.id}
+              href={`/c/${cat.slug}`}
+              className="flex shrink-0 items-center gap-2 rounded-full border bg-card px-4 py-2 text-sm font-medium transition-colors hover:bg-primary hover:text-primary-foreground"
+            >
+              {icon && <HugeiconsIcon icon={icon} size={16} />}
+              {cat.name}
+            </Link>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/components/storefront/category-nav.tsx
+++ b/components/storefront/category-nav.tsx
@@ -43,7 +43,7 @@ export function CategoryNav({ categories }: { categories: Category[] }) {
       <div
         ref={scrollRef}
         {...dragProps}
-        className="flex cursor-grab gap-3 overflow-x-auto scrollbar-none active:cursor-grabbing"
+        className="flex cursor-grab select-none gap-3 overflow-x-auto scrollbar-none active:cursor-grabbing"
       >
         {categories.map((cat) => {
           const icon = CATEGORY_ICONS[cat.slug];

--- a/components/storefront/horizontal-section.tsx
+++ b/components/storefront/horizontal-section.tsx
@@ -21,7 +21,7 @@ export function HorizontalSection({
   if (products.length === 0) return null;
 
   return (
-    <section>
+    <section /* no content-visibility:auto — it applies contain:paint which clips overflow-x scrolling */>
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-lg font-bold sm:text-xl">{title}</h2>
         {href ? (

--- a/components/storefront/horizontal-section.tsx
+++ b/components/storefront/horizontal-section.tsx
@@ -42,7 +42,7 @@ export function HorizontalSection({
         <div
           ref={scrollRef}
           {...dragProps}
-          className="flex cursor-grab gap-3 overflow-x-auto pb-2 scrollbar-none active:cursor-grabbing sm:gap-4"
+          className="flex cursor-grab select-none gap-3 overflow-x-auto pb-2 scrollbar-none active:cursor-grabbing sm:gap-4"
         >
           {products.map((product) => (
             <div key={product.id} className="w-[160px] shrink-0 sm:w-[200px]">

--- a/components/storefront/horizontal-section.tsx
+++ b/components/storefront/horizontal-section.tsx
@@ -1,6 +1,10 @@
+"use client";
+
 import Link from "next/link";
 import type { Product } from "@/lib/db/types";
 import { ProductCard } from "@/components/storefront/product-card";
+import { useHorizontalScroll } from "@/hooks/use-horizontal-scroll";
+import { ScrollButtons } from "@/components/storefront/scroll-buttons";
 
 export function HorizontalSection({
   title,
@@ -11,10 +15,13 @@ export function HorizontalSection({
   href?: string;
   products: Product[];
 }) {
+  const { scrollRef, canScrollLeft, canScrollRight, scroll, dragProps } =
+    useHorizontalScroll();
+
   if (products.length === 0) return null;
 
   return (
-    <section className="[content-visibility:auto] [contain-intrinsic-size:auto_400px]">
+    <section>
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-lg font-bold sm:text-xl">{title}</h2>
         {href ? (
@@ -26,12 +33,23 @@ export function HorizontalSection({
           </Link>
         ) : null}
       </div>
-      <div className="flex gap-3 overflow-x-auto pb-2 scrollbar-none sm:gap-4">
-        {products.map((product) => (
-          <div key={product.id} className="w-[160px] shrink-0 sm:w-[200px]">
-            <ProductCard product={product} />
-          </div>
-        ))}
+      <div className="group relative">
+        <ScrollButtons
+          canScrollLeft={canScrollLeft}
+          canScrollRight={canScrollRight}
+          onScroll={scroll}
+        />
+        <div
+          ref={scrollRef}
+          {...dragProps}
+          className="flex cursor-grab gap-3 overflow-x-auto pb-2 scrollbar-none active:cursor-grabbing sm:gap-4"
+        >
+          {products.map((product) => (
+            <div key={product.id} className="w-[160px] shrink-0 sm:w-[200px]">
+              <ProductCard product={product} />
+            </div>
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/components/storefront/horizontal-section.tsx
+++ b/components/storefront/horizontal-section.tsx
@@ -20,8 +20,9 @@ export function HorizontalSection({
 
   if (products.length === 0) return null;
 
+  // no content-visibility:auto — contain:paint clips overflow-x scrolling
   return (
-    <section /* no content-visibility:auto — it applies contain:paint which clips overflow-x scrolling */>
+    <section>
       <div className="mb-4 flex items-center justify-between">
         <h2 className="text-lg font-bold sm:text-xl">{title}</h2>
         {href ? (

--- a/components/storefront/scroll-buttons.tsx
+++ b/components/storefront/scroll-buttons.tsx
@@ -1,0 +1,34 @@
+export function ScrollButtons({
+  canScrollLeft,
+  canScrollRight,
+  onScroll,
+}: {
+  canScrollLeft: boolean;
+  canScrollRight: boolean;
+  onScroll: (direction: "left" | "right") => void;
+}) {
+  return (
+    <>
+      {canScrollLeft && (
+        <button
+          type="button"
+          onClick={() => onScroll("left")}
+          className="absolute -left-2 top-1/2 z-10 hidden -translate-y-1/2 rounded-full bg-background/90 p-2 shadow-md ring-1 ring-border backdrop-blur-sm opacity-0 transition-opacity group-hover:opacity-100 hover:bg-background sm:block"
+          aria-label="Défiler à gauche"
+        >
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+        </button>
+      )}
+      {canScrollRight && (
+        <button
+          type="button"
+          onClick={() => onScroll("right")}
+          className="absolute -right-2 top-1/2 z-10 hidden -translate-y-1/2 rounded-full bg-background/90 p-2 shadow-md ring-1 ring-border backdrop-blur-sm opacity-0 transition-opacity group-hover:opacity-100 hover:bg-background sm:block"
+          aria-label="Défiler à droite"
+        >
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m9 18 6-6-6-6"/></svg>
+        </button>
+      )}
+    </>
+  );
+}

--- a/components/storefront/scroll-buttons.tsx
+++ b/components/storefront/scroll-buttons.tsx
@@ -21,7 +21,7 @@ export function ScrollButtons({
         <button
           type="button"
           onClick={() => onScroll("left")}
-          className="absolute -left-2 top-1/2 z-10 hidden -translate-y-1/2 rounded-full bg-background/90 p-2 shadow-md ring-1 ring-border backdrop-blur-sm opacity-0 transition-opacity group-hover:opacity-100 hover:bg-background sm:block"
+          className="absolute -left-2 top-1/2 z-10 hidden -translate-y-1/2 rounded-full bg-background/90 p-2 shadow-md ring-1 ring-border backdrop-blur-sm pointer-events-none opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 hover:bg-background sm:block"
           aria-label="Défiler à gauche"
         >
           {chevronLeft}
@@ -31,7 +31,7 @@ export function ScrollButtons({
         <button
           type="button"
           onClick={() => onScroll("right")}
-          className="absolute -right-2 top-1/2 z-10 hidden -translate-y-1/2 rounded-full bg-background/90 p-2 shadow-md ring-1 ring-border backdrop-blur-sm opacity-0 transition-opacity group-hover:opacity-100 hover:bg-background sm:block"
+          className="absolute -right-2 top-1/2 z-10 hidden -translate-y-1/2 rounded-full bg-background/90 p-2 shadow-md ring-1 ring-border backdrop-blur-sm pointer-events-none opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 hover:bg-background sm:block"
           aria-label="Défiler à droite"
         >
           {chevronRight}

--- a/components/storefront/scroll-buttons.tsx
+++ b/components/storefront/scroll-buttons.tsx
@@ -1,3 +1,11 @@
+const chevronLeft = (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+);
+
+const chevronRight = (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m9 18 6-6-6-6"/></svg>
+);
+
 export function ScrollButtons({
   canScrollLeft,
   canScrollRight,
@@ -16,7 +24,7 @@ export function ScrollButtons({
           className="absolute -left-2 top-1/2 z-10 hidden -translate-y-1/2 rounded-full bg-background/90 p-2 shadow-md ring-1 ring-border backdrop-blur-sm opacity-0 transition-opacity group-hover:opacity-100 hover:bg-background sm:block"
           aria-label="Défiler à gauche"
         >
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m15 18-6-6 6-6"/></svg>
+          {chevronLeft}
         </button>
       )}
       {canScrollRight && (
@@ -26,7 +34,7 @@ export function ScrollButtons({
           className="absolute -right-2 top-1/2 z-10 hidden -translate-y-1/2 rounded-full bg-background/90 p-2 shadow-md ring-1 ring-border backdrop-blur-sm opacity-0 transition-opacity group-hover:opacity-100 hover:bg-background sm:block"
           aria-label="Défiler à droite"
         >
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m9 18 6-6-6-6"/></svg>
+          {chevronRight}
         </button>
       )}
     </>

--- a/hooks/use-horizontal-scroll.ts
+++ b/hooks/use-horizontal-scroll.ts
@@ -43,7 +43,6 @@ export function useHorizontalScroll() {
     if (!el) return;
     isDragging.current = true;
     dragState.current = { startX: e.clientX, scrollLeft: el.scrollLeft, hasMoved: false };
-    el.setPointerCapture(e.pointerId);
   }, []);
 
   const onPointerMove = useCallback((e: React.PointerEvent) => {
@@ -51,13 +50,20 @@ export function useHorizontalScroll() {
     const el = scrollRef.current;
     if (!el) return;
     const dx = e.clientX - dragState.current.startX;
-    if (Math.abs(dx) > 3) dragState.current.hasMoved = true;
+    if (Math.abs(dx) > 3) {
+      if (!dragState.current.hasMoved) {
+        dragState.current.hasMoved = true;
+        el.setPointerCapture(e.pointerId);
+      }
+    }
     el.scrollLeft = dragState.current.scrollLeft - dx;
   }, []);
 
   const onPointerUp = useCallback((e: React.PointerEvent) => {
+    if (dragState.current.hasMoved) {
+      scrollRef.current?.releasePointerCapture(e.pointerId);
+    }
     isDragging.current = false;
-    scrollRef.current?.releasePointerCapture(e.pointerId);
   }, []);
 
   const onClickCapture = useCallback((e: React.MouseEvent) => {

--- a/hooks/use-horizontal-scroll.ts
+++ b/hooks/use-horizontal-scroll.ts
@@ -1,0 +1,88 @@
+"use client";
+
+import { useRef, useState, useEffect, useCallback } from "react";
+
+export function useHorizontalScroll() {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+  const isDragging = useRef(false);
+  const dragState = useRef({ startX: 0, scrollLeft: 0, hasMoved: false });
+
+  const updateScrollState = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 0);
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    updateScrollState();
+    el.addEventListener("scroll", updateScrollState, { passive: true });
+    const ro = new ResizeObserver(updateScrollState);
+    ro.observe(el);
+    return () => {
+      el.removeEventListener("scroll", updateScrollState);
+      ro.disconnect();
+    };
+  }, [updateScrollState]);
+
+  const scroll = (direction: "left" | "right") => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollBy({
+      left: direction === "left" ? -el.clientWidth * 0.75 : el.clientWidth * 0.75,
+      behavior: "smooth",
+    });
+  };
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    const el = scrollRef.current;
+    if (!el) return;
+    isDragging.current = true;
+    dragState.current = { startX: e.clientX, scrollLeft: el.scrollLeft, hasMoved: false };
+    el.setPointerCapture(e.pointerId);
+  };
+
+  const onPointerMove = (e: React.PointerEvent) => {
+    if (!isDragging.current) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    const dx = e.clientX - dragState.current.startX;
+    if (Math.abs(dx) > 3) dragState.current.hasMoved = true;
+    el.scrollLeft = dragState.current.scrollLeft - dx;
+  };
+
+  const onPointerUp = (e: React.PointerEvent) => {
+    isDragging.current = false;
+    scrollRef.current?.releasePointerCapture(e.pointerId);
+  };
+
+  const onClickCapture = (e: React.MouseEvent) => {
+    if (dragState.current.hasMoved) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  };
+
+  const onDragStart = (e: React.DragEvent) => {
+    e.preventDefault();
+  };
+
+  return {
+    scrollRef,
+    canScrollLeft,
+    canScrollRight,
+    scroll,
+    dragProps: {
+      onPointerDown,
+      onPointerMove,
+      onPointerUp,
+      onPointerCancel: onPointerUp,
+      onClickCapture,
+      onDragStart,
+    },
+  };
+}

--- a/hooks/use-horizontal-scroll.ts
+++ b/hooks/use-horizontal-scroll.ts
@@ -64,6 +64,7 @@ export function useHorizontalScroll() {
       scrollRef.current?.releasePointerCapture(e.pointerId);
     }
     isDragging.current = false;
+    dragState.current.hasMoved = false;
   }, []);
 
   const onClickCapture = useCallback((e: React.MouseEvent) => {

--- a/hooks/use-horizontal-scroll.ts
+++ b/hooks/use-horizontal-scroll.ts
@@ -29,47 +29,47 @@ export function useHorizontalScroll() {
     };
   }, [updateScrollState]);
 
-  const scroll = (direction: "left" | "right") => {
+  const scroll = useCallback((direction: "left" | "right") => {
     const el = scrollRef.current;
     if (!el) return;
     el.scrollBy({
       left: direction === "left" ? -el.clientWidth * 0.75 : el.clientWidth * 0.75,
       behavior: "smooth",
     });
-  };
+  }, []);
 
-  const onPointerDown = (e: React.PointerEvent) => {
+  const onPointerDown = useCallback((e: React.PointerEvent) => {
     const el = scrollRef.current;
     if (!el) return;
     isDragging.current = true;
     dragState.current = { startX: e.clientX, scrollLeft: el.scrollLeft, hasMoved: false };
     el.setPointerCapture(e.pointerId);
-  };
+  }, []);
 
-  const onPointerMove = (e: React.PointerEvent) => {
+  const onPointerMove = useCallback((e: React.PointerEvent) => {
     if (!isDragging.current) return;
     const el = scrollRef.current;
     if (!el) return;
     const dx = e.clientX - dragState.current.startX;
     if (Math.abs(dx) > 3) dragState.current.hasMoved = true;
     el.scrollLeft = dragState.current.scrollLeft - dx;
-  };
+  }, []);
 
-  const onPointerUp = (e: React.PointerEvent) => {
+  const onPointerUp = useCallback((e: React.PointerEvent) => {
     isDragging.current = false;
     scrollRef.current?.releasePointerCapture(e.pointerId);
-  };
+  }, []);
 
-  const onClickCapture = (e: React.MouseEvent) => {
+  const onClickCapture = useCallback((e: React.MouseEvent) => {
     if (dragState.current.hasMoved) {
       e.preventDefault();
       e.stopPropagation();
     }
-  };
+  }, []);
 
-  const onDragStart = (e: React.DragEvent) => {
+  const onDragStart = useCallback((e: React.DragEvent) => {
     e.preventDefault();
-  };
+  }, []);
 
   return {
     scrollRef,

--- a/hooks/use-horizontal-scroll.ts
+++ b/hooks/use-horizontal-scroll.ts
@@ -64,13 +64,13 @@ export function useHorizontalScroll() {
       scrollRef.current?.releasePointerCapture(e.pointerId);
     }
     isDragging.current = false;
-    dragState.current.hasMoved = false;
   }, []);
 
   const onClickCapture = useCallback((e: React.MouseEvent) => {
     if (dragState.current.hasMoved) {
       e.preventDefault();
       e.stopPropagation();
+      dragState.current.hasMoved = false;
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- Fix horizontal scroll broken by `content-visibility: auto` clipping overflow
- Add drag-to-scroll (pointer events) for desktop users
- Add left/right arrow buttons on hover for all scrollable sections
- Add scroll support to category nav bar
- Extract reusable `useHorizontalScroll` hook and `ScrollButtons` component

## Performance (Vercel best practices)
- Static SVGs hoisted outside components (`rendering-hoist-jsx`)
- All handlers stabilized with `useCallback` (`rerender-functional-setstate`)
- Scroll listener uses `{ passive: true }` (`client-passive-event-listeners`)
- Drag state uses `useRef` instead of `useState` to avoid re-renders

## Test plan
- [ ] Horizontal scroll works via drag on product sections
- [ ] Horizontal scroll works via drag on category nav
- [ ] Arrow buttons appear on hover, hidden by default
- [ ] Clicking a product card navigates to product page
- [ ] Scroll buttons work on all sections
- [ ] Mobile touch scroll still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)