### PR TITLE
fix: add aria-label to logo links for accessibility

### DIFF
--- a/components/storefront/footer.tsx
+++ b/components/storefront/footer.tsx
@@ -34,7 +34,7 @@ export function Footer() {
         <div className="grid gap-8 sm:grid-cols-2 md:grid-cols-4">
           {/* Brand */}
           <div>
-            <Link href="/" className="inline-block">
+            <Link href="/" className="inline-block" aria-label="NETEREKA — Accueil">
               <Image
                 src="/logo.png"
                 alt={SITE_NAME}

--- a/components/storefront/header.tsx
+++ b/components/storefront/header.tsx
@@ -16,7 +16,7 @@ export async function Header() {
   return (
     <header className="sticky top-0 z-50 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="relative mx-auto flex h-16 max-w-7xl items-center justify-between px-4">
-        <Link href="/" className="flex items-center">
+        <Link href="/" className="flex items-center" aria-label="NETEREKA — Accueil">
           <Image
             src="/logo.png"
             alt={SITE_NAME}


### PR DESCRIPTION
## Summary
- Add `aria-label="NETEREKA — Accueil"` on header logo link (image-only `<a>`)
- Add `aria-label="NETEREKA — Accueil"` on footer logo link (image-only `<a>`)

Fixes Lighthouse accessibility audit: links without discernible text.

## Test plan
- [ ] Header logo link has accessible name in screen reader
- [ ] Footer logo link has accessible name in screen reader

🤖 Generated with [Claude Code](https://claude.com/claude-code)