### PR TITLE
feat: add customer management admin section

### DIFF
--- a/actions/admin/customers.ts
+++ b/actions/admin/customers.ts
@@ -1,0 +1,101 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { requireAdmin } from "@/lib/auth/guards";
+import { execute, queryFirst } from "@/lib/db";
+import type { ActionResult } from "@/lib/utils";
+import type { UserRole } from "@/lib/db/types";
+
+const idSchema = z.string().min(1, "ID requis");
+
+const roleSchema = z.enum(["customer", "admin", "super_admin"], {
+  message: "Rôle invalide",
+});
+
+export async function updateCustomerRole(
+  customerId: string,
+  newRole: UserRole
+): Promise<ActionResult> {
+  const session = await requireAdmin();
+
+  // Only super_admin can change roles
+  if (session.user.role !== "super_admin") {
+    return {
+      success: false,
+      error: "Seuls les super administrateurs peuvent modifier les rôles",
+    };
+  }
+
+  const idResult = idSchema.safeParse(customerId);
+  if (!idResult.success) {
+    return { success: false, error: "ID client invalide" };
+  }
+
+  const roleResult = roleSchema.safeParse(newRole);
+  if (!roleResult.success) {
+    return { success: false, error: roleResult.error.issues[0].message };
+  }
+
+  // Prevent self-demotion
+  if (customerId === session.user.id && newRole !== "super_admin") {
+    return {
+      success: false,
+      error: "Vous ne pouvez pas modifier votre propre rôle",
+    };
+  }
+
+  // Check if user exists
+  const user = await queryFirst<{ id: string; role: string }>(
+    "SELECT id, role FROM users WHERE id = ?",
+    [customerId]
+  );
+
+  if (!user) {
+    return { success: false, error: "Client introuvable" };
+  }
+
+  await execute(
+    "UPDATE users SET role = ?, updated_at = datetime('now') WHERE id = ?",
+    [roleResult.data, customerId]
+  );
+
+  revalidatePath("/customers");
+  revalidatePath(`/customers/${customerId}`);
+
+  return { success: true };
+}
+
+export async function toggleCustomerActive(
+  customerId: string
+): Promise<ActionResult> {
+  await requireAdmin();
+
+  const idResult = idSchema.safeParse(customerId);
+  if (!idResult.success) {
+    return { success: false, error: "ID client invalide" };
+  }
+
+  // Check if user exists and get current status
+  const user = await queryFirst<{ id: string; is_active: number | null }>(
+    "SELECT id, is_active FROM users WHERE id = ?",
+    [customerId]
+  );
+
+  if (!user) {
+    return { success: false, error: "Client introuvable" };
+  }
+
+  const currentActive = user.is_active ?? 1;
+  const newActive = currentActive === 1 ? 0 : 1;
+
+  await execute(
+    "UPDATE users SET is_active = ?, updated_at = datetime('now') WHERE id = ?",
+    [newActive, customerId]
+  );
+
+  revalidatePath("/customers");
+  revalidatePath(`/customers/${customerId}`);
+
+  return { success: true };
+}

