### PR TITLE
feat: admin UX improvements — user menu, sticky headers, cross-navigation

### DIFF
--- a/app/(admin)/audit-log/page.tsx
+++ b/app/(admin)/audit-log/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { AdminHeader } from "@/components/admin/admin-header";
+import { AdminPageHeader } from "@/components/admin/admin-page-header";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -110,9 +111,10 @@ export default async function AuditLogPage({ searchParams }: Props) {
 
   return (
     <div>
-      <AdminHeader title="Journal d'audit" />
-
-      <AuditLogFilters />
+      <AdminPageHeader className="space-y-4">
+        <AdminHeader title="Journal d'audit" />
+        <AuditLogFilters />
+      </AdminPageHeader>
 
       {logs.length === 0 ? (
         <div className="rounded-lg border p-8 text-center text-muted-foreground">

--- a/app/(admin)/categories/page.tsx
+++ b/app/(admin)/categories/page.tsx
@@ -1,4 +1,5 @@
 import { AdminHeader } from "@/components/admin/admin-header";
+import { AdminPageHeader } from "@/components/admin/admin-page-header";
 import { CategoryCreateButton } from "./category-create-button";
 import { getAllCategories } from "@/lib/db/admin/categories";
 import { CategoriesPageClient } from "./categories-page-client";
@@ -8,15 +9,16 @@ export default async function CategoriesPage() {
 
   return (
     <div>
-      <AdminHeader title="Catégories" />
-
-      {/* Desktop header */}
-      <div className="mb-4 hidden items-center justify-between lg:flex">
-        <p className="text-sm text-muted-foreground">
-          {categories.length} catégorie(s)
-        </p>
-        <CategoryCreateButton />
-      </div>
+      <AdminPageHeader className="space-y-4">
+        <AdminHeader title="Catégories" />
+        {/* Desktop header */}
+        <div className="hidden items-center justify-between lg:flex">
+          <p className="text-sm text-muted-foreground">
+            {categories.length} catégorie(s)
+          </p>
+          <CategoryCreateButton />
+        </div>
+      </AdminPageHeader>
 
       {/* Mobile/responsive content */}
       <CategoriesPageClient categories={categories} />

--- a/app/(admin)/customers/[id]/page.tsx
+++ b/app/(admin)/customers/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ArrowLeft02Icon } from "@hugeicons/core-free-icons";
+import { AdminPageHeader } from "@/components/admin/admin-page-header";
 import { requireAdmin } from "@/lib/auth/guards";
 import { getAdminCustomerById } from "@/lib/db/admin/customers";
 import { getUserTypeLabel } from "@/lib/constants/customers";
@@ -29,25 +30,27 @@ export default async function CustomerDetailPage({ params }: Props) {
 
   return (
     <div>
-      <header className="mb-6 flex items-center gap-3">
-        <Button
-          variant="ghost"
-          size="icon"
-          asChild
-          className="h-11 w-11 shrink-0"
-          aria-label="Retour à la liste des utilisateurs"
-        >
-          <Link href="/customers">{backIcon}</Link>
-        </Button>
-        <div className="min-w-0">
-          <h1 className="truncate text-lg font-bold sm:text-2xl">
-            {customer.name}
-          </h1>
-          <p className="text-sm text-muted-foreground">
-            Fiche {getUserTypeLabel(customer.role)}
-          </p>
-        </div>
-      </header>
+      <AdminPageHeader>
+        <header className="flex items-center gap-3">
+          <Button
+            variant="ghost"
+            size="icon"
+            asChild
+            className="h-11 w-11 shrink-0"
+            aria-label="Retour à la liste des utilisateurs"
+          >
+            <Link href="/customers">{backIcon}</Link>
+          </Button>
+          <div className="min-w-0">
+            <h1 className="truncate text-lg font-bold sm:text-2xl">
+              {customer.name}
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              Fiche {getUserTypeLabel(customer.role)}
+            </p>
+          </div>
+        </header>
+      </AdminPageHeader>
 
       <div className="grid gap-6 lg:grid-cols-3">
         {/* Main Content */}

--- a/app/(admin)/customers/page.tsx
+++ b/app/(admin)/customers/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { AdminHeader } from "@/components/admin/admin-header";
+import { AdminPageHeader } from "@/components/admin/admin-page-header";
 import { CustomersClientWrapper } from "./_components/customers-client-wrapper";
 import { Button } from "@/components/ui/button";
 import {
@@ -59,7 +60,9 @@ export default async function CustomersPage({ searchParams }: Props) {
 
   return (
     <div>
-      <AdminHeader title="Utilisateurs" />
+      <AdminPageHeader>
+        <AdminHeader title="Utilisateurs" />
+      </AdminPageHeader>
 
       {/* Client wrapper handles responsive filters + data list */}
       <CustomersClientWrapper customers={customers} />

--- a/app/(admin)/dashboard/page.tsx
+++ b/app/(admin)/dashboard/page.tsx
@@ -1,5 +1,6 @@
 import { getDashboardStats } from "@/lib/db/admin/dashboard";
 import { AdminHeader } from "@/components/admin/admin-header";
+import { AdminPageHeader } from "@/components/admin/admin-page-header";
 import { StatsCard } from "@/components/admin/stats-card";
 
 export default async function DashboardPage() {
@@ -7,7 +8,9 @@ export default async function DashboardPage() {
 
   return (
     <div>
-      <AdminHeader title="Dashboard" />
+      <AdminPageHeader>
+        <AdminHeader title="Dashboard" />
+      </AdminPageHeader>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <StatsCard
           title="Produits"

--- a/app/(admin)/layout.tsx
+++ b/app/(admin)/layout.tsx
@@ -17,7 +17,7 @@ export default async function AdminLayout({
     <AdminUserProvider user={session.user}>
     <ViewProvider>
       <div className="flex min-h-dvh">
-        <aside className="hidden w-64 shrink-0 border-r bg-sidebar lg:block">
+        <aside className="sticky top-0 hidden h-dvh w-64 shrink-0 overflow-y-auto border-r bg-sidebar lg:block">
           <Sidebar />
         </aside>
         <main className="flex-1 overflow-x-hidden p-4 sm:p-6">{children}</main>

--- a/app/(admin)/layout.tsx
+++ b/app/(admin)/layout.tsx
@@ -20,7 +20,7 @@ export default async function AdminLayout({
         <aside className="sticky top-0 hidden h-dvh w-64 shrink-0 overflow-y-auto border-r bg-sidebar lg:block">
           <Sidebar />
         </aside>
-        <main className="flex-1 overflow-x-hidden p-4 sm:p-6">{children}</main>
+        <main className="flex-1 h-dvh overflow-x-hidden overflow-y-auto p-4 sm:p-6">{children}</main>
         <Toaster richColors position="top-right" />
       </div>
     </ViewProvider>

--- a/app/(admin)/layout.tsx
+++ b/app/(admin)/layout.tsx
@@ -1,6 +1,7 @@
 import { requireAdmin } from "@/lib/auth/guards";
 import { Sidebar } from "@/components/admin/sidebar";
 import { ViewProvider } from "@/components/admin/view-context";
+import { AdminUserProvider } from "@/components/admin/admin-user-context";
 import { Toaster } from "@/components/ui/sonner";
 
 export const dynamic = "force-dynamic";
@@ -10,9 +11,10 @@ export default async function AdminLayout({
 }: {
   children: React.ReactNode;
 }) {
-  await requireAdmin();
+  const session = await requireAdmin();
 
   return (
+    <AdminUserProvider user={session.user}>
     <ViewProvider>
       <div className="flex min-h-dvh">
         <aside className="hidden w-64 shrink-0 border-r bg-sidebar lg:block">
@@ -22,5 +24,6 @@ export default async function AdminLayout({
         <Toaster richColors position="top-right" />
       </div>
     </ViewProvider>
+    </AdminUserProvider>
   );
 }

--- a/app/(admin)/orders/[id]/page.tsx
+++ b/app/(admin)/orders/[id]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ArrowLeft02Icon } from "@hugeicons/core-free-icons";
+import { AdminPageHeader } from "@/components/admin/admin-page-header";
 import { getAdminOrderById } from "@/lib/db/admin/orders";
 import { OrderMainContent } from "./_components/order-main-content";
 import { OrderSidebarAsync, OrderSidebarSkeleton } from "./_components/order-sidebar";
@@ -23,25 +24,27 @@ export default async function OrderDetailPage({ params }: Props) {
 
   return (
     <div>
-      <header className="mb-6 flex items-center gap-3">
-        <Button
-          variant="ghost"
-          size="icon"
-          asChild
-          className="h-11 w-11 shrink-0"
-          aria-label="Retour à la liste des commandes"
-        >
-          <Link href="/orders">
-            {backIcon}
-          </Link>
-        </Button>
-        <div className="min-w-0">
-          <h1 className="truncate text-lg font-bold sm:text-2xl">
-            {order.order_number}
-          </h1>
-          <p className="text-sm text-muted-foreground">Détails de la commande</p>
-        </div>
-      </header>
+      <AdminPageHeader>
+        <header className="flex items-center gap-3">
+          <Button
+            variant="ghost"
+            size="icon"
+            asChild
+            className="h-11 w-11 shrink-0"
+            aria-label="Retour à la liste des commandes"
+          >
+            <Link href="/orders">
+              {backIcon}
+            </Link>
+          </Button>
+          <div className="min-w-0">
+            <h1 className="truncate text-lg font-bold sm:text-2xl">
+              {order.order_number}
+            </h1>
+            <p className="text-sm text-muted-foreground">Détails de la commande</p>
+          </div>
+        </header>
+      </AdminPageHeader>
 
       <div className="grid gap-6 lg:grid-cols-3">
         {/* Main Content - Synchronous since order data is already fetched */}

--- a/app/(admin)/orders/page.tsx
+++ b/app/(admin)/orders/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { AdminHeader } from "@/components/admin/admin-header";
+import { AdminPageHeader } from "@/components/admin/admin-page-header";
 import { OrdersClientWrapper } from "./_components/orders-client-wrapper";
 import { OrderExportButton } from "@/components/admin/order-export-button";
 import { Button } from "@/components/ui/button";
@@ -58,10 +59,12 @@ export default async function OrdersPage({ searchParams }: Props) {
 
   return (
     <div>
-      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
-        <AdminHeader title="Commandes" className="mb-0" />
-        <OrderExportButton />
-      </div>
+      <AdminPageHeader>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <AdminHeader title="Commandes" />
+          <OrderExportButton />
+        </div>
+      </AdminPageHeader>
 
       {/* Client wrapper handles responsive filters + data list */}
       <OrdersClientWrapper orders={orderListData} communes={communes} />

--- a/app/(admin)/products/[id]/edit/page.tsx
+++ b/app/(admin)/products/[id]/edit/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ArrowLeft02Icon } from "@hugeicons/core-free-icons";
 import { Button } from "@/components/ui/button";
+import { AdminPageHeader } from "@/components/admin/admin-page-header";
 import { ProductForm } from "@/components/admin/product-form";
 import { VariantList } from "@/components/admin/variant-list";
 import { ImageManager } from "@/components/admin/image-manager";
@@ -25,23 +26,25 @@ export default async function EditProductPage({ params }: Props) {
 
   return (
     <div>
-      <header className="mb-6 flex items-center gap-3">
-        <Button
-          variant="ghost"
-          size="icon"
-          asChild
-          className="h-11 w-11 shrink-0"
-          aria-label="Retour aux produits"
-        >
-          <Link href="/products">
-            <HugeiconsIcon icon={ArrowLeft02Icon} size={20} />
-          </Link>
-        </Button>
-        <div className="min-w-0">
-          <h1 className="truncate text-lg font-bold sm:text-2xl">{product.name}</h1>
-          <p className="text-sm text-muted-foreground">Modifier le produit</p>
-        </div>
-      </header>
+      <AdminPageHeader>
+        <header className="flex items-center gap-3">
+          <Button
+            variant="ghost"
+            size="icon"
+            asChild
+            className="h-11 w-11 shrink-0"
+            aria-label="Retour aux produits"
+          >
+            <Link href="/products">
+              <HugeiconsIcon icon={ArrowLeft02Icon} size={20} />
+            </Link>
+          </Button>
+          <div className="min-w-0">
+            <h1 className="truncate text-lg font-bold sm:text-2xl">{product.name}</h1>
+            <p className="text-sm text-muted-foreground">Modifier le produit</p>
+          </div>
+        </header>
+      </AdminPageHeader>
       <Tabs defaultValue="info" className="space-y-6">
         <TabsList>
           <TabsTrigger value="info">Informations</TabsTrigger>

--- a/app/(admin)/products/new/page.tsx
+++ b/app/(admin)/products/new/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ArrowLeft02Icon } from "@hugeicons/core-free-icons";
 import { Button } from "@/components/ui/button";
+import { AdminPageHeader } from "@/components/admin/admin-page-header";
 import { ProductForm } from "@/components/admin/product-form";
 import { getAllCategories } from "@/lib/db/admin/categories";
 
@@ -10,23 +11,25 @@ export default async function NewProductPage() {
 
   return (
     <div>
-      <header className="mb-6 flex items-center gap-3">
-        <Button
-          variant="ghost"
-          size="icon"
-          asChild
-          className="h-11 w-11 shrink-0"
-          aria-label="Retour aux produits"
-        >
-          <Link href="/products">
-            <HugeiconsIcon icon={ArrowLeft02Icon} size={20} />
-          </Link>
-        </Button>
-        <div className="min-w-0">
-          <h1 className="text-lg font-bold sm:text-2xl">Nouveau produit</h1>
-          <p className="text-sm text-muted-foreground">Créer un produit</p>
-        </div>
-      </header>
+      <AdminPageHeader>
+        <header className="flex items-center gap-3">
+          <Button
+            variant="ghost"
+            size="icon"
+            asChild
+            className="h-11 w-11 shrink-0"
+            aria-label="Retour aux produits"
+          >
+            <Link href="/products">
+              <HugeiconsIcon icon={ArrowLeft02Icon} size={20} />
+            </Link>
+          </Button>
+          <div className="min-w-0">
+            <h1 className="text-lg font-bold sm:text-2xl">Nouveau produit</h1>
+            <p className="text-sm text-muted-foreground">Créer un produit</p>
+          </div>
+        </header>
+      </AdminPageHeader>
       <ProductForm categories={categories.map((c) => ({ id: c.id, name: c.name }))} />
     </div>
   );

--- a/app/(admin)/products/page.tsx
+++ b/app/(admin)/products/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { AdminHeader } from "@/components/admin/admin-header";
+import { AdminPageHeader } from "@/components/admin/admin-page-header";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { ProductFilters } from "@/components/admin/product-filters";
@@ -57,18 +58,19 @@ export default async function ProductsPage({ searchParams }: Props) {
 
   return (
     <div>
-      <AdminHeader title="Produits" />
-
-      {/* Desktop filters - instant filtering */}
-      <div className="mb-4 hidden items-center justify-between gap-3 lg:flex">
-        <ProductFilters
-          categories={categories.map((c) => ({ id: c.id, name: c.name }))}
-          className="flex-1"
-        />
-        <Button asChild>
-          <Link href="/products/new">Nouveau produit</Link>
-        </Button>
-      </div>
+      <AdminPageHeader className="space-y-4">
+        <AdminHeader title="Produits" />
+        {/* Desktop filters - instant filtering */}
+        <div className="hidden items-center justify-between gap-3 lg:flex">
+          <ProductFilters
+            categories={categories.map((c) => ({ id: c.id, name: c.name }))}
+            className="flex-1"
+          />
+          <Button asChild>
+            <Link href="/products/new">Nouveau produit</Link>
+          </Button>
+        </div>
+      </AdminPageHeader>
 
       {/* Mobile header with filter sheet and view switcher */}
       <ProductsPageClient

--- a/components/admin/admin-header.tsx
+++ b/components/admin/admin-header.tsx
@@ -14,7 +14,7 @@ interface AdminHeaderProps {
 
 export function AdminHeader({ title, className }: AdminHeaderProps) {
   return (
-    <header className={cn("mb-6 flex items-center gap-4", className)}>
+    <header className={cn("flex items-center gap-4", className)}>
       <Sheet>
         <SheetTrigger asChild>
           <Button variant="ghost" size="icon" className="lg:hidden">

--- a/components/admin/admin-page-header.tsx
+++ b/components/admin/admin-page-header.tsx
@@ -1,0 +1,22 @@
+import { cn } from "@/lib/utils";
+
+export function AdminPageHeader({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "sticky -top-4 sm:-top-6 z-10 bg-background",
+        "-mx-4 -mt-4 mb-4 px-4 pt-6 pb-4",
+        "sm:-mx-6 sm:-mt-6 sm:mb-6 sm:px-6 sm:pt-9",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/components/admin/admin-page-header.tsx
+++ b/components/admin/admin-page-header.tsx
@@ -7,6 +7,8 @@ export function AdminPageHeader({
   children: React.ReactNode;
   className?: string;
 }) {
+  // Negative margins/top mirror <main>'s p-4 sm:p-6 to extend the bg to the edges.
+  // If main padding changes, update these values accordingly.
   return (
     <div
       className={cn(

--- a/components/admin/admin-user-context.tsx
+++ b/components/admin/admin-user-context.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
+
+export type AdminUser = {
+  id: string;
+  name: string;
+  email: string;
+  image?: string | null;
+  role: string;
+};
+
+const AdminUserContext = createContext<AdminUser | null>(null);
+
+export function AdminUserProvider({
+  user,
+  children,
+}: {
+  user: AdminUser;
+  children: ReactNode;
+}) {
+  return (
+    <AdminUserContext.Provider value={user}>
+      {children}
+    </AdminUserContext.Provider>
+  );
+}
+
+export function useAdminUser(): AdminUser {
+  const ctx = useContext(AdminUserContext);
+  if (!ctx) {
+    throw new Error("useAdminUser must be used within an AdminUserProvider");
+  }
+  return ctx;
+}

--- a/components/admin/admin-user-context.tsx
+++ b/components/admin/admin-user-context.tsx
@@ -7,7 +7,7 @@ export type AdminUser = {
   name: string;
   email: string;
   image?: string | null;
-  role: string;
+  role: "customer" | "admin" | "super_admin";
 };
 
 const AdminUserContext = createContext<AdminUser | null>(null);

--- a/components/admin/sidebar-user-menu.tsx
+++ b/components/admin/sidebar-user-menu.tsx
@@ -50,7 +50,7 @@ export function SidebarUserMenu() {
           </DropdownMenuLabel>
           <DropdownMenuSeparator />
           <DropdownMenuItem asChild>
-            <Link href="/">
+            <Link href="/" target="_blank">
               <HugeiconsIcon icon={ShoppingBag01Icon} size={16} />
               Voir la boutique
             </Link>

--- a/components/admin/sidebar-user-menu.tsx
+++ b/components/admin/sidebar-user-menu.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ShoppingBag01Icon, Logout01Icon } from "@hugeicons/core-free-icons";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useAdminUser } from "./admin-user-context";
+import { authClient } from "@/lib/auth/client";
+
+export function SidebarUserMenu() {
+  const user = useAdminUser();
+  const router = useRouter();
+
+  const initials = (user.name || "?")
+    .split(" ")
+    .filter(Boolean)
+    .map((w) => w[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+
+  return (
+    <div className="border-t p-4">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium outline-none transition-colors hover:bg-sidebar-accent/50 focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label="Menu utilisateur"
+          >
+            <Avatar size="default">
+              {user.image && <AvatarImage src={user.image} alt={user.name} />}
+              <AvatarFallback>{initials}</AvatarFallback>
+            </Avatar>
+            <span className="truncate">{user.name}</span>
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent side="top" align="start" className="w-52">
+          <DropdownMenuLabel className="font-normal">
+            <p className="text-sm font-medium">{user.name}</p>
+            <p className="text-xs text-muted-foreground">{user.email}</p>
+          </DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem asChild>
+            <Link href="/">
+              <HugeiconsIcon icon={ShoppingBag01Icon} size={16} />
+              Voir la boutique
+            </Link>
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            variant="destructive"
+            onClick={async () => {
+              await authClient.signOut();
+              router.refresh();
+            }}
+          >
+            <HugeiconsIcon icon={Logout01Icon} size={16} />
+            Déconnexion
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/components/admin/sidebar-user-menu.tsx
+++ b/components/admin/sidebar-user-menu.tsx
@@ -66,7 +66,7 @@ export function SidebarUserMenu() {
             variant="destructive"
             onClick={async () => {
               await authClient.signOut();
-              router.refresh();
+              router.push("/auth/sign-in");
             }}
           >
             <HugeiconsIcon icon={Logout01Icon} size={16} />

--- a/components/admin/sidebar-user-menu.tsx
+++ b/components/admin/sidebar-user-menu.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { ShoppingBag01Icon, Logout01Icon } from "@hugeicons/core-free-icons";
+import { UserIcon, ShoppingBag01Icon, Logout01Icon } from "@hugeicons/core-free-icons";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import {
   DropdownMenu,
@@ -49,6 +49,12 @@ export function SidebarUserMenu() {
             <p className="text-xs text-muted-foreground">{user.email}</p>
           </DropdownMenuLabel>
           <DropdownMenuSeparator />
+          <DropdownMenuItem asChild>
+            <Link href="/account" target="_blank">
+              <HugeiconsIcon icon={UserIcon} size={16} />
+              Mon profil
+            </Link>
+          </DropdownMenuItem>
           <DropdownMenuItem asChild>
             <Link href="/" target="_blank">
               <HugeiconsIcon icon={ShoppingBag01Icon} size={16} />

--- a/components/admin/sidebar.tsx
+++ b/components/admin/sidebar.tsx
@@ -12,6 +12,7 @@ import {
   Audit01Icon,
 } from "@hugeicons/core-free-icons";
 import { cn } from "@/lib/utils";
+import { SidebarUserMenu } from "./sidebar-user-menu";
 
 const navItems = [
   { href: "/dashboard", label: "Dashboard", icon: DashboardSquare01Icon },
@@ -28,41 +29,46 @@ export function Sidebar() {
   const pathname = usePathname();
 
   return (
-    <nav className="flex flex-col gap-1 p-4">
-      <div className="mb-6 px-3">
-        <h2 className="text-lg font-bold tracking-tight">NETEREKA</h2>
-        <p className="text-xs text-muted-foreground">Administration</p>
-      </div>
-      {navItems.map((item) => {
-        const isActive =
-          pathname === item.href ||
-          (item.href !== "/dashboard" && pathname.startsWith(item.href));
-        return (
-          <Link
-            key={item.href}
-            href={item.href}
-            className={cn(
-              "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
-              isActive
-                ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                : "text-sidebar-foreground hover:bg-sidebar-accent/50"
-            )}
+    <div className="flex h-full flex-col">
+      <nav className="flex flex-col gap-1 p-4">
+        <div className="mb-6 px-3">
+          <h2 className="text-lg font-bold tracking-tight">NETEREKA</h2>
+          <p className="text-xs text-muted-foreground">Administration</p>
+        </div>
+        {navItems.map((item) => {
+          const isActive =
+            pathname === item.href ||
+            (item.href !== "/dashboard" && pathname.startsWith(item.href));
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+                isActive
+                  ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                  : "text-sidebar-foreground hover:bg-sidebar-accent/50"
+              )}
+            >
+              <HugeiconsIcon icon={item.icon} size={20} />
+              {item.label}
+            </Link>
+          );
+        })}
+        {disabledItems.map((item) => (
+          <span
+            key={item.label}
+            className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium opacity-40"
+            aria-disabled="true"
           >
             <HugeiconsIcon icon={item.icon} size={20} />
             {item.label}
-          </Link>
-        );
-      })}
-      {disabledItems.map((item) => (
-        <span
-          key={item.label}
-          className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium opacity-40"
-          aria-disabled="true"
-        >
-          <HugeiconsIcon icon={item.icon} size={20} />
-          {item.label}
-        </span>
-      ))}
-    </nav>
+          </span>
+        ))}
+      </nav>
+      <div className="mt-auto">
+        <SidebarUserMenu />
+      </div>
+    </div>
   );
 }

--- a/components/admin/sidebar.tsx
+++ b/components/admin/sidebar.tsx
@@ -46,7 +46,7 @@ export function Sidebar() {
               className={cn(
                 "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
                 isActive
-                  ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                  ? "bg-primary/10 font-medium text-primary"
                   : "text-sidebar-foreground hover:bg-sidebar-accent/50"
               )}
             >

--- a/components/storefront/header-user-menu.tsx
+++ b/components/storefront/header-user-menu.tsx
@@ -95,14 +95,12 @@ export function HeaderUserMenu({ user }: { user: User }) {
           <p className="text-xs text-muted-foreground">{user.email}</p>
         </DropdownMenuLabel>
         {(user.role === "admin" || user.role === "super_admin") && (
-          <>
-            <DropdownMenuItem asChild>
-              <Link href="/dashboard">
-                <HugeiconsIcon icon={DashboardSquare01Icon} size={16} />
-                Administration
-              </Link>
-            </DropdownMenuItem>
-          </>
+          <DropdownMenuItem asChild>
+            <Link href="/dashboard" target="_blank">
+              <HugeiconsIcon icon={DashboardSquare01Icon} size={16} />
+              Administration
+            </Link>
+          </DropdownMenuItem>
         )}
         <DropdownMenuSeparator />
         {menuItems.map((item) => (

--- a/components/storefront/header-user-menu.tsx
+++ b/components/storefront/header-user-menu.tsx
@@ -20,6 +20,7 @@ import {
   FavouriteIcon,
   StarIcon,
   Logout01Icon,
+  DashboardSquare01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
@@ -28,6 +29,7 @@ type User = {
   name: string;
   email: string;
   image?: string | null;
+  role?: string;
 } | null;
 
 function UserAvatar({ user }: { user: NonNullable<User> }) {
@@ -92,6 +94,16 @@ export function HeaderUserMenu({ user }: { user: User }) {
           <p className="text-sm font-medium">{user.name}</p>
           <p className="text-xs text-muted-foreground">{user.email}</p>
         </DropdownMenuLabel>
+        {(user.role === "admin" || user.role === "super_admin") && (
+          <>
+            <DropdownMenuItem asChild>
+              <Link href="/dashboard">
+                <HugeiconsIcon icon={DashboardSquare01Icon} size={16} />
+                Administration
+              </Link>
+            </DropdownMenuItem>
+          </>
+        )}
         <DropdownMenuSeparator />
         {menuItems.map((item) => (
           <DropdownMenuItem key={item.href} asChild>

--- a/components/storefront/header.tsx
+++ b/components/storefront/header.tsx
@@ -17,7 +17,7 @@ export async function Header() {
         <nav className="flex items-center gap-1">
           <SearchAutocomplete />
           <CartIcon />
-          <HeaderUserMenu user={session?.user ?? null} />
+          <HeaderUserMenu user={session?.user ? { id: session.user.id, name: session.user.name, email: session.user.email, image: session.user.image, role: session.user.role } : null} />
         </nav>
       </div>
     </header>

--- a/components/storefront/header.tsx
+++ b/components/storefront/header.tsx
@@ -8,6 +8,10 @@ import { SearchAutocomplete } from "@/components/storefront/search-autocomplete"
 export async function Header() {
   const session = await getOptionalSession();
 
+  const userForMenu = session?.user
+    ? { id: session.user.id, name: session.user.name, email: session.user.email, image: session.user.image, role: session.user.role }
+    : null;
+
   return (
     <header className="sticky top-0 z-50 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="relative mx-auto flex h-16 max-w-7xl items-center justify-between px-4">
@@ -17,7 +21,7 @@ export async function Header() {
         <nav className="flex items-center gap-1">
           <SearchAutocomplete />
           <CartIcon />
-          <HeaderUserMenu user={session?.user ? { id: session.user.id, name: session.user.name, email: session.user.email, image: session.user.image, role: session.user.role } : null} />
+          <HeaderUserMenu user={userForMenu} />
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- Add user menu at the bottom of the admin sidebar (avatar, name, profile, store link, sign-out)
- Add sticky headers to all 10 admin pages so title/filters stay visible when scrolling
- Add "Administration" link in storefront user menu (admin/super_admin only)
- Add "Mon profil" link in admin user menu
- Store/admin cross-navigation links open in new tabs to preserve context
- Align admin sidebar active state color with storefront account nav (`bg-primary/10`)
- Make admin sidebar sticky so user menu is always reachable

## Changes
- **Created** `components/admin/admin-user-context.tsx` — React Context + `useAdminUser` hook
- **Created** `components/admin/sidebar-user-menu.tsx` — Avatar + dropdown menu component
- **Created** `components/admin/admin-page-header.tsx` — Sticky header wrapper with negative margin technique
- **Modified** `components/admin/sidebar.tsx` — Flex layout + user menu + active state color
- **Modified** `components/admin/admin-header.tsx` — Remove default `mb-6` (managed by AdminPageHeader)
- **Modified** `app/(admin)/layout.tsx` — Capture session, `AdminUserProvider`, sticky sidebar, scroll container
- **Modified** all 10 admin pages — Wrap headers with `AdminPageHeader`
- **Modified** `components/storefront/header-user-menu.tsx` — Admin link for admin users
- **Modified** `components/storefront/header.tsx` — Pass role to user menu

## Test plan
- [ ] `/dashboard` → sidebar shows user menu at bottom with avatar + name
- [ ] Click user menu → dropdown with profile, store link, sign-out
- [ ] "Mon profil" and "Voir la boutique" open in new tabs
- [ ] "Déconnexion" signs out and redirects
- [ ] `/products` desktop → scroll 147 products → header + filters stay fixed at top
- [ ] `/orders` → scroll → title + export button stay fixed
- [ ] Detail pages (e.g. `/products/xxx/edit`) → back arrow + title stay fixed
- [ ] Mobile hamburger menu → user menu visible at bottom of Sheet
- [ ] Storefront → click avatar → "Administration" link visible for admin users, opens in new tab
- [ ] Storefront → login as regular user → no "Administration" link
- [ ] Active sidebar item uses primary color (matches account nav)

🤖 Generated with [Claude Code](https://claude.com/claude-code)