### PR TITLE
feat: visual attribute editor for product variants

### DIFF
--- a/actions/admin/variants.ts
+++ b/actions/admin/variants.ts
@@ -15,7 +15,20 @@ const variantSchema = z.object({
   price: z.coerce.number().int().min(0, "Le prix doit être positif"),
   compare_price: z.coerce.number().int().min(0).optional(),
   stock_quantity: z.coerce.number().int().min(0).default(0),
-  attributes: z.string().default("{}"),
+  attributes: z
+    .string()
+    .default("{}")
+    .refine(
+      (val) => {
+        try {
+          const obj = JSON.parse(val);
+          return typeof obj === "object" && obj !== null && !Array.isArray(obj);
+        } catch {
+          return false;
+        }
+      },
+      { message: "Attributs JSON invalides" }
+    ),
   is_active: z.coerce.number().min(0).max(1).default(1),
   sort_order: z.coerce.number().int().min(0).default(0),
 });

--- a/components/admin/attribute-editor.tsx
+++ b/components/admin/attribute-editor.tsx
@@ -28,6 +28,14 @@ const PREDEFINED_COLORS = [
   { name: "Argent", hex: "#9CA3AF" },
 ] as const;
 
+const PREDEFINED_STORAGE = [
+  "32 Go", "64 Go", "128 Go", "256 Go", "512 Go", "1 To", "2 To",
+] as const;
+
+const PREDEFINED_RAM = [
+  "2 Go", "3 Go", "4 Go", "6 Go", "8 Go", "12 Go", "16 Go", "32 Go",
+] as const;
+
 const PREDEFINED_ATTRIBUTES = [
   { label: "Couleur", value: "color" },
   { label: "Stockage", value: "storage" },
@@ -167,6 +175,70 @@ function ColorValueInput({
   );
 }
 
+function ChipValueInput({
+  options,
+  value,
+  onChange,
+  label,
+}: {
+  options: readonly string[];
+  value: string;
+  onChange: (val: string) => void;
+  label: string;
+}) {
+  const [showCustom, setShowCustom] = useState(
+    () => !!value && !options.includes(value)
+  );
+
+  return (
+    <div className="flex flex-1 flex-col gap-2">
+      <div className="flex flex-wrap items-center gap-1.5">
+        {options.map((opt) => (
+          <button
+            key={opt}
+            type="button"
+            onClick={() => {
+              setShowCustom(false);
+              onChange(opt);
+            }}
+            className={`rounded-md border px-2 py-0.5 text-xs transition-colors ${
+              value === opt
+                ? "border-primary bg-primary text-primary-foreground"
+                : "border-border bg-background hover:bg-muted"
+            }`}
+            aria-label={`${label} ${opt}`}
+          >
+            {opt}
+          </button>
+        ))}
+        <button
+          type="button"
+          onClick={() => {
+            setShowCustom(true);
+            onChange("");
+          }}
+          className={`rounded-md border border-dashed px-2 py-0.5 text-xs text-muted-foreground transition-colors ${
+            showCustom
+              ? "border-primary bg-primary text-primary-foreground"
+              : "border-border hover:bg-muted"
+          }`}
+          aria-label={`${label} personnalisé`}
+        >
+          Autre
+        </button>
+      </div>
+      {showCustom && (
+        <Input
+          placeholder={`Ex: 24 Go`}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          aria-label={`Valeur personnalisée ${label}`}
+        />
+      )}
+    </div>
+  );
+}
+
 interface AttributeEditorProps {
   defaultValue?: string | null;
 }
@@ -286,6 +358,20 @@ export function AttributeEditor({ defaultValue }: AttributeEditorProps) {
               <ColorValueInput
                 value={pair.value}
                 onChange={(val) => updateValue(pair.id, val)}
+              />
+            ) : pair.key === "storage" ? (
+              <ChipValueInput
+                options={PREDEFINED_STORAGE}
+                value={pair.value}
+                onChange={(val) => updateValue(pair.id, val)}
+                label="Stockage"
+              />
+            ) : pair.key === "ram" ? (
+              <ChipValueInput
+                options={PREDEFINED_RAM}
+                value={pair.value}
+                onChange={(val) => updateValue(pair.id, val)}
+                label="RAM"
               />
             ) : (
               <Input

--- a/components/admin/attribute-editor.tsx
+++ b/components/admin/attribute-editor.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Add01Icon, Cancel01Icon, Delete02Icon } from "@hugeicons/core-free-icons";
+
+const PREDEFINED_ATTRIBUTES = [
+  { label: "Couleur", value: "color" },
+  { label: "Stockage", value: "storage" },
+  { label: "RAM", value: "ram" },
+] as const;
+
+function getLabelForKey(key: string): string {
+  return PREDEFINED_ATTRIBUTES.find((a) => a.value === key)?.label ?? key;
+}
+
+interface AttributePair {
+  id: number;
+  key: string;
+  value: string;
+  custom: boolean;
+}
+
+let nextId = 0;
+
+function parseAttributes(json: string | undefined | null): AttributePair[] {
+  if (!json) return [];
+  try {
+    const obj = JSON.parse(json);
+    if (typeof obj !== "object" || obj === null) return [];
+    return Object.entries(obj).map(([key, val]) => ({
+      id: ++nextId,
+      key,
+      value: String(val),
+      custom: !PREDEFINED_ATTRIBUTES.some((a) => a.value === key),
+    }));
+  } catch {
+    return [];
+  }
+}
+
+function serializeAttributes(pairs: AttributePair[]): string {
+  const obj: Record<string, string> = {};
+  for (const pair of pairs) {
+    const k = pair.key.trim();
+    const v = pair.value.trim();
+    if (k && v) obj[k] = v;
+  }
+  return JSON.stringify(obj);
+}
+
+interface AttributeEditorProps {
+  defaultValue?: string | null;
+}
+
+export function AttributeEditor({ defaultValue }: AttributeEditorProps) {
+  const idCounter = useRef(nextId);
+  const [pairs, setPairs] = useState<AttributePair[]>(() =>
+    parseAttributes(defaultValue)
+  );
+
+  function addPair() {
+    idCounter.current += 1;
+    setPairs((prev) => [
+      ...prev,
+      { id: idCounter.current, key: "", value: "", custom: false },
+    ]);
+  }
+
+  function removePair(id: number) {
+    setPairs((prev) => prev.filter((p) => p.id !== id));
+  }
+
+  function updateKey(id: number, newKey: string) {
+    setPairs((prev) =>
+      prev.map((p) => (p.id === id ? { ...p, key: newKey, custom: false } : p))
+    );
+  }
+
+  function setCustomKey(id: number) {
+    setPairs((prev) =>
+      prev.map((p) => (p.id === id ? { ...p, key: "", custom: true } : p))
+    );
+  }
+
+  function resetToSelect(id: number) {
+    setPairs((prev) =>
+      prev.map((p) => (p.id === id ? { ...p, key: "", custom: false } : p))
+    );
+  }
+
+  function updateCustomKey(id: number, newKey: string) {
+    setPairs((prev) =>
+      prev.map((p) => (p.id === id ? { ...p, key: newKey } : p))
+    );
+  }
+
+  function updateValue(id: number, newValue: string) {
+    setPairs((prev) =>
+      prev.map((p) => (p.id === id ? { ...p, value: newValue } : p))
+    );
+  }
+
+  const usedKeys = useMemo(() => pairs.map((p) => p.key), [pairs]);
+
+  return (
+    <fieldset className="space-y-2">
+      <Label asChild>
+        <legend>Attributs</legend>
+      </Label>
+      {pairs.map((pair, index) => {
+        const keyLabel = getLabelForKey(pair.key) || `#${index + 1}`;
+        return (
+          <div key={pair.id} className="flex items-center gap-2">
+            {pair.custom ? (
+              <div className="flex flex-1 items-center gap-1">
+                <Input
+                  placeholder="Clé"
+                  value={pair.key}
+                  onChange={(e) => updateCustomKey(pair.id, e.target.value)}
+                  aria-label={`Clé personnalisée de l'attribut ${index + 1}`}
+                  className="flex-1"
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={() => resetToSelect(pair.id)}
+                  aria-label="Revenir à la liste prédéfinie"
+                >
+                  <HugeiconsIcon icon={Cancel01Icon} size={14} />
+                </Button>
+              </div>
+            ) : (
+              <Select
+                value={pair.key}
+                onValueChange={(val) => {
+                  if (val === "__custom__") {
+                    setCustomKey(pair.id);
+                  } else {
+                    updateKey(pair.id, val);
+                  }
+                }}
+              >
+                <SelectTrigger
+                  className="flex-1 h-9"
+                  aria-label={`Type de l'attribut ${index + 1}`}
+                >
+                  <SelectValue placeholder="Attribut" />
+                </SelectTrigger>
+                <SelectContent>
+                  {PREDEFINED_ATTRIBUTES.map((attr) => (
+                    <SelectItem
+                      key={attr.value}
+                      value={attr.value}
+                      disabled={
+                        usedKeys.includes(attr.value) && pair.key !== attr.value
+                      }
+                    >
+                      {attr.label}
+                    </SelectItem>
+                  ))}
+                  <SelectItem value="__custom__">Personnalisé…</SelectItem>
+                </SelectContent>
+              </Select>
+            )}
+            <Input
+              placeholder="Valeur"
+              value={pair.value}
+              onChange={(e) => updateValue(pair.id, e.target.value)}
+              aria-label={`Valeur de l'attribut ${keyLabel}`}
+              className="flex-1"
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              onClick={() => removePair(pair.id)}
+              aria-label={`Supprimer l'attribut ${keyLabel}`}
+            >
+              <HugeiconsIcon icon={Delete02Icon} size={16} />
+            </Button>
+          </div>
+        );
+      })}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={addPair}
+        className="w-full"
+      >
+        <HugeiconsIcon icon={Add01Icon} size={16} />
+        Ajouter un attribut
+      </Button>
+      <input type="hidden" name="attributes" value={serializeAttributes(pairs)} />
+    </fieldset>
+  );
+}

--- a/components/admin/attribute-editor.tsx
+++ b/components/admin/attribute-editor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, useRef, useState } from "react";
+import { HexColorPicker } from "react-colorful";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -141,21 +142,25 @@ function ColorValueInput({
         )}
       </div>
       {showCustom && (
-        <div className="flex items-center gap-2">
-          <input
-            type="color"
-            value={customHex}
-            onChange={(e) => setCustomHex(e.target.value)}
-            className="h-8 w-8 cursor-pointer rounded border-0 bg-transparent p-0"
-            aria-label="Sélecteur de couleur"
+        <div className="flex flex-col gap-2">
+          <HexColorPicker
+            color={customHex}
+            onChange={setCustomHex}
+            style={{ width: "100%", height: 150 }}
           />
-          <Input
-            placeholder="Nom (ex: Turquoise)"
-            value={value}
-            onChange={(e) => onChange(e.target.value)}
-            className="flex-1"
-            aria-label="Nom de la couleur personnalisée"
-          />
+          <div className="flex items-center gap-2">
+            <span
+              className="size-8 shrink-0 rounded border border-border"
+              style={{ backgroundColor: customHex }}
+            />
+            <Input
+              placeholder="Nom (ex: Turquoise)"
+              value={value}
+              onChange={(e) => onChange(e.target.value)}
+              className="flex-1"
+              aria-label="Nom de la couleur personnalisée"
+            />
+          </div>
         </div>
       )}
     </div>

