### PR TITLE
feat: add customer account section

### DIFF
--- a/actions/account.ts
+++ b/actions/account.ts
@@ -5,12 +5,7 @@ import { revalidatePath } from "next/cache";
 import { requireAuth } from "@/lib/auth/guards";
 import { initAuth } from "@/lib/auth";
 import { profileSchema, changePasswordSchema, type ProfileInput, type ChangePasswordInput } from "@/lib/validations/account";
-
-interface ActionResult {
-  success: boolean;
-  error?: string;
-  fieldErrors?: Record<string, string[]>;
-}
+import type { ActionResult } from "@/lib/types/actions";
 
 export async function updateProfile(input: ProfileInput): Promise<ActionResult> {
   await requireAuth();

--- a/actions/account.ts
+++ b/actions/account.ts
@@ -1,0 +1,66 @@
+"use server";
+
+import { headers } from "next/headers";
+import { revalidatePath } from "next/cache";
+import { requireAuth } from "@/lib/auth/guards";
+import { initAuth } from "@/lib/auth";
+import { profileSchema, changePasswordSchema, type ProfileInput, type ChangePasswordInput } from "@/lib/validations/account";
+
+interface ActionResult {
+  success: boolean;
+  error?: string;
+  fieldErrors?: Record<string, string[]>;
+}
+
+export async function updateProfile(input: ProfileInput): Promise<ActionResult> {
+  await requireAuth();
+
+  const parsed = profileSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: "Données invalides",
+      fieldErrors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+    };
+  }
+
+  const auth = await initAuth();
+  await auth.api.updateUser({
+    headers: await headers(),
+    body: {
+      name: parsed.data.name,
+      phone: parsed.data.phone,
+    },
+  });
+
+  revalidatePath("/account");
+  return { success: true };
+}
+
+export async function changePassword(input: ChangePasswordInput): Promise<ActionResult> {
+  await requireAuth();
+
+  const parsed = changePasswordSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: "Données invalides",
+      fieldErrors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+    };
+  }
+
+  try {
+    const auth = await initAuth();
+    await auth.api.changePassword({
+      headers: await headers(),
+      body: {
+        currentPassword: parsed.data.currentPassword,
+        newPassword: parsed.data.newPassword,
+      },
+    });
+  } catch {
+    return { success: false, error: "Mot de passe actuel incorrect" };
+  }
+
+  return { success: true };
+}

--- a/actions/addresses.ts
+++ b/actions/addresses.ts
@@ -1,0 +1,101 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { requireAuth } from "@/lib/auth/guards";
+import { addressSchema, type AddressInput } from "@/lib/validations/address";
+import {
+  createAddress,
+  updateAddress,
+  deleteAddress,
+  setDefaultAddress,
+  getAddressById,
+} from "@/lib/db/addresses";
+import { getDeliveryZoneByCommune } from "@/lib/db/delivery-zones";
+
+interface ActionResult {
+  success: boolean;
+  error?: string;
+  fieldErrors?: Record<string, string[]>;
+}
+
+export async function createAddressAction(input: AddressInput): Promise<ActionResult> {
+  const session = await requireAuth();
+
+  const parsed = addressSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: "Données invalides",
+      fieldErrors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+    };
+  }
+
+  const zone = await getDeliveryZoneByCommune(parsed.data.commune);
+
+  await createAddress({
+    userId: session.user.id,
+    label: parsed.data.label,
+    fullName: parsed.data.fullName,
+    phone: parsed.data.phone,
+    street: parsed.data.street,
+    commune: parsed.data.commune,
+    zoneId: zone?.id ?? null,
+    instructions: parsed.data.instructions ?? null,
+  });
+
+  revalidatePath("/account/addresses");
+  return { success: true };
+}
+
+export async function updateAddressAction(
+  id: string,
+  input: AddressInput
+): Promise<ActionResult> {
+  const session = await requireAuth();
+
+  const existing = await getAddressById(id, session.user.id);
+  if (!existing) {
+    return { success: false, error: "Adresse introuvable" };
+  }
+
+  const parsed = addressSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: "Données invalides",
+      fieldErrors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+    };
+  }
+
+  const zone = await getDeliveryZoneByCommune(parsed.data.commune);
+
+  await updateAddress(id, session.user.id, {
+    label: parsed.data.label,
+    fullName: parsed.data.fullName,
+    phone: parsed.data.phone,
+    street: parsed.data.street,
+    commune: parsed.data.commune,
+    zoneId: zone?.id ?? null,
+    instructions: parsed.data.instructions ?? null,
+  });
+
+  revalidatePath("/account/addresses");
+  return { success: true };
+}
+
+export async function deleteAddressAction(id: string): Promise<ActionResult> {
+  const session = await requireAuth();
+  const deleted = await deleteAddress(id, session.user.id);
+  if (!deleted) {
+    return { success: false, error: "Adresse introuvable" };
+  }
+  revalidatePath("/account/addresses");
+  return { success: true };
+}
+
+export async function setDefaultAddressAction(id: string): Promise<ActionResult> {
+  const session = await requireAuth();
+  await setDefaultAddress(id, session.user.id);
+  revalidatePath("/account/addresses");
+  return { success: true };
+}

--- a/actions/addresses.ts
+++ b/actions/addresses.ts
@@ -11,12 +11,7 @@ import {
   getAddressById,
 } from "@/lib/db/addresses";
 import { getDeliveryZoneByCommune } from "@/lib/db/delivery-zones";
-
-interface ActionResult {
-  success: boolean;
-  error?: string;
-  fieldErrors?: Record<string, string[]>;
-}
+import type { ActionResult } from "@/lib/types/actions";
 
 export async function createAddressAction(input: AddressInput): Promise<ActionResult> {
   const session = await requireAuth();
@@ -39,6 +34,7 @@ export async function createAddressAction(input: AddressInput): Promise<ActionRe
     phone: parsed.data.phone,
     street: parsed.data.street,
     commune: parsed.data.commune,
+    city: parsed.data.city,
     zoneId: zone?.id ?? null,
     instructions: parsed.data.instructions ?? null,
   });
@@ -75,6 +71,7 @@ export async function updateAddressAction(
     phone: parsed.data.phone,
     street: parsed.data.street,
     commune: parsed.data.commune,
+    city: parsed.data.city,
     zoneId: zone?.id ?? null,
     instructions: parsed.data.instructions ?? null,
   });
@@ -95,7 +92,10 @@ export async function deleteAddressAction(id: string): Promise<ActionResult> {
 
 export async function setDefaultAddressAction(id: string): Promise<ActionResult> {
   const session = await requireAuth();
-  await setDefaultAddress(id, session.user.id);
+  const updated = await setDefaultAddress(id, session.user.id);
+  if (!updated) {
+    return { success: false, error: "Adresse introuvable" };
+  }
   revalidatePath("/account/addresses");
   return { success: true };
 }

--- a/actions/checkout.ts
+++ b/actions/checkout.ts
@@ -237,6 +237,7 @@ export async function createOrder(input: CheckoutInput): Promise<CreateOrderResu
       phone: addressPhone,
       street: addressStreet,
       commune: addressCommune,
+      city: "Abidjan",
       zoneId: zone.id,
       instructions: data.instructions ?? null,
     });

--- a/actions/reviews.ts
+++ b/actions/reviews.ts
@@ -1,0 +1,46 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { requireAuth } from "@/lib/auth/guards";
+import { reviewSchema, type ReviewInput } from "@/lib/validations/review";
+import { createReview, canUserReview } from "@/lib/db/reviews";
+
+interface ActionResult {
+  success: boolean;
+  error?: string;
+  fieldErrors?: Record<string, string[]>;
+}
+
+export async function submitReview(input: ReviewInput): Promise<ActionResult> {
+  const session = await requireAuth();
+  const userId = session.user.id;
+
+  const parsed = reviewSchema.safeParse(input);
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: "Données invalides",
+      fieldErrors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+    };
+  }
+
+  const allowed = await canUserReview(userId, parsed.data.productId);
+  if (!allowed) {
+    return {
+      success: false,
+      error: "Vous devez avoir acheté et reçu ce produit pour laisser un avis",
+    };
+  }
+
+  await createReview({
+    productId: parsed.data.productId,
+    userId,
+    rating: parsed.data.rating,
+    comment: parsed.data.comment ?? null,
+    isVerifiedPurchase: true,
+  });
+
+  revalidatePath(`/account/reviews`);
+  revalidatePath(`/p/[slug]`, "page");
+  return { success: true };
+}

--- a/actions/wishlist.ts
+++ b/actions/wishlist.ts
@@ -1,0 +1,20 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { requireAuth } from "@/lib/auth/guards";
+import { addToWishlist, removeFromWishlist, isInWishlist } from "@/lib/db/wishlist";
+
+export async function toggleWishlist(productId: string): Promise<{ success: boolean; added: boolean }> {
+  const session = await requireAuth();
+  const userId = session.user.id;
+
+  const exists = await isInWishlist(userId, productId);
+  if (exists) {
+    await removeFromWishlist(userId, productId);
+  } else {
+    await addToWishlist(userId, productId);
+  }
+
+  revalidatePath("/account/wishlist");
+  return { success: true, added: !exists };
+}

