### PR TITLE
feat: admin back-office for order management

### DIFF
--- a/actions/admin/orders.ts
+++ b/actions/admin/orders.ts
@@ -1,0 +1,289 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { nanoid } from "nanoid";
+import { z } from "zod";
+import { requireAdmin } from "@/lib/auth/guards";
+import { execute, queryFirst } from "@/lib/db";
+import { getDB } from "@/lib/cloudflare/context";
+import { refundOrderStock } from "@/lib/db/orders";
+import { getAdminOrders, type AdminOrderFilters } from "@/lib/db/admin/orders";
+import { ordersToCSV } from "@/lib/csv/orders";
+import type { ActionResult } from "@/lib/utils";
+import type { Order } from "@/lib/db/types";
+
+const idSchema = z.string().min(1, "ID requis");
+
+// Status transition rules
+const validTransitions: Record<string, string[]> = {
+  pending: ["confirmed", "cancelled"],
+  confirmed: ["preparing", "cancelled"],
+  preparing: ["shipping", "cancelled"],
+  shipping: ["delivered", "returned"],
+  delivered: ["returned"],
+  cancelled: [],
+  returned: [],
+};
+
+async function addStatusHistory(
+  orderId: string,
+  fromStatus: string | null,
+  toStatus: string,
+  changedBy: string,
+  note?: string
+): Promise<void> {
+  const db = await getDB();
+  await db
+    .prepare(
+      `INSERT INTO order_status_history (id, order_id, from_status, to_status, changed_by, note)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    )
+    .bind(nanoid(), orderId, fromStatus, toStatus, changedBy, note || null)
+    .run();
+}
+
+export async function updateOrderStatus(
+  orderId: string,
+  newStatus: string,
+  note?: string
+): Promise<ActionResult> {
+  const session = await requireAdmin();
+
+  const idResult = idSchema.safeParse(orderId);
+  if (!idResult.success) return { success: false, error: "ID commande invalide" };
+
+  const order = await queryFirst<Order>("SELECT * FROM orders WHERE id = ?", [
+    orderId,
+  ]);
+  if (!order) return { success: false, error: "Commande introuvable" };
+
+  const currentStatus = order.status;
+  const allowed = validTransitions[currentStatus] || [];
+
+  if (!allowed.includes(newStatus)) {
+    return {
+      success: false,
+      error: `Transition de "${currentStatus}" vers "${newStatus}" non autorisée`,
+    };
+  }
+
+  const db = await getDB();
+  const statements: D1PreparedStatement[] = [];
+
+  // Determine timestamp field to update
+  const timestampField =
+    newStatus === "confirmed"
+      ? "confirmed_at"
+      : newStatus === "preparing"
+        ? "preparing_at"
+        : newStatus === "shipping"
+          ? "shipping_at"
+          : newStatus === "delivered"
+            ? "delivered_at"
+            : newStatus === "returned"
+              ? "returned_at"
+              : newStatus === "cancelled"
+                ? "cancelled_at"
+                : null;
+
+  if (timestampField) {
+    statements.push(
+      db
+        .prepare(
+          `UPDATE orders SET status = ?, ${timestampField} = datetime('now'), updated_at = datetime('now') WHERE id = ?`
+        )
+        .bind(newStatus, orderId)
+    );
+  } else {
+    statements.push(
+      db
+        .prepare(
+          "UPDATE orders SET status = ?, updated_at = datetime('now') WHERE id = ?"
+        )
+        .bind(newStatus, orderId)
+    );
+  }
+
+  await db.batch(statements);
+
+  // Add history entry
+  await addStatusHistory(
+    orderId,
+    currentStatus,
+    newStatus,
+    session.user.email,
+    note
+  );
+
+  // Refund stock if cancelled or returned (except for delivered orders that are cancelled - they shouldn't exist)
+  if (
+    newStatus === "cancelled" ||
+    (newStatus === "returned" && currentStatus !== "delivered")
+  ) {
+    await refundOrderStock(orderId);
+  }
+
+  revalidatePath("/orders");
+  revalidatePath(`/orders/${orderId}`);
+
+  return { success: true };
+}
+
+export async function updateInternalNotes(
+  orderId: string,
+  notes: string
+): Promise<ActionResult> {
+  await requireAdmin();
+
+  const idResult = idSchema.safeParse(orderId);
+  if (!idResult.success) return { success: false, error: "ID commande invalide" };
+
+  await execute(
+    "UPDATE orders SET internal_notes = ?, updated_at = datetime('now') WHERE id = ?",
+    [notes || null, orderId]
+  );
+
+  revalidatePath(`/orders/${orderId}`);
+
+  return { success: true };
+}
+
+export async function assignDeliveryPerson(
+  orderId: string,
+  personId: string | null,
+  personName: string | null
+): Promise<ActionResult> {
+  await requireAdmin();
+
+  const idResult = idSchema.safeParse(orderId);
+  if (!idResult.success) return { success: false, error: "ID commande invalide" };
+
+  await execute(
+    "UPDATE orders SET delivery_person_id = ?, delivery_person_name = ?, updated_at = datetime('now') WHERE id = ?",
+    [personId, personName, orderId]
+  );
+
+  revalidatePath(`/orders/${orderId}`);
+
+  return { success: true };
+}
+
+export async function cancelOrderAdmin(
+  orderId: string,
+  reason: string,
+  refundStock: boolean = true
+): Promise<ActionResult> {
+  const session = await requireAdmin();
+
+  const idResult = idSchema.safeParse(orderId);
+  if (!idResult.success) return { success: false, error: "ID commande invalide" };
+
+  const order = await queryFirst<Order>("SELECT * FROM orders WHERE id = ?", [
+    orderId,
+  ]);
+  if (!order) return { success: false, error: "Commande introuvable" };
+
+  const allowed = validTransitions[order.status] || [];
+  if (!allowed.includes("cancelled")) {
+    return {
+      success: false,
+      error: `Impossible d'annuler une commande avec le statut "${order.status}"`,
+    };
+  }
+
+  await execute(
+    `UPDATE orders SET
+       status = 'cancelled',
+       cancelled_at = datetime('now'),
+       cancellation_reason = ?,
+       updated_at = datetime('now')
+     WHERE id = ?`,
+    [reason, orderId]
+  );
+
+  await addStatusHistory(
+    orderId,
+    order.status,
+    "cancelled",
+    session.user.email,
+    reason
+  );
+
+  if (refundStock) {
+    await refundOrderStock(orderId);
+  }
+
+  revalidatePath("/orders");
+  revalidatePath(`/orders/${orderId}`);
+
+  return { success: true };
+}
+
+export async function processReturn(
+  orderId: string,
+  reason: string
+): Promise<ActionResult> {
+  const session = await requireAdmin();
+
+  const idResult = idSchema.safeParse(orderId);
+  if (!idResult.success) return { success: false, error: "ID commande invalide" };
+
+  const order = await queryFirst<Order>("SELECT * FROM orders WHERE id = ?", [
+    orderId,
+  ]);
+  if (!order) return { success: false, error: "Commande introuvable" };
+
+  const allowed = validTransitions[order.status] || [];
+  if (!allowed.includes("returned")) {
+    return {
+      success: false,
+      error: `Impossible de retourner une commande avec le statut "${order.status}"`,
+    };
+  }
+
+  await execute(
+    `UPDATE orders SET
+       status = 'returned',
+       returned_at = datetime('now'),
+       return_reason = ?,
+       updated_at = datetime('now')
+     WHERE id = ?`,
+    [reason, orderId]
+  );
+
+  await addStatusHistory(
+    orderId,
+    order.status,
+    "returned",
+    session.user.email,
+    reason
+  );
+
+  // Refund stock for returns
+  await refundOrderStock(orderId);
+
+  revalidatePath("/orders");
+  revalidatePath(`/orders/${orderId}`);
+
+  return { success: true };
+}
+
+export async function exportOrdersCSV(
+  filters: AdminOrderFilters
+): Promise<{ success: boolean; csv?: string; error?: string }> {
+  await requireAdmin();
+
+  // Fetch all orders matching filters (no pagination for export)
+  const orders = await getAdminOrders({
+    ...filters,
+    limit: 10000,
+    offset: 0,
+  });
+
+  if (orders.length === 0) {
+    return { success: false, error: "Aucune commande à exporter" };
+  }
+
+  const csv = ordersToCSV(orders);
+  return { success: true, csv };
+}