--- a/components/admin/variant-form.tsx
+++ b/components/admin/variant-form.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { AttributeEditor } from "@/components/admin/attribute-editor";
 import {
   Dialog,
   DialogContent,
@@ -117,17 +118,7 @@ export function VariantForm({
               defaultValue={variant?.stock_quantity ?? 0}
             />
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="v-attributes">
-              Attributs (JSON)
-            </Label>
-            <Input
-              id="v-attributes"
-              name="attributes"
-              defaultValue={variant?.attributes ?? "{}"}
-              placeholder='{"color":"Bleu","storage":"256 Go"}'
-            />
-          </div>
+          <AttributeEditor defaultValue={variant?.attributes} />
           <input type="hidden" name="is_active" value={variant?.is_active ?? 1} />
           <Button type="submit" className="w-full" disabled={isPending}>
             {isPending ? "Enregistrement..." : isEdit ? "Mettre à jour" : "Ajouter"}

--- a/components/admin/variant-form.tsx
+++ b/components/admin/variant-form.tsx
@@ -48,7 +48,7 @@ export function VariantForm({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>
             {isEdit ? "Modifier la variante" : "Ajouter une variante"}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -59,7 +59,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] max-h-[calc(100dvh-2rem)] overflow-y-auto overscroll-contain gap-4 rounded-xl p-4 text-xs/relaxed ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
+          "bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] max-h-[calc(100dvh-2rem)] overflow-y-auto overscroll-contain gap-4 rounded-xl p-4 text-xs/relaxed ring-1 duration-100 sm:max-w-lg fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
           className
         )}
         {...props}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -59,7 +59,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-4 rounded-xl p-4 text-xs/relaxed ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
+          "bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] max-h-[calc(100dvh-2rem)] overflow-y-auto overscroll-contain gap-4 rounded-xl p-4 text-xs/relaxed ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
           className
         )}
         {...props}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -59,7 +59,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] max-h-[calc(100dvh-2rem)] overflow-y-auto overscroll-contain gap-4 rounded-xl p-4 text-xs/relaxed ring-1 duration-100 sm:max-w-lg fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
