### PR TITLE
perf: minimal DTOs to reduce RSC payload for client components

### DIFF
--- a/app/(admin)/customers/[id]/_components/customer-sidebar.tsx
+++ b/app/(admin)/customers/[id]/_components/customer-sidebar.tsx
@@ -14,10 +14,10 @@ import {
 import { formatPrice, formatDateLong } from "@/lib/utils";
 import { ROLE_OPTIONS } from "@/lib/constants/customers";
 import { updateCustomerRole, toggleCustomerActive } from "@/actions/admin/customers";
-import type { AdminCustomerDetail, UserRole } from "@/lib/db/types";
+import type { CustomerSidebarData, UserRole } from "@/lib/db/types";
 
 interface CustomerSidebarProps {
-  customer: AdminCustomerDetail;
+  customer: CustomerSidebarData;
   isSuperAdmin: boolean;
 }
 

--- a/app/(admin)/customers/[id]/page.tsx
+++ b/app/(admin)/customers/[id]/page.tsx
@@ -10,6 +10,7 @@ import { CustomerInfo } from "./_components/customer-info";
 import { CustomerAddresses } from "./_components/customer-addresses";
 import { CustomerOrders } from "./_components/customer-orders";
 import { CustomerSidebar } from "./_components/customer-sidebar";
+import type { CustomerSidebarData } from "@/lib/db/types";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -57,7 +58,17 @@ export default async function CustomerDetailPage({ params }: Props) {
         </div>
 
         {/* Sidebar */}
-        <CustomerSidebar customer={customer} isSuperAdmin={isSuperAdmin} />
+        <CustomerSidebar
+          customer={{
+            id: customer.id,
+            order_count: customer.order_count,
+            total_spent: customer.total_spent,
+            createdAt: customer.createdAt,
+            role: customer.role,
+            is_active: customer.is_active,
+          } satisfies CustomerSidebarData}
+          isSuperAdmin={isSuperAdmin}
+        />
       </div>
     </div>
   );

--- a/app/(admin)/orders/_components/orders-client-wrapper.tsx
+++ b/app/(admin)/orders/_components/orders-client-wrapper.tsx
@@ -7,10 +7,10 @@ import { OrderTable } from "@/components/admin/order-table";
 import { OrderCardMobile } from "@/components/admin/order-card-mobile";
 import { OrderFilters } from "@/components/admin/order-filters";
 import { OrderFilterSheet } from "@/components/admin/order-filter-sheet";
-import type { AdminOrder } from "@/lib/db/types";
+import type { OrderListItem } from "@/lib/db/types";
 
 interface OrdersClientWrapperProps {
-  orders: AdminOrder[];
+  orders: OrderListItem[];
   communes: string[];
 }
 

--- a/app/(admin)/orders/page.tsx
+++ b/app/(admin)/orders/page.tsx
@@ -8,6 +8,7 @@ import {
   getAdminOrderCount,
   getDistinctCommunes,
 } from "@/lib/db/admin/orders";
+import type { OrderListItem } from "@/lib/db/types";
 
 interface Props {
   searchParams: Promise<{
@@ -43,6 +44,18 @@ export default async function OrdersPage({ searchParams }: Props) {
 
   const totalPages = Math.ceil(totalCount / PAGE_SIZE);
 
+  const orderListData: OrderListItem[] = orders.map((o) => ({
+    id: o.id,
+    order_number: o.order_number,
+    created_at: o.created_at,
+    user_name: o.user_name,
+    delivery_phone: o.delivery_phone,
+    delivery_commune: o.delivery_commune,
+    total: o.total,
+    item_count: o.item_count,
+    status: o.status,
+  }));
+
   return (
     <div>
       <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
@@ -51,7 +64,7 @@ export default async function OrdersPage({ searchParams }: Props) {
       </div>
 
       {/* Client wrapper handles responsive filters + data list */}
-      <OrdersClientWrapper orders={orders} communes={communes} />
+      <OrdersClientWrapper orders={orderListData} communes={communes} />
 
       {totalPages > 1 && (
         <div className="mt-4 flex items-center justify-between text-sm text-muted-foreground">

--- a/app/(storefront)/search/filter-context.tsx
+++ b/app/(storefront)/search/filter-context.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { createContext, useContext } from "react";
-import type { Category, PriceRange } from "@/lib/db/types";
+import type { CategoryFilterItem, PriceRange } from "@/lib/db/types";
 
 interface FilterData {
-  categories: Category[];
+  categories: CategoryFilterItem[];
   brands: string[];
   priceRange: PriceRange;
   basePath: string;

--- a/app/(storefront)/search/page.tsx
+++ b/app/(storefront)/search/page.tsx
@@ -64,7 +64,7 @@ export default async function SearchPage({ searchParams }: Props) {
   const hasMore = (currentPage - 1) * limit + products.length < total;
 
   return (
-    <FilterProvider categories={categories} brands={brands} priceRange={priceRange}>
+    <FilterProvider categories={categories.map((c) => ({ id: c.id, name: c.name, slug: c.slug }))} brands={brands} priceRange={priceRange}>
       <div className="mx-auto max-w-7xl px-4 py-6">
         {/* Header */}
         <div className="mb-6">

--- a/app/(storefront)/search/page.tsx
+++ b/app/(storefront)/search/page.tsx
@@ -3,7 +3,7 @@ import { searchProducts, countSearchResults, getBrandsInUse, getPriceRange } fro
 import { getCategories } from "@/lib/db/categories";
 import { ProductGrid } from "@/components/storefront/product-grid";
 import { SITE_NAME } from "@/lib/utils/constants";
-import type { SearchOptions } from "@/lib/db/types";
+import type { SearchOptions, CategoryFilterItem } from "@/lib/db/types";
 import { FilterProvider } from "./filter-context";
 import { SearchFilters } from "./search-filters";
 import { SearchSort } from "./search-sort";
@@ -63,8 +63,12 @@ export default async function SearchPage({ searchParams }: Props) {
 
   const hasMore = (currentPage - 1) * limit + products.length < total;
 
+  const categoryFilterData = categories.map((c) => ({
+    id: c.id, name: c.name, slug: c.slug,
+  } satisfies CategoryFilterItem));
+
   return (
-    <FilterProvider categories={categories.map((c) => ({ id: c.id, name: c.name, slug: c.slug }))} brands={brands} priceRange={priceRange}>
+    <FilterProvider categories={categoryFilterData} brands={brands} priceRange={priceRange}>
       <div className="mx-auto max-w-7xl px-4 py-6">
         {/* Header */}
         <div className="mb-6">

--- a/components/admin/order-card-mobile.tsx
+++ b/components/admin/order-card-mobile.tsx
@@ -15,10 +15,10 @@ import { StatusBadge } from "@/components/ui/status-badge";
 import { ActionSheet, type ActionSheetItem } from "./action-sheet";
 import { formatPrice, formatOrderDate } from "@/lib/utils";
 import { ORDER_STATUS_CONFIG, getOrderStatus } from "@/lib/constants/orders";
-import type { AdminOrder } from "@/lib/db/types";
+import type { OrderListItem } from "@/lib/db/types";
 
 interface OrderCardMobileProps {
-  order: AdminOrder;
+  order: OrderListItem;
 }
 
 export function OrderCardMobile({ order }: OrderCardMobileProps) {

--- a/components/admin/order-table.tsx
+++ b/components/admin/order-table.tsx
@@ -23,7 +23,7 @@ import { MoreVerticalIcon, ViewIcon, PrinterIcon } from "@hugeicons/core-free-ic
 import { StatusBadge } from "@/components/ui/status-badge";
 import { formatPrice, formatOrderDate } from "@/lib/utils";
 import { ORDER_STATUS_CONFIG, getOrderStatus } from "@/lib/constants/orders";
-import type { AdminOrder } from "@/lib/db/types";
+import type { OrderListItem } from "@/lib/db/types";
 
 // Hoisted static JSX element (rendering-hoist-jsx)
 const moreIcon = <HugeiconsIcon icon={MoreVerticalIcon} size={16} />;
@@ -33,7 +33,7 @@ const viewIcon = <HugeiconsIcon icon={ViewIcon} size={14} />;
 const printerIcon = <HugeiconsIcon icon={PrinterIcon} size={14} />;
 
 // Memoized row component for better performance (rerender-memo)
-const OrderRow = memo(function OrderRow({ order }: { order: AdminOrder }) {
+const OrderRow = memo(function OrderRow({ order }: { order: OrderListItem }) {
   const orderStatus = getOrderStatus(order.status);
   const statusConfig = ORDER_STATUS_CONFIG[orderStatus];
   return (
@@ -106,7 +106,7 @@ const OrderRow = memo(function OrderRow({ order }: { order: AdminOrder }) {
 });
 
 // Memoized table component to prevent unnecessary re-renders (rerender-memo)
-export const OrderTable = memo(function OrderTable({ orders }: { orders: AdminOrder[] }) {
+export const OrderTable = memo(function OrderTable({ orders }: { orders: OrderListItem[] }) {
   if (orders.length === 0) {
     return (
       <div className="rounded-lg border p-8 text-center text-muted-foreground">

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -261,34 +261,20 @@ export interface AdminCustomerDetail extends AdminCustomer {
 }
 
 /** Order data for admin list views (table/cards). */
-export interface OrderListItem {
-  id: string;
-  order_number: string;
-  created_at: string;
-  user_name: string;
-  delivery_phone: string;
-  delivery_commune: string;
-  total: number;
-  item_count: number;
-  status: string;
-}
+export type OrderListItem = Pick<
+  AdminOrder,
+  'id' | 'order_number' | 'created_at' | 'user_name' |
+  'delivery_phone' | 'delivery_commune' | 'total' | 'item_count' | 'status'
+>;
 
 /** Customer data for admin sidebar actions. */
-export interface CustomerSidebarData {
-  id: string;
-  order_count: number;
-  total_spent: number;
-  createdAt: string;
-  role: UserRole;
-  is_active: number;
-}
+export type CustomerSidebarData = Pick<
+  AdminCustomerDetail,
+  'id' | 'order_count' | 'total_spent' | 'createdAt' | 'role' | 'is_active'
+>;
 
 /** Category data for filter/picker UIs. */
-export interface CategoryFilterItem {
-  id: string;
-  name: string;
-  slug: string;
-}
+export type CategoryFilterItem = Pick<Category, 'id' | 'name' | 'slug'>;
 
 // Audit Log Types
 export type AuditAction =

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -260,6 +260,36 @@ export interface AdminCustomerDetail extends AdminCustomer {
   recent_orders: AdminOrder[];
 }
 
+/** Order data for admin list views (table/cards). */
+export interface OrderListItem {
+  id: string;
+  order_number: string;
+  created_at: string;
+  user_name: string;
+  delivery_phone: string;
+  delivery_commune: string;
+  total: number;
+  item_count: number;
+  status: string;
+}
+
+/** Customer data for admin sidebar actions. */
+export interface CustomerSidebarData {
+  id: string;
+  order_count: number;
+  total_spent: number;
+  createdAt: string;
+  role: UserRole;
+  is_active: number;
+}
+
+/** Category data for filter/picker UIs. */
+export interface CategoryFilterItem {
+  id: string;
+  name: string;
+  slug: string;
+}
+
 // Audit Log Types
 export type AuditAction =
   | "user.role_changed"


### PR DESCRIPTION
## Summary

- **Added 3 lightweight DTO interfaces** in `lib/db/types.ts`: `OrderListItem` (9 fields), `CustomerSidebarData` (6 fields), `CategoryFilterItem` (3 fields)
- **Admin Orders list**: maps `AdminOrder` (21+ fields) → `OrderListItem` server-side before passing to client wrapper, table, and mobile card components (~12 unused fields dropped per order × 20/page)
- **Customer Sidebar**: extracts 6 scalar fields from `AdminCustomerDetail` instead of serializing the full object with nested `recent_orders[]` (10 × 21+ fields) and `addresses[]` (N × 11 fields)
- **Search Filters**: maps `Category` (10 fields) → `CategoryFilterItem` (3 fields) before passing to `FilterProvider` client context

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] `npm run lint` passes (verified locally)
- [ ] `/orders` — table and card views render correctly
- [ ] `/customers/:id` — sidebar displays stats, role select, active toggle
- [ ] `/search` — category filters work (select/deselect)
- [ ] Verify in DevTools (Network > `_rsc`) that RSC payload is reduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)