--- a/app/(admin)/orders/[id]/_components/order-main-content.tsx
+++ b/app/(admin)/orders/[id]/_components/order-main-content.tsx
@@ -1,0 +1,134 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { OrderStatusTimeline } from "@/components/storefront/order-status-timeline";
+import { OrderStatusActions } from "@/components/admin/order-status-actions";
+import { OrderStatusHistory } from "@/components/admin/order-status-history";
+import { formatPrice } from "@/lib/utils";
+import type { AdminOrderDetail } from "@/lib/db/types";
+
+interface OrderMainContentProps {
+  order: AdminOrderDetail;
+}
+
+export function OrderMainContent({ order }: OrderMainContentProps) {
+  return (
+    <div className="space-y-6 lg:col-span-2">
+      {/* Status Timeline */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Statut</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <OrderStatusTimeline status={order.status} />
+          <Separator />
+          <OrderStatusActions orderId={order.id} currentStatus={order.status} />
+        </CardContent>
+      </Card>
+
+      {/* Order Items */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">
+            Articles ({order.items.length})
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="divide-y">
+            {order.items.map((item) => (
+              <div
+                key={item.id}
+                className="flex items-center justify-between py-3 first:pt-0 last:pb-0"
+                // content-visibility for long item lists (rendering-content-visibility)
+                style={{ contentVisibility: "auto", containIntrinsicSize: "0 56px" }}
+              >
+                <div>
+                  <p className="font-medium">{item.product_name}</p>
+                  {item.variant_name && (
+                    <p className="text-xs text-muted-foreground">
+                      {item.variant_name}
+                    </p>
+                  )}
+                  <p className="text-xs text-muted-foreground">
+                    {formatPrice(item.unit_price)} × {item.quantity}
+                  </p>
+                </div>
+                <p className="font-mono text-sm">
+                  {formatPrice(item.total_price)}
+                </p>
+              </div>
+            ))}
+          </div>
+
+          <Separator className="my-4" />
+
+          <div className="space-y-2 text-sm">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Sous-total</span>
+              <span className="font-mono">{formatPrice(order.subtotal)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Livraison</span>
+              <span className="font-mono">
+                {formatPrice(order.delivery_fee)}
+              </span>
+            </div>
+            {order.discount_amount > 0 && (
+              <div className="flex justify-between text-green-600">
+                <span>Réduction</span>
+                <span className="font-mono">
+                  -{formatPrice(order.discount_amount)}
+                </span>
+              </div>
+            )}
+            <Separator />
+            <div className="flex justify-between font-medium">
+              <span>Total</span>
+              <span className="font-mono">{formatPrice(order.total)}</span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Status History */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Historique des statuts</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <OrderStatusHistory history={order.status_history} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// Skeleton for Suspense fallback
+export function OrderMainContentSkeleton() {
+  return (
+    <div className="space-y-6 lg:col-span-2">
+      <Card>
+        <CardHeader>
+          <div className="h-4 w-16 animate-pulse rounded bg-muted" />
+        </CardHeader>
+        <CardContent>
+          <div className="h-12 w-full animate-pulse rounded bg-muted" />
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <div className="h-4 w-24 animate-pulse rounded bg-muted" />
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {[...Array(3)].map((_, i) => (
+              <div key={i} className="flex justify-between">
+                <div className="h-4 w-32 animate-pulse rounded bg-muted" />
+                <div className="h-4 w-20 animate-pulse rounded bg-muted" />
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/(admin)/orders/[id]/_components/order-sidebar.tsx
+++ b/app/(admin)/orders/[id]/_components/order-sidebar.tsx
@@ -1,0 +1,218 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { DeliveryPersonSelect } from "@/components/admin/delivery-person-select";
+import { OrderNotesForm } from "@/components/admin/order-notes-form";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { PrinterIcon } from "@hugeicons/core-free-icons";
+import Link from "next/link";
+import { getDeliveryPersons } from "@/lib/db/admin/orders";
+import type { AdminOrderDetail } from "@/lib/db/types";
+
+// Hoisted format options (rendering-hoist-jsx)
+const dateTimeFormatOptions: Intl.DateTimeFormatOptions = {
+  day: "2-digit",
+  month: "long",
+  year: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+};
+
+function formatDateTime(dateStr: string | null): string {
+  if (!dateStr) return "—";
+  return new Date(dateStr).toLocaleDateString("fr-FR", dateTimeFormatOptions);
+}
+
+// Hoisted static icon (rendering-hoist-jsx)
+const printerIcon = <HugeiconsIcon icon={PrinterIcon} size={16} className="mr-2" />;
+
+interface OrderSidebarProps {
+  order: AdminOrderDetail;
+}
+
+// Async component that fetches delivery persons (async-suspense-boundaries)
+export async function OrderSidebarAsync({ order }: OrderSidebarProps) {
+  const deliveryPersons = await getDeliveryPersons();
+
+  return (
+    <div className="space-y-6">
+      {/* Client Info */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Client</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <p className="font-medium">{order.user_name}</p>
+          <p className="text-muted-foreground">{order.user_email}</p>
+          {order.user_phone && (
+            <p className="text-muted-foreground">{order.user_phone}</p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Delivery Info */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Livraison</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm">
+          <div>
+            <p className="text-muted-foreground">Adresse</p>
+            <p>{order.delivery_address}</p>
+            <p>{order.delivery_commune}</p>
+          </div>
+          <div>
+            <p className="text-muted-foreground">Téléphone</p>
+            <p>{order.delivery_phone}</p>
+          </div>
+          {order.delivery_instructions && (
+            <div>
+              <p className="text-muted-foreground">Instructions</p>
+              <p>{order.delivery_instructions}</p>
+            </div>
+          )}
+          {order.estimated_delivery && (
+            <div>
+              <p className="text-muted-foreground">Livraison estimée</p>
+              <p>{formatDateTime(order.estimated_delivery)}</p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Delivery Person */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Livreur assigné</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <DeliveryPersonSelect
+            orderId={order.id}
+            currentPersonId={order.delivery_person_id}
+            deliveryPersons={deliveryPersons}
+          />
+          {order.delivery_person_name && (
+            <p className="mt-2 text-xs text-muted-foreground">
+              Actuellement : {order.delivery_person_name}
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Internal Notes */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Notes internes</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <OrderNotesForm
+            orderId={order.id}
+            initialNotes={order.internal_notes}
+          />
+        </CardContent>
+      </Card>
+
+      {/* Timestamps */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Dates</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-xs">
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Créée</span>
+            <span>{formatDateTime(order.created_at)}</span>
+          </div>
+          {order.confirmed_at && (
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Confirmée</span>
+              <span>{formatDateTime(order.confirmed_at)}</span>
+            </div>
+          )}
+          {order.preparing_at && (
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Préparation</span>
+              <span>{formatDateTime(order.preparing_at)}</span>
+            </div>
+          )}
+          {order.shipping_at && (
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Expédition</span>
+              <span>{formatDateTime(order.shipping_at)}</span>
+            </div>
+          )}
+          {order.delivered_at && (
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Livrée</span>
+              <span>{formatDateTime(order.delivered_at)}</span>
+            </div>
+          )}
+          {order.cancelled_at && (
+            <div className="flex justify-between text-destructive">
+              <span>Annulée</span>
+              <span>{formatDateTime(order.cancelled_at)}</span>
+            </div>
+          )}
+          {order.returned_at && (
+            <div className="flex justify-between text-destructive">
+              <span>Retournée</span>
+              <span>{formatDateTime(order.returned_at)}</span>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Cancellation/Return Reason */}
+      {(order.cancellation_reason || order.return_reason) && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm">
+              {order.status === "cancelled"
+                ? "Raison d'annulation"
+                : "Raison du retour"}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              {order.cancellation_reason || order.return_reason}
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Actions */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Actions</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <Button variant="outline" className="w-full" asChild>
+            <Link href={`/orders/${order.id}/invoice`}>
+              {printerIcon}
+              Voir facture
+            </Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// Skeleton for Suspense fallback
+export function OrderSidebarSkeleton() {
+  return (
+    <div className="space-y-6">
+      {[...Array(5)].map((_, i) => (
+        <Card key={i}>
+          <CardHeader>
+            <div className="h-4 w-20 animate-pulse rounded bg-muted" />
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              <div className="h-4 w-full animate-pulse rounded bg-muted" />
+              <div className="h-4 w-3/4 animate-pulse rounded bg-muted" />
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/app/(admin)/orders/[id]/invoice/page.tsx
+++ b/app/(admin)/orders/[id]/invoice/page.tsx
@@ -1,0 +1,185 @@
+import { notFound } from "next/navigation";
+import { getAdminOrderById } from "@/lib/db/admin/orders";
+import { formatPrice } from "@/lib/utils";
+import { InvoicePrintButton } from "./print-button";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("fr-FR", {
+    day: "2-digit",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+export default async function InvoicePage({ params }: Props) {
+  const { id } = await params;
+  const order = await getAdminOrderById(id);
+
+  if (!order) notFound();
+
+  return (
+    <>
+      {/* Print styles */}
+      <style>{`
+        @media print {
+          body * {
+            visibility: hidden;
+          }
+          #invoice, #invoice * {
+            visibility: visible;
+          }
+          #invoice {
+            position: absolute;
+            left: 0;
+            top: 0;
+            width: 100%;
+            padding: 20mm;
+            font-size: 12pt;
+          }
+          .no-print {
+            display: none !important;
+          }
+          @page {
+            margin: 0;
+            size: A4;
+          }
+        }
+      `}</style>
+
+      {/* Print Button */}
+      <div className="no-print mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Facture {order.order_number}</h1>
+        <InvoicePrintButton />
+      </div>
+
+      {/* Invoice Content */}
+      <div
+        id="invoice"
+        className="mx-auto max-w-2xl rounded-lg border bg-white p-8 text-black shadow-sm print:border-0 print:shadow-none"
+      >
+        {/* Header */}
+        <div className="mb-8 flex items-start justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-primary">NETEREKA</h1>
+            <p className="text-sm text-gray-600">Electronic</p>
+            <p className="mt-2 text-xs text-gray-500">
+              Abidjan, Côte d&apos;Ivoire
+              <br />
+              contact@netereka.ci
+              <br />
+              +225 XX XX XX XX XX
+            </p>
+          </div>
+          <div className="text-right">
+            <h2 className="text-xl font-semibold">FACTURE</h2>
+            <p className="text-sm text-gray-600">N° {order.order_number}</p>
+            <p className="text-sm text-gray-600">
+              Date: {formatDate(order.created_at)}
+            </p>
+          </div>
+        </div>
+
+        {/* Client Info */}
+        <div className="mb-8 grid grid-cols-2 gap-8">
+          <div>
+            <h3 className="mb-2 text-sm font-semibold uppercase text-gray-500">
+              Facturé à
+            </h3>
+            <p className="font-medium">{order.user_name}</p>
+            <p className="text-sm text-gray-600">{order.user_email}</p>
+            {order.user_phone && (
+              <p className="text-sm text-gray-600">{order.user_phone}</p>
+            )}
+          </div>
+          <div>
+            <h3 className="mb-2 text-sm font-semibold uppercase text-gray-500">
+              Livraison
+            </h3>
+            <p className="text-sm text-gray-600">{order.delivery_address}</p>
+            <p className="text-sm text-gray-600">{order.delivery_commune}</p>
+            <p className="text-sm text-gray-600">{order.delivery_phone}</p>
+          </div>
+        </div>
+
+        {/* Items Table */}
+        <table className="mb-8 w-full">
+          <thead>
+            <tr className="border-b-2 border-gray-200">
+              <th className="pb-2 text-left text-sm font-semibold">Article</th>
+              <th className="pb-2 text-right text-sm font-semibold">Qté</th>
+              <th className="pb-2 text-right text-sm font-semibold">
+                Prix unitaire
+              </th>
+              <th className="pb-2 text-right text-sm font-semibold">Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            {order.items.map((item) => (
+              <tr key={item.id} className="border-b border-gray-100">
+                <td className="py-3">
+                  <p className="font-medium">{item.product_name}</p>
+                  {item.variant_name && (
+                    <p className="text-xs text-gray-500">{item.variant_name}</p>
+                  )}
+                </td>
+                <td className="py-3 text-right">{item.quantity}</td>
+                <td className="py-3 text-right font-mono text-sm">
+                  {formatPrice(item.unit_price)}
+                </td>
+                <td className="py-3 text-right font-mono text-sm">
+                  {formatPrice(item.total_price)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        {/* Totals */}
+        <div className="mb-8 flex justify-end">
+          <div className="w-64 space-y-2">
+            <div className="flex justify-between text-sm">
+              <span className="text-gray-600">Sous-total</span>
+              <span className="font-mono">{formatPrice(order.subtotal)}</span>
+            </div>
+            <div className="flex justify-between text-sm">
+              <span className="text-gray-600">Frais de livraison</span>
+              <span className="font-mono">{formatPrice(order.delivery_fee)}</span>
+            </div>
+            {order.discount_amount > 0 && (
+              <div className="flex justify-between text-sm text-green-600">
+                <span>Réduction</span>
+                <span className="font-mono">
+                  -{formatPrice(order.discount_amount)}
+                </span>
+              </div>
+            )}
+            <div className="flex justify-between border-t border-gray-200 pt-2 text-base font-semibold">
+              <span>Total TTC</span>
+              <span className="font-mono">{formatPrice(order.total)}</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Payment Info */}
+        <div className="mb-8 rounded-lg bg-gray-50 p-4">
+          <h3 className="mb-2 text-sm font-semibold">Mode de paiement</h3>
+          <p className="text-sm text-gray-600">
+            Paiement à la livraison (COD)
+          </p>
+        </div>
+
+        {/* Footer */}
+        <div className="border-t border-gray-200 pt-4 text-center text-xs text-gray-500">
+          <p>Merci pour votre confiance !</p>
+          <p className="mt-1">
+            NETEREKA Electronic - www.netereka.ci
+          </p>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/(admin)/orders/[id]/invoice/print-button.tsx
+++ b/app/(admin)/orders/[id]/invoice/print-button.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { PrinterIcon, ArrowLeft02Icon } from "@hugeicons/core-free-icons";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+
+export function InvoicePrintButton() {
+  const params = useParams();
+  const orderId = params.id as string;
+
+  return (
+    <div className="flex gap-2">
+      <Button variant="outline" asChild>
+        <Link href={`/orders/${orderId}`}>
+          <HugeiconsIcon icon={ArrowLeft02Icon} size={16} className="mr-2" />
+          Retour
+        </Link>
+      </Button>
+      <Button onClick={() => window.print()}>
+        <HugeiconsIcon icon={PrinterIcon} size={16} className="mr-2" />
+        Imprimer
+      </Button>
+    </div>
+  );
+}

--- a/app/(admin)/orders/[id]/page.tsx
+++ b/app/(admin)/orders/[id]/page.tsx
@@ -1,0 +1,303 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { AdminHeader } from "@/components/admin/admin-header";
+import { OrderStatusTimeline } from "@/components/storefront/order-status-timeline";
+import { OrderStatusActions } from "@/components/admin/order-status-actions";
+import { OrderNotesForm } from "@/components/admin/order-notes-form";
+import { DeliveryPersonSelect } from "@/components/admin/delivery-person-select";
+import { OrderStatusHistory } from "@/components/admin/order-status-history";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ArrowLeft02Icon, PrinterIcon } from "@hugeicons/core-free-icons";
+import { formatPrice } from "@/lib/utils";
+import { getAdminOrderById, getDeliveryPersons } from "@/lib/db/admin/orders";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+function formatDateTime(dateStr: string | null): string {
+  if (!dateStr) return "—";
+  return new Date(dateStr).toLocaleDateString("fr-FR", {
+    day: "2-digit",
+    month: "long",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export default async function OrderDetailPage({ params }: Props) {
+  const { id } = await params;
+  const [order, deliveryPersons] = await Promise.all([
+    getAdminOrderById(id),
+    getDeliveryPersons(),
+  ]);
+
+  if (!order) notFound();
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center gap-4">
+        <Button variant="ghost" size="icon" asChild>
+          <Link href="/orders">
+            <HugeiconsIcon icon={ArrowLeft02Icon} size={20} />
+          </Link>
+        </Button>
+        <AdminHeader title={`Commande ${order.order_number}`} />
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        {/* Main Content */}
+        <div className="space-y-6 lg:col-span-2">
+          {/* Status Timeline */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-sm">Statut</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <OrderStatusTimeline status={order.status} />
+              <Separator />
+              <OrderStatusActions orderId={order.id} currentStatus={order.status} />
+            </CardContent>
+          </Card>
+
+          {/* Order Items */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-sm">
+                Articles ({order.items.length})
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="divide-y">
+                {order.items.map((item) => (
+                  <div
+                    key={item.id}
+                    className="flex items-center justify-between py-3 first:pt-0 last:pb-0"
+                  >
+                    <div>
+                      <p className="font-medium">{item.product_name}</p>
+                      {item.variant_name && (
+                        <p className="text-xs text-muted-foreground">
+                          {item.variant_name}
+                        </p>
+                      )}
+                      <p className="text-xs text-muted-foreground">
+                        {formatPrice(item.unit_price)} × {item.quantity}
+                      </p>
+                    </div>
+                    <p className="font-mono text-sm">
+                      {formatPrice(item.total_price)}
+                    </p>
+                  </div>
+                ))}
+              </div>
+
+              <Separator className="my-4" />
+
+              <div className="space-y-2 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Sous-total</span>
+                  <span className="font-mono">{formatPrice(order.subtotal)}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Livraison</span>
+                  <span className="font-mono">
+                    {formatPrice(order.delivery_fee)}
+                  </span>
+                </div>
+                {order.discount_amount > 0 && (
+                  <div className="flex justify-between text-green-600">
+                    <span>Réduction</span>
+                    <span className="font-mono">
+                      -{formatPrice(order.discount_amount)}
+                    </span>
+                  </div>
+                )}
+                <Separator />
+                <div className="flex justify-between font-medium">
+                  <span>Total</span>
+                  <span className="font-mono">{formatPrice(order.total)}</span>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Status History */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-sm">Historique des statuts</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <OrderStatusHistory history={order.status_history} />
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Sidebar */}
+        <div className="space-y-6">
+          {/* Client Info */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-sm">Client</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm">
+              <p className="font-medium">{order.user_name}</p>
+              <p className="text-muted-foreground">{order.user_email}</p>
+              {order.user_phone && (
+                <p className="text-muted-foreground">{order.user_phone}</p>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Delivery Info */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-sm">Livraison</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              <div>
+                <p className="text-muted-foreground">Adresse</p>
+                <p>{order.delivery_address}</p>
+                <p>{order.delivery_commune}</p>
+              </div>
+              <div>
+                <p className="text-muted-foreground">Téléphone</p>
+                <p>{order.delivery_phone}</p>
+              </div>
+              {order.delivery_instructions && (
+                <div>
+                  <p className="text-muted-foreground">Instructions</p>
+                  <p>{order.delivery_instructions}</p>
+                </div>
+              )}
+              {order.estimated_delivery && (
+                <div>
+                  <p className="text-muted-foreground">Livraison estimée</p>
+                  <p>{formatDateTime(order.estimated_delivery)}</p>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Delivery Person */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-sm">Livreur assigné</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <DeliveryPersonSelect
+                orderId={order.id}
+                currentPersonId={order.delivery_person_id}
+                deliveryPersons={deliveryPersons}
+              />
+              {order.delivery_person_name && (
+                <p className="mt-2 text-xs text-muted-foreground">
+                  Actuellement : {order.delivery_person_name}
+                </p>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Internal Notes */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-sm">Notes internes</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <OrderNotesForm
+                orderId={order.id}
+                initialNotes={order.internal_notes}
+              />
+            </CardContent>
+          </Card>
+
+          {/* Timestamps */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-sm">Dates</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-xs">
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Créée</span>
+                <span>{formatDateTime(order.created_at)}</span>
+              </div>
+              {order.confirmed_at && (
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Confirmée</span>
+                  <span>{formatDateTime(order.confirmed_at)}</span>
+                </div>
+              )}
+              {order.preparing_at && (
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Préparation</span>
+                  <span>{formatDateTime(order.preparing_at)}</span>
+                </div>
+              )}
+              {order.shipping_at && (
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Expédition</span>
+                  <span>{formatDateTime(order.shipping_at)}</span>
+                </div>
+              )}
+              {order.delivered_at && (
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Livrée</span>
+                  <span>{formatDateTime(order.delivered_at)}</span>
+                </div>
+              )}
+              {order.cancelled_at && (
+                <div className="flex justify-between text-destructive">
+                  <span>Annulée</span>
+                  <span>{formatDateTime(order.cancelled_at)}</span>
+                </div>
+              )}
+              {order.returned_at && (
+                <div className="flex justify-between text-destructive">
+                  <span>Retournée</span>
+                  <span>{formatDateTime(order.returned_at)}</span>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Cancellation/Return Reason */}
+          {(order.cancellation_reason || order.return_reason) && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-sm">
+                  {order.status === "cancelled"
+                    ? "Raison d'annulation"
+                    : "Raison du retour"}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground">
+                  {order.cancellation_reason || order.return_reason}
+                </p>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Actions */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-sm">Actions</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <Button variant="outline" className="w-full" asChild>
+                <Link href={`/orders/${order.id}/invoice`}>
+                  <HugeiconsIcon icon={PrinterIcon} size={16} className="mr-2" />
+                  Voir facture
+                </Link>
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(admin)/orders/[id]/page.tsx
+++ b/app/(admin)/orders/[id]/page.tsx
@@ -1,47 +1,24 @@
+import { Suspense } from "react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { AdminHeader } from "@/components/admin/admin-header";
-import { OrderStatusTimeline } from "@/components/storefront/order-status-timeline";
-import { OrderStatusActions } from "@/components/admin/order-status-actions";
-import { OrderNotesForm } from "@/components/admin/order-notes-form";
-import { DeliveryPersonSelect } from "@/components/admin/delivery-person-select";
-import { OrderStatusHistory } from "@/components/admin/order-status-history";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { ArrowLeft02Icon, PrinterIcon } from "@hugeicons/core-free-icons";
-import { formatPrice } from "@/lib/utils";
-import { getAdminOrderById, getDeliveryPersons } from "@/lib/db/admin/orders";
+import { ArrowLeft02Icon } from "@hugeicons/core-free-icons";
+import { getAdminOrderById } from "@/lib/db/admin/orders";
+import { OrderMainContent } from "./_components/order-main-content";
+import { OrderSidebarAsync, OrderSidebarSkeleton } from "./_components/order-sidebar";
 
 interface Props {
   params: Promise<{ id: string }>;
 }
 
-// Hoisted format options (rendering-hoist-jsx)
-const dateTimeFormatOptions: Intl.DateTimeFormatOptions = {
-  day: "2-digit",
-  month: "long",
-  year: "numeric",
-  hour: "2-digit",
-  minute: "2-digit",
-};
-
-function formatDateTime(dateStr: string | null): string {
-  if (!dateStr) return "—";
-  return new Date(dateStr).toLocaleDateString("fr-FR", dateTimeFormatOptions);
-}
-
-// Hoisted static icons (rendering-hoist-jsx)
+// Hoisted static icon (rendering-hoist-jsx)
 const backIcon = <HugeiconsIcon icon={ArrowLeft02Icon} size={20} />;
-const printerIcon = <HugeiconsIcon icon={PrinterIcon} size={16} className="mr-2" />;
 
 export default async function OrderDetailPage({ params }: Props) {
   const { id } = await params;
-  const [order, deliveryPersons] = await Promise.all([
-    getAdminOrderById(id),
-    getDeliveryPersons(),
-  ]);
+  const order = await getAdminOrderById(id);
 
   if (!order) notFound();
 
@@ -57,253 +34,13 @@ export default async function OrderDetailPage({ params }: Props) {
       </div>
 
       <div className="grid gap-6 lg:grid-cols-3">
-        {/* Main Content */}
-        <div className="space-y-6 lg:col-span-2">
-          {/* Status Timeline */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-sm">Statut</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <OrderStatusTimeline status={order.status} />
-              <Separator />
-              <OrderStatusActions orderId={order.id} currentStatus={order.status} />
-            </CardContent>
-          </Card>
+        {/* Main Content - Synchronous since order data is already fetched */}
+        <OrderMainContent order={order} />
 
-          {/* Order Items */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-sm">
-                Articles ({order.items.length})
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="divide-y">
-                {order.items.map((item) => (
-                  <div
-                    key={item.id}
-                    className="flex items-center justify-between py-3 first:pt-0 last:pb-0"
-                  >
-                    <div>
-                      <p className="font-medium">{item.product_name}</p>
-                      {item.variant_name && (
-                        <p className="text-xs text-muted-foreground">
-                          {item.variant_name}
-                        </p>
-                      )}
-                      <p className="text-xs text-muted-foreground">
-                        {formatPrice(item.unit_price)} × {item.quantity}
-                      </p>
-                    </div>
-                    <p className="font-mono text-sm">
-                      {formatPrice(item.total_price)}
-                    </p>
-                  </div>
-                ))}
-              </div>
-
-              <Separator className="my-4" />
-
-              <div className="space-y-2 text-sm">
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Sous-total</span>
-                  <span className="font-mono">{formatPrice(order.subtotal)}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Livraison</span>
-                  <span className="font-mono">
-                    {formatPrice(order.delivery_fee)}
-                  </span>
-                </div>
-                {order.discount_amount > 0 && (
-                  <div className="flex justify-between text-green-600">
-                    <span>Réduction</span>
-                    <span className="font-mono">
-                      -{formatPrice(order.discount_amount)}
-                    </span>
-                  </div>
-                )}
-                <Separator />
-                <div className="flex justify-between font-medium">
-                  <span>Total</span>
-                  <span className="font-mono">{formatPrice(order.total)}</span>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Status History */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-sm">Historique des statuts</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <OrderStatusHistory history={order.status_history} />
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* Sidebar */}
-        <div className="space-y-6">
-          {/* Client Info */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-sm">Client</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-2 text-sm">
-              <p className="font-medium">{order.user_name}</p>
-              <p className="text-muted-foreground">{order.user_email}</p>
-              {order.user_phone && (
-                <p className="text-muted-foreground">{order.user_phone}</p>
-              )}
-            </CardContent>
-          </Card>
-
-          {/* Delivery Info */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-sm">Livraison</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-3 text-sm">
-              <div>
-                <p className="text-muted-foreground">Adresse</p>
-                <p>{order.delivery_address}</p>
-                <p>{order.delivery_commune}</p>
-              </div>
-              <div>
-                <p className="text-muted-foreground">Téléphone</p>
-                <p>{order.delivery_phone}</p>
-              </div>
-              {order.delivery_instructions && (
-                <div>
-                  <p className="text-muted-foreground">Instructions</p>
-                  <p>{order.delivery_instructions}</p>
-                </div>
-              )}
-              {order.estimated_delivery && (
-                <div>
-                  <p className="text-muted-foreground">Livraison estimée</p>
-                  <p>{formatDateTime(order.estimated_delivery)}</p>
-                </div>
-              )}
-            </CardContent>
-          </Card>
-
-          {/* Delivery Person */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-sm">Livreur assigné</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <DeliveryPersonSelect
-                orderId={order.id}
-                currentPersonId={order.delivery_person_id}
-                deliveryPersons={deliveryPersons}
-              />
-              {order.delivery_person_name && (
-                <p className="mt-2 text-xs text-muted-foreground">
-                  Actuellement : {order.delivery_person_name}
-                </p>
-              )}
-            </CardContent>
-          </Card>
-
-          {/* Internal Notes */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-sm">Notes internes</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <OrderNotesForm
-                orderId={order.id}
-                initialNotes={order.internal_notes}
-              />
-            </CardContent>
-          </Card>
-
-          {/* Timestamps */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-sm">Dates</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-2 text-xs">
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">Créée</span>
-                <span>{formatDateTime(order.created_at)}</span>
-              </div>
-              {order.confirmed_at && (
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Confirmée</span>
-                  <span>{formatDateTime(order.confirmed_at)}</span>
-                </div>
-              )}
-              {order.preparing_at && (
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Préparation</span>
-                  <span>{formatDateTime(order.preparing_at)}</span>
-                </div>
-              )}
-              {order.shipping_at && (
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Expédition</span>
-                  <span>{formatDateTime(order.shipping_at)}</span>
-                </div>
-              )}
-              {order.delivered_at && (
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Livrée</span>
-                  <span>{formatDateTime(order.delivered_at)}</span>
-                </div>
-              )}
-              {order.cancelled_at && (
-                <div className="flex justify-between text-destructive">
-                  <span>Annulée</span>
-                  <span>{formatDateTime(order.cancelled_at)}</span>
-                </div>
-              )}
-              {order.returned_at && (
-                <div className="flex justify-between text-destructive">
-                  <span>Retournée</span>
-                  <span>{formatDateTime(order.returned_at)}</span>
-                </div>
-              )}
-            </CardContent>
-          </Card>
-
-          {/* Cancellation/Return Reason */}
-          {(order.cancellation_reason || order.return_reason) && (
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm">
-                  {order.status === "cancelled"
-                    ? "Raison d'annulation"
-                    : "Raison du retour"}
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm text-muted-foreground">
-                  {order.cancellation_reason || order.return_reason}
-                </p>
-              </CardContent>
-            </Card>
-          )}
-
-          {/* Actions */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-sm">Actions</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-2">
-              <Button variant="outline" className="w-full" asChild>
-                <Link href={`/orders/${order.id}/invoice`}>
-                  {printerIcon}
-                  Voir facture
-                </Link>
-              </Button>
-            </CardContent>
-          </Card>
-        </div>
+        {/* Sidebar with Suspense - Fetches delivery persons independently (async-suspense-boundaries) */}
+        <Suspense fallback={<OrderSidebarSkeleton />}>
+          <OrderSidebarAsync order={order} />
+        </Suspense>
       </div>
     </div>
   );

--- a/app/(admin)/orders/[id]/page.tsx
+++ b/app/(admin)/orders/[id]/page.tsx
@@ -18,16 +18,23 @@ interface Props {
   params: Promise<{ id: string }>;
 }
 
+// Hoisted format options (rendering-hoist-jsx)
+const dateTimeFormatOptions: Intl.DateTimeFormatOptions = {
+  day: "2-digit",
+  month: "long",
+  year: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+};
+
 function formatDateTime(dateStr: string | null): string {
   if (!dateStr) return "—";
-  return new Date(dateStr).toLocaleDateString("fr-FR", {
-    day: "2-digit",
-    month: "long",
-    year: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  return new Date(dateStr).toLocaleDateString("fr-FR", dateTimeFormatOptions);
 }
+
+// Hoisted static icons (rendering-hoist-jsx)
+const backIcon = <HugeiconsIcon icon={ArrowLeft02Icon} size={20} />;
+const printerIcon = <HugeiconsIcon icon={PrinterIcon} size={16} className="mr-2" />;
 
 export default async function OrderDetailPage({ params }: Props) {
   const { id } = await params;
@@ -43,7 +50,7 @@ export default async function OrderDetailPage({ params }: Props) {
       <div className="mb-6 flex items-center gap-4">
         <Button variant="ghost" size="icon" asChild>
           <Link href="/orders">
-            <HugeiconsIcon icon={ArrowLeft02Icon} size={20} />
+            {backIcon}
           </Link>
         </Button>
         <AdminHeader title={`Commande ${order.order_number}`} />
@@ -290,7 +297,7 @@ export default async function OrderDetailPage({ params }: Props) {
             <CardContent className="space-y-2">
               <Button variant="outline" className="w-full" asChild>
                 <Link href={`/orders/${order.id}/invoice`}>
-                  <HugeiconsIcon icon={PrinterIcon} size={16} className="mr-2" />
+                  {printerIcon}
                   Voir facture
                 </Link>
               </Button>

--- a/app/(admin)/orders/loading.tsx
+++ b/app/(admin)/orders/loading.tsx
@@ -1,0 +1,17 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function OrdersLoading() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-8 w-48" />
+      <div className="flex flex-wrap gap-3">
+        <Skeleton className="h-9 w-48" />
+        <Skeleton className="h-9 w-32" />
+        <Skeleton className="h-9 w-32" />
+        <Skeleton className="h-9 w-36" />
+        <Skeleton className="h-9 w-36" />
+      </div>
+      <Skeleton className="h-96 w-full" />
+    </div>
+  );
+}

--- a/app/(admin)/orders/page.tsx
+++ b/app/(admin)/orders/page.tsx
@@ -1,0 +1,95 @@
+import Link from "next/link";
+import { AdminHeader } from "@/components/admin/admin-header";
+import { OrderTable } from "@/components/admin/order-table";
+import { OrderFilters } from "@/components/admin/order-filters";
+import { OrderExportButton } from "@/components/admin/order-export-button";
+import { Button } from "@/components/ui/button";
+import {
+  getAdminOrders,
+  getAdminOrderCount,
+  getDistinctCommunes,
+} from "@/lib/db/admin/orders";
+
+interface Props {
+  searchParams: Promise<{
+    search?: string;
+    status?: string;
+    commune?: string;
+    dateFrom?: string;
+    dateTo?: string;
+    page?: string;
+  }>;
+}
+
+const PAGE_SIZE = 20;
+
+export default async function OrdersPage({ searchParams }: Props) {
+  const params = await searchParams;
+  const page = Math.max(1, Number(params.page) || 1);
+  const filters = {
+    search: params.search,
+    status: params.status,
+    commune: params.commune,
+    dateFrom: params.dateFrom,
+    dateTo: params.dateTo,
+    limit: PAGE_SIZE,
+    offset: (page - 1) * PAGE_SIZE,
+  };
+
+  const [orders, totalCount, communes] = await Promise.all([
+    getAdminOrders(filters),
+    getAdminOrderCount(filters),
+    getDistinctCommunes(),
+  ]);
+
+  const totalPages = Math.ceil(totalCount / PAGE_SIZE);
+
+  return (
+    <div>
+      <AdminHeader title="Commandes" />
+
+      <div className="mb-4 space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <OrderFilters communes={communes} />
+          <OrderExportButton />
+        </div>
+      </div>
+
+      <OrderTable orders={orders} />
+
+      {totalPages > 1 && (
+        <div className="mt-4 flex items-center justify-between text-sm text-muted-foreground">
+          <span>
+            {totalCount} commande(s) — Page {page}/{totalPages}
+          </span>
+          <div className="flex gap-2">
+            {page > 1 && (
+              <Button variant="outline" size="sm" asChild>
+                <Link
+                  href={{
+                    pathname: "/orders",
+                    query: { ...params, page: String(page - 1) },
+                  }}
+                >
+                  Précédent
+                </Link>
+              </Button>
+            )}
+            {page < totalPages && (
+              <Button variant="outline" size="sm" asChild>
+                <Link
+                  href={{
+                    pathname: "/orders",
+                    query: { ...params, page: String(page + 1) },
+                  }}
+                >
+                  Suivant
+                </Link>
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(admin)/products/products-page-client.tsx
+++ b/app/(admin)/products/products-page-client.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { ProductTable } from "@/components/admin/product-table";
+import { ProductCardMobile } from "@/components/admin/product-card-mobile";
+import { ResponsiveDataList } from "@/components/admin/responsive-data-list";
+import { AdminMobileFilterSheet } from "@/components/admin/mobile-filter-sheet";
+import { ViewSwitcher } from "@/components/admin/view-switcher";
+
+interface ProductData {
+  id: string;
+  name: string;
+  brand: string | null;
+  sku: string | null;
+  category_name?: string | null;
+  base_price: number;
+  stock_quantity: number;
+  is_active: number;
+  is_featured: number;
+  image_url?: string | null;
+}
+
+interface ProductsPageClientProps {
+  products: ProductData[];
+  categories: { id: string; name: string }[];
+  totalCount: number;
+}
+
+export function ProductsPageClient({
+  products,
+  categories,
+  totalCount,
+}: ProductsPageClientProps) {
+  return (
+    <>
+      {/* Mobile toolbar */}
+      <div className="mb-4 flex items-center justify-between gap-3 lg:hidden">
+        <div className="flex items-center gap-2">
+          <AdminMobileFilterSheet categories={categories} basePath="/products" />
+          <ViewSwitcher />
+        </div>
+        <Button asChild size="sm">
+          <Link href="/products/new">Nouveau</Link>
+        </Button>
+      </div>
+
+      {/* Product count (mobile) */}
+      <p className="mb-3 text-sm text-muted-foreground lg:hidden">
+        {totalCount} produit(s)
+      </p>
+
+      {/* Responsive data list */}
+      <ResponsiveDataList
+        data={products}
+        tableView={<ProductTable products={products} />}
+        renderCard={(product) => <ProductCardMobile product={product} />}
+        emptyMessage="Aucun produit trouvé"
+      />
+    </>
+  );
+}

--- a/components/admin/delivery-person-select.tsx
+++ b/components/admin/delivery-person-select.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useTransition } from "react";
+import { toast } from "sonner";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { assignDeliveryPerson } from "@/actions/admin/orders";
+
+interface DeliveryPersonSelectProps {
+  orderId: string;
+  currentPersonId: string | null;
+  deliveryPersons: { id: string; name: string }[];
+}
+
+export function DeliveryPersonSelect({
+  orderId,
+  currentPersonId,
+  deliveryPersons,
+}: DeliveryPersonSelectProps) {
+  const [isPending, startTransition] = useTransition();
+
+  function handleChange(value: string) {
+    if (value === currentPersonId) return;
+
+    const person = value === "none" ? null : deliveryPersons.find((p) => p.id === value);
+
+    startTransition(async () => {
+      const result = await assignDeliveryPerson(
+        orderId,
+        value === "none" ? null : value,
+        person?.name || null
+      );
+      if (result.success) {
+        toast.success("Livreur assigné");
+      } else {
+        toast.error(result.error);
+      }
+    });
+  }
+
+  return (
+    <Select
+      value={currentPersonId || "none"}
+      onValueChange={handleChange}
+      disabled={isPending}
+    >
+      <SelectTrigger className="w-full">
+        <SelectValue placeholder="Sélectionner un livreur" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="none">Non assigné</SelectItem>
+        {deliveryPersons.map((person) => (
+          <SelectItem key={person.id} value={person.id}>
+            {person.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/components/admin/order-export-button.tsx
+++ b/components/admin/order-export-button.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useTransition } from "react";
+import { useSearchParams } from "next/navigation";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { FileDownloadIcon } from "@hugeicons/core-free-icons";
+import { exportOrdersCSV } from "@/actions/admin/orders";
+
+export function OrderExportButton() {
+  const [isPending, startTransition] = useTransition();
+  const searchParams = useSearchParams();
+
+  function handleExport() {
+    startTransition(async () => {
+      const filters = {
+        search: searchParams.get("search") || undefined,
+        status: searchParams.get("status") || undefined,
+        commune: searchParams.get("commune") || undefined,
+        dateFrom: searchParams.get("dateFrom") || undefined,
+        dateTo: searchParams.get("dateTo") || undefined,
+      };
+
+      const result = await exportOrdersCSV(filters);
+
+      if (!result.success || !result.csv) {
+        toast.error(result.error || "Erreur lors de l'export");
+        return;
+      }
+
+      // Create and download the file
+      const blob = new Blob([result.csv], { type: "text/csv;charset=utf-8;" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `commandes_${new Date().toISOString().split("T")[0]}.csv`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+
+      toast.success("Export téléchargé");
+    });
+  }
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={handleExport}
+      disabled={isPending}
+    >
+      <HugeiconsIcon icon={FileDownloadIcon} size={16} className="mr-1.5" />
+      {isPending ? "Export..." : "Exporter CSV"}
+    </Button>
+  );
+}

--- a/components/admin/order-filters.tsx
+++ b/components/admin/order-filters.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useTransition } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+interface OrderFiltersProps {
+  communes: string[];
+}
+
+export function OrderFilters({ communes }: OrderFiltersProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
+  const createQueryString = useCallback(
+    (updates: Record<string, string | null>) => {
+      const params = new URLSearchParams(searchParams.toString());
+      Object.entries(updates).forEach(([key, value]) => {
+        if (value === null || value === "") {
+          params.delete(key);
+        } else {
+          params.set(key, value);
+        }
+      });
+      // Reset page when filters change
+      if (!("page" in updates)) {
+        params.delete("page");
+      }
+      return params.toString();
+    },
+    [searchParams]
+  );
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    const updates: Record<string, string | null> = {
+      search: formData.get("search") as string,
+      status: formData.get("status") as string,
+      commune: formData.get("commune") as string,
+      dateFrom: formData.get("dateFrom") as string,
+      dateTo: formData.get("dateTo") as string,
+    };
+
+    startTransition(() => {
+      router.push(`/orders?${createQueryString(updates)}`);
+    });
+  }
+
+  function handleReset() {
+    startTransition(() => {
+      router.push("/orders");
+    });
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-wrap items-end gap-3"
+    >
+      <div className="flex flex-col gap-1">
+        <label className="text-xs text-muted-foreground">Recherche</label>
+        <Input
+          name="search"
+          placeholder="N° commande, nom, tél..."
+          defaultValue={searchParams.get("search") ?? ""}
+          className="w-full sm:w-48"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label className="text-xs text-muted-foreground">Statut</label>
+        <select
+          name="status"
+          defaultValue={searchParams.get("status") ?? "all"}
+          className="h-9 rounded-md border bg-background px-3 text-sm"
+        >
+          <option value="all">Tous</option>
+          <option value="pending">En attente</option>
+          <option value="confirmed">Confirmée</option>
+          <option value="preparing">Préparation</option>
+          <option value="shipping">Livraison</option>
+          <option value="delivered">Livrée</option>
+          <option value="cancelled">Annulée</option>
+          <option value="returned">Retournée</option>
+        </select>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label className="text-xs text-muted-foreground">Commune</label>
+        <select
+          name="commune"
+          defaultValue={searchParams.get("commune") ?? ""}
+          className="h-9 rounded-md border bg-background px-3 text-sm"
+        >
+          <option value="">Toutes</option>
+          {communes.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label className="text-xs text-muted-foreground">Date début</label>
+        <Input
+          name="dateFrom"
+          type="date"
+          defaultValue={searchParams.get("dateFrom") ?? ""}
+          className="w-36"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <label className="text-xs text-muted-foreground">Date fin</label>
+        <Input
+          name="dateTo"
+          type="date"
+          defaultValue={searchParams.get("dateTo") ?? ""}
+          className="w-36"
+        />
+      </div>
+
+      <div className="flex gap-2">
+        <Button type="submit" variant="secondary" size="sm" disabled={isPending}>
+          Filtrer
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={handleReset}
+          disabled={isPending}
+        >
+          Réinitialiser
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/components/admin/order-notes-form.tsx
+++ b/components/admin/order-notes-form.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { updateInternalNotes } from "@/actions/admin/orders";
+
+interface OrderNotesFormProps {
+  orderId: string;
+  initialNotes: string | null;
+}
+
+export function OrderNotesForm({ orderId, initialNotes }: OrderNotesFormProps) {
+  const [notes, setNotes] = useState(initialNotes || "");
+  const [isPending, startTransition] = useTransition();
+  const [isSaved, setIsSaved] = useState(true);
+
+  function handleChange(value: string) {
+    setNotes(value);
+    setIsSaved(false);
+  }
+
+  function handleSave() {
+    startTransition(async () => {
+      const result = await updateInternalNotes(orderId, notes);
+      if (result.success) {
+        toast.success("Notes enregistrées");
+        setIsSaved(true);
+      } else {
+        toast.error(result.error);
+      }
+    });
+  }
+
+  return (
+    <div className="space-y-2">
+      <Textarea
+        value={notes}
+        onChange={(e) => handleChange(e.target.value)}
+        placeholder="Notes internes (non visibles par le client)..."
+        className="min-h-24"
+      />
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-muted-foreground">
+          {isSaved ? "Sauvegardé" : "Modifications non enregistrées"}
+        </span>
+        <Button
+          size="sm"
+          onClick={handleSave}
+          disabled={isPending || isSaved}
+        >
+          {isPending ? "Sauvegarde..." : "Sauvegarder"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/order-status-actions.tsx
+++ b/components/admin/order-status-actions.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import {
+  updateOrderStatus,
+  cancelOrderAdmin,
+  processReturn,
+} from "@/actions/admin/orders";
+
+const validTransitions: Record<string, string[]> = {
+  pending: ["confirmed", "cancelled"],
+  confirmed: ["preparing", "cancelled"],
+  preparing: ["shipping", "cancelled"],
+  shipping: ["delivered", "returned"],
+  delivered: ["returned"],
+  cancelled: [],
+  returned: [],
+};
+
+const statusLabels: Record<string, string> = {
+  confirmed: "Confirmer",
+  preparing: "Mettre en préparation",
+  shipping: "Mettre en livraison",
+  delivered: "Marquer livrée",
+  cancelled: "Annuler",
+  returned: "Traiter retour",
+};
+
+interface OrderStatusActionsProps {
+  orderId: string;
+  currentStatus: string;
+}
+
+export function OrderStatusActions({
+  orderId,
+  currentStatus,
+}: OrderStatusActionsProps) {
+  const [isPending, startTransition] = useTransition();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [dialogAction, setDialogAction] = useState<string | null>(null);
+  const [note, setNote] = useState("");
+
+  const allowed = validTransitions[currentStatus] || [];
+
+  if (allowed.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Aucune action disponible pour ce statut.
+      </p>
+    );
+  }
+
+  function openDialog(action: string) {
+    setDialogAction(action);
+    setNote("");
+    setDialogOpen(true);
+  }
+
+  function handleAction() {
+    if (!dialogAction) return;
+
+    startTransition(async () => {
+      let result;
+
+      if (dialogAction === "cancelled") {
+        result = await cancelOrderAdmin(orderId, note, true);
+      } else if (dialogAction === "returned") {
+        result = await processReturn(orderId, note);
+      } else {
+        result = await updateOrderStatus(orderId, dialogAction, note);
+      }
+
+      if (result.success) {
+        toast.success("Statut mis à jour");
+        setDialogOpen(false);
+      } else {
+        toast.error(result.error);
+      }
+    });
+  }
+
+  const isDestructiveAction =
+    dialogAction === "cancelled" || dialogAction === "returned";
+
+  return (
+    <>
+      <div className="flex flex-wrap gap-2">
+        {allowed.map((status) => (
+          <Button
+            key={status}
+            variant={
+              status === "cancelled" || status === "returned"
+                ? "outline"
+                : "default"
+            }
+            size="sm"
+            onClick={() => openDialog(status)}
+            disabled={isPending}
+            className={
+              status === "cancelled" || status === "returned"
+                ? "text-destructive hover:text-destructive"
+                : ""
+            }
+          >
+            {statusLabels[status] || status}
+          </Button>
+        ))}
+      </div>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {dialogAction && statusLabels[dialogAction]}
+            </DialogTitle>
+            <DialogDescription>
+              {isDestructiveAction
+                ? "Cette action est irréversible. Le stock sera remboursé."
+                : "Vous pouvez ajouter une note optionnelle."}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-2">
+            <Label htmlFor="note">
+              {isDestructiveAction ? "Raison" : "Note (optionnel)"}
+            </Label>
+            <Textarea
+              id="note"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder={
+                isDestructiveAction
+                  ? "Raison de l'annulation ou du retour..."
+                  : "Ajouter une note..."
+              }
+              required={isDestructiveAction}
+            />
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setDialogOpen(false)}
+              disabled={isPending}
+            >
+              Annuler
+            </Button>
+            <Button
+              variant={isDestructiveAction ? "destructive" : "default"}
+              onClick={handleAction}
+              disabled={isPending || (isDestructiveAction && !note.trim())}
+            >
+              {isPending ? "Chargement..." : "Confirmer"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/components/admin/order-status-actions.tsx
+++ b/components/admin/order-status-actions.tsx
@@ -18,25 +18,11 @@ import {
   cancelOrderAdmin,
   processReturn,
 } from "@/actions/admin/orders";
-
-const validTransitions: Record<string, string[]> = {
-  pending: ["confirmed", "cancelled"],
-  confirmed: ["preparing", "cancelled"],
-  preparing: ["shipping", "cancelled"],
-  shipping: ["delivered", "returned"],
-  delivered: ["returned"],
-  cancelled: [],
-  returned: [],
-};
-
-const statusLabels: Record<string, string> = {
-  confirmed: "Confirmer",
-  preparing: "Mettre en préparation",
-  shipping: "Mettre en livraison",
-  delivered: "Marquer livrée",
-  cancelled: "Annuler",
-  returned: "Traiter retour",
-};
+import {
+  ORDER_STATUS_TRANSITIONS,
+  ORDER_STATUS_ACTION_LABELS,
+} from "@/lib/constants/orders";
+import type { OrderStatus } from "@/lib/db/types";
 
 interface OrderStatusActionsProps {
   orderId: string;
@@ -52,7 +38,7 @@ export function OrderStatusActions({
   const [dialogAction, setDialogAction] = useState<string | null>(null);
   const [note, setNote] = useState("");
 
-  const allowed = validTransitions[currentStatus] || [];
+  const allowed = ORDER_STATUS_TRANSITIONS[currentStatus as OrderStatus] || [];
 
   if (allowed.length === 0) {
     return (
@@ -114,7 +100,7 @@ export function OrderStatusActions({
                 : ""
             }
           >
-            {statusLabels[status] || status}
+            {ORDER_STATUS_ACTION_LABELS[status] || status}
           </Button>
         ))}
       </div>
@@ -123,7 +109,7 @@ export function OrderStatusActions({
         <DialogContent>
           <DialogHeader>
             <DialogTitle>
-              {dialogAction && statusLabels[dialogAction]}
+              {dialogAction && ORDER_STATUS_ACTION_LABELS[dialogAction]}
             </DialogTitle>
             <DialogDescription>
               {isDestructiveAction

--- a/components/admin/order-status-history.tsx
+++ b/components/admin/order-status-history.tsx
@@ -1,0 +1,66 @@
+import type { OrderStatusHistory as History } from "@/lib/db/types";
+
+const statusLabels: Record<string, string> = {
+  pending: "En attente",
+  confirmed: "Confirmée",
+  preparing: "En préparation",
+  shipping: "En livraison",
+  delivered: "Livrée",
+  cancelled: "Annulée",
+  returned: "Retournée",
+};
+
+function formatDateTime(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("fr-FR", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+interface OrderStatusHistoryProps {
+  history: History[];
+}
+
+export function OrderStatusHistory({ history }: OrderStatusHistoryProps) {
+  if (history.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">Aucun historique disponible.</p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {history.map((entry) => (
+        <div
+          key={entry.id}
+          className="flex gap-3 border-l-2 border-muted pl-3 pb-3"
+        >
+          <div className="flex-1 space-y-1">
+            <div className="flex items-center gap-2 text-sm">
+              {entry.from_status && (
+                <>
+                  <span className="text-muted-foreground">
+                    {statusLabels[entry.from_status] || entry.from_status}
+                  </span>
+                  <span className="text-muted-foreground">→</span>
+                </>
+              )}
+              <span className="font-medium">
+                {statusLabels[entry.to_status] || entry.to_status}
+              </span>
+            </div>
+            {entry.note && (
+              <p className="text-xs text-muted-foreground">{entry.note}</p>
+            )}
+            <p className="text-[10px] text-muted-foreground">
+              {formatDateTime(entry.created_at)} par {entry.changed_by}
+            </p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/admin/order-status-history.tsx
+++ b/components/admin/order-status-history.tsx
@@ -1,14 +1,5 @@
 import type { OrderStatusHistory as History } from "@/lib/db/types";
-
-const statusLabels: Record<string, string> = {
-  pending: "En attente",
-  confirmed: "Confirmée",
-  preparing: "En préparation",
-  shipping: "En livraison",
-  delivered: "Livrée",
-  cancelled: "Annulée",
-  returned: "Retournée",
-};
+import { ORDER_STATUS_LABELS } from "@/lib/constants/orders";
 
 function formatDateTime(dateStr: string): string {
   return new Date(dateStr).toLocaleDateString("fr-FR", {
@@ -43,13 +34,13 @@ export function OrderStatusHistory({ history }: OrderStatusHistoryProps) {
               {entry.from_status && (
                 <>
                   <span className="text-muted-foreground">
-                    {statusLabels[entry.from_status] || entry.from_status}
+                    {ORDER_STATUS_LABELS[entry.from_status as keyof typeof ORDER_STATUS_LABELS] || entry.from_status}
                   </span>
                   <span className="text-muted-foreground">→</span>
                 </>
               )}
               <span className="font-medium">
-                {statusLabels[entry.to_status] || entry.to_status}
+                {ORDER_STATUS_LABELS[entry.to_status as keyof typeof ORDER_STATUS_LABELS] || entry.to_status}
               </span>
             </div>
             {entry.note && (

--- a/components/admin/order-table.tsx
+++ b/components/admin/order-table.tsx
@@ -21,17 +21,8 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { MoreVerticalIcon } from "@hugeicons/core-free-icons";
 import { formatPrice } from "@/lib/utils";
-import type { AdminOrder } from "@/lib/db/types";
-
-const statusConfig: Record<string, { label: string; variant: "default" | "secondary" | "destructive" | "outline" }> = {
-  pending: { label: "En attente", variant: "secondary" },
-  confirmed: { label: "Confirmée", variant: "outline" },
-  preparing: { label: "Préparation", variant: "outline" },
-  shipping: { label: "Livraison", variant: "default" },
-  delivered: { label: "Livrée", variant: "default" },
-  cancelled: { label: "Annulée", variant: "destructive" },
-  returned: { label: "Retournée", variant: "destructive" },
-};
+import { ORDER_STATUS_CONFIG } from "@/lib/constants/orders";
+import type { AdminOrder, OrderStatus } from "@/lib/db/types";
 
 // Hoisted date formatter options (rendering-hoist-jsx)
 const dateFormatOptions: Intl.DateTimeFormatOptions = {
@@ -50,7 +41,7 @@ const moreIcon = <HugeiconsIcon icon={MoreVerticalIcon} size={16} />;
 
 // Memoized row component for better performance (rerender-memo)
 const OrderRow = memo(function OrderRow({ order }: { order: AdminOrder }) {
-  const status = statusConfig[order.status] || statusConfig.pending;
+  const status = ORDER_STATUS_CONFIG[order.status as OrderStatus] || ORDER_STATUS_CONFIG.pending;
   return (
     <TableRow
       // content-visibility for rendering performance (rendering-content-visibility)

--- a/components/admin/order-table.tsx
+++ b/components/admin/order-table.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import Link from "next/link";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { MoreVerticalIcon } from "@hugeicons/core-free-icons";
+import { formatPrice } from "@/lib/utils";
+import type { AdminOrder } from "@/lib/db/types";
+
+const statusConfig: Record<string, { label: string; variant: "default" | "secondary" | "destructive" | "outline" }> = {
+  pending: { label: "En attente", variant: "secondary" },
+  confirmed: { label: "Confirmée", variant: "outline" },
+  preparing: { label: "Préparation", variant: "outline" },
+  shipping: { label: "Livraison", variant: "default" },
+  delivered: { label: "Livrée", variant: "default" },
+  cancelled: { label: "Annulée", variant: "destructive" },
+  returned: { label: "Retournée", variant: "destructive" },
+};
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("fr-FR", {
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function OrderTable({ orders }: { orders: AdminOrder[] }) {
+  if (orders.length === 0) {
+    return (
+      <div className="rounded-lg border p-8 text-center text-muted-foreground">
+        Aucune commande trouvée
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>N° Commande</TableHead>
+            <TableHead className="hidden sm:table-cell">Date</TableHead>
+            <TableHead>Client</TableHead>
+            <TableHead className="hidden md:table-cell">Commune</TableHead>
+            <TableHead>Total</TableHead>
+            <TableHead className="hidden md:table-cell">Articles</TableHead>
+            <TableHead>Statut</TableHead>
+            <TableHead className="w-10"></TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {orders.map((order) => {
+            const status = statusConfig[order.status] || statusConfig.pending;
+            return (
+              <TableRow key={order.id}>
+                <TableCell>
+                  <Link
+                    href={`/orders/${order.id}`}
+                    className="font-mono text-xs font-medium hover:underline"
+                  >
+                    {order.order_number}
+                  </Link>
+                </TableCell>
+                <TableCell className="hidden sm:table-cell text-muted-foreground">
+                  {formatDate(order.created_at)}
+                </TableCell>
+                <TableCell>
+                  <div className="flex flex-col">
+                    <span className="font-medium">{order.user_name}</span>
+                    <span className="text-muted-foreground text-[10px]">
+                      {order.delivery_phone}
+                    </span>
+                  </div>
+                </TableCell>
+                <TableCell className="hidden md:table-cell">
+                  {order.delivery_commune}
+                </TableCell>
+                <TableCell className="font-mono">
+                  {formatPrice(order.total)}
+                </TableCell>
+                <TableCell className="hidden md:table-cell">
+                  <Badge variant="secondary">{order.item_count}</Badge>
+                </TableCell>
+                <TableCell>
+                  <Badge variant={status.variant}>{status.label}</Badge>
+                </TableCell>
+                <TableCell>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" size="icon-xs">
+                        <HugeiconsIcon icon={MoreVerticalIcon} size={16} />
+                        <span className="sr-only">Actions</span>
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem asChild>
+                        <Link href={`/orders/${order.id}`}>Voir détails</Link>
+                      </DropdownMenuItem>
+                      <DropdownMenuItem asChild>
+                        <Link href={`/orders/${order.id}/invoice`}>
+                          Voir facture
+                        </Link>
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/components/admin/order-table.tsx
+++ b/components/admin/order-table.tsx
@@ -32,14 +32,20 @@ const statusConfig: Record<string, { label: string; variant: "default" | "second
   returned: { label: "Retournée", variant: "destructive" },
 };
 
+// Hoisted date formatter options (rendering-hoist-jsx)
+const dateFormatOptions: Intl.DateTimeFormatOptions = {
+  day: "2-digit",
+  month: "short",
+  hour: "2-digit",
+  minute: "2-digit",
+};
+
 function formatDate(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString("fr-FR", {
-    day: "2-digit",
-    month: "short",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  return new Date(dateStr).toLocaleDateString("fr-FR", dateFormatOptions);
 }
+
+// Hoisted static JSX element (rendering-hoist-jsx)
+const moreIcon = <HugeiconsIcon icon={MoreVerticalIcon} size={16} />;
 
 export function OrderTable({ orders }: { orders: AdminOrder[] }) {
   if (orders.length === 0) {
@@ -105,7 +111,7 @@ export function OrderTable({ orders }: { orders: AdminOrder[] }) {
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                       <Button variant="ghost" size="icon-xs">
-                        <HugeiconsIcon icon={MoreVerticalIcon} size={16} />
+                        {moreIcon}
                         <span className="sr-only">Actions</span>
                       </Button>
                     </DropdownMenuTrigger>

--- a/components/admin/sidebar.tsx
+++ b/components/admin/sidebar.tsx
@@ -15,11 +15,10 @@ const navItems = [
   { href: "/dashboard", label: "Dashboard", icon: DashboardSquare01Icon },
   { href: "/products", label: "Produits", icon: Package02Icon },
   { href: "/categories", label: "Catégories", icon: FolderLibraryIcon },
+  { href: "/orders", label: "Commandes", icon: ShoppingBag01Icon },
 ];
 
-const disabledItems = [
-  { label: "Commandes", icon: ShoppingBag01Icon },
-];
+const disabledItems: typeof navItems = [];
 
 export function Sidebar() {
   const pathname = usePathname();

--- a/components/storefront/order-card.tsx
+++ b/components/storefront/order-card.tsx
@@ -1,20 +1,11 @@
 import Link from "next/link";
 import type { Order, OrderStatus } from "@/lib/db/types";
 import { Badge } from "@/components/ui/badge";
-import { formatPrice } from "@/lib/utils/format";
-import { formatDate } from "@/lib/utils/format";
-
-const statusConfig: Record<OrderStatus, { label: string; variant: "default" | "secondary" | "destructive" | "outline" }> = {
-  pending: { label: "En attente", variant: "outline" },
-  confirmed: { label: "Confirmée", variant: "secondary" },
-  preparing: { label: "En préparation", variant: "secondary" },
-  shipping: { label: "En livraison", variant: "default" },
-  delivered: { label: "Livrée", variant: "default" },
-  cancelled: { label: "Annulée", variant: "destructive" },
-};
+import { formatPrice, formatDate } from "@/lib/utils/format";
+import { ORDER_STATUS_CONFIG } from "@/lib/constants/orders";
 
 export function OrderCard({ order }: { order: Order }) {
-  const status = statusConfig[order.status as OrderStatus] ?? { label: order.status, variant: "outline" as const };
+  const status = ORDER_STATUS_CONFIG[order.status as OrderStatus] ?? { label: order.status, variant: "outline" as const };
 
   return (
     <Link
@@ -36,4 +27,5 @@ export function OrderCard({ order }: { order: Order }) {
   );
 }
 
-export { statusConfig };
+// Re-export for backwards compatibility
+export { ORDER_STATUS_CONFIG as statusConfig };

--- a/components/storefront/order-status-timeline.tsx
+++ b/components/storefront/order-status-timeline.tsx
@@ -21,6 +21,14 @@ export function OrderStatusTimeline({ status }: { status: string }) {
     );
   }
 
+  if (status === "returned") {
+    return (
+      <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-3 text-center text-sm text-destructive">
+        Commande retournée
+      </div>
+    );
+  }
+
   const currentIdx = stepIndex[status] ?? 0;
 
   return (

--- a/db/migrations/0005_admin_orders.sql
+++ b/db/migrations/0005_admin_orders.sql
@@ -1,0 +1,25 @@
+-- Migration: Admin Orders Enhancement
+-- Adds fields for order management: internal notes, delivery person assignment, status timestamps
+
+-- Add new columns to orders table
+ALTER TABLE orders ADD COLUMN internal_notes TEXT;
+ALTER TABLE orders ADD COLUMN delivery_person_id TEXT;
+ALTER TABLE orders ADD COLUMN delivery_person_name TEXT;
+ALTER TABLE orders ADD COLUMN confirmed_at TEXT;
+ALTER TABLE orders ADD COLUMN preparing_at TEXT;
+ALTER TABLE orders ADD COLUMN shipping_at TEXT;
+ALTER TABLE orders ADD COLUMN returned_at TEXT;
+ALTER TABLE orders ADD COLUMN return_reason TEXT;
+
+-- Create order status history table for audit trail
+CREATE TABLE IF NOT EXISTS order_status_history (
+  id TEXT PRIMARY KEY,
+  order_id TEXT NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+  from_status TEXT,
+  to_status TEXT NOT NULL,
+  changed_by TEXT NOT NULL,
+  note TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_order_status_history_order ON order_status_history(order_id);

--- a/lib/constants/orders.ts
+++ b/lib/constants/orders.ts
@@ -1,0 +1,98 @@
+import type { OrderStatus } from "@/lib/db/types";
+
+/**
+ * Valid status transitions for orders.
+ * Terminal states (cancelled, returned) have no valid transitions.
+ */
+export const ORDER_STATUS_TRANSITIONS: Record<OrderStatus, OrderStatus[]> = {
+  pending: ["confirmed", "cancelled"],
+  confirmed: ["preparing", "cancelled"],
+  preparing: ["shipping", "cancelled"],
+  shipping: ["delivered", "returned"],
+  delivered: ["returned"],
+  cancelled: [],
+  returned: [],
+};
+
+/**
+ * Human-readable labels for order statuses (French).
+ */
+export const ORDER_STATUS_LABELS: Record<OrderStatus, string> = {
+  pending: "En attente",
+  confirmed: "Confirmée",
+  preparing: "En préparation",
+  shipping: "En livraison",
+  delivered: "Livrée",
+  cancelled: "Annulée",
+  returned: "Retournée",
+};
+
+/**
+ * Action button labels for status transitions (French).
+ */
+export const ORDER_STATUS_ACTION_LABELS: Record<string, string> = {
+  confirmed: "Confirmer",
+  preparing: "Mettre en préparation",
+  shipping: "Mettre en livraison",
+  delivered: "Marquer livrée",
+  cancelled: "Annuler",
+  returned: "Traiter retour",
+};
+
+/**
+ * Badge variants for status display in UI.
+ */
+export const ORDER_STATUS_BADGE_VARIANTS: Record<
+  OrderStatus,
+  "default" | "secondary" | "destructive" | "outline"
+> = {
+  pending: "secondary",
+  confirmed: "outline",
+  preparing: "outline",
+  shipping: "default",
+  delivered: "default",
+  cancelled: "destructive",
+  returned: "destructive",
+};
+
+/**
+ * Combined status configuration for UI display.
+ */
+export const ORDER_STATUS_CONFIG: Record<
+  OrderStatus,
+  { label: string; variant: "default" | "secondary" | "destructive" | "outline" }
+> = {
+  pending: { label: ORDER_STATUS_LABELS.pending, variant: ORDER_STATUS_BADGE_VARIANTS.pending },
+  confirmed: { label: ORDER_STATUS_LABELS.confirmed, variant: ORDER_STATUS_BADGE_VARIANTS.confirmed },
+  preparing: { label: ORDER_STATUS_LABELS.preparing, variant: ORDER_STATUS_BADGE_VARIANTS.preparing },
+  shipping: { label: ORDER_STATUS_LABELS.shipping, variant: ORDER_STATUS_BADGE_VARIANTS.shipping },
+  delivered: { label: ORDER_STATUS_LABELS.delivered, variant: ORDER_STATUS_BADGE_VARIANTS.delivered },
+  cancelled: { label: ORDER_STATUS_LABELS.cancelled, variant: ORDER_STATUS_BADGE_VARIANTS.cancelled },
+  returned: { label: ORDER_STATUS_LABELS.returned, variant: ORDER_STATUS_BADGE_VARIANTS.returned },
+};
+
+/**
+ * Check if a status transition is valid.
+ */
+export function isValidStatusTransition(
+  fromStatus: OrderStatus,
+  toStatus: OrderStatus
+): boolean {
+  const allowed = ORDER_STATUS_TRANSITIONS[fromStatus] || [];
+  return allowed.includes(toStatus);
+}
+
+/**
+ * Get the timestamp field name for a given status.
+ */
+export function getStatusTimestampField(status: OrderStatus): string | null {
+  const fieldMap: Record<string, string> = {
+    confirmed: "confirmed_at",
+    preparing: "preparing_at",
+    shipping: "shipping_at",
+    delivered: "delivered_at",
+    cancelled: "cancelled_at",
+    returned: "returned_at",
+  };
+  return fieldMap[status] || null;
+}

--- a/lib/csv/orders.ts
+++ b/lib/csv/orders.ts
@@ -1,0 +1,75 @@
+import type { AdminOrder } from "@/lib/db/types";
+
+function escapeCSV(value: string | null | undefined): string {
+  if (value == null) return "";
+  const str = String(value);
+  if (str.includes('"') || str.includes(",") || str.includes("\n")) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  return date.toLocaleDateString("fr-FR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatStatus(status: string): string {
+  const statusMap: Record<string, string> = {
+    pending: "En attente",
+    confirmed: "Confirmée",
+    preparing: "En préparation",
+    shipping: "En livraison",
+    delivered: "Livrée",
+    cancelled: "Annulée",
+    returned: "Retournée",
+  };
+  return statusMap[status] || status;
+}
+
+export function ordersToCSV(orders: AdminOrder[]): string {
+  const headers = [
+    "Numéro",
+    "Date",
+    "Client",
+    "Email",
+    "Téléphone",
+    "Commune",
+    "Adresse",
+    "Sous-total",
+    "Livraison",
+    "Réduction",
+    "Total",
+    "Statut",
+    "Articles",
+  ];
+
+  const rows = orders.map((order) => [
+    escapeCSV(order.order_number),
+    escapeCSV(formatDate(order.created_at)),
+    escapeCSV(order.user_name),
+    escapeCSV(order.user_email),
+    escapeCSV(order.delivery_phone),
+    escapeCSV(order.delivery_commune),
+    escapeCSV(order.delivery_address),
+    order.subtotal.toString(),
+    order.delivery_fee.toString(),
+    order.discount_amount.toString(),
+    order.total.toString(),
+    escapeCSV(formatStatus(order.status)),
+    order.item_count.toString(),
+  ]);
+
+  const csvContent = [
+    headers.join(","),
+    ...rows.map((row) => row.join(",")),
+  ].join("\n");
+
+  return csvContent;
+}

--- a/lib/db/admin/orders.ts
+++ b/lib/db/admin/orders.ts
@@ -1,0 +1,164 @@
+import { query, queryFirst } from "@/lib/db";
+import type {
+  Order,
+  OrderItem,
+  OrderStatusHistory,
+  AdminOrder,
+  AdminOrderDetail,
+} from "@/lib/db/types";
+
+export interface AdminOrderFilters {
+  search?: string;
+  status?: string;
+  commune?: string;
+  dateFrom?: string;
+  dateTo?: string;
+  sort?: "newest" | "oldest" | "total_asc" | "total_desc";
+  limit?: number;
+  offset?: number;
+}
+
+function buildFilterClause(opts: AdminOrderFilters): {
+  where: string;
+  params: unknown[];
+} {
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+
+  if (opts.search) {
+    conditions.push(
+      "(o.order_number LIKE ? OR u.first_name LIKE ? OR u.last_name LIKE ? OR u.email LIKE ? OR o.delivery_phone LIKE ?)"
+    );
+    const term = `%${opts.search}%`;
+    params.push(term, term, term, term, term);
+  }
+
+  if (opts.status && opts.status !== "all") {
+    conditions.push("o.status = ?");
+    params.push(opts.status);
+  }
+
+  if (opts.commune) {
+    conditions.push("o.delivery_commune = ?");
+    params.push(opts.commune);
+  }
+
+  if (opts.dateFrom) {
+    conditions.push("o.created_at >= ?");
+    params.push(opts.dateFrom);
+  }
+
+  if (opts.dateTo) {
+    conditions.push("o.created_at <= ?");
+    params.push(opts.dateTo + " 23:59:59");
+  }
+
+  const where =
+    conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+  return { where, params };
+}
+
+export async function getAdminOrders(
+  opts: AdminOrderFilters = {}
+): Promise<AdminOrder[]> {
+  const limit = opts.limit ?? 20;
+  const offset = opts.offset ?? 0;
+  const { where, params } = buildFilterClause(opts);
+
+  let orderBy = "o.created_at DESC";
+  switch (opts.sort) {
+    case "oldest":
+      orderBy = "o.created_at ASC";
+      break;
+    case "total_asc":
+      orderBy = "o.total ASC";
+      break;
+    case "total_desc":
+      orderBy = "o.total DESC";
+      break;
+  }
+
+  return query<AdminOrder>(
+    `SELECT o.*,
+       (SELECT COUNT(*) FROM order_items oi WHERE oi.order_id = o.id) as item_count,
+       u.email as user_email,
+       (u.first_name || ' ' || u.last_name) as user_name,
+       u.phone as user_phone
+     FROM orders o
+     LEFT JOIN users u ON u.id = o.user_id
+     ${where}
+     ORDER BY ${orderBy}
+     LIMIT ? OFFSET ?`,
+    [...params, limit, offset]
+  );
+}
+
+export async function getAdminOrderCount(
+  opts: AdminOrderFilters = {}
+): Promise<number> {
+  const { where, params } = buildFilterClause(opts);
+
+  const result = await queryFirst<{ count: number }>(
+    `SELECT COUNT(*) as count FROM orders o
+     LEFT JOIN users u ON u.id = o.user_id
+     ${where}`,
+    params
+  );
+  return result?.count ?? 0;
+}
+
+export async function getAdminOrderById(
+  id: string
+): Promise<AdminOrderDetail | null> {
+  const order = await queryFirst<
+    Order & { user_email: string; user_name: string; user_phone: string | null }
+  >(
+    `SELECT o.*,
+       u.email as user_email,
+       (u.first_name || ' ' || u.last_name) as user_name,
+       u.phone as user_phone
+     FROM orders o
+     LEFT JOIN users u ON u.id = o.user_id
+     WHERE o.id = ?`,
+    [id]
+  );
+
+  if (!order) return null;
+
+  const [items, status_history] = await Promise.all([
+    query<OrderItem>("SELECT * FROM order_items WHERE order_id = ?", [id]),
+    query<OrderStatusHistory>(
+      "SELECT * FROM order_status_history WHERE order_id = ? ORDER BY created_at DESC",
+      [id]
+    ),
+  ]);
+
+  return { ...order, items, status_history };
+}
+
+export async function getOrderStatusHistory(
+  orderId: string
+): Promise<OrderStatusHistory[]> {
+  return query<OrderStatusHistory>(
+    "SELECT * FROM order_status_history WHERE order_id = ? ORDER BY created_at DESC",
+    [orderId]
+  );
+}
+
+export async function getDistinctCommunes(): Promise<string[]> {
+  const rows = await query<{ commune: string }>(
+    "SELECT DISTINCT delivery_commune as commune FROM orders ORDER BY commune ASC"
+  );
+  return rows.map((r) => r.commune);
+}
+
+export async function getDeliveryPersons(): Promise<
+  { id: string; name: string }[]
+> {
+  return query<{ id: string; name: string }>(
+    `SELECT id, (first_name || ' ' || last_name) as name
+     FROM users
+     WHERE role IN ('admin', 'super_admin')
+     ORDER BY name ASC`
+  );
+}

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -109,6 +109,15 @@ export interface Order {
   delivered_at: string | null;
   cancelled_at: string | null;
   cancellation_reason: string | null;
+  // Admin-specific fields
+  internal_notes: string | null;
+  delivery_person_id: string | null;
+  delivery_person_name: string | null;
+  confirmed_at: string | null;
+  preparing_at: string | null;
+  shipping_at: string | null;
+  returned_at: string | null;
+  return_reason: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -201,4 +210,30 @@ export type OrderStatus =
   | "preparing"
   | "shipping"
   | "delivered"
-  | "cancelled";
+  | "cancelled"
+  | "returned";
+
+export interface OrderStatusHistory {
+  id: string;
+  order_id: string;
+  from_status: string | null;
+  to_status: string;
+  changed_by: string;
+  note: string | null;
+  created_at: string;
+}
+
+export interface AdminOrder extends Order {
+  item_count: number;
+  user_email: string;
+  user_name: string;
+  user_phone: string | null;
+}
+
+export interface AdminOrderDetail extends Order {
+  items: OrderItem[];
+  status_history: OrderStatusHistory[];
+  user_email: string;
+  user_name: string;
+  user_phone: string | null;
+}


### PR DESCRIPTION
## Summary

Implements the full order management module for the admin dashboard:

- **Database migration** adding internal_notes, delivery_person fields, status timestamps, and order_status_history audit table
- **Order list page** with search, filters (status, commune, date range), pagination, and CSV export
- **Order detail page** with status timeline, items, totals, client info, delivery assignment
- **Status workflow** with transition validation (pending → confirmed → preparing → shipping → delivered)
- **Cancellation & returns** with automatic stock refund
- **Printable invoice page** with @media print styles

## Changes

### Database
- `db/migrations/0005_admin_orders.sql` - New columns and audit table

### Backend
- `lib/db/types.ts` - Extended Order, added OrderStatusHistory, AdminOrder types
- `lib/db/admin/orders.ts` - Admin query functions
- `lib/db/orders.ts` - Added refundOrderStock()
- `lib/csv/orders.ts` - CSV export utility
- `actions/admin/orders.ts` - Server actions with status validation

### Components
- `order-table.tsx`, `order-filters.tsx`, `order-status-actions.tsx`
- `order-notes-form.tsx`, `delivery-person-select.tsx`
- `order-export-button.tsx`, `order-status-history.tsx`

### Pages
- `/orders` - List with filters and export
- `/orders/[id]` - Order detail
- `/orders/[id]/invoice` - Printable invoice

## Test plan

- [ ] Navigate to `/orders` and verify order list loads
- [ ] Test filters (status, search, commune, date range)
- [ ] Test pagination
- [ ] Test CSV export downloads file
- [ ] Open order detail page
- [ ] Test status transitions (confirm, prepare, ship, deliver)
- [ ] Test cancellation with reason
- [ ] Test delivery person assignment
- [ ] Test internal notes save
- [ ] View and print invoice page

🤖 Generated with [Claude Code](https://claude.com/claude-code)