+          "bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] max-h-[calc(100dvh-2rem)] overflow-y-auto overscroll-contain gap-4 rounded-xl p-4 text-xs/relaxed ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
           className
         )}
         {...props}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "nuqs": "^2.8.7",
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
+        "react-colorful": "^5.6.1",
         "react-dom": "19.2.3",
         "react-hook-form": "^7.71.1",
         "resend": "^6.9.1",
@@ -22295,6 +22296,16 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-colorful": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "nuqs": "^2.8.7",
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
+    "react-colorful": "^5.6.1",
     "react-dom": "19.2.3",
     "react-hook-form": "^7.71.1",
     "resend": "^6.9.1",


### PR DESCRIPTION
## Summary

- Replace raw JSON text input with a structured attribute editor for product variants
- Add visual color picker with 10 predefined color swatches + custom color via `react-colorful`
- Add predefined chip selectors for Storage (32 Go–2 To) and RAM (2–32 Go) attributes
- Fix dialog scroll on small viewports (`max-h` + `overflow-y-auto` + `overscroll-contain`)
- Widen dialog to `max-w-lg` on desktop for better chip/swatch layout

## Test plan

- [ ] Open variant create/edit dialog — attribute editor renders instead of raw JSON
- [ ] Select "Couleur" attribute → color swatches appear, clicking one sets the value
- [ ] Click "+" custom color → react-colorful picker + name input appear
- [ ] Select "Stockage" or "RAM" → predefined chip values appear
- [ ] Click "Autre" chip → free text input appears
- [ ] Existing variant with `{"color":"Bleu"}` → Bleu swatch is pre-selected
- [ ] Save variant → JSON in DB remains `{"color":"Bleu"}` format (unchanged)
- [ ] Test on mobile viewport — dialog scrolls correctly, swatches/chips are tappable
- [ ] Open two variant dialogs concurrently — no ID collisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)