--- a/app/(admin)/customers/[id]/_components/customer-addresses.tsx
+++ b/app/(admin)/customers/[id]/_components/customer-addresses.tsx
@@ -1,0 +1,74 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Location01Icon } from "@hugeicons/core-free-icons";
+import type { Address } from "@/lib/db/types";
+
+interface CustomerAddressesProps {
+  addresses: Address[];
+}
+
+export function CustomerAddresses({ addresses }: CustomerAddressesProps) {
+  if (addresses.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Carnet d&apos;adresses</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">Aucune adresse enregistrée</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm">
+          Carnet d&apos;adresses ({addresses.length})
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {addresses.map((address) => (
+            <div
+              key={address.id}
+              className="flex gap-3 rounded-lg border p-3"
+              style={{ contentVisibility: "auto", containIntrinsicSize: "0 80px" }}
+            >
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted">
+                <HugeiconsIcon
+                  icon={Location01Icon}
+                  size={20}
+                  className="text-muted-foreground"
+                />
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 mb-1">
+                  <span className="font-medium text-sm truncate">{address.label}</span>
+                  {address.is_default === 1 && (
+                    <Badge variant="secondary" className="text-[10px]">
+                      Par défaut
+                    </Badge>
+                  )}
+                </div>
+                <p className="text-sm">{address.full_name}</p>
+                <p className="text-sm text-muted-foreground">{address.street}</p>
+                <p className="text-sm text-muted-foreground">
+                  {address.commune}, {address.city}
+                </p>
+                <p className="text-sm text-muted-foreground">{address.phone}</p>
+                {address.instructions && (
+                  <p className="text-xs text-muted-foreground mt-1 italic">
+                    &quot;{address.instructions}&quot;
+                  </p>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/(admin)/customers/[id]/_components/customer-info.tsx
+++ b/app/(admin)/customers/[id]/_components/customer-info.tsx
@@ -1,0 +1,103 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { CheckmarkCircle02Icon, Cancel01Icon, Mail01Icon, SmartPhone01Icon } from "@hugeicons/core-free-icons";
+import type { AdminCustomerDetail } from "@/lib/db/types";
+
+interface CustomerInfoProps {
+  customer: AdminCustomerDetail;
+}
+
+const ROLE_LABELS: Record<string, string> = {
+  customer: "Client",
+  admin: "Admin",
+  super_admin: "Super Admin",
+};
+
+const ROLE_VARIANTS: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
+  customer: "secondary",
+  admin: "default",
+  super_admin: "destructive",
+};
+
+function getInitials(name: string): string {
+  return name
+    .split(" ")
+    .map((n) => n[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("fr-FR", {
+    day: "2-digit",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+export function CustomerInfo({ customer }: CustomerInfoProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm">Informations client</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-start gap-4">
+          <Avatar className="h-16 w-16 shrink-0">
+            {customer.image && (
+              <AvatarImage src={customer.image} alt={customer.name} />
+            )}
+            <AvatarFallback className="text-lg">
+              {getInitials(customer.name)}
+            </AvatarFallback>
+          </Avatar>
+
+          <div className="flex-1 min-w-0 space-y-2">
+            <div>
+              <h3 className="text-lg font-semibold truncate">{customer.name}</h3>
+              <div className="flex flex-wrap items-center gap-2 mt-1">
+                <Badge variant={ROLE_VARIANTS[customer.role] || "secondary"}>
+                  {ROLE_LABELS[customer.role] || customer.role}
+                </Badge>
+                {customer.is_active === 0 && (
+                  <Badge variant="destructive">Inactif</Badge>
+                )}
+                {customer.emailVerified ? (
+                  <Badge variant="outline" className="gap-1 text-green-600 border-green-600">
+                    <HugeiconsIcon icon={CheckmarkCircle02Icon} size={12} />
+                    Email vérifié
+                  </Badge>
+                ) : (
+                  <Badge variant="outline" className="gap-1 text-amber-600 border-amber-600">
+                    <HugeiconsIcon icon={Cancel01Icon} size={12} />
+                    Non vérifié
+                  </Badge>
+                )}
+              </div>
+            </div>
+
+            <div className="space-y-1 text-sm text-muted-foreground">
+              <div className="flex items-center gap-2">
+                <HugeiconsIcon icon={Mail01Icon} size={14} />
+                <span className="truncate">{customer.email}</span>
+              </div>
+              {customer.phone && (
+                <div className="flex items-center gap-2">
+                  <HugeiconsIcon icon={SmartPhone01Icon} size={14} />
+                  <span>{customer.phone}</span>
+                </div>
+              )}
+            </div>
+
+            <p className="text-xs text-muted-foreground">
+              Membre depuis le {formatDate(customer.createdAt)}
+            </p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/(admin)/customers/[id]/_components/customer-info.tsx
+++ b/app/(admin)/customers/[id]/_components/customer-info.tsx
@@ -3,23 +3,13 @@ import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { CheckmarkCircle02Icon, Cancel01Icon, Mail01Icon, SmartPhone01Icon } from "@hugeicons/core-free-icons";
+import { formatDateLong } from "@/lib/utils";
+import { ROLE_LABELS, ROLE_VARIANTS } from "@/lib/constants/customers";
 import type { AdminCustomerDetail } from "@/lib/db/types";
 
 interface CustomerInfoProps {
   customer: AdminCustomerDetail;
 }
-
-const ROLE_LABELS: Record<string, string> = {
-  customer: "Client",
-  admin: "Admin",
-  super_admin: "Super Admin",
-};
-
-const ROLE_VARIANTS: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
-  customer: "secondary",
-  admin: "default",
-  super_admin: "destructive",
-};
 
 function getInitials(name: string): string {
   return name
@@ -28,14 +18,6 @@ function getInitials(name: string): string {
     .join("")
     .toUpperCase()
     .slice(0, 2);
-}
-
-function formatDate(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString("fr-FR", {
-    day: "2-digit",
-    month: "long",
-    year: "numeric",
-  });
 }
 
 export function CustomerInfo({ customer }: CustomerInfoProps) {
@@ -93,7 +75,7 @@ export function CustomerInfo({ customer }: CustomerInfoProps) {
             </div>
 
             <p className="text-xs text-muted-foreground">
-              Membre depuis le {formatDate(customer.createdAt)}
+              Membre depuis le {formatDateLong(customer.createdAt)}
             </p>
           </div>
         </div>

--- a/app/(admin)/customers/[id]/_components/customer-orders.tsx
+++ b/app/(admin)/customers/[id]/_components/customer-orders.tsx
@@ -1,0 +1,77 @@
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { StatusBadge } from "@/components/ui/status-badge";
+import { formatPrice, formatOrderDate } from "@/lib/utils";
+import { ORDER_STATUS_CONFIG, getOrderStatus } from "@/lib/constants/orders";
+import type { AdminOrder } from "@/lib/db/types";
+
+interface CustomerOrdersProps {
+  orders: AdminOrder[];
+}
+
+export function CustomerOrders({ orders }: CustomerOrdersProps) {
+  if (orders.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Historique des commandes</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">Aucune commande</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle className="text-sm">
+          Historique des commandes ({orders.length})
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="divide-y">
+          {orders.map((order) => {
+            const orderStatus = getOrderStatus(order.status);
+            const statusConfig = ORDER_STATUS_CONFIG[orderStatus];
+            return (
+              <Link
+                key={order.id}
+                href={`/orders/${order.id}`}
+                className="flex items-center justify-between py-3 first:pt-0 last:pb-0 hover:bg-muted/30 -mx-2 px-2 rounded-lg transition-colors"
+                style={{ contentVisibility: "auto", containIntrinsicSize: "0 56px" }}
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className="font-mono text-sm font-medium">
+                      {order.order_number}
+                    </span>
+                    <StatusBadge
+                      status={orderStatus}
+                      label={statusConfig.label}
+                      variant={statusConfig.variant}
+                      className="text-[10px]"
+                    />
+                  </div>
+                  <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                    <span>{formatOrderDate(order.created_at)}</span>
+                    <Badge variant="outline" className="text-[10px]">
+                      {order.item_count} art.
+                    </Badge>
+                  </div>
+                </div>
+                <div className="text-right shrink-0 ml-2">
+                  <span className="font-mono text-sm font-semibold">
+                    {formatPrice(order.total)}
+                  </span>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/(admin)/customers/[id]/_components/customer-sidebar.tsx
+++ b/app/(admin)/customers/[id]/_components/customer-sidebar.tsx
@@ -11,7 +11,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { formatPrice } from "@/lib/utils";
+import { formatPrice, formatDateLong } from "@/lib/utils";
+import { ROLE_OPTIONS } from "@/lib/constants/customers";
 import { updateCustomerRole, toggleCustomerActive } from "@/actions/admin/customers";
 import type { AdminCustomerDetail, UserRole } from "@/lib/db/types";
 
@@ -19,20 +20,6 @@ interface CustomerSidebarProps {
   customer: AdminCustomerDetail;
   isSuperAdmin: boolean;
 }
-
-function formatDate(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString("fr-FR", {
-    day: "2-digit",
-    month: "long",
-    year: "numeric",
-  });
-}
-
-const ROLE_OPTIONS: { value: UserRole; label: string }[] = [
-  { value: "customer", label: "Client" },
-  { value: "admin", label: "Admin" },
-  { value: "super_admin", label: "Super Admin" },
-];
 
 export function CustomerSidebar({ customer, isSuperAdmin }: CustomerSidebarProps) {
   const router = useRouter();
@@ -83,7 +70,7 @@ export function CustomerSidebar({ customer, isSuperAdmin }: CustomerSidebarProps
           </div>
           <div className="flex justify-between items-center">
             <span className="text-sm text-muted-foreground">Membre depuis</span>
-            <span className="text-sm">{formatDate(customer.createdAt)}</span>
+            <span className="text-sm">{formatDateLong(customer.createdAt)}</span>
           </div>
           {customer.order_count > 0 && (
             <div className="flex justify-between items-center">

--- a/app/(admin)/customers/[id]/_components/customer-sidebar.tsx
+++ b/app/(admin)/customers/[id]/_components/customer-sidebar.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { formatPrice } from "@/lib/utils";
+import { updateCustomerRole, toggleCustomerActive } from "@/actions/admin/customers";
+import type { AdminCustomerDetail, UserRole } from "@/lib/db/types";
+
+interface CustomerSidebarProps {
+  customer: AdminCustomerDetail;
+  isSuperAdmin: boolean;
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("fr-FR", {
+    day: "2-digit",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+const ROLE_OPTIONS: { value: UserRole; label: string }[] = [
+  { value: "customer", label: "Client" },
+  { value: "admin", label: "Admin" },
+  { value: "super_admin", label: "Super Admin" },
+];
+
+export function CustomerSidebar({ customer, isSuperAdmin }: CustomerSidebarProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleRoleChange(newRole: UserRole) {
+    setError(null);
+    startTransition(async () => {
+      const result = await updateCustomerRole(customer.id, newRole);
+      if (!result.success) {
+        setError(result.error || "Erreur lors du changement de rôle");
+      } else {
+        router.refresh();
+      }
+    });
+  }
+
+  async function handleToggleActive() {
+    setError(null);
+    startTransition(async () => {
+      const result = await toggleCustomerActive(customer.id);
+      if (!result.success) {
+        setError(result.error || "Erreur lors du changement de statut");
+      } else {
+        router.refresh();
+      }
+    });
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Stats */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Statistiques</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="flex justify-between items-center">
+            <span className="text-sm text-muted-foreground">Total commandes</span>
+            <span className="font-semibold">{customer.order_count}</span>
+          </div>
+          <div className="flex justify-between items-center">
+            <span className="text-sm text-muted-foreground">Total dépensé</span>
+            <span className="font-mono font-semibold">
+              {formatPrice(customer.total_spent)}
+            </span>
+          </div>
+          <div className="flex justify-between items-center">
+            <span className="text-sm text-muted-foreground">Membre depuis</span>
+            <span className="text-sm">{formatDate(customer.createdAt)}</span>
+          </div>
+          {customer.order_count > 0 && (
+            <div className="flex justify-between items-center">
+              <span className="text-sm text-muted-foreground">Panier moyen</span>
+              <span className="font-mono text-sm">
+                {formatPrice(Math.round(customer.total_spent / customer.order_count))}
+              </span>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Admin Actions */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Actions administrateur</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {error && (
+            <p className="text-sm text-destructive">{error}</p>
+          )}
+
+          {/* Role change - only for super_admin */}
+          {isSuperAdmin && (
+            <div>
+              <label className="text-sm text-muted-foreground mb-2 block">
+                Changer le rôle
+              </label>
+              <Select
+                value={customer.role}
+                onValueChange={(value) => handleRoleChange(value as UserRole)}
+                disabled={isPending}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {ROLE_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {/* Toggle active status */}
+          <div>
+            <label className="text-sm text-muted-foreground mb-2 block">
+              Statut du compte
+            </label>
+            <Button
+              variant={customer.is_active === 1 ? "destructive" : "default"}
+              className="w-full"
+              onClick={handleToggleActive}
+              disabled={isPending}
+            >
+              {isPending
+                ? "Mise à jour..."
+                : customer.is_active === 1
+                ? "Désactiver le compte"
+                : "Activer le compte"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/(admin)/customers/[id]/page.tsx
+++ b/app/(admin)/customers/[id]/page.tsx
@@ -1,0 +1,61 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ArrowLeft02Icon } from "@hugeicons/core-free-icons";
+import { requireAdmin } from "@/lib/auth/guards";
+import { getAdminCustomerById } from "@/lib/db/admin/customers";
+import { CustomerInfo } from "./_components/customer-info";
+import { CustomerAddresses } from "./_components/customer-addresses";
+import { CustomerOrders } from "./_components/customer-orders";
+import { CustomerSidebar } from "./_components/customer-sidebar";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+const backIcon = <HugeiconsIcon icon={ArrowLeft02Icon} size={20} />;
+
+export default async function CustomerDetailPage({ params }: Props) {
+  const session = await requireAdmin();
+  const { id } = await params;
+  const customer = await getAdminCustomerById(id);
+
+  if (!customer) notFound();
+
+  const isSuperAdmin = session.user.role === "super_admin";
+
+  return (
+    <div>
+      <header className="mb-6 flex items-center gap-3">
+        <Button
+          variant="ghost"
+          size="icon"
+          asChild
+          className="h-11 w-11 shrink-0"
+          aria-label="Retour à la liste des clients"
+        >
+          <Link href="/customers">{backIcon}</Link>
+        </Button>
+        <div className="min-w-0">
+          <h1 className="truncate text-lg font-bold sm:text-2xl">
+            {customer.name}
+          </h1>
+          <p className="text-sm text-muted-foreground">Détails du client</p>
+        </div>
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        {/* Main Content */}
+        <div className="space-y-6 lg:col-span-2">
+          <CustomerInfo customer={customer} />
+          <CustomerAddresses addresses={customer.addresses} />
+          <CustomerOrders orders={customer.recent_orders} />
+        </div>
+
+        {/* Sidebar */}
+        <CustomerSidebar customer={customer} isSuperAdmin={isSuperAdmin} />
+      </div>
+    </div>
+  );
+}

--- a/app/(admin)/customers/[id]/page.tsx
+++ b/app/(admin)/customers/[id]/page.tsx
@@ -17,8 +17,8 @@ interface Props {
 const backIcon = <HugeiconsIcon icon={ArrowLeft02Icon} size={20} />;
 
 export default async function CustomerDetailPage({ params }: Props) {
-  const session = await requireAdmin();
-  const { id } = await params;
+  // Parallelize auth check and params resolution (async-parallel)
+  const [session, { id }] = await Promise.all([requireAdmin(), params]);
   const customer = await getAdminCustomerById(id);
 
   if (!customer) notFound();

--- a/app/(admin)/customers/_components/customers-client-wrapper.tsx
+++ b/app/(admin)/customers/_components/customers-client-wrapper.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { ViewProvider } from "@/components/admin/view-context";
+import { ViewSwitcher } from "@/components/admin/view-switcher";
+import { ResponsiveDataList } from "@/components/admin/responsive-data-list";
+import { CustomerTable } from "@/components/admin/customer-table";
+import { CustomerCardMobile } from "@/components/admin/customer-card-mobile";
+import { CustomerFilters } from "@/components/admin/customer-filters";
+import { CustomerFilterSheet } from "@/components/admin/customer-filter-sheet";
+import type { AdminCustomer } from "@/lib/db/types";
+
+interface CustomersClientWrapperProps {
+  customers: AdminCustomer[];
+}
+
+export function CustomersClientWrapper({
+  customers,
+}: CustomersClientWrapperProps) {
+  return (
+    <ViewProvider>
+      <div className="w-full space-y-4">
+        {/* Filter row */}
+        <div className="flex flex-wrap items-center gap-3">
+          {/* Mobile: filter sheet */}
+          <CustomerFilterSheet className="lg:hidden" />
+
+          {/* Desktop: inline filters */}
+          <div className="hidden lg:block">
+            <CustomerFilters />
+          </div>
+
+          {/* View switcher - show on larger mobile screens */}
+          <ViewSwitcher className="ml-auto hidden sm:flex lg:hidden" />
+        </div>
+
+        {/* Data list */}
+        <ResponsiveDataList
+          data={customers}
+          tableView={<CustomerTable customers={customers} />}
+          renderCard={(customer) => <CustomerCardMobile customer={customer} />}
+          emptyMessage="Aucun client trouvé"
+        />
+      </div>
+    </ViewProvider>
+  );
+}

--- a/app/(admin)/customers/loading.tsx
+++ b/app/(admin)/customers/loading.tsx
@@ -1,0 +1,16 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function CustomersLoading() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-8 w-32" />
+      <div className="flex flex-wrap gap-3">
+        <Skeleton className="h-9 w-48" />
+        <Skeleton className="h-9 w-32" />
+        <Skeleton className="h-9 w-36" />
+        <Skeleton className="h-9 w-36" />
+      </div>
+      <Skeleton className="h-96 w-full" />
+    </div>
+  );
+}

--- a/app/(admin)/customers/page.tsx
+++ b/app/(admin)/customers/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { redirect } from "next/navigation";
 import { AdminHeader } from "@/components/admin/admin-header";
 import { CustomersClientWrapper } from "./_components/customers-client-wrapper";
 import { Button } from "@/components/ui/button";
@@ -21,7 +22,30 @@ const PAGE_SIZE = 20;
 
 export default async function CustomersPage({ searchParams }: Props) {
   const params = await searchParams;
-  const page = Math.max(1, Number(params.page) || 1);
+  const requestedPage = Math.max(1, Number(params.page) || 1);
+
+  // First get count to validate page bounds
+  const totalCount = await getAdminCustomerCount({
+    search: params.search,
+    role: params.role,
+    dateFrom: params.dateFrom,
+    dateTo: params.dateTo,
+  });
+
+  const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
+
+  // Redirect if page is out of bounds
+  if (requestedPage > totalPages && totalPages > 0) {
+    const newParams = new URLSearchParams();
+    if (params.search) newParams.set("search", params.search);
+    if (params.role) newParams.set("role", params.role);
+    if (params.dateFrom) newParams.set("dateFrom", params.dateFrom);
+    if (params.dateTo) newParams.set("dateTo", params.dateTo);
+    newParams.set("page", String(totalPages));
+    redirect(`/customers?${newParams.toString()}`);
+  }
+
+  const page = Math.min(requestedPage, totalPages);
   const filters = {
     search: params.search,
     role: params.role,
@@ -31,12 +55,7 @@ export default async function CustomersPage({ searchParams }: Props) {
     offset: (page - 1) * PAGE_SIZE,
   };
 
-  const [customers, totalCount] = await Promise.all([
-    getAdminCustomers(filters),
-    getAdminCustomerCount(filters),
-  ]);
-
-  const totalPages = Math.ceil(totalCount / PAGE_SIZE);
+  const customers = await getAdminCustomers(filters);
 
   return (
     <div>

--- a/app/(admin)/customers/page.tsx
+++ b/app/(admin)/customers/page.tsx
@@ -1,0 +1,83 @@
+import Link from "next/link";
+import { AdminHeader } from "@/components/admin/admin-header";
+import { CustomersClientWrapper } from "./_components/customers-client-wrapper";
+import { Button } from "@/components/ui/button";
+import {
+  getAdminCustomers,
+  getAdminCustomerCount,
+} from "@/lib/db/admin/customers";
+
+interface Props {
+  searchParams: Promise<{
+    search?: string;
+    role?: string;
+    dateFrom?: string;
+    dateTo?: string;
+    page?: string;
+  }>;
+}
+
+const PAGE_SIZE = 20;
+
+export default async function CustomersPage({ searchParams }: Props) {
+  const params = await searchParams;
+  const page = Math.max(1, Number(params.page) || 1);
+  const filters = {
+    search: params.search,
+    role: params.role,
+    dateFrom: params.dateFrom,
+    dateTo: params.dateTo,
+    limit: PAGE_SIZE,
+    offset: (page - 1) * PAGE_SIZE,
+  };
+
+  const [customers, totalCount] = await Promise.all([
+    getAdminCustomers(filters),
+    getAdminCustomerCount(filters),
+  ]);
+
+  const totalPages = Math.ceil(totalCount / PAGE_SIZE);
+
+  return (
+    <div>
+      <AdminHeader title="Clients" />
+
+      {/* Client wrapper handles responsive filters + data list */}
+      <CustomersClientWrapper customers={customers} />
+
+      {totalPages > 1 && (
+        <div className="mt-4 flex items-center justify-between text-sm text-muted-foreground">
+          <span>
+            {totalCount} client(s) — Page {page}/{totalPages}
+          </span>
+          <div className="flex gap-2">
+            {page > 1 && (
+              <Button variant="outline" size="sm" asChild>
+                <Link
+                  href={{
+                    pathname: "/customers",
+                    query: { ...params, page: String(page - 1) },
+                  }}
+                >
+                  Précédent
+                </Link>
+              </Button>
+            )}
+            {page < totalPages && (
+              <Button variant="outline" size="sm" asChild>
+                <Link
+                  href={{
+                    pathname: "/customers",
+                    query: { ...params, page: String(page + 1) },
+                  }}
+                >
+                  Suivant
+                </Link>
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/admin/customer-card-mobile.tsx
+++ b/components/admin/customer-card-mobile.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { MoreVerticalIcon, ViewIcon } from "@hugeicons/core-free-icons";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { ActionSheet, type ActionSheetItem } from "./action-sheet";
+import { formatPrice } from "@/lib/utils";
+import type { AdminCustomer } from "@/lib/db/types";
+
+interface CustomerCardMobileProps {
+  customer: AdminCustomer;
+}
+
+const ROLE_LABELS: Record<string, string> = {
+  customer: "Client",
+  admin: "Admin",
+  super_admin: "Super Admin",
+};
+
+const ROLE_VARIANTS: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
+  customer: "secondary",
+  admin: "default",
+  super_admin: "destructive",
+};
+
+function getInitials(name: string): string {
+  return name
+    .split(" ")
+    .map((n) => n[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("fr-FR", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+export function CustomerCardMobile({ customer }: CustomerCardMobileProps) {
+  const router = useRouter();
+  const [actionSheetOpen, setActionSheetOpen] = useState(false);
+
+  const actions: ActionSheetItem[] = [
+    {
+      label: "Voir détails",
+      icon: ViewIcon,
+      onClick: () => {
+        router.push(`/customers/${customer.id}`);
+      },
+    },
+  ];
+
+  return (
+    <>
+      <Link
+        href={`/customers/${customer.id}`}
+        className="flex items-center gap-3 rounded-xl border bg-card p-3 transition-colors hover:bg-muted/30 active:bg-muted/50 touch-manipulation"
+        style={{ contentVisibility: "auto", containIntrinsicSize: "0 100px" }}
+      >
+        {/* Avatar */}
+        <Avatar className="h-16 w-16 shrink-0">
+          {customer.image && <AvatarImage src={customer.image} alt={customer.name} />}
+          <AvatarFallback className="text-lg">
+            {getInitials(customer.name)}
+          </AvatarFallback>
+        </Avatar>
+
+        {/* Content */}
+        <div className="flex flex-1 flex-col gap-1 overflow-hidden">
+          {/* Name + date */}
+          <div className="flex items-center justify-between gap-2">
+            <span className="truncate font-medium">{customer.name}</span>
+            <span className="shrink-0 text-[10px] text-muted-foreground">
+              {formatDate(customer.createdAt)}
+            </span>
+          </div>
+
+          {/* Email */}
+          <div className="truncate text-sm text-muted-foreground">
+            {customer.email}
+          </div>
+
+          {/* Phone */}
+          {customer.phone && (
+            <div className="truncate text-xs text-muted-foreground">
+              {customer.phone}
+            </div>
+          )}
+
+          {/* Badges row */}
+          <div className="flex flex-wrap items-center gap-1.5 mt-1">
+            <Badge
+              variant={ROLE_VARIANTS[customer.role] || "secondary"}
+              className="text-[10px]"
+            >
+              {ROLE_LABELS[customer.role] || customer.role}
+            </Badge>
+            <Badge variant="outline" className="text-[10px]">
+              {customer.order_count} cmd.
+            </Badge>
+            {customer.is_active === 0 && (
+              <Badge variant="destructive" className="text-[10px]">
+                Inactif
+              </Badge>
+            )}
+          </div>
+
+          {/* Total spent */}
+          <div className="mt-1 text-sm font-semibold tabular-nums">
+            {formatPrice(customer.total_spent)}
+          </div>
+        </div>
+
+        {/* Action button */}
+        <button
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setActionSheetOpen(true);
+          }}
+          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none"
+          aria-label="Plus d'options"
+        >
+          <HugeiconsIcon icon={MoreVerticalIcon} size={20} />
+        </button>
+      </Link>
+
+      <ActionSheet
+        open={actionSheetOpen}
+        onOpenChange={setActionSheetOpen}
+        title={customer.name}
+        items={actions}
+      />
+    </>
+  );
+}

--- a/components/admin/customer-card-mobile.tsx
+++ b/components/admin/customer-card-mobile.tsx
@@ -8,7 +8,8 @@ import { MoreVerticalIcon, ViewIcon } from "@hugeicons/core-free-icons";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { ActionSheet, type ActionSheetItem } from "./action-sheet";
-import { formatPrice } from "@/lib/utils";
+import { formatPrice, formatDateShort } from "@/lib/utils";
+import { ROLE_LABELS, ROLE_VARIANTS } from "@/lib/constants/customers";
 import type { AdminCustomer } from "@/lib/db/types";
 
 // Hoisted static icon (rendering-hoist-jsx)
@@ -18,18 +19,6 @@ interface CustomerCardMobileProps {
   customer: AdminCustomer;
 }
 
-const ROLE_LABELS: Record<string, string> = {
-  customer: "Client",
-  admin: "Admin",
-  super_admin: "Super Admin",
-};
-
-const ROLE_VARIANTS: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
-  customer: "secondary",
-  admin: "default",
-  super_admin: "destructive",
-};
-
 function getInitials(name: string): string {
   return name
     .split(" ")
@@ -37,14 +26,6 @@ function getInitials(name: string): string {
     .join("")
     .toUpperCase()
     .slice(0, 2);
-}
-
-function formatDate(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString("fr-FR", {
-    day: "2-digit",
-    month: "short",
-    year: "numeric",
-  });
 }
 
 export function CustomerCardMobile({ customer }: CustomerCardMobileProps) {
@@ -83,7 +64,7 @@ export function CustomerCardMobile({ customer }: CustomerCardMobileProps) {
           <div className="flex items-center justify-between gap-2">
             <span className="truncate font-medium">{customer.name}</span>
             <span className="shrink-0 text-[10px] text-muted-foreground">
-              {formatDate(customer.createdAt)}
+              {formatDateShort(customer.createdAt)}
             </span>
           </div>
 

--- a/components/admin/customer-card-mobile.tsx
+++ b/components/admin/customer-card-mobile.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useMemo, useCallback } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -10,6 +10,9 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { ActionSheet, type ActionSheetItem } from "./action-sheet";
 import { formatPrice } from "@/lib/utils";
 import type { AdminCustomer } from "@/lib/db/types";
+
+// Hoisted static icon (rendering-hoist-jsx)
+const moreIcon = <HugeiconsIcon icon={MoreVerticalIcon} size={20} />;
 
 interface CustomerCardMobileProps {
   customer: AdminCustomer;
@@ -48,15 +51,16 @@ export function CustomerCardMobile({ customer }: CustomerCardMobileProps) {
   const router = useRouter();
   const [actionSheetOpen, setActionSheetOpen] = useState(false);
 
-  const actions: ActionSheetItem[] = [
-    {
-      label: "Voir détails",
-      icon: ViewIcon,
-      onClick: () => {
-        router.push(`/customers/${customer.id}`);
-      },
-    },
-  ];
+  // Stable callback to avoid recreating on each render (rerender-memo-with-default-value)
+  const handleViewDetails = useCallback(() => {
+    router.push(`/customers/${customer.id}`);
+  }, [router, customer.id]);
+
+  // Memoize actions array (rerender-memo-with-default-value)
+  const actions = useMemo<ActionSheetItem[]>(
+    () => [{ label: "Voir détails", icon: ViewIcon, onClick: handleViewDetails }],
+    [handleViewDetails]
+  );
 
   return (
     <>
@@ -129,7 +133,7 @@ export function CustomerCardMobile({ customer }: CustomerCardMobileProps) {
           className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none"
           aria-label="Plus d'options"
         >
-          <HugeiconsIcon icon={MoreVerticalIcon} size={20} />
+          {moreIcon}
         </button>
       </Link>
 

--- a/components/admin/customer-filter-sheet.tsx
+++ b/components/admin/customer-filter-sheet.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useEffect, useState, useMemo } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Cancel01Icon, FilterIcon, Search01Icon } from "@hugeicons/core-free-icons";
+import { cn } from "@/lib/utils";
+
+interface CustomerFilterSheetProps {
+  className?: string;
+}
+
+interface FilterState {
+  search: string;
+  role: string;
+  dateFrom: string;
+  dateTo: string;
+}
+
+const ROLE_OPTIONS = [
+  { value: "all", label: "Tous" },
+  { value: "customer", label: "Client" },
+  { value: "admin", label: "Admin" },
+  { value: "super_admin", label: "Super Admin" },
+];
+
+function getFiltersFromParams(params: URLSearchParams): FilterState {
+  return {
+    search: params.get("search") ?? "",
+    role: params.get("role") ?? "all",
+    dateFrom: params.get("dateFrom") ?? "",
+    dateTo: params.get("dateTo") ?? "",
+  };
+}
+
+export function CustomerFilterSheet({ className }: CustomerFilterSheetProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [open, setOpen] = useState(false);
+
+  const filtersFromUrl = useMemo(
+    () => getFiltersFromParams(searchParams),
+    [searchParams]
+  );
+
+  const [filters, setFilters] = useState<FilterState>(filtersFromUrl);
+
+  const urlKey = searchParams.toString();
+  useEffect(() => {
+    setFilters(getFiltersFromParams(searchParams));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlKey]);
+
+  const activeFilterCount =
+    (filters.search ? 1 : 0) +
+    (filters.role !== "all" ? 1 : 0) +
+    (filters.dateFrom ? 1 : 0) +
+    (filters.dateTo ? 1 : 0);
+
+  useEffect(() => {
+    document.body.classList.toggle("overflow-hidden", open);
+    return () => {
+      document.body.classList.remove("overflow-hidden");
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  function handleApply() {
+    const params = new URLSearchParams();
+    if (filters.search) params.set("search", filters.search);
+    if (filters.role && filters.role !== "all") params.set("role", filters.role);
+    if (filters.dateFrom) params.set("dateFrom", filters.dateFrom);
+    if (filters.dateTo) params.set("dateTo", filters.dateTo);
+    router.push(`/customers?${params.toString()}`);
+    setOpen(false);
+  }
+
+  function handleClear() {
+    setFilters({
+      search: "",
+      role: "all",
+      dateFrom: "",
+      dateTo: "",
+    });
+  }
+
+  function updateFilter<K extends keyof FilterState>(key: K, value: FilterState[K]) {
+    setFilters((prev) => ({ ...prev, [key]: value }));
+  }
+
+  return (
+    <>
+      {/* Trigger button */}
+      <button
+        onClick={() => setOpen(true)}
+        className={cn(
+          "relative flex h-11 items-center gap-2 rounded-lg border px-4 text-sm font-medium hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none",
+          className
+        )}
+      >
+        <HugeiconsIcon icon={FilterIcon} size={18} aria-hidden="true" />
+        Filtres
+        {activeFilterCount > 0 && (
+          <span className="absolute -right-1.5 -top-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-primary text-[10px] font-semibold text-primary-foreground">
+            {activeFilterCount}
+          </span>
+        )}
+      </button>
+
+      {/* Backdrop */}
+      <div
+        className={cn(
+          "fixed inset-0 z-[60] bg-black/40 transition-opacity duration-300",
+          open ? "opacity-100" : "pointer-events-none opacity-0"
+        )}
+        onClick={() => setOpen(false)}
+        aria-hidden="true"
+      />
+
+      {/* Sheet */}
+      <div
+        role="dialog"
+        aria-modal={open}
+        aria-label="Filtres des clients"
+        className={cn(
+          "fixed inset-x-0 bottom-0 z-[61] flex max-h-[85vh] flex-col rounded-t-2xl bg-background shadow-xl transition-transform duration-300 ease-out pb-safe",
+          open ? "translate-y-0" : "translate-y-full"
+        )}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b px-4 py-3">
+          <h2 className="text-lg font-semibold">Filtres</h2>
+          <button
+            onClick={() => setOpen(false)}
+            className="flex h-11 w-11 items-center justify-center rounded-full hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none"
+            aria-label="Fermer"
+          >
+            <HugeiconsIcon icon={Cancel01Icon} size={20} aria-hidden="true" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto overscroll-contain p-4 touch-manipulation">
+          {/* Search */}
+          <div className="mb-6">
+            <label className="mb-2 block text-sm font-medium">Recherche</label>
+            <div className="relative">
+              <HugeiconsIcon
+                icon={Search01Icon}
+                size={18}
+                className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+                aria-hidden="true"
+              />
+              <input
+                type="text"
+                value={filters.search}
+                onChange={(e) => updateFilter("search", e.target.value)}
+                placeholder="Nom, email, tél..."
+                className="h-12 w-full rounded-lg border bg-background pl-10 pr-4 text-sm focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none"
+              />
+            </div>
+          </div>
+
+          {/* Role */}
+          <div className="mb-6">
+            <label className="mb-2 block text-sm font-medium">Rôle</label>
+            <div className="flex flex-wrap gap-2">
+              {ROLE_OPTIONS.map((opt) => (
+                <button
+                  key={opt.value}
+                  onClick={() => updateFilter("role", opt.value)}
+                  className={cn(
+                    "flex h-10 items-center gap-1.5 rounded-lg border px-3 text-sm font-medium transition-colors",
+                    filters.role === opt.value
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "hover:bg-muted"
+                  )}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Date range */}
+          <div className="mb-6">
+            <label className="mb-2 block text-sm font-medium">
+              Date d&apos;inscription
+            </label>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="mb-1 block text-xs text-muted-foreground">
+                  Du
+                </label>
+                <input
+                  type="date"
+                  value={filters.dateFrom}
+                  onChange={(e) => updateFilter("dateFrom", e.target.value)}
+                  className="h-12 w-full rounded-lg border bg-background px-3 text-sm focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-xs text-muted-foreground">
+                  Au
+                </label>
+                <input
+                  type="date"
+                  value={filters.dateTo}
+                  onChange={(e) => updateFilter("dateTo", e.target.value)}
+                  className="h-12 w-full rounded-lg border bg-background px-3 text-sm focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex gap-3 border-t p-4">
+          <button
+            onClick={handleClear}
+            className="h-12 flex-1 rounded-xl border text-sm font-semibold hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none"
+          >
+            Effacer
+          </button>
+          <button
+            onClick={handleApply}
+            className="h-12 flex-1 rounded-xl bg-primary text-sm font-semibold text-primary-foreground hover:bg-primary/90 focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none"
+          >
+            Appliquer
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/components/admin/customer-filters.tsx
+++ b/components/admin/customer-filters.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Search01Icon, Cancel01Icon } from "@hugeicons/core-free-icons";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { useInstantFilters } from "@/hooks/use-instant-filters";
+
+interface CustomerFiltersProps {
+  className?: string;
+}
+
+const ROLE_OPTIONS = [
+  { value: "all", label: "Tous" },
+  { value: "customer", label: "Client" },
+  { value: "admin", label: "Admin" },
+  { value: "super_admin", label: "Super Admin" },
+];
+
+export function CustomerFilters({ className }: CustomerFiltersProps) {
+  const {
+    isPending,
+    updateFilters,
+    clearFilters,
+    getFilter,
+    searchValue,
+    handleSearchChange,
+    clearSearch,
+  } = useInstantFilters({ basePath: "/customers" });
+
+  const hasActiveFilters =
+    searchValue ||
+    getFilter("role") ||
+    getFilter("dateFrom") ||
+    getFilter("dateTo");
+
+  return (
+    <div className={className} data-pending={isPending || undefined}>
+      <div className="flex flex-wrap items-end gap-3">
+        {/* Search input with clear button */}
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="search" className="text-xs text-muted-foreground">
+            Recherche
+          </Label>
+          <div className="relative">
+            <HugeiconsIcon
+              icon={Search01Icon}
+              size={16}
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+            />
+            <Input
+              id="search"
+              placeholder="Nom, email, tél..."
+              value={searchValue}
+              onChange={(e) => handleSearchChange(e.target.value)}
+              className="w-full pl-9 pr-9 sm:w-48"
+            />
+            {searchValue && (
+              <button
+                type="button"
+                onClick={clearSearch}
+                className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                aria-label="Effacer la recherche"
+              >
+                <HugeiconsIcon icon={Cancel01Icon} size={14} />
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Role filter */}
+        <div className="flex flex-col gap-1.5">
+          <Label className="text-xs text-muted-foreground">Rôle</Label>
+          <Select
+            value={getFilter("role") || "all"}
+            onValueChange={(value) => updateFilters({ role: value })}
+          >
+            <SelectTrigger className="min-w-36">
+              <SelectValue placeholder="Tous" />
+            </SelectTrigger>
+            <SelectContent>
+              {ROLE_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* Date from */}
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="dateFrom" className="text-xs text-muted-foreground">
+            Inscrit depuis
+          </Label>
+          <Input
+            id="dateFrom"
+            type="date"
+            value={getFilter("dateFrom")}
+            onChange={(e) => updateFilters({ dateFrom: e.target.value })}
+            className="min-w-36"
+          />
+        </div>
+
+        {/* Date to */}
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="dateTo" className="text-xs text-muted-foreground">
+            Jusqu&apos;au
+          </Label>
+          <Input
+            id="dateTo"
+            type="date"
+            value={getFilter("dateTo")}
+            onChange={(e) => updateFilters({ dateTo: e.target.value })}
+            className="min-w-36"
+          />
+        </div>
+
+        {/* Clear all filters button */}
+        {hasActiveFilters && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={clearFilters}
+            className="gap-1.5 text-muted-foreground"
+          >
+            <HugeiconsIcon icon={Cancel01Icon} size={14} />
+            Tout effacer
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/admin/customer-table.tsx
+++ b/components/admin/customer-table.tsx
@@ -21,20 +21,9 @@ import {
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { MoreVerticalIcon, ViewIcon } from "@hugeicons/core-free-icons";
-import { formatPrice } from "@/lib/utils";
+import { formatPrice, formatDateShort } from "@/lib/utils";
+import { ROLE_LABELS, ROLE_VARIANTS } from "@/lib/constants/customers";
 import type { AdminCustomer } from "@/lib/db/types";
-
-const ROLE_LABELS: Record<string, string> = {
-  customer: "Client",
-  admin: "Admin",
-  super_admin: "Super Admin",
-};
-
-const ROLE_VARIANTS: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
-  customer: "secondary",
-  admin: "default",
-  super_admin: "destructive",
-};
 
 function getInitials(name: string): string {
   return name
@@ -43,14 +32,6 @@ function getInitials(name: string): string {
     .join("")
     .toUpperCase()
     .slice(0, 2);
-}
-
-function formatDate(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString("fr-FR", {
-    day: "2-digit",
-    month: "short",
-    year: "numeric",
-  });
 }
 
 // Hoisted static icons
@@ -91,7 +72,7 @@ const CustomerRow = memo(function CustomerRow({
         </Badge>
       </TableCell>
       <TableCell className="hidden lg:table-cell text-muted-foreground">
-        {formatDate(customer.createdAt)}
+        {formatDateShort(customer.createdAt)}
       </TableCell>
       <TableCell className="hidden sm:table-cell text-center">
         <Badge variant="outline">{customer.order_count}</Badge>

--- a/components/admin/customer-table.tsx
+++ b/components/admin/customer-table.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { memo } from "react";
+import Link from "next/link";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { MoreVerticalIcon, ViewIcon } from "@hugeicons/core-free-icons";
+import { formatPrice } from "@/lib/utils";
+import type { AdminCustomer } from "@/lib/db/types";
+
+const ROLE_LABELS: Record<string, string> = {
+  customer: "Client",
+  admin: "Admin",
+  super_admin: "Super Admin",
+};
+
+const ROLE_VARIANTS: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
+  customer: "secondary",
+  admin: "default",
+  super_admin: "destructive",
+};
+
+function getInitials(name: string): string {
+  return name
+    .split(" ")
+    .map((n) => n[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("fr-FR", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+// Hoisted static icons
+const moreIcon = <HugeiconsIcon icon={MoreVerticalIcon} size={16} />;
+const viewIcon = <HugeiconsIcon icon={ViewIcon} size={14} />;
+
+const CustomerRow = memo(function CustomerRow({
+  customer,
+}: {
+  customer: AdminCustomer;
+}) {
+  return (
+    <TableRow
+      style={{ contentVisibility: "auto", containIntrinsicSize: "0 56px" }}
+      className="transition-colors hover:bg-muted/50"
+    >
+      <TableCell>
+        <Link
+          href={`/customers/${customer.id}`}
+          className="flex items-center gap-3 hover:underline"
+        >
+          <Avatar className="h-8 w-8">
+            {customer.image && <AvatarImage src={customer.image} alt={customer.name} />}
+            <AvatarFallback className="text-xs">
+              {getInitials(customer.name)}
+            </AvatarFallback>
+          </Avatar>
+          <span className="font-medium">{customer.name}</span>
+        </Link>
+      </TableCell>
+      <TableCell className="text-muted-foreground">{customer.email}</TableCell>
+      <TableCell className="hidden md:table-cell text-muted-foreground">
+        {customer.phone || "—"}
+      </TableCell>
+      <TableCell>
+        <Badge variant={ROLE_VARIANTS[customer.role] || "secondary"}>
+          {ROLE_LABELS[customer.role] || customer.role}
+        </Badge>
+      </TableCell>
+      <TableCell className="hidden lg:table-cell text-muted-foreground">
+        {formatDate(customer.createdAt)}
+      </TableCell>
+      <TableCell className="hidden sm:table-cell text-center">
+        <Badge variant="outline">{customer.order_count}</Badge>
+      </TableCell>
+      <TableCell className="hidden sm:table-cell font-mono">
+        {formatPrice(customer.total_spent)}
+      </TableCell>
+      <TableCell>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon-xs">
+              {moreIcon}
+              <span className="sr-only">Actions</span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem asChild>
+              <Link href={`/customers/${customer.id}`} className="gap-2">
+                {viewIcon}
+                Voir détails
+              </Link>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </TableCell>
+    </TableRow>
+  );
+});
+
+export const CustomerTable = memo(function CustomerTable({
+  customers,
+}: {
+  customers: AdminCustomer[];
+}) {
+  if (customers.length === 0) {
+    return (
+      <div className="rounded-lg border p-8 text-center text-muted-foreground">
+        Aucun client trouvé
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Client</TableHead>
+            <TableHead>Email</TableHead>
+            <TableHead className="hidden md:table-cell">Téléphone</TableHead>
+            <TableHead>Rôle</TableHead>
+            <TableHead className="hidden lg:table-cell">Membre depuis</TableHead>
+            <TableHead className="hidden sm:table-cell text-center">Commandes</TableHead>
+            <TableHead className="hidden sm:table-cell">Total dépensé</TableHead>
+            <TableHead className="w-10"></TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {customers.map((customer) => (
+            <CustomerRow key={customer.id} customer={customer} />
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+});

--- a/components/admin/sidebar.tsx
+++ b/components/admin/sidebar.tsx
@@ -8,6 +8,7 @@ import {
   Package02Icon,
   FolderLibraryIcon,
   ShoppingBag01Icon,
+  UserGroup02Icon,
 } from "@hugeicons/core-free-icons";
 import { cn } from "@/lib/utils";
 
@@ -16,6 +17,7 @@ const navItems = [
   { href: "/products", label: "Produits", icon: Package02Icon },
   { href: "/categories", label: "Catégories", icon: FolderLibraryIcon },
   { href: "/orders", label: "Commandes", icon: ShoppingBag01Icon },
+  { href: "/customers", label: "Clients", icon: UserGroup02Icon },
 ];
 
 const disabledItems: typeof navItems = [];

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -1,0 +1,109 @@
+"use client"
+
+import * as React from "react"
+import { Avatar as AvatarPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Avatar({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Root> & {
+  size?: "default" | "sm" | "lg"
+}) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      data-size={size}
+      className={cn(
+        "size-8 rounded-full after:rounded-full data-[size=lg]:size-10 data-[size=sm]:size-6 after:border-border group/avatar relative flex shrink-0 select-none after:absolute after:inset-0 after:border after:mix-blend-darken dark:after:mix-blend-lighten",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarImage({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn(
+        "rounded-full aspect-square size-full object-cover",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        "bg-muted text-muted-foreground rounded-full flex size-full items-center justify-center text-sm group-data-[size=sm]/avatar:text-xs",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="avatar-badge"
+      className={cn(
+        "bg-primary text-primary-foreground ring-background absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full bg-blend-color ring-2 select-none",
+        "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
+        "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
+        "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group"
+      className={cn(
+        "*:data-[slot=avatar]:ring-background group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroupCount({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group-count"
+      className={cn("bg-muted text-muted-foreground size-8 rounded-full text-xs/relaxed group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3 ring-background relative flex shrink-0 items-center justify-center ring-2", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+  AvatarGroup,
+  AvatarGroupCount,
+  AvatarBadge,
+}

--- a/db/migrations/0006_users_is_active.sql
+++ b/db/migrations/0006_users_is_active.sql
@@ -1,0 +1,5 @@
+-- Add is_active column to users table for customer management
+ALTER TABLE users ADD COLUMN is_active INTEGER NOT NULL DEFAULT 1;
+
+-- Create index for filtering by active status
+CREATE INDEX IF NOT EXISTS idx_users_is_active ON users(is_active);

--- a/lib/constants/customers.ts
+++ b/lib/constants/customers.ts
@@ -1,0 +1,22 @@
+import type { UserRole } from "@/lib/db/types";
+
+export const ROLE_LABELS: Record<UserRole, string> = {
+  customer: "Client",
+  admin: "Admin",
+  super_admin: "Super Admin",
+};
+
+export const ROLE_VARIANTS: Record<
+  UserRole,
+  "default" | "secondary" | "destructive" | "outline"
+> = {
+  customer: "secondary",
+  admin: "default",
+  super_admin: "destructive",
+};
+
+export const ROLE_OPTIONS: { value: UserRole; label: string }[] = [
+  { value: "customer", label: "Client" },
+  { value: "admin", label: "Admin" },
+  { value: "super_admin", label: "Super Admin" },
+];

--- a/lib/db/admin/customers.ts
+++ b/lib/db/admin/customers.ts
@@ -1,0 +1,177 @@
+import { query, queryFirst } from "@/lib/db";
+import type {
+  Address,
+  AdminOrder,
+  AdminCustomer,
+  AdminCustomerDetail,
+  UserRole,
+} from "@/lib/db/types";
+
+export interface AdminCustomerFilters {
+  search?: string;
+  role?: string;
+  dateFrom?: string;
+  dateTo?: string;
+  sort?: "newest" | "oldest" | "name_asc" | "name_desc" | "spent_desc";
+  limit?: number;
+  offset?: number;
+}
+
+function buildFilterClause(opts: AdminCustomerFilters): {
+  where: string;
+  params: unknown[];
+} {
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+
+  if (opts.search) {
+    conditions.push(
+      "((u.first_name || ' ' || u.last_name) LIKE ? OR u.email LIKE ? OR u.phone LIKE ?)"
+    );
+    const term = `%${opts.search}%`;
+    params.push(term, term, term);
+  }
+
+  if (opts.role && opts.role !== "all") {
+    conditions.push("u.role = ?");
+    params.push(opts.role);
+  }
+
+  if (opts.dateFrom) {
+    conditions.push("u.created_at >= ?");
+    params.push(opts.dateFrom);
+  }
+
+  if (opts.dateTo) {
+    conditions.push("u.created_at <= ?");
+    params.push(opts.dateTo + " 23:59:59");
+  }
+
+  const where =
+    conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+  return { where, params };
+}
+
+export async function getAdminCustomers(
+  opts: AdminCustomerFilters = {}
+): Promise<AdminCustomer[]> {
+  const limit = opts.limit ?? 20;
+  const offset = opts.offset ?? 0;
+  const { where, params } = buildFilterClause(opts);
+
+  let orderBy = "u.created_at DESC";
+  switch (opts.sort) {
+    case "oldest":
+      orderBy = "u.created_at ASC";
+      break;
+    case "name_asc":
+      orderBy = "name ASC";
+      break;
+    case "name_desc":
+      orderBy = "name DESC";
+      break;
+    case "spent_desc":
+      orderBy = "total_spent DESC";
+      break;
+  }
+
+  return query<AdminCustomer>(
+    `SELECT
+       u.id,
+       (u.first_name || ' ' || u.last_name) as name,
+       u.email,
+       u.phone,
+       u.role,
+       u.email_verified as emailVerified,
+       u.image,
+       COALESCE(u.is_active, 1) as is_active,
+       u.created_at as createdAt,
+       COALESCE(stats.order_count, 0) as order_count,
+       COALESCE(stats.total_spent, 0) as total_spent
+     FROM users u
+     LEFT JOIN (
+       SELECT
+         user_id,
+         COUNT(*) as order_count,
+         SUM(total) as total_spent
+       FROM orders
+       WHERE status NOT IN ('cancelled', 'returned')
+       GROUP BY user_id
+     ) stats ON stats.user_id = u.id
+     ${where}
+     ORDER BY ${orderBy}
+     LIMIT ? OFFSET ?`,
+    [...params, limit, offset]
+  );
+}
+
+export async function getAdminCustomerCount(
+  opts: AdminCustomerFilters = {}
+): Promise<number> {
+  const { where, params } = buildFilterClause(opts);
+
+  const result = await queryFirst<{ count: number }>(
+    `SELECT COUNT(*) as count FROM users u ${where}`,
+    params
+  );
+  return result?.count ?? 0;
+}
+
+export async function getAdminCustomerById(
+  id: string
+): Promise<AdminCustomerDetail | null> {
+  const customer = await queryFirst<AdminCustomer>(
+    `SELECT
+       u.id,
+       (u.first_name || ' ' || u.last_name) as name,
+       u.email,
+       u.phone,
+       u.role,
+       u.email_verified as emailVerified,
+       u.image,
+       COALESCE(u.is_active, 1) as is_active,
+       u.created_at as createdAt,
+       COALESCE(stats.order_count, 0) as order_count,
+       COALESCE(stats.total_spent, 0) as total_spent
+     FROM users u
+     LEFT JOIN (
+       SELECT
+         user_id,
+         COUNT(*) as order_count,
+         SUM(total) as total_spent
+       FROM orders
+       WHERE status NOT IN ('cancelled', 'returned')
+       GROUP BY user_id
+     ) stats ON stats.user_id = u.id
+     WHERE u.id = ?`,
+    [id]
+  );
+
+  if (!customer) return null;
+
+  const [addresses, recent_orders] = await Promise.all([
+    query<Address>("SELECT * FROM addresses WHERE user_id = ? ORDER BY is_default DESC, created_at DESC", [id]),
+    query<AdminOrder>(
+      `SELECT o.*,
+         (SELECT COUNT(*) FROM order_items oi WHERE oi.order_id = o.id) as item_count,
+         u.email as user_email,
+         (u.first_name || ' ' || u.last_name) as user_name,
+         u.phone as user_phone
+       FROM orders o
+       LEFT JOIN users u ON u.id = o.user_id
+       WHERE o.user_id = ?
+       ORDER BY o.created_at DESC
+       LIMIT 10`,
+      [id]
+    ),
+  ]);
+
+  return { ...customer, addresses, recent_orders };
+}
+
+export async function getDistinctRoles(): Promise<UserRole[]> {
+  const rows = await query<{ role: UserRole }>(
+    "SELECT DISTINCT role FROM users ORDER BY role ASC"
+  );
+  return rows.map((r) => r.role);
+}

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -237,3 +237,25 @@ export interface AdminOrderDetail extends Order {
   user_name: string;
   user_phone: string | null;
 }
+
+// Customer Management Types
+export type UserRole = "customer" | "admin" | "super_admin";
+
+export interface AdminCustomer {
+  id: string;
+  name: string;
+  email: string;
+  phone: string | null;
+  role: UserRole;
+  emailVerified: number;
+  image: string | null;
+  is_active: number;
+  createdAt: string;
+  order_count: number;
+  total_spent: number;
+}
+
+export interface AdminCustomerDetail extends AdminCustomer {
+  addresses: Address[];
+  recent_orders: AdminOrder[];
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -30,6 +30,28 @@ export function formatOrderDate(dateStr: string): string {
   return new Date(dateStr).toLocaleDateString("fr-FR", orderDateFormatOptions);
 }
 
+// Short date format: "25 janv. 2024" (for tables/lists)
+const shortDateFormatOptions: Intl.DateTimeFormatOptions = {
+  day: "2-digit",
+  month: "short",
+  year: "numeric",
+};
+
+export function formatDateShort(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("fr-FR", shortDateFormatOptions);
+}
+
+// Long date format: "25 janvier 2024" (for detail pages)
+const longDateFormatOptions: Intl.DateTimeFormatOptions = {
+  day: "2-digit",
+  month: "long",
+  year: "numeric",
+};
+
+export function formatDateLong(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("fr-FR", longDateFormatOptions);
+}
+
 export interface ActionResult {
   success: boolean;
   error?: string;


### PR DESCRIPTION
## Summary
- Add `/customers` list page with filters (search, role, date range) and pagination
- Add `/customers/[id]` detail page with customer info, addresses, and order history
- Add admin actions: change user role (super_admin only), toggle account active/inactive
- Responsive design following existing patterns (table on desktop, cards on mobile)

## New Files
- `lib/db/admin/customers.ts` - Database queries
- `actions/admin/customers.ts` - Server actions
- `app/(admin)/customers/` - List and detail pages
- `components/admin/customer-*.tsx` - Table, card, filters components
- `components/ui/avatar.tsx` - Avatar component (shadcn)

## Modified Files
- `lib/db/types.ts` - Added `UserRole`, `AdminCustomer`, `AdminCustomerDetail` types
- `components/admin/sidebar.tsx` - Added "Clients" nav item

## Test plan
- [ ] Navigate to `/customers` and verify list displays
- [ ] Test search filter (name, email, phone)
- [ ] Test role filter dropdown
- [ ] Test date range filters
- [ ] Test pagination
- [ ] Click on a customer to view detail page
- [ ] Verify customer info, addresses, and orders display correctly
- [ ] Test toggle active/inactive (as admin)
- [ ] Test change role (as super_admin only)
- [ ] Verify responsive design on mobile

🤖 Generated with [Claude Code](https://claude.ai/code)