### PR TITLE
feat: description & caractéristiques produit avec onglets

### DIFF
--- a/app/(storefront)/p/[slug]/page.tsx
+++ b/app/(storefront)/p/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { VariantSelector } from "@/components/storefront/variant-selector";
 import { AddToCartButton } from "@/components/storefront/add-to-cart-button";
 import { HorizontalSection } from "@/components/storefront/horizontal-section";
 import { WishlistButton } from "@/components/storefront/wishlist-button";
+import { ProductDetails } from "@/components/storefront/product-details";
 import { StarRating } from "@/components/storefront/star-rating";
 import { JsonLd } from "@/components/seo/json-ld";
 import { BreadcrumbSchema } from "@/components/seo/breadcrumb-schema";
@@ -303,16 +304,14 @@ export default async function ProductPage({ params }: Props) {
             </div>
           )}
 
-          {product.description ? (
-            <div className="border-t pt-4">
-              <h3 className="mb-2 text-sm font-semibold">Description</h3>
-              <p className="text-sm leading-relaxed text-muted-foreground">
-                {product.description}
-              </p>
-            </div>
-          ) : null}
         </div>
       </div>
+
+      {/* Description & Characteristics */}
+      <ProductDetails
+        description={product.description}
+        attributes={product.attributes}
+      />
 
       {/* Reviews */}
       <Suspense fallback={null}>