--- a/app/(storefront)/account/addresses/address-list.tsx
+++ b/app/(storefront)/account/addresses/address-list.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState } from "react";
+import type { Address } from "@/lib/db/types";
+import { AddressCard } from "@/components/storefront/address-card";
+import { AddressForm } from "@/components/storefront/address-form";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+export function AddressList({ addresses }: { addresses: Address[] }) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingAddress, setEditingAddress] = useState<Address | null>(null);
+
+  function openCreate() {
+    setEditingAddress(null);
+    setDialogOpen(true);
+  }
+
+  function openEdit(address: Address) {
+    setEditingAddress(address);
+    setDialogOpen(true);
+  }
+
+  function closeDialog() {
+    setDialogOpen(false);
+    setEditingAddress(null);
+  }
+
+  return (
+    <>
+      <Button size="sm" onClick={openCreate}>
+        Ajouter une adresse
+      </Button>
+
+      {addresses.length === 0 ? (
+        <div className="py-12 text-center text-sm text-muted-foreground">
+          Aucune adresse enregistrée
+        </div>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2">
+          {addresses.map((addr) => (
+            <AddressCard key={addr.id} address={addr} onEdit={openEdit} />
+          ))}
+        </div>
+      )}
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {editingAddress ? "Modifier l'adresse" : "Nouvelle adresse"}
+            </DialogTitle>
+          </DialogHeader>
+          <AddressForm address={editingAddress} onDone={closeDialog} />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/app/(storefront)/account/addresses/address-list.tsx
+++ b/app/(storefront)/account/addresses/address-list.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -55,6 +56,9 @@ export function AddressList({ addresses }: { addresses: Address[] }) {
             <DialogTitle>
               {editingAddress ? "Modifier l'adresse" : "Nouvelle adresse"}
             </DialogTitle>
+            <DialogDescription>
+              {editingAddress ? "Modifiez les informations de cette adresse." : "Ajoutez une nouvelle adresse de livraison."}
+            </DialogDescription>
           </DialogHeader>
           <AddressForm address={editingAddress} onDone={closeDialog} />
         </DialogContent>

--- a/app/(storefront)/account/addresses/page.tsx
+++ b/app/(storefront)/account/addresses/page.tsx
@@ -1,0 +1,15 @@
+import { requireAuth } from "@/lib/auth/guards";
+import { getUserAddresses } from "@/lib/db/addresses";
+import { AddressList } from "./address-list";
+
+export default async function AddressesPage() {
+  const session = await requireAuth();
+  const addresses = await getUserAddresses(session.user.id);
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-base font-semibold">Mes adresses</h2>
+      <AddressList addresses={addresses} />
+    </div>
+  );
+}

--- a/app/(storefront)/account/layout.tsx
+++ b/app/(storefront)/account/layout.tsx
@@ -1,0 +1,24 @@
+import { requireAuth } from "@/lib/auth/guards";
+import { AccountNav } from "@/components/storefront/account-nav";
+
+export const metadata = {
+  title: "Mon compte | NETEREKA",
+};
+
+export default async function AccountLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  await requireAuth();
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-6">
+      <h1 className="mb-6 text-xl font-bold sm:text-2xl">Mon compte</h1>
+      <div className="grid gap-6 md:grid-cols-[200px_1fr]">
+        <AccountNav />
+        <div>{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/app/(storefront)/account/orders/[orderNumber]/actions.ts
+++ b/app/(storefront)/account/orders/[orderNumber]/actions.ts
@@ -1,0 +1,16 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { requireAuth } from "@/lib/auth/guards";
+import { cancelOrder } from "@/lib/db/orders";
+
+export async function cancelOrderAction(orderNumber: string) {
+  const session = await requireAuth();
+  const ok = await cancelOrder(orderNumber, session.user.id, "Annulée par le client");
+  if (!ok) {
+    return { success: false, error: "Impossible d'annuler cette commande" };
+  }
+  revalidatePath(`/account/orders/${orderNumber}`);
+  revalidatePath("/account/orders");
+  return { success: true };
+}

--- a/app/(storefront)/account/orders/[orderNumber]/cancel-button.tsx
+++ b/app/(storefront)/account/orders/[orderNumber]/cancel-button.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useTransition, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { cancelOrderAction } from "./actions";
+import { toast } from "sonner";
+
+export function CancelOrderButton({ orderNumber }: { orderNumber: string }) {
+  const [pending, startTransition] = useTransition();
+  const [confirming, setConfirming] = useState(false);
+
+  if (!confirming) {
+    return (
+      <Button variant="destructive" size="sm" onClick={() => setConfirming(true)}>
+        Annuler la commande
+      </Button>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button
+        variant="destructive"
+        size="sm"
+        disabled={pending}
+        onClick={() =>
+          startTransition(async () => {
+            const result = await cancelOrderAction(orderNumber);
+            if (result.success) {
+              toast.success("Commande annulée");
+              setConfirming(false);
+            } else {
+              toast.error(result.error ?? "Erreur");
+            }
+          })
+        }
+      >
+        {pending ? "Annulation..." : "Confirmer l'annulation"}
+      </Button>
+      <Button variant="outline" size="sm" onClick={() => setConfirming(false)}>
+        Non
+      </Button>
+    </div>
+  );
+}

--- a/app/(storefront)/account/orders/[orderNumber]/page.tsx
+++ b/app/(storefront)/account/orders/[orderNumber]/page.tsx
@@ -12,9 +12,13 @@ interface Props {
   params: Promise<{ orderNumber: string }>;
 }
 
+const ORDER_NUMBER_REGEX = /^ORD-[A-Z0-9]{4,10}$/;
+
 export default async function OrderDetailPage({ params }: Props) {
   const session = await requireAuth();
   const { orderNumber } = await params;
+
+  if (!ORDER_NUMBER_REGEX.test(orderNumber)) notFound();
 
   const result = await getOrderDetail(orderNumber, session.user.id);
   if (!result) notFound();

--- a/app/(storefront)/account/orders/[orderNumber]/page.tsx
+++ b/app/(storefront)/account/orders/[orderNumber]/page.tsx
@@ -1,0 +1,102 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { requireAuth } from "@/lib/auth/guards";
+import { getOrderDetail } from "@/lib/db/orders";
+import { OrderStatusTimeline } from "@/components/storefront/order-status-timeline";
+import { Badge } from "@/components/ui/badge";
+import { formatPrice, formatDateTime } from "@/lib/utils/format";
+import { statusConfig } from "@/components/storefront/order-card";
+import { CancelOrderButton } from "./cancel-button";
+
+interface Props {
+  params: Promise<{ orderNumber: string }>;
+}
+
+export default async function OrderDetailPage({ params }: Props) {
+  const session = await requireAuth();
+  const { orderNumber } = await params;
+
+  const result = await getOrderDetail(orderNumber, session.user.id);
+  if (!result) notFound();
+
+  const { order, items } = result;
+  const status = statusConfig[order.status] ?? { label: order.status, variant: "outline" as const };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-2">
+        <Link href="/account/orders" className="text-sm text-muted-foreground hover:text-foreground">
+          &larr; Commandes
+        </Link>
+      </div>
+
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <h2 className="text-base font-semibold">{order.order_number}</h2>
+          <p className="text-xs text-muted-foreground">{formatDateTime(order.created_at)}</p>
+        </div>
+        <Badge variant={status.variant}>{status.label}</Badge>
+      </div>
+
+      {/* Status timeline */}
+      <OrderStatusTimeline status={order.status} />
+
+      {/* Items */}
+      <div className="space-y-2">
+        <h3 className="text-sm font-medium">Articles</h3>
+        <div className="divide-y rounded-lg border">
+          {items.map((item) => (
+            <div key={item.id} className="flex items-center justify-between p-3">
+              <div>
+                <p className="text-sm font-medium">{item.product_name}</p>
+                {item.variant_name && (
+                  <p className="text-xs text-muted-foreground">{item.variant_name}</p>
+                )}
+                <p className="text-xs text-muted-foreground">Qté: {item.quantity}</p>
+              </div>
+              <p className="text-sm font-medium">{formatPrice(item.total_price)}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Summary */}
+      <div className="space-y-2 rounded-lg border p-4 text-sm">
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">Sous-total</span>
+          <span>{formatPrice(order.subtotal)}</span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">Livraison</span>
+          <span>{formatPrice(order.delivery_fee)}</span>
+        </div>
+        {order.discount_amount > 0 && (
+          <div className="flex justify-between text-green-600">
+            <span>Réduction</span>
+            <span>-{formatPrice(order.discount_amount)}</span>
+          </div>
+        )}
+        <hr />
+        <div className="flex justify-between font-semibold">
+          <span>Total</span>
+          <span>{formatPrice(order.total)}</span>
+        </div>
+      </div>
+
+      {/* Delivery info */}
+      <div className="space-y-1 text-sm">
+        <h3 className="font-medium">Adresse de livraison</h3>
+        <p className="text-muted-foreground">{order.delivery_address}</p>
+        <p className="text-muted-foreground">{order.delivery_phone}</p>
+        {order.delivery_instructions && (
+          <p className="text-muted-foreground">Instructions: {order.delivery_instructions}</p>
+        )}
+      </div>
+
+      {/* Cancel button */}
+      {order.status === "pending" && (
+        <CancelOrderButton orderNumber={order.order_number} />
+      )}
+    </div>
+  );
+}

--- a/app/(storefront)/account/orders/[orderNumber]/page.tsx
+++ b/app/(storefront)/account/orders/[orderNumber]/page.tsx
@@ -24,7 +24,7 @@ export default async function OrderDetailPage({ params }: Props) {
   if (!result) notFound();
 
   const { order, items } = result;
-  const status = statusConfig[order.status] ?? { label: order.status, variant: "outline" as const };
+  const status = statusConfig[order.status as import("@/lib/db/types").OrderStatus] ?? { label: order.status, variant: "outline" as const };
 
   return (
     <div className="space-y-6">

--- a/app/(storefront)/account/orders/page.tsx
+++ b/app/(storefront)/account/orders/page.tsx
@@ -1,0 +1,89 @@
+import { requireAuth } from "@/lib/auth/guards";
+import { getUserOrders } from "@/lib/db/orders";
+import { OrderCard } from "@/components/storefront/order-card";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+
+const tabs = [
+  { key: "", label: "Toutes" },
+  { key: "pending", label: "En attente" },
+  { key: "shipping", label: "En cours" },
+  { key: "delivered", label: "Livrées" },
+  { key: "cancelled", label: "Annulées" },
+];
+
+interface Props {
+  searchParams: Promise<{ status?: string; page?: string }>;
+}
+
+export default async function OrdersPage({ searchParams }: Props) {
+  const session = await requireAuth();
+  const sp = await searchParams;
+  const status = sp.status ?? "";
+  const page = Math.max(1, parseInt(sp.page ?? "1", 10));
+  const limit = 10;
+
+  const { orders, total } = await getUserOrders(session.user.id, {
+    limit,
+    offset: (page - 1) * limit,
+    status: status || undefined,
+  });
+
+  const totalPages = Math.ceil(total / limit);
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-base font-semibold">Mes commandes</h2>
+
+      {/* Status filter tabs */}
+      <div className="flex gap-1 overflow-x-auto">
+        {tabs.map((tab) => (
+          <Link
+            key={tab.key}
+            href={`/account/orders${tab.key ? `?status=${tab.key}` : ""}`}
+            className={cn(
+              "shrink-0 rounded-full px-3 py-1 text-xs font-medium transition-colors",
+              status === tab.key
+                ? "bg-primary text-primary-foreground"
+                : "bg-muted text-muted-foreground hover:text-foreground"
+            )}
+          >
+            {tab.label}
+          </Link>
+        ))}
+      </div>
+
+      {orders.length === 0 ? (
+        <div className="py-12 text-center text-sm text-muted-foreground">
+          Aucune commande trouvée
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {orders.map((order) => (
+            <OrderCard key={order.id} order={order} />
+          ))}
+        </div>
+      )}
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex justify-center gap-2 pt-4">
+          {Array.from({ length: totalPages }, (_, i) => i + 1).map((p) => (
+            <Link
+              key={p}
+              href={`/account/orders?${status ? `status=${status}&` : ""}page=${p}`}
+              className={cn(
+                "flex size-8 items-center justify-center rounded-lg text-xs font-medium",
+                p === page
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-muted text-muted-foreground hover:text-foreground"
+              )}
+            >
+              {p}
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(storefront)/account/page.tsx
+++ b/app/(storefront)/account/page.tsx
@@ -13,7 +13,7 @@ export default async function AccountPage() {
         <ProfileForm
           defaultValues={{
             name: user.name,
-            phone: (user as Record<string, unknown>).phone as string ?? "",
+            phone: String((user as Record<string, unknown>).phone ?? ""),
           }}
           email={user.email}
         />

--- a/app/(storefront)/account/page.tsx
+++ b/app/(storefront)/account/page.tsx
@@ -1,0 +1,30 @@
+import { requireAuth } from "@/lib/auth/guards";
+import { ProfileForm } from "./profile-form";
+import { PasswordForm } from "./password-form";
+
+export default async function AccountPage() {
+  const session = await requireAuth();
+  const user = session.user;
+
+  return (
+    <div className="space-y-8">
+      <section>
+        <h2 className="mb-4 text-base font-semibold">Informations personnelles</h2>
+        <ProfileForm
+          defaultValues={{
+            name: user.name,
+            phone: (user as Record<string, unknown>).phone as string ?? "",
+          }}
+          email={user.email}
+        />
+      </section>
+
+      <hr />
+
+      <section>
+        <h2 className="mb-4 text-base font-semibold">Changer le mot de passe</h2>
+        <PasswordForm />
+      </section>
+    </div>
+  );
+}

--- a/app/(storefront)/account/password-form.tsx
+++ b/app/(storefront)/account/password-form.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useTransition, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { changePassword } from "@/actions/account";
+import { toast } from "sonner";
+
+export function PasswordForm() {
+  const [pending, startTransition] = useTransition();
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    startTransition(async () => {
+      const result = await changePassword({
+        currentPassword,
+        newPassword,
+        confirmPassword,
+      });
+      if (result.success) {
+        toast.success("Mot de passe modifié");
+        setCurrentPassword("");
+        setNewPassword("");
+        setConfirmPassword("");
+      } else {
+        toast.error(result.error ?? "Erreur");
+      }
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="max-w-md space-y-4">
+      <div className="space-y-1.5">
+        <Label htmlFor="currentPassword">Mot de passe actuel</Label>
+        <Input
+          id="currentPassword"
+          type="password"
+          value={currentPassword}
+          onChange={(e) => setCurrentPassword(e.target.value)}
+          required
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="newPassword">Nouveau mot de passe</Label>
+        <Input
+          id="newPassword"
+          type="password"
+          value={newPassword}
+          onChange={(e) => setNewPassword(e.target.value)}
+          required
+          minLength={8}
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="confirmPassword">Confirmer</Label>
+        <Input
+          id="confirmPassword"
+          type="password"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          required
+        />
+      </div>
+      <Button type="submit" disabled={pending}>
+        {pending ? "Modification..." : "Changer le mot de passe"}
+      </Button>
+    </form>
+  );
+}

--- a/app/(storefront)/account/profile-form.tsx
+++ b/app/(storefront)/account/profile-form.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useTransition, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { updateProfile } from "@/actions/account";
+import { toast } from "sonner";
+
+interface Props {
+  defaultValues: { name: string; phone: string };
+  email: string;
+}
+
+export function ProfileForm({ defaultValues, email }: Props) {
+  const [pending, startTransition] = useTransition();
+  const [name, setName] = useState(defaultValues.name);
+  const [phone, setPhone] = useState(defaultValues.phone);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    startTransition(async () => {
+      const result = await updateProfile({ name, phone });
+      if (result.success) {
+        toast.success("Profil mis à jour");
+      } else {
+        toast.error(result.error ?? "Erreur");
+      }
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="max-w-md space-y-4">
+      <div className="space-y-1.5">
+        <Label htmlFor="email">Email</Label>
+        <Input id="email" value={email} disabled className="bg-muted" />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="name">Nom complet</Label>
+        <Input
+          id="name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+          minLength={2}
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="phone">Téléphone</Label>
+        <Input
+          id="phone"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+          required
+          placeholder="0701020304"
+        />
+      </div>
+      <Button type="submit" disabled={pending}>
+        {pending ? "Enregistrement..." : "Enregistrer"}
+      </Button>
+    </form>
+  );
+}

--- a/app/(storefront)/account/reviews/page.tsx
+++ b/app/(storefront)/account/reviews/page.tsx
@@ -1,0 +1,61 @@
+import { requireAuth } from "@/lib/auth/guards";
+import { getUserReviews, getReviewableProducts } from "@/lib/db/reviews";
+import { StarRating } from "@/components/storefront/star-rating";
+import { formatDate } from "@/lib/utils/format";
+import Link from "next/link";
+import { ReviewableProducts } from "./reviewable-products";
+
+export default async function ReviewsPage() {
+  const session = await requireAuth();
+  const [reviews, reviewable] = await Promise.all([
+    getUserReviews(session.user.id),
+    getReviewableProducts(session.user.id),
+  ]);
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-base font-semibold">Mes avis</h2>
+
+      {/* Reviewable products */}
+      {reviewable.length > 0 && (
+        <section className="space-y-3">
+          <h3 className="text-sm font-medium text-muted-foreground">Produits en attente d&apos;avis</h3>
+          <ReviewableProducts products={reviewable} />
+        </section>
+      )}
+
+      {/* Existing reviews */}
+      {reviews.length === 0 ? (
+        <div className="py-12 text-center text-sm text-muted-foreground">
+          Vous n&apos;avez pas encore laissé d&apos;avis
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {reviews.map((review) => (
+            <div key={review.id} className="rounded-xl border p-4">
+              <div className="flex items-start justify-between gap-2">
+                <div>
+                  <Link
+                    href={`/p/${review.product_slug}`}
+                    className="text-sm font-medium hover:underline"
+                  >
+                    {review.product_name}
+                  </Link>
+                  <div className="mt-1">
+                    <StarRating value={review.rating} readonly />
+                  </div>
+                </div>
+                <span className="text-xs text-muted-foreground">
+                  {formatDate(review.created_at)}
+                </span>
+              </div>
+              {review.comment && (
+                <p className="mt-2 text-sm text-muted-foreground">{review.comment}</p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(storefront)/account/reviews/reviewable-products.tsx
+++ b/app/(storefront)/account/reviews/reviewable-products.tsx
@@ -6,6 +6,7 @@ import { ReviewForm } from "@/components/storefront/review-form";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -40,6 +41,9 @@ export function ReviewableProducts({ products }: { products: ReviewableProduct[]
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Laisser un avis</DialogTitle>
+            <DialogDescription>
+              Partagez votre expérience avec ce produit.
+            </DialogDescription>
           </DialogHeader>
           {selected && (
             <ReviewForm

--- a/app/(storefront)/account/reviews/reviewable-products.tsx
+++ b/app/(storefront)/account/reviews/reviewable-products.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { ReviewForm } from "@/components/storefront/review-form";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface ReviewableProduct {
+  product_id: string;
+  product_name: string;
+  product_slug: string;
+  order_number: string;
+}
+
+export function ReviewableProducts({ products }: { products: ReviewableProduct[] }) {
+  const [selected, setSelected] = useState<ReviewableProduct | null>(null);
+
+  return (
+    <>
+      <div className="space-y-2">
+        {products.map((p) => (
+          <div key={`${p.product_id}-${p.order_number}`} className="flex items-center justify-between rounded-lg border p-3">
+            <div>
+              <p className="text-sm font-medium">{p.product_name}</p>
+              <p className="text-xs text-muted-foreground">Commande {p.order_number}</p>
+            </div>
+            <Button size="xs" variant="outline" onClick={() => setSelected(p)}>
+              Laisser un avis
+            </Button>
+          </div>
+        ))}
+      </div>
+
+      <Dialog open={!!selected} onOpenChange={(open) => !open && setSelected(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Laisser un avis</DialogTitle>
+          </DialogHeader>
+          {selected && (
+            <ReviewForm
+              productId={selected.product_id}
+              productName={selected.product_name}
+              onDone={() => setSelected(null)}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/app/(storefront)/account/wishlist/page.tsx
+++ b/app/(storefront)/account/wishlist/page.tsx
@@ -1,0 +1,37 @@
+import { requireAuth } from "@/lib/auth/guards";
+import { getUserWishlist } from "@/lib/db/wishlist";
+import { WishlistGrid } from "./wishlist-grid";
+import Link from "next/link";
+
+export default async function WishlistPage() {
+  const session = await requireAuth();
+  const items = await getUserWishlist(session.user.id);
+
+  // Only pass fields needed by the client component (server-serialization)
+  const clientItems = items.map((item) => ({
+    id: item.id,
+    product_id: item.product_id,
+    name: item.name,
+    slug: item.slug,
+    base_price: item.base_price,
+    brand: item.brand,
+    image_url: item.image_url,
+  }));
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-base font-semibold">Mes favoris</h2>
+
+      {items.length === 0 ? (
+        <div className="py-12 text-center">
+          <p className="text-sm text-muted-foreground">Votre liste de favoris est vide</p>
+          <Link href="/" className="mt-2 inline-block text-sm font-medium text-primary hover:underline">
+            Parcourir le catalogue
+          </Link>
+        </div>
+      ) : (
+        <WishlistGrid items={clientItems} />
+      )}
+    </div>
+  );
+}

--- a/app/(storefront)/account/wishlist/wishlist-grid.tsx
+++ b/app/(storefront)/account/wishlist/wishlist-grid.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useTransition } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { formatPrice } from "@/lib/utils/format";
+import { getImageUrl } from "@/lib/utils/images";
+import { Button } from "@/components/ui/button";
+import { toggleWishlist } from "@/actions/wishlist";
+import { toast } from "sonner";
+
+interface WishlistClientItem {
+  id: string;
+  product_id: string;
+  name: string;
+  slug: string;
+  base_price: number;
+  brand: string | null;
+  image_url: string | null;
+}
+
+export function WishlistGrid({ items }: { items: WishlistClientItem[] }) {
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+      {items.map((item) => (
+        <WishlistCard key={item.id} item={item} />
+      ))}
+    </div>
+  );
+}
+
+function WishlistCard({ item }: { item: WishlistClientItem }) {
+  const [pending, startTransition] = useTransition();
+
+  function handleRemove(e: React.MouseEvent) {
+    e.preventDefault();
+    startTransition(async () => {
+      await toggleWishlist(item.product_id);
+      toast.success("Retiré des favoris");
+    });
+  }
+
+  return (
+    <div className="group flex flex-col overflow-hidden rounded-xl border bg-card">
+      <Link href={`/p/${item.slug}`} className="relative aspect-square overflow-hidden bg-muted">
+        <Image
+          src={getImageUrl(item.image_url)}
+          alt={item.name}
+          fill
+          className="object-contain p-4"
+          sizes="(max-width: 640px) 50vw, 33vw"
+        />
+      </Link>
+      <div className="flex flex-1 flex-col gap-1 p-3">
+        {item.brand && (
+          <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+            {item.brand}
+          </span>
+        )}
+        <Link href={`/p/${item.slug}`} className="line-clamp-2 text-sm font-medium leading-tight hover:underline">
+          {item.name}
+        </Link>
+        <p className="mt-auto pt-1 text-sm font-bold">{formatPrice(item.base_price)}</p>
+        <Button
+          variant="ghost"
+          size="xs"
+          className="mt-1 w-full text-destructive"
+          onClick={handleRemove}
+          disabled={pending}
+        >
+          Retirer
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/(storefront)/account/wishlist/wishlist-grid.tsx
+++ b/app/(storefront)/account/wishlist/wishlist-grid.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTransition } from "react";
+import { useRouter } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
 import { formatPrice } from "@/lib/utils/format";
@@ -31,12 +32,14 @@ export function WishlistGrid({ items }: { items: WishlistClientItem[] }) {
 
 function WishlistCard({ item }: { item: WishlistClientItem }) {
   const [pending, startTransition] = useTransition();
+  const router = useRouter();
 
   function handleRemove(e: React.MouseEvent) {
     e.preventDefault();
     startTransition(async () => {
       await toggleWishlist(item.product_id);
       toast.success("Retiré des favoris");
+      router.refresh();
     });
   }
 

--- a/app/(storefront)/p/[slug]/page.tsx
+++ b/app/(storefront)/p/[slug]/page.tsx
@@ -90,6 +90,7 @@ async function ProductReviews({ productId }: { productId: string }) {
         <h2 className="text-lg font-semibold">Avis clients</h2>
         <div className="flex items-center gap-1.5">
           <StarRating value={Math.round(stats.average)} readonly />
+          <span className="text-sm font-medium">{stats.average.toFixed(1)}</span>
           <span className="text-sm text-muted-foreground">
             ({stats.count} avis)
           </span>

--- a/app/(storefront)/p/[slug]/page.tsx
+++ b/app/(storefront)/p/[slug]/page.tsx
@@ -7,8 +7,13 @@ import { ImageGallery } from "@/components/storefront/image-gallery";
 import { VariantSelector } from "@/components/storefront/variant-selector";
 import { AddToCartButton } from "@/components/storefront/add-to-cart-button";
 import { HorizontalSection } from "@/components/storefront/horizontal-section";
+import { WishlistButton } from "@/components/storefront/wishlist-button";
+import { StarRating } from "@/components/storefront/star-rating";
 import { SITE_NAME } from "@/lib/utils/constants";
-import { formatPrice } from "@/lib/utils/format";
+import { formatPrice, formatDate } from "@/lib/utils/format";
+import { getOptionalSession } from "@/lib/auth/guards";
+import { isInWishlist } from "@/lib/db/wishlist";
+import { getProductReviews, getProductRatingStats } from "@/lib/db/reviews";
 
 const getProductCached = cache(getProductBySlug);
 
@@ -71,10 +76,58 @@ function RelatedProductsSkeleton() {
   );
 }
 
+async function ProductReviews({ productId }: { productId: string }) {
+  const [reviews, stats] = await Promise.all([
+    getProductReviews(productId, 10),
+    getProductRatingStats(productId),
+  ]);
+
+  if (stats.count === 0) return null;
+
+  return (
+    <div className="mt-12 space-y-4">
+      <div className="flex items-center gap-3">
+        <h2 className="text-lg font-semibold">Avis clients</h2>
+        <div className="flex items-center gap-1.5">
+          <StarRating value={Math.round(stats.average)} readonly />
+          <span className="text-sm text-muted-foreground">
+            ({stats.count} avis)
+          </span>
+        </div>
+      </div>
+      <div className="space-y-3">
+        {reviews.map((review) => (
+          <div key={review.id} className="rounded-lg border p-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium">{review.user_name}</span>
+                <StarRating value={review.rating} readonly size="sm" />
+              </div>
+              <span className="text-xs text-muted-foreground">
+                {formatDate(review.created_at)}
+              </span>
+            </div>
+            {review.comment && (
+              <p className="mt-1.5 text-sm text-muted-foreground">{review.comment}</p>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export default async function ProductPage({ params }: Props) {
   const { slug } = await params;
-  const product = await getProductCached(slug);
+  const [product, session] = await Promise.all([
+    getProductCached(slug),
+    getOptionalSession(),
+  ]);
   if (!product) notFound();
+
+  const wishlisted = session
+    ? await isInWishlist(session.user.id, product.id)
+    : false;
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-6">
@@ -104,12 +157,19 @@ export default async function ProductPage({ params }: Props) {
 
         {/* Product info */}
         <div className="space-y-4">
-          {product.brand ? (
-            <span className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
-              {product.brand}
-            </span>
-          ) : null}
-          <h1 className="text-2xl font-bold sm:text-3xl">{product.name}</h1>
+          <div className="flex items-start justify-between gap-2">
+            <div>
+              {product.brand ? (
+                <span className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+                  {product.brand}
+                </span>
+              ) : null}
+              <h1 className="text-2xl font-bold sm:text-3xl">{product.name}</h1>
+            </div>
+            {session && (
+              <WishlistButton productId={product.id} isWishlisted={wishlisted} />
+            )}
+          </div>
 
           {product.variants.length > 0 ? (
             <VariantSelector
@@ -151,6 +211,11 @@ export default async function ProductPage({ params }: Props) {
           ) : null}
         </div>
       </div>
+
+      {/* Reviews */}
+      <Suspense fallback={null}>
+        <ProductReviews productId={product.id} />
+      </Suspense>
 
       {/* Related */}
       <Suspense fallback={<RelatedProductsSkeleton />}>

--- a/components/storefront/account-nav.tsx
+++ b/components/storefront/account-nav.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+
+const navItems = [
+  { href: "/account", label: "Profil" },
+  { href: "/account/orders", label: "Commandes" },
+  { href: "/account/addresses", label: "Adresses" },
+  { href: "/account/wishlist", label: "Favoris" },
+  { href: "/account/reviews", label: "Avis" },
+];
+
+export function AccountNav() {
+  const pathname = usePathname();
+
+  function isActive(href: string) {
+    if (href === "/account") return pathname === "/account";
+    return pathname.startsWith(href);
+  }
+
+  return (
+    <>
+      {/* Desktop sidebar */}
+      <nav className="hidden md:block">
+        <ul className="space-y-1">
+          {navItems.map((item) => (
+            <li key={item.href}>
+              <Link
+                href={item.href}
+                className={cn(
+                  "block rounded-lg px-3 py-2 text-sm transition-colors",
+                  isActive(item.href)
+                    ? "bg-primary/10 font-medium text-primary"
+                    : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                )}
+              >
+                {item.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      {/* Mobile tabs */}
+      <nav className="mb-4 flex gap-1 overflow-x-auto md:hidden">
+        {navItems.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={cn(
+              "shrink-0 rounded-full px-3 py-1.5 text-xs font-medium transition-colors",
+              isActive(item.href)
+                ? "bg-primary text-primary-foreground"
+                : "bg-muted text-muted-foreground"
+            )}
+          >
+            {item.label}
+          </Link>
+        ))}
+      </nav>
+    </>
+  );
+}

--- a/components/storefront/address-card.tsx
+++ b/components/storefront/address-card.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useTransition } from "react";
+import type { Address } from "@/lib/db/types";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { deleteAddressAction, setDefaultAddressAction } from "@/actions/addresses";
+import { toast } from "sonner";
+
+interface Props {
+  address: Address;
+  onEdit: (address: Address) => void;
+}
+
+export function AddressCard({ address, onEdit }: Props) {
+  const [pending, startTransition] = useTransition();
+
+  function handleDelete() {
+    if (!confirm("Supprimer cette adresse ?")) return;
+    startTransition(async () => {
+      const result = await deleteAddressAction(address.id);
+      if (result.success) toast.success("Adresse supprimée");
+      else toast.error(result.error ?? "Erreur");
+    });
+  }
+
+  function handleSetDefault() {
+    startTransition(async () => {
+      const result = await setDefaultAddressAction(address.id);
+      if (result.success) toast.success("Adresse par défaut mise à jour");
+      else toast.error(result.error ?? "Erreur");
+    });
+  }
+
+  return (
+    <div className="rounded-xl border p-4">
+      <div className="flex items-start justify-between gap-2">
+        <div className="space-y-0.5">
+          <div className="flex items-center gap-2">
+            <p className="text-sm font-medium">{address.label}</p>
+            {address.is_default === 1 && <Badge variant="secondary">Par défaut</Badge>}
+          </div>
+          <p className="text-sm">{address.full_name}</p>
+          <p className="text-xs text-muted-foreground">{address.street}</p>
+          <p className="text-xs text-muted-foreground">{address.commune}, {address.city}</p>
+          <p className="text-xs text-muted-foreground">{address.phone}</p>
+          {address.instructions && (
+            <p className="text-xs text-muted-foreground italic">{address.instructions}</p>
+          )}
+        </div>
+      </div>
+      <div className="mt-3 flex gap-2">
+        <Button variant="outline" size="xs" onClick={() => onEdit(address)} disabled={pending}>
+          Modifier
+        </Button>
+        {address.is_default !== 1 && (
+          <Button variant="outline" size="xs" onClick={handleSetDefault} disabled={pending}>
+            Par défaut
+          </Button>
+        )}
+        <Button variant="ghost" size="xs" onClick={handleDelete} disabled={pending} className="text-destructive">
+          Supprimer
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/storefront/address-card.tsx
+++ b/components/storefront/address-card.tsx
@@ -1,9 +1,20 @@
 "use client";
 
-import { useTransition } from "react";
+import { useTransition, useState } from "react";
 import type { Address } from "@/lib/db/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { deleteAddressAction, setDefaultAddressAction } from "@/actions/addresses";
 import { toast } from "sonner";
 
@@ -14,13 +25,17 @@ interface Props {
 
 export function AddressCard({ address, onEdit }: Props) {
   const [pending, startTransition] = useTransition();
+  const [deleteOpen, setDeleteOpen] = useState(false);
 
   function handleDelete() {
-    if (!confirm("Supprimer cette adresse ?")) return;
     startTransition(async () => {
       const result = await deleteAddressAction(address.id);
-      if (result.success) toast.success("Adresse supprimée");
-      else toast.error(result.error ?? "Erreur");
+      if (result.success) {
+        toast.success("Adresse supprimée");
+        setDeleteOpen(false);
+      } else {
+        toast.error(result.error ?? "Erreur");
+      }
     });
   }
 
@@ -58,9 +73,27 @@ export function AddressCard({ address, onEdit }: Props) {
             Par défaut
           </Button>
         )}
-        <Button variant="ghost" size="xs" onClick={handleDelete} disabled={pending} className="text-destructive">
-          Supprimer
-        </Button>
+        <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+          <AlertDialogTrigger asChild>
+            <Button variant="ghost" size="xs" disabled={pending} className="text-destructive">
+              Supprimer
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent size="sm">
+            <AlertDialogHeader>
+              <AlertDialogTitle>Supprimer cette adresse ?</AlertDialogTitle>
+              <AlertDialogDescription>
+                L&apos;adresse &quot;{address.label}&quot; sera définitivement supprimée.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel size="sm">Annuler</AlertDialogCancel>
+              <AlertDialogAction variant="destructive" size="sm" onClick={handleDelete} disabled={pending}>
+                {pending ? "Suppression..." : "Supprimer"}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </div>
     </div>
   );

--- a/components/storefront/address-form.tsx
+++ b/components/storefront/address-form.tsx
@@ -21,11 +21,12 @@ export function AddressForm({ address, onDone }: Props) {
   const [phone, setPhone] = useState(address?.phone ?? "");
   const [street, setStreet] = useState(address?.street ?? "");
   const [commune, setCommune] = useState(address?.commune ?? "");
+  const [city, setCity] = useState(address?.city ?? "Abidjan");
   const [instructions, setInstructions] = useState(address?.instructions ?? "");
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    const data = { label, fullName, phone, street, commune, instructions: instructions || undefined };
+    const data = { label, fullName, phone, street, commune, city, instructions: instructions || undefined };
 
     startTransition(async () => {
       const result = address
@@ -59,9 +60,15 @@ export function AddressForm({ address, onDone }: Props) {
         <Label htmlFor="addr-street">Adresse</Label>
         <Input id="addr-street" value={street} onChange={(e) => setStreet(e.target.value)} required minLength={3} />
       </div>
-      <div className="space-y-1.5">
-        <Label htmlFor="addr-commune">Commune</Label>
-        <Input id="addr-commune" value={commune} onChange={(e) => setCommune(e.target.value)} required />
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1.5">
+          <Label htmlFor="addr-commune">Commune</Label>
+          <Input id="addr-commune" value={commune} onChange={(e) => setCommune(e.target.value)} required />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="addr-city">Ville</Label>
+          <Input id="addr-city" value={city} onChange={(e) => setCity(e.target.value)} required />
+        </div>
       </div>
       <div className="space-y-1.5">
         <Label htmlFor="addr-instructions">Instructions (optionnel)</Label>

--- a/components/storefront/address-form.tsx
+++ b/components/storefront/address-form.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useTransition, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { createAddressAction, updateAddressAction } from "@/actions/addresses";
+import type { Address } from "@/lib/db/types";
+import { toast } from "sonner";
+
+interface Props {
+  address?: Address | null;
+  onDone: () => void;
+}
+
+export function AddressForm({ address, onDone }: Props) {
+  const [pending, startTransition] = useTransition();
+  const [label, setLabel] = useState(address?.label ?? "");
+  const [fullName, setFullName] = useState(address?.full_name ?? "");
+  const [phone, setPhone] = useState(address?.phone ?? "");
+  const [street, setStreet] = useState(address?.street ?? "");
+  const [commune, setCommune] = useState(address?.commune ?? "");
+  const [instructions, setInstructions] = useState(address?.instructions ?? "");
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const data = { label, fullName, phone, street, commune, instructions: instructions || undefined };
+
+    startTransition(async () => {
+      const result = address
+        ? await updateAddressAction(address.id, data)
+        : await createAddressAction(data);
+
+      if (result.success) {
+        toast.success(address ? "Adresse modifiée" : "Adresse ajoutée");
+        onDone();
+      } else {
+        toast.error(result.error ?? "Erreur");
+      }
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <div className="space-y-1.5">
+        <Label htmlFor="addr-label">Libellé</Label>
+        <Input id="addr-label" value={label} onChange={(e) => setLabel(e.target.value)} placeholder="Domicile, Bureau..." required />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="addr-name">Nom complet</Label>
+        <Input id="addr-name" value={fullName} onChange={(e) => setFullName(e.target.value)} required minLength={2} />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="addr-phone">Téléphone</Label>
+        <Input id="addr-phone" value={phone} onChange={(e) => setPhone(e.target.value)} required placeholder="0701020304" />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="addr-street">Adresse</Label>
+        <Input id="addr-street" value={street} onChange={(e) => setStreet(e.target.value)} required minLength={3} />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="addr-commune">Commune</Label>
+        <Input id="addr-commune" value={commune} onChange={(e) => setCommune(e.target.value)} required />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="addr-instructions">Instructions (optionnel)</Label>
+        <Textarea id="addr-instructions" value={instructions} onChange={(e) => setInstructions(e.target.value)} rows={2} />
+      </div>
+      <div className="flex gap-2">
+        <Button type="submit" disabled={pending}>
+          {pending ? "Enregistrement..." : address ? "Modifier" : "Ajouter"}
+        </Button>
+        <Button type="button" variant="outline" onClick={onDone}>
+          Annuler
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/components/storefront/header-user-menu.tsx
+++ b/components/storefront/header-user-menu.tsx
@@ -1,9 +1,27 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { authClient } from "@/lib/auth/client";
 import { useRouter } from "next/navigation";
+import {
+  UserIcon,
+  ShoppingBag01Icon,
+  Location01Icon,
+  FavouriteIcon,
+  StarIcon,
+  Logout01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 
 type User = {
   id: string;
@@ -11,6 +29,41 @@ type User = {
   email: string;
   image?: string | null;
 } | null;
+
+function UserAvatar({ user }: { user: NonNullable<User> }) {
+  const initials = user.name
+    .split(" ")
+    .map((w) => w[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+
+  if (user.image) {
+    return (
+      <Image
+        src={user.image}
+        alt={user.name}
+        width={32}
+        height={32}
+        className="size-8 rounded-full object-cover"
+      />
+    );
+  }
+
+  return (
+    <span className="flex size-8 items-center justify-center rounded-full bg-primary text-[11px] font-semibold text-primary-foreground">
+      {initials}
+    </span>
+  );
+}
+
+const menuItems = [
+  { href: "/account", label: "Mon profil", icon: UserIcon },
+  { href: "/account/orders", label: "Mes commandes", icon: ShoppingBag01Icon },
+  { href: "/account/addresses", label: "Mes adresses", icon: Location01Icon },
+  { href: "/account/wishlist", label: "Mes favoris", icon: FavouriteIcon },
+  { href: "/account/reviews", label: "Mes avis", icon: StarIcon },
+];
 
 export function HeaderUserMenu({ user }: { user: User }) {
   const router = useRouter();
@@ -24,23 +77,41 @@ export function HeaderUserMenu({ user }: { user: User }) {
   }
 
   return (
-    <div className="flex items-center gap-3">
-      <Link
-        href="/account"
-        className="text-xs font-medium hover:text-foreground text-muted-foreground"
-      >
-        {user.name}
-      </Link>
-      <Button
-        variant="ghost"
-        size="default"
-        onClick={async () => {
-          await authClient.signOut();
-          router.refresh();
-        }}
-      >
-        Déconnexion
-      </Button>
-    </div>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          className="cursor-pointer rounded-full outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label="Menu utilisateur"
+        >
+          <UserAvatar user={user} />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-52">
+        <DropdownMenuLabel className="font-normal">
+          <p className="text-sm font-medium">{user.name}</p>
+          <p className="text-xs text-muted-foreground">{user.email}</p>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {menuItems.map((item) => (
+          <DropdownMenuItem key={item.href} asChild>
+            <Link href={item.href}>
+              <HugeiconsIcon icon={item.icon} size={16} />
+              {item.label}
+            </Link>
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          variant="destructive"
+          onClick={async () => {
+            await authClient.signOut();
+            router.refresh();
+          }}
+        >
+          <HugeiconsIcon icon={Logout01Icon} size={16} />
+          Déconnexion
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/components/storefront/header-user-menu.tsx
+++ b/components/storefront/header-user-menu.tsx
@@ -31,8 +31,9 @@ type User = {
 } | null;
 
 function UserAvatar({ user }: { user: NonNullable<User> }) {
-  const initials = user.name
+  const initials = (user.name || "?")
     .split(" ")
+    .filter(Boolean)
     .map((w) => w[0])
     .join("")
     .slice(0, 2)

--- a/components/storefront/order-card.tsx
+++ b/components/storefront/order-card.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import type { Order } from "@/lib/db/types";
+import { Badge } from "@/components/ui/badge";
+import { formatPrice } from "@/lib/utils/format";
+import { formatDate } from "@/lib/utils/format";
+
+const statusConfig: Record<string, { label: string; variant: "default" | "secondary" | "destructive" | "outline" }> = {
+  pending: { label: "En attente", variant: "outline" },
+  confirmed: { label: "Confirmée", variant: "secondary" },
+  preparing: { label: "En préparation", variant: "secondary" },
+  shipping: { label: "En livraison", variant: "default" },
+  delivered: { label: "Livrée", variant: "default" },
+  cancelled: { label: "Annulée", variant: "destructive" },
+};
+
+export function OrderCard({ order }: { order: Order }) {
+  const status = statusConfig[order.status] ?? { label: order.status, variant: "outline" as const };
+
+  return (
+    <Link
+      href={`/account/orders/${order.order_number}`}
+      className="block rounded-xl border p-4 transition-colors hover:bg-muted/50"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="space-y-1">
+          <p className="text-sm font-medium">{order.order_number}</p>
+          <p className="text-xs text-muted-foreground">{formatDate(order.created_at)}</p>
+        </div>
+        <Badge variant={status.variant}>{status.label}</Badge>
+      </div>
+      <div className="mt-3 flex items-center justify-between text-sm">
+        <span className="text-muted-foreground">Total</span>
+        <span className="font-semibold">{formatPrice(order.total)}</span>
+      </div>
+    </Link>
+  );
+}
+
+export { statusConfig };

--- a/components/storefront/order-card.tsx
+++ b/components/storefront/order-card.tsx
@@ -1,10 +1,10 @@
 import Link from "next/link";
-import type { Order } from "@/lib/db/types";
+import type { Order, OrderStatus } from "@/lib/db/types";
 import { Badge } from "@/components/ui/badge";
 import { formatPrice } from "@/lib/utils/format";
 import { formatDate } from "@/lib/utils/format";
 
-const statusConfig: Record<string, { label: string; variant: "default" | "secondary" | "destructive" | "outline" }> = {
+const statusConfig: Record<OrderStatus, { label: string; variant: "default" | "secondary" | "destructive" | "outline" }> = {
   pending: { label: "En attente", variant: "outline" },
   confirmed: { label: "Confirmée", variant: "secondary" },
   preparing: { label: "En préparation", variant: "secondary" },
@@ -14,7 +14,7 @@ const statusConfig: Record<string, { label: string; variant: "default" | "second
 };
 
 export function OrderCard({ order }: { order: Order }) {
-  const status = statusConfig[order.status] ?? { label: order.status, variant: "outline" as const };
+  const status = statusConfig[order.status as OrderStatus] ?? { label: order.status, variant: "outline" as const };
 
   return (
     <Link

--- a/components/storefront/order-status-timeline.tsx
+++ b/components/storefront/order-status-timeline.tsx
@@ -1,0 +1,71 @@
+import { cn } from "@/lib/utils";
+import type { OrderStatus } from "@/lib/db/types";
+
+const steps: { key: OrderStatus; label: string }[] = [
+  { key: "pending", label: "En attente" },
+  { key: "confirmed", label: "Confirmée" },
+  { key: "preparing", label: "Préparation" },
+  { key: "shipping", label: "Livraison" },
+  { key: "delivered", label: "Livrée" },
+];
+
+const stepIndex: Record<string, number> = {};
+steps.forEach((s, i) => (stepIndex[s.key] = i));
+
+export function OrderStatusTimeline({ status }: { status: string }) {
+  if (status === "cancelled") {
+    return (
+      <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-3 text-center text-sm text-destructive">
+        Commande annulée
+      </div>
+    );
+  }
+
+  const currentIdx = stepIndex[status] ?? 0;
+
+  return (
+    <div className="flex items-center gap-1">
+      {steps.map((step, i) => {
+        const isDone = i <= currentIdx;
+        return (
+          <div key={step.key} className="flex flex-1 flex-col items-center gap-1.5">
+            <div className="flex w-full items-center">
+              {i > 0 && (
+                <div
+                  className={cn(
+                    "h-0.5 flex-1",
+                    i <= currentIdx ? "bg-primary" : "bg-muted"
+                  )}
+                />
+              )}
+              <div
+                className={cn(
+                  "size-3 shrink-0 rounded-full border-2",
+                  isDone
+                    ? "border-primary bg-primary"
+                    : "border-muted-foreground/30 bg-background"
+                )}
+              />
+              {i < steps.length - 1 && (
+                <div
+                  className={cn(
+                    "h-0.5 flex-1",
+                    i < currentIdx ? "bg-primary" : "bg-muted"
+                  )}
+                />
+              )}
+            </div>
+            <span
+              className={cn(
+                "text-center text-[10px] leading-tight",
+                isDone ? "font-medium text-foreground" : "text-muted-foreground"
+              )}
+            >
+              {step.label}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/storefront/product-card.tsx
+++ b/components/storefront/product-card.tsx
@@ -3,8 +3,15 @@ import Image from "next/image";
 import type { Product } from "@/lib/db/types";
 import { formatPrice } from "@/lib/utils/format";
 import { getImageUrl } from "@/lib/utils/images";
+import { WishlistButton } from "@/components/storefront/wishlist-button";
 
-export function ProductCard({ product }: { product: Product }) {
+interface Props {
+  product: Product;
+  isWishlisted?: boolean;
+  showWishlist?: boolean;
+}
+
+export function ProductCard({ product, isWishlisted = false, showWishlist = false }: Props) {
   const hasVariants = (product.variant_count ?? 0) > 1;
 
   return (
@@ -20,6 +27,13 @@ export function ProductCard({ product }: { product: Product }) {
           className="object-contain p-4 transition-transform group-hover:scale-105"
           sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
         />
+        {showWishlist && (
+          <WishlistButton
+            productId={product.id}
+            isWishlisted={isWishlisted}
+            className="absolute right-2 top-2 z-10"
+          />
+        )}
         {product.category_name ? (
           <span className="absolute left-2 top-2 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
             {product.category_name}

--- a/components/storefront/review-form.tsx
+++ b/components/storefront/review-form.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useTransition, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { StarRating } from "@/components/storefront/star-rating";
+import { submitReview } from "@/actions/reviews";
+import { toast } from "sonner";
+
+interface Props {
+  productId: string;
+  productName: string;
+  onDone?: () => void;
+}
+
+export function ReviewForm({ productId, productName, onDone }: Props) {
+  const [pending, startTransition] = useTransition();
+  const [rating, setRating] = useState(0);
+  const [comment, setComment] = useState("");
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (rating === 0) {
+      toast.error("Veuillez sélectionner une note");
+      return;
+    }
+    startTransition(async () => {
+      const result = await submitReview({
+        productId,
+        rating,
+        comment: comment || undefined,
+      });
+      if (result.success) {
+        toast.success("Avis publié");
+        onDone?.();
+      } else {
+        toast.error(result.error ?? "Erreur");
+      }
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <p className="text-sm font-medium">{productName}</p>
+      <div className="space-y-1.5">
+        <Label>Note</Label>
+        <StarRating value={rating} onChange={setRating} size="md" />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="review-comment">Commentaire (optionnel)</Label>
+        <Textarea
+          id="review-comment"
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+          rows={3}
+          maxLength={1000}
+          placeholder="Partagez votre expérience..."
+        />
+      </div>
+      <Button type="submit" size="sm" disabled={pending}>
+        {pending ? "Publication..." : "Publier l'avis"}
+      </Button>
+    </form>
+  );
+}

--- a/components/storefront/star-rating.tsx
+++ b/components/storefront/star-rating.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+interface Props {
+  value: number;
+  onChange?: (value: number) => void;
+  size?: "sm" | "md";
+  readonly?: boolean;
+}
+
+export function StarRating({ value, onChange, size = "sm", readonly = false }: Props) {
+  const starSize = size === "md" ? "size-5" : "size-4";
+
+  return (
+    <div className="inline-flex gap-0.5" role={readonly ? "img" : "radiogroup"} aria-label={`${value} sur 5 étoiles`}>
+      {[1, 2, 3, 4, 5].map((star) => (
+        <button
+          key={star}
+          type="button"
+          disabled={readonly}
+          onClick={() => onChange?.(star)}
+          className={cn(
+            starSize,
+            "transition-colors",
+            !readonly && "cursor-pointer hover:text-yellow-500",
+            readonly && "cursor-default"
+          )}
+          aria-label={`${star} étoile${star > 1 ? "s" : ""}`}
+        >
+          <svg
+            viewBox="0 0 24 24"
+            fill={star <= value ? "currentColor" : "none"}
+            stroke="currentColor"
+            strokeWidth={1.5}
+            className={cn(
+              "size-full",
+              star <= value ? "text-yellow-500" : "text-muted-foreground/40"
+            )}
+          >
+            <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+          </svg>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/components/storefront/wishlist-button.tsx
+++ b/components/storefront/wishlist-button.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useTransition, useOptimistic } from "react";
+import { toggleWishlist } from "@/actions/wishlist";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  productId: string;
+  isWishlisted: boolean;
+  className?: string;
+}
+
+export function WishlistButton({ productId, isWishlisted, className }: Props) {
+  const [pending, startTransition] = useTransition();
+  const [optimistic, setOptimistic] = useOptimistic(isWishlisted);
+
+  function handleClick(e: React.MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    startTransition(async () => {
+      setOptimistic(!optimistic);
+      await toggleWishlist(productId);
+    });
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={pending}
+      className={cn(
+        "flex size-8 items-center justify-center rounded-full bg-background/80 text-muted-foreground backdrop-blur-sm transition-colors hover:text-destructive",
+        optimistic && "text-destructive",
+        className
+      )}
+      aria-label={optimistic ? "Retirer des favoris" : "Ajouter aux favoris"}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        className="size-4"
+        fill={optimistic ? "currentColor" : "none"}
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+      </svg>
+    </button>
+  );
+}

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import * as React from "react"
+import { Checkbox as CheckboxPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Tick02Icon } from "@hugeicons/core-free-icons"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "border-input dark:bg-input/30 data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary data-checked:border-primary aria-invalid:aria-checked:border-primary aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 flex size-4 items-center justify-center rounded-[4px] border transition-shadow group-has-disabled/field:opacity-50 focus-visible:ring-[2px] aria-invalid:ring-[2px] peer relative shrink-0 outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="[&>svg]:size-3.5 grid place-content-center text-current transition-none"
+      >
+        <HugeiconsIcon icon={Tick02Icon} strokeWidth={2} />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,155 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Cancel01Icon } from "@hugeicons/core-free-icons"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn("data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/80 duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 isolate z-50", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-4 rounded-xl p-4 text-xs/relaxed ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close data-slot="dialog-close" asChild>
+            <Button variant="ghost" className="absolute top-2 right-2" size="icon-sm">
+              <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2} />
+              <span className="sr-only">Close</span>
+            </Button>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("gap-1 flex flex-col", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "gap-2 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-sm font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground *:[a]:hover:text-foreground text-xs/relaxed *:[a]:underline *:[a]:underline-offset-3", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -1,0 +1,134 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as SheetPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { Cancel01Icon } from "@hugeicons/core-free-icons"
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn("data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/80 duration-100 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-50", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left"
+  showCloseButton?: boolean
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        data-side={side}
+        className={cn("bg-background data-open:animate-in data-closed:animate-out data-[side=right]:data-closed:slide-out-to-right-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=top]:data-closed:slide-out-to-top-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:fade-out-0 data-open:fade-in-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=bottom]:data-open:slide-in-from-bottom-10 fixed z-50 flex flex-col bg-clip-padding text-xs/relaxed shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm", className)}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close data-slot="sheet-close" asChild>
+            <Button variant="ghost" className="absolute top-4 right-4" size="icon-sm">
+              <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2} />
+              <span className="sr-only">Close</span>
+            </Button>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("gap-1.5 p-6 flex flex-col", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("gap-2 p-6 mt-auto flex flex-col", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("text-foreground text-sm font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-muted-foreground text-xs/relaxed", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("bg-muted rounded-md animate-pulse", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { CheckmarkCircle02Icon, InformationCircleIcon, Alert02Icon, MultiplicationSignCircleIcon, Loading03Icon } from "@hugeicons/core-free-icons"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      icons={{
+        success: (
+          <HugeiconsIcon icon={CheckmarkCircle02Icon} strokeWidth={2} className="size-4" />
+        ),
+        info: (
+          <HugeiconsIcon icon={InformationCircleIcon} strokeWidth={2} className="size-4" />
+        ),
+        warning: (
+          <HugeiconsIcon icon={Alert02Icon} strokeWidth={2} className="size-4" />
+        ),
+        error: (
+          <HugeiconsIcon icon={MultiplicationSignCircleIcon} strokeWidth={2} className="size-4" />
+        ),
+        loading: (
+          <HugeiconsIcon icon={Loading03Icon} strokeWidth={2} className="size-4 animate-spin" />
+        ),
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      toastOptions={{
+        classNames: {
+          toast: "cn-toast",
+        },
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import * as React from "react"
+import { Switch as SwitchPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-[2px] aria-invalid:ring-[2px] data-[size=default]:h-[16.6px] data-[size=default]:w-[28px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] peer group/switch relative inline-flex items-center transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-3.5 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 pointer-events-none block ring-0 transition-transform"
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,0 +1,101 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div data-slot="table-container" className="relative w-full overflow-x-auto">
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-xs", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn("bg-muted/50 border-t font-medium [&>tr]:last:border-b-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn("hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors", className)}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn("text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn("p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("text-muted-foreground mt-4 text-xs", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,0 +1,90 @@
+"use client"
+
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Tabs as TabsPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      className={cn(
+        "gap-2 group/tabs flex data-[orientation=horizontal]:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const tabsListVariants = cva(
+  "rounded-lg p-[3px] group-data-horizontal/tabs:h-8 data-[variant=line]:rounded-none group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List> &
+  VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-xs font-medium group-data-vertical/tabs:py-[calc(--spacing(1.25))] [&_svg:not([class*='size-'])]:size-3.5 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center whitespace-nowrap transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
+        "data-active:bg-background dark:data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 data-active:text-foreground",
+        "after:bg-foreground after:absolute after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("text-xs/relaxed flex-1 outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }

--- a/db/migrations/0004_account_features.sql
+++ b/db/migrations/0004_account_features.sql
@@ -1,0 +1,14 @@
+-- Wishlist table
+CREATE TABLE IF NOT EXISTS wishlist (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  product_id TEXT NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(user_id, product_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_wishlist_user ON wishlist(user_id);
+CREATE INDEX IF NOT EXISTS idx_wishlist_product ON wishlist(product_id);
+
+-- Index on reviews(user_id) for account reviews page
+CREATE INDEX IF NOT EXISTS idx_reviews_user ON reviews(user_id);

--- a/lib/db/addresses.ts
+++ b/lib/db/addresses.ts
@@ -107,9 +107,12 @@ export async function deleteAddress(id: string, userId: string): Promise<boolean
 }
 
 export async function setDefaultAddress(id: string, userId: string): Promise<boolean> {
+  // Verify target exists before modifying anything
+  const target = await getAddressById(id, userId);
+  if (!target) return false;
+
   const db = await getDB();
-  // Unset all defaults, then set the target
-  const results = await db.batch([
+  await db.batch([
     db
       .prepare("UPDATE addresses SET is_default = 0 WHERE user_id = ?")
       .bind(userId),
@@ -117,7 +120,5 @@ export async function setDefaultAddress(id: string, userId: string): Promise<boo
       .prepare("UPDATE addresses SET is_default = 1 WHERE id = ? AND user_id = ?")
       .bind(id, userId),
   ]);
-  // If the target didn't exist, restore the previous default
-  if (results[1].meta.changes === 0) return false;
   return true;
 }

--- a/lib/db/orders.ts
+++ b/lib/db/orders.ts
@@ -230,16 +230,13 @@ export async function cancelOrder(
   userId: string,
   reason: string
 ): Promise<boolean> {
-  const order = await getOrderByNumber(orderNumber, userId);
-  if (!order || order.status !== "pending") return false;
-
   const db = await getDB();
-  await db
+  const result = await db
     .prepare(
       `UPDATE orders SET status = 'cancelled', cancelled_at = datetime('now'), cancellation_reason = ?, updated_at = datetime('now')
-       WHERE id = ? AND user_id = ? AND status = 'pending'`
+       WHERE order_number = ? AND user_id = ? AND status = 'pending'`
     )
-    .bind(reason, order.id, userId)
+    .bind(reason, orderNumber, userId)
     .run();
-  return true;
+  return result.meta.changes > 0;
 }

--- a/lib/db/reviews.ts
+++ b/lib/db/reviews.ts
@@ -1,0 +1,117 @@
+import { query, queryFirst, execute } from "@/lib/db";
+import { nanoid } from "nanoid";
+import type { Review } from "@/lib/db/types";
+
+export async function getProductReviews(
+  productId: string,
+  limit = 20,
+  offset = 0
+): Promise<Review[]> {
+  return query<Review>(
+    `SELECT r.id, r.product_id, r.user_id, r.rating, r.comment,
+            r.is_verified_purchase, r.created_at,
+            u.name as user_name
+     FROM reviews r
+     JOIN "user" u ON u.id = r.user_id
+     WHERE r.product_id = ?
+     ORDER BY r.created_at DESC
+     LIMIT ? OFFSET ?`,
+    [productId, limit, offset]
+  );
+}
+
+export async function getProductRatingStats(
+  productId: string
+): Promise<{ average: number; count: number }> {
+  const row = await queryFirst<{ average: number; count: number }>(
+    `SELECT COALESCE(AVG(rating), 0) as average, COUNT(*) as count
+     FROM reviews WHERE product_id = ?`,
+    [productId]
+  );
+  return { average: row?.average ?? 0, count: row?.count ?? 0 };
+}
+
+export async function getUserReviews(userId: string): Promise<Review[]> {
+  return query<Review>(
+    `SELECT r.id, r.product_id, r.user_id, r.rating, r.comment,
+            r.is_verified_purchase, r.created_at,
+            u.name as user_name,
+            p.name as product_name, p.slug as product_slug,
+            (SELECT pi.url FROM product_images pi WHERE pi.product_id = p.id AND pi.is_primary = 1 LIMIT 1) as product_image_url
+     FROM reviews r
+     JOIN "user" u ON u.id = r.user_id
+     JOIN products p ON p.id = r.product_id
+     WHERE r.user_id = ?
+     ORDER BY r.created_at DESC`,
+    [userId]
+  );
+}
+
+export async function createReview(data: {
+  productId: string;
+  userId: string;
+  rating: number;
+  comment: string | null;
+  isVerifiedPurchase: boolean;
+}): Promise<string> {
+  const id = nanoid();
+  await execute(
+    `INSERT INTO reviews (id, product_id, user_id, rating, comment, is_verified_purchase)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [id, data.productId, data.userId, data.rating, data.comment, data.isVerifiedPurchase ? 1 : 0]
+  );
+  return id;
+}
+
+export async function hasUserReviewedProduct(
+  userId: string,
+  productId: string
+): Promise<boolean> {
+  const row = await queryFirst<{ count: number }>(
+    "SELECT COUNT(*) as count FROM reviews WHERE user_id = ? AND product_id = ?",
+    [userId, productId]
+  );
+  return (row?.count ?? 0) > 0;
+}
+
+export async function canUserReview(
+  userId: string,
+  productId: string
+): Promise<boolean> {
+  // User must have purchased the product (delivered order) and not already reviewed
+  const hasReviewed = await hasUserReviewedProduct(userId, productId);
+  if (hasReviewed) return false;
+
+  const row = await queryFirst<{ count: number }>(
+    `SELECT COUNT(*) as count FROM order_items oi
+     JOIN orders o ON o.id = oi.order_id
+     WHERE o.user_id = ? AND oi.product_id = ? AND o.status = 'delivered'`,
+    [userId, productId]
+  );
+  return (row?.count ?? 0) > 0;
+}
+
+export async function getReviewableProducts(userId: string): Promise<
+  Array<{
+    product_id: string;
+    product_name: string;
+    product_slug: string;
+    product_image_url: string | null;
+    order_number: string;
+    delivered_at: string | null;
+  }>
+> {
+  return query(
+    `SELECT DISTINCT oi.product_id, oi.product_name,
+            p.slug as product_slug,
+            (SELECT pi.url FROM product_images pi WHERE pi.product_id = p.id AND pi.is_primary = 1 LIMIT 1) as product_image_url,
+            o.order_number, o.delivered_at
+     FROM order_items oi
+     JOIN orders o ON o.id = oi.order_id
+     JOIN products p ON p.id = oi.product_id
+     WHERE o.user_id = ? AND o.status = 'delivered'
+       AND NOT EXISTS (SELECT 1 FROM reviews r WHERE r.user_id = ? AND r.product_id = oi.product_id)
+     ORDER BY o.delivered_at DESC`,
+    [userId, userId]
+  );
+}

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -163,3 +163,42 @@ export interface PromoCode {
   is_active: number;
   created_at: string;
 }
+
+export interface WishlistItem {
+  id: string;
+  product_id: string;
+  created_at: string;
+  // Joined from products
+  name: string;
+  slug: string;
+  base_price: number;
+  compare_price: number | null;
+  brand: string | null;
+  stock_quantity: number;
+  is_active: number;
+  image_url: string | null;
+  category_name: string | null;
+}
+
+export interface Review {
+  id: string;
+  product_id: string;
+  user_id: string;
+  rating: number;
+  comment: string | null;
+  is_verified_purchase: number;
+  created_at: string;
+  // Joined fields
+  user_name?: string;
+  product_name?: string;
+  product_slug?: string;
+  product_image_url?: string | null;
+}
+
+export type OrderStatus =
+  | "pending"
+  | "confirmed"
+  | "preparing"
+  | "shipping"
+  | "delivered"
+  | "cancelled";

--- a/lib/db/wishlist.ts
+++ b/lib/db/wishlist.ts
@@ -1,0 +1,50 @@
+import { query, queryFirst, execute } from "@/lib/db";
+import { nanoid } from "nanoid";
+import type { WishlistItem } from "@/lib/db/types";
+
+export async function getUserWishlist(userId: string): Promise<WishlistItem[]> {
+  return query<WishlistItem>(
+    `SELECT w.id, w.product_id, w.created_at,
+            p.name, p.slug, p.base_price, p.compare_price, p.brand,
+            p.stock_quantity, p.is_active,
+            (SELECT pi.url FROM product_images pi WHERE pi.product_id = p.id AND pi.is_primary = 1 LIMIT 1) as image_url,
+            c.name as category_name
+     FROM wishlist w
+     JOIN products p ON p.id = w.product_id
+     LEFT JOIN categories c ON c.id = p.category_id
+     WHERE w.user_id = ?
+     ORDER BY w.created_at DESC`,
+    [userId]
+  );
+}
+
+export async function addToWishlist(userId: string, productId: string): Promise<void> {
+  const id = nanoid();
+  await execute(
+    "INSERT OR IGNORE INTO wishlist (id, user_id, product_id) VALUES (?, ?, ?)",
+    [id, userId, productId]
+  );
+}
+
+export async function removeFromWishlist(userId: string, productId: string): Promise<void> {
+  await execute(
+    "DELETE FROM wishlist WHERE user_id = ? AND product_id = ?",
+    [userId, productId]
+  );
+}
+
+export async function isInWishlist(userId: string, productId: string): Promise<boolean> {
+  const row = await queryFirst<{ count: number }>(
+    "SELECT COUNT(*) as count FROM wishlist WHERE user_id = ? AND product_id = ?",
+    [userId, productId]
+  );
+  return (row?.count ?? 0) > 0;
+}
+
+export async function getUserWishlistProductIds(userId: string): Promise<Set<string>> {
+  const rows = await query<{ product_id: string }>(
+    "SELECT product_id FROM wishlist WHERE user_id = ?",
+    [userId]
+  );
+  return new Set(rows.map((r) => r.product_id));
+}

--- a/lib/db/wishlist.ts
+++ b/lib/db/wishlist.ts
@@ -44,19 +44,18 @@ export async function isInWishlist(userId: string, productId: string): Promise<b
 
 export async function atomicToggleWishlist(userId: string, productId: string): Promise<boolean> {
   const db = await getDB();
-  // Try to delete first — if it existed, we removed it
-  const del = await db
-    .prepare("DELETE FROM wishlist WHERE user_id = ? AND product_id = ?")
-    .bind(userId, productId)
-    .run();
-  if (del.meta.changes > 0) return false; // was removed
-
-  // Didn't exist, insert (INSERT OR IGNORE handles any remaining race)
   const id = nanoid();
-  await db
-    .prepare("INSERT OR IGNORE INTO wishlist (id, user_id, product_id) VALUES (?, ?, ?)")
-    .bind(id, userId, productId)
-    .run();
+  // Batch: delete then insert — both run atomically in a single round-trip
+  const [delResult] = await db.batch([
+    db.prepare("DELETE FROM wishlist WHERE user_id = ? AND product_id = ?").bind(userId, productId),
+    db.prepare("INSERT OR IGNORE INTO wishlist (id, user_id, product_id) VALUES (?, ?, ?)").bind(id, userId, productId),
+  ]);
+  if (delResult.meta.changes > 0) {
+    // It existed and was deleted; the INSERT created a new row — remove it
+    await db.prepare("DELETE FROM wishlist WHERE id = ?").bind(id).run();
+    return false; // was removed
+  }
+  // Didn't exist before, INSERT added it
   return true; // was added
 }
 

--- a/lib/types/actions.ts
+++ b/lib/types/actions.ts
@@ -1,0 +1,5 @@
+export interface ActionResult {
+  success: boolean;
+  error?: string;
+  fieldErrors?: Record<string, string[]>;
+}

--- a/lib/validations/account.ts
+++ b/lib/validations/account.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+export const profileSchema = z.object({
+  name: z.string().min(2, "Le nom doit contenir au moins 2 caractères").max(100),
+  phone: z
+    .string()
+    .transform((v) => v.replace(/[\s\-]/g, ""))
+    .pipe(
+      z.string().regex(/^(\+225)?[0-9]{10}$/, "Numéro ivoirien invalide (10 chiffres, optionnel +225)")
+    ),
+});
+
+export type ProfileInput = z.input<typeof profileSchema>;
+
+export const changePasswordSchema = z
+  .object({
+    currentPassword: z.string().min(1, "Mot de passe actuel requis"),
+    newPassword: z.string().min(8, "Le nouveau mot de passe doit contenir au moins 8 caractères"),
+    confirmPassword: z.string().min(1, "Confirmation requise"),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: "Les mots de passe ne correspondent pas",
+    path: ["confirmPassword"],
+  });
+
+export type ChangePasswordInput = z.input<typeof changePasswordSchema>;

--- a/lib/validations/address.ts
+++ b/lib/validations/address.ts
@@ -11,6 +11,7 @@ export const addressSchema = z.object({
     ),
   street: z.string().min(3, "Adresse requise").max(200),
   commune: z.string().min(1, "Commune requise"),
+  city: z.string().min(1).max(100).default("Abidjan"),
   instructions: z.string().max(500).optional(),
 });
 

--- a/lib/validations/address.ts
+++ b/lib/validations/address.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const addressSchema = z.object({
+  label: z.string().min(1, "Libellé requis").max(50),
+  fullName: z.string().min(2, "Nom complet requis").max(100),
+  phone: z
+    .string()
+    .transform((v) => v.replace(/[\s\-]/g, ""))
+    .pipe(
+      z.string().regex(/^(\+225)?[0-9]{10}$/, "Numéro ivoirien invalide (10 chiffres, optionnel +225)")
+    ),
+  street: z.string().min(3, "Adresse requise").max(200),
+  commune: z.string().min(1, "Commune requise"),
+  instructions: z.string().max(500).optional(),
+});
+
+export type AddressInput = z.input<typeof addressSchema>;

--- a/lib/validations/review.ts
+++ b/lib/validations/review.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const reviewSchema = z.object({
+  productId: z.string().min(1),
+  rating: z.number().int().min(1, "Note requise").max(5),
+  comment: z.string().max(1000).optional(),
+});
+
+export type ReviewInput = z.input<typeof reviewSchema>;


### PR DESCRIPTION
## Summary
- Full customer account area under `/account` with auth-protected layout, sidebar nav (desktop) and tabs (mobile)
- **Profile**: edit name/phone + change password via Better Auth API
- **Orders**: paginated history with status filter tabs, detail view with visual status timeline, order cancellation
- **Addresses**: full CRUD with dialog forms, default toggle, Zod validation
- **Wishlist**: toggle button integrated into ProductCard and product page, dedicated favorites page
- **Reviews**: star rating system with verified purchase checks, reviewable products list, reviews displayed on product pages with Suspense streaming

## Technical details
- Migration `0004_account_features.sql`: wishlist table + reviews user index
- 4 new server actions modules with auth guards and Zod validation
- 3 new Zod validation schemas
- DB helpers extended: orders (getUserOrders, getOrderDetail, cancelOrder), addresses (update, delete, setDefault), new wishlist + reviews modules
- Audited against Vercel React Best Practices: parallel fetches, Suspense boundaries, minimal client serialization, useTransition + useOptimistic

## Test plan
- [ ] Navigate to `/account` without auth → should redirect to sign-in
- [ ] Edit profile (name, phone) and verify changes persist
- [ ] Change password with current + new password
- [ ] View order history, filter by status, paginate
- [ ] View order detail with timeline, cancel a pending order
- [ ] CRUD addresses: add, edit, delete, set default
- [ ] Toggle wishlist on product card and product page
- [ ] View wishlist page, remove items
- [ ] Submit review for a delivered product
- [ ] View reviews on product page

🤖 Generated with [Claude Code](https://claude.com/claude-code)