### PR TITLE
fix: resolve dev environment blockers for local D1 + better-auth

### DIFF
--- a/app/(admin)/layout.tsx
+++ b/app/(admin)/layout.tsx
@@ -1,13 +1,7 @@
-// Aliased to avoid conflict with `export const dynamic = "force-dynamic"` below
-import nextDynamic from "next/dynamic";
 import { requireAdmin } from "@/lib/auth/guards";
 import { Sidebar } from "@/components/admin/sidebar";
 import { ViewProvider } from "@/components/admin/view-context";
-
-const Toaster = nextDynamic(
-  () => import("@/components/ui/sonner").then((m) => ({ default: m.Toaster })),
-  { ssr: false }
-);
+import { Toaster } from "@/components/ui/sonner";
 
 export const dynamic = "force-dynamic";
 

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -3,17 +3,18 @@ import { captcha } from "better-auth/plugins";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { drizzle } from "drizzle-orm/d1";
+import * as schema from "@/lib/db/schema";
 
 export async function initAuth() {
   const { env } = await getCloudflareContext();
   const cfEnv = env as CloudflareEnv;
 
-  const db = drizzle(cfEnv.DB);
+  const db = drizzle(cfEnv.DB, { schema });
 
   return betterAuth({
     baseURL: cfEnv.SITE_URL,
     secret: cfEnv.BETTER_AUTH_SECRET,
-    database: drizzleAdapter(db, { provider: "sqlite" }),
+    database: drizzleAdapter(db, { provider: "sqlite", schema }),
     emailAndPassword: {
       enabled: true,
     },


### PR DESCRIPTION
## Summary

- **Admin layout: remove `next/dynamic` with `ssr: false`** — Not allowed in Server Components since Next.js 16. The `Toaster` from `components/ui/sonner.tsx` already has `"use client"`, so a direct import works.
- **Pass Drizzle schema to better-auth adapter** — Without schema, the adapter couldn't find the `user` model, causing `BetterAuthError: The model "user" was not found`.
- **Add `dateText` custom column type** — better-auth passes JS `Date` objects for session/account date fields, but D1's `bind()` rejects non-primitive values. `dateText` serializes `Date` → ISO string before hitting D1 while keeping `TEXT` as the SQL type (no migration needed).

### Dev setup note
Developers need to create `.dev.vars` and `.env.local` locally (both are gitignored):

```bash
# .dev.vars
BETTER_AUTH_SECRET=dev-secret-change-me-in-production
SITE_URL=http://localhost:3000
TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA
GOOGLE_CLIENT_ID=placeholder
GOOGLE_CLIENT_SECRET=placeholder
FACEBOOK_APP_ID=placeholder
FACEBOOK_APP_SECRET=placeholder
APPLE_CLIENT_ID=placeholder
APPLE_CLIENT_SECRET=placeholder

# .env.local
NEXT_PUBLIC_TURNSTILE_SITE_KEY=1x00000000000000000000AA
```

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] Login with `admin@netereka.test` / `Test123!` succeeds
- [x] `/orders` loads — table, filters, view switcher all functional
- [x] No console errors on `/orders`

🤖 Generated with [Claude Code](https://claude.com/claude-code)