--- a/components/storefront/product-details.tsx
+++ b/components/storefront/product-details.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import type { ProductAttribute } from "@/lib/db/types";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+interface ProductDetailsProps {
+  description: string | null;
+  attributes: ProductAttribute[];
+}
+
+export function ProductDetails({ description, attributes }: ProductDetailsProps) {
+  const hasDescription = !!description;
+  const hasAttributes = attributes.length > 0;
+
+  if (!hasDescription && !hasAttributes) return null;
+
+  // If only one section exists, render it directly without tabs
+  if (!hasAttributes && hasDescription) {
+    return (
+      <section className="mt-10 border-t pt-8">
+        <h2 className="mb-4 text-lg font-semibold">Description</h2>
+        <DescriptionContent description={description} />
+      </section>
+    );
+  }
+
+  if (hasAttributes && !hasDescription) {
+    return (
+      <section className="mt-10 border-t pt-8">
+        <h2 className="mb-4 text-lg font-semibold">Caractéristiques</h2>
+        <AttributesTable attributes={attributes} />
+      </section>
+    );
+  }
+
+  // Both exist: show tabs
+  return (
+    <section className="mt-10 border-t pt-8">
+      <Tabs defaultValue="description">
+        <TabsList variant="line" className="mb-6">
+          <TabsTrigger value="description" className="text-sm">
+            Description
+          </TabsTrigger>
+          <TabsTrigger value="characteristics" className="text-sm">
+            Caractéristiques
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="description">
+          <DescriptionContent description={description} />
+        </TabsContent>
+
+        <TabsContent value="characteristics">
+          <AttributesTable attributes={attributes} />
+        </TabsContent>
+      </Tabs>
+    </section>
+  );
+}
+
+function DescriptionContent({ description }: { description: string | null }) {
+  if (!description) return null;
+
+  // Split by double newlines for paragraph breaks
+  const paragraphs = description.split(/\n{2,}/).filter(Boolean);
+
+  return (
+    <div className="max-w-prose space-y-3">
+      {paragraphs.map((paragraph, i) => (
+        <p key={i} className="text-sm leading-relaxed text-muted-foreground">
+          {paragraph}
+        </p>
+      ))}
+    </div>
+  );
+}
+
+function AttributesTable({ attributes }: { attributes: ProductAttribute[] }) {
+  return (
+    <dl className="grid grid-cols-1 gap-px overflow-hidden rounded-lg border bg-border sm:grid-cols-2">
+      {attributes.map((attr) => (
+        <div
+          key={attr.id}
+          className="flex items-baseline gap-4 bg-background px-4 py-3"
+        >
+          <dt className="shrink-0 text-sm text-muted-foreground">
+            {attr.name}
+          </dt>
+          <dd className="ml-auto text-right text-sm font-medium">
+            {attr.value}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/components/storefront/product-details.tsx
+++ b/components/storefront/product-details.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type { ProductAttribute } from "@/lib/db/types";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
@@ -47,7 +45,7 @@ export function ProductDetails({ description, attributes }: ProductDetailsProps)
         </TabsList>
 
         <TabsContent value="description">
-          <DescriptionContent description={description} />
+          <DescriptionContent description={description!} />
         </TabsContent>
 
         <TabsContent value="characteristics">

--- a/lib/db/admin/products.ts
+++ b/lib/db/admin/products.ts
@@ -120,7 +120,7 @@ export async function getAdminProductById(
       [product.id]
     ),
     query<ProductAttribute>(
-      "SELECT * FROM product_attributes WHERE product_id = ?",
+      "SELECT * FROM product_attributes WHERE product_id = ? ORDER BY name ASC",
       [product.id]
     ),
   ]);

--- a/lib/db/admin/products.ts
+++ b/lib/db/admin/products.ts
@@ -1,6 +1,7 @@
 import { query, queryFirst } from "@/lib/db";
 import type {
   Product,
+  ProductAttribute,
   ProductDetail,
   ProductImage,
   ProductVariant,
@@ -109,7 +110,7 @@ export async function getAdminProductById(
   );
   if (!product) return null;
 
-  const [images, variants] = await Promise.all([
+  const [images, variants, attributes] = await Promise.all([
     query<ProductImage>(
       "SELECT * FROM product_images WHERE product_id = ? ORDER BY sort_order ASC",
       [product.id]
@@ -118,7 +119,11 @@ export async function getAdminProductById(
       "SELECT * FROM product_variants WHERE product_id = ? ORDER BY sort_order ASC",
       [product.id]
     ),
+    query<ProductAttribute>(
+      "SELECT * FROM product_attributes WHERE product_id = ?",
+      [product.id]
+    ),
   ]);
 
-  return { ...product, images, variants };
+  return { ...product, images, variants, attributes };
 }

--- a/lib/db/products.ts
+++ b/lib/db/products.ts
@@ -49,7 +49,7 @@ export async function getProductBySlug(slug: string): Promise<ProductDetail | nu
       [product.id]
     ),
     query<ProductAttribute>(
-      "SELECT * FROM product_attributes WHERE product_id = ?",
+      "SELECT * FROM product_attributes WHERE product_id = ? ORDER BY name ASC",
       [product.id]
     ),
   ]);

--- a/lib/db/products.ts
+++ b/lib/db/products.ts
@@ -1,5 +1,5 @@
 import { query, queryFirst } from "@/lib/db";
-import type { Product, ProductDetail, ProductImage, ProductVariant } from "@/lib/db/types";
+import type { Product, ProductAttribute, ProductDetail, ProductImage, ProductVariant } from "@/lib/db/types";
 
 export async function getProductsByCategory(
   categoryId: string,
@@ -39,7 +39,7 @@ export async function getProductBySlug(slug: string): Promise<ProductDetail | nu
   );
   if (!product) return null;
 
-  const [images, variants] = await Promise.all([
+  const [images, variants, attributes] = await Promise.all([
     query<ProductImage>(
       "SELECT * FROM product_images WHERE product_id = ? ORDER BY sort_order ASC",
       [product.id]
@@ -48,9 +48,13 @@ export async function getProductBySlug(slug: string): Promise<ProductDetail | nu
       "SELECT * FROM product_variants WHERE product_id = ? AND is_active = 1 ORDER BY price ASC",
       [product.id]
     ),
+    query<ProductAttribute>(
+      "SELECT * FROM product_attributes WHERE product_id = ?",
+      [product.id]
+    ),
   ]);
 
-  return { ...product, images, variants };
+  return { ...product, images, variants, attributes };
 }
 
 export async function getFeaturedProducts(limit = 10): Promise<Product[]> {

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -55,9 +55,17 @@ export interface ProductImage {
   is_primary: number;
 }
 
+export interface ProductAttribute {
+  id: string;
+  product_id: string;
+  name: string;
+  value: string;
+}
+
 export interface ProductDetail extends Product {
   images: ProductImage[];
   variants: ProductVariant[];
+  attributes: ProductAttribute[];
 }
 
 export interface ParsedVariantAttributes {


### PR DESCRIPTION
## Summary
- Ajout d'un composant `ProductDetails` avec onglets (Description / Caractéristiques) sur la page produit
- Requête de la table `product_attributes` dans `getProductBySlug()` et `getAdminProductById()`
- Ajout du type `ProductAttribute` et mise à jour de `ProductDetail`

## Détails
- **Tabs** (variante `line` de shadcn) quand description ET caractéristiques existent
- **Section simple** avec titre quand un seul type de contenu est disponible
- **Retour `null`** quand aucune donnée → aucun impact sur les produits sans données
- Grille `<dl>` sémantique responsive (2 colonnes sur desktop) pour les spécifications
- Paragraphes séparés automatiquement via double saut de ligne dans la description
- Section positionnée en pleine largeur sous la grille image/info produit

## Fichiers modifiés
| Fichier | Changement |
|---------|-----------|
| `components/storefront/product-details.tsx` | **Nouveau** — composant client avec tabs |
| `lib/db/types.ts` | Ajout `ProductAttribute`, mise à jour `ProductDetail` |
| `lib/db/products.ts` | Requête `product_attributes` dans `getProductBySlug` |
| `lib/db/admin/products.ts` | Requête `product_attributes` dans `getAdminProductById` |
| `app/(storefront)/p/[slug]/page.tsx` | Intégration du composant `ProductDetails` |

## Test plan
- [ ] Vérifier l'onglet Description avec un produit ayant une description
- [ ] Vérifier l'onglet Caractéristiques avec un produit ayant des attributs
- [ ] Vérifier que les deux onglets s'affichent quand les deux types de données existent
- [ ] Vérifier qu'une seule section (sans tabs) s'affiche quand un seul type existe
- [ ] Vérifier que rien ne s'affiche pour un produit sans description ni attributs
- [ ] Vérifier le rendu responsive (mobile / desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)