### PR TITLE
feat: add global 404 and 500 error pages

### DIFF
--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+export default function GlobalError({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <html lang="fr">
+      <body
+        style={{
+          margin: 0,
+          fontFamily:
+            "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          minHeight: "100dvh",
+          textAlign: "center",
+          backgroundColor: "#fafafa",
+          color: "#111",
+        }}
+      >
+        <div>
+          <p style={{ fontSize: "3rem", fontWeight: 700, color: "#183C78", margin: 0 }}>
+            500
+          </p>
+          <h1 style={{ fontSize: "1.5rem", fontWeight: 700, marginTop: "1rem" }}>
+            Erreur interne du serveur
+          </h1>
+          <p style={{ fontSize: "0.875rem", color: "#666", marginTop: "0.5rem" }}>
+            Une erreur inattendue s&apos;est produite. Veuillez réessayer.
+          </p>
+          <button
+            onClick={reset}
+            style={{
+              marginTop: "2rem",
+              padding: "0.625rem 1.5rem",
+              fontSize: "0.875rem",
+              fontWeight: 500,
+              color: "#fff",
+              backgroundColor: "#183C78",
+              border: "none",
+              borderRadius: "0.75rem",
+              cursor: "pointer",
+            }}
+          >
+            Réessayer
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,11 +1,17 @@
 "use client";
 
+import { useEffect } from "react";
+
 export default function GlobalError({
+  error,
   reset,
 }: {
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  useEffect(() => {
+    console.error("Global error:", error);
+  }, [error]);
   return (
     <html lang="fr">
       <body
@@ -44,7 +50,10 @@ export default function GlobalError({
               border: "none",
               borderRadius: "0.75rem",
               cursor: "pointer",
+              transition: "opacity 0.2s",
             }}
+            onMouseOver={(e) => (e.currentTarget.style.opacity = "0.9")}
+            onMouseOut={(e) => (e.currentTarget.style.opacity = "1")}
           >
             Réessayer
           </button>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+import { Header } from "@/components/storefront/header";
+import { Footer } from "@/components/storefront/footer";
+
+export default function NotFound() {
+  return (
+    <>
+      <Header />
+      <main className="flex min-h-[calc(100dvh-8rem)] flex-col items-center justify-center px-4 text-center">
+        <p className="text-6xl font-bold text-primary">404</p>
+        <h1 className="mt-4 text-2xl font-bold">Page introuvable</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          La page que vous recherchez n&apos;existe pas ou a été déplacée.
+        </p>
+        <Link
+          href="/"
+          className="mt-8 rounded-xl bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground"
+        >
+          Retour à l&apos;accueil
+        </Link>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -14,7 +14,7 @@ export default function NotFound() {
         </p>
         <Link
           href="/"
-          className="mt-8 rounded-xl bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground"
+          className="mt-8 rounded-xl bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
         >
           Retour à l&apos;accueil
         </Link>


### PR DESCRIPTION
## Summary
- Add `app/not-found.tsx` — global 404 page with header/footer and "Retour à l'accueil" button
- Add `app/global-error.tsx` — global 500 page with inline styles (resilient if CSS fails to load), "Réessayer" button

## Test plan
- [ ] Navigate to a non-existent URL (e.g. `/page-qui-nexiste-pas`) — shows 404 with header/footer
- [ ] Verify header navigation and footer links work from 404 page
- [ ] Verify global-error renders with inline styles (no Tailwind dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)