### PR TITLE
feat: sync cart with Cloudflare KV

### DIFF
--- a/actions/cart.ts
+++ b/actions/cart.ts
@@ -1,0 +1,88 @@
+"use server";
+
+import { headers } from "next/headers";
+import { initAuth } from "@/lib/auth";
+import { getKV } from "@/lib/cloudflare/context";
+import type { CartItem } from "@/lib/types/cart";
+import { cartItemKey } from "@/lib/types/cart";
+
+const CART_TTL = 60 * 60 * 24 * 30; // 30 days
+const MAX_QUANTITY = 10;
+
+function cartKey(userId: string) {
+  return `cart:${userId}`;
+}
+
+async function getSessionUserId(): Promise<string | null> {
+  const auth = await initAuth();
+  const session = await auth.api.getSession({ headers: await headers() });
+  return session?.user?.id ?? null;
+}
+
+/**
+ * Merge local cart items with server-side KV cart.
+ * Returns the merged cart to update the client store.
+ */
+export async function syncCart(
+  localItems: CartItem[]
+): Promise<CartItem[]> {
+  const userId = await getSessionUserId();
+  if (!userId) return localItems;
+
+  const kv = await getKV();
+  const stored = await kv.get(cartKey(userId), "json") as CartItem[] | null;
+  const serverItems = stored ?? [];
+
+  // Build map from server items
+  const merged = new Map<string, CartItem>();
+  for (const item of serverItems) {
+    merged.set(cartItemKey(item), item);
+  }
+
+  // Merge local items: add quantities for duplicates
+  for (const item of localItems) {
+    const key = cartItemKey(item);
+    const existing = merged.get(key);
+    if (existing) {
+      merged.set(key, {
+        ...item,
+        quantity: Math.min(existing.quantity + item.quantity, MAX_QUANTITY),
+      });
+    } else {
+      merged.set(key, item);
+    }
+  }
+
+  const result = Array.from(merged.values());
+
+  // Persist merged cart
+  await kv.put(cartKey(userId), JSON.stringify(result), {
+    expirationTtl: CART_TTL,
+  });
+
+  return result;
+}
+
+/**
+ * Save the full cart to KV. Called on every cart mutation.
+ */
+export async function saveCart(items: CartItem[]): Promise<void> {
+  const userId = await getSessionUserId();
+  if (!userId) return;
+
+  const kv = await getKV();
+  await kv.put(cartKey(userId), JSON.stringify(items), {
+    expirationTtl: CART_TTL,
+  });
+}
+
+/**
+ * Clear the server-side cart. Called on checkout or explicit clear.
+ */
+export async function clearServerCart(): Promise<void> {
+  const userId = await getSessionUserId();
+  if (!userId) return;
+
+  const kv = await getKV();
+  await kv.delete(cartKey(userId));
+}

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -1,3 +1,10 @@
+import { CartSync } from "@/components/storefront/cart-sync";
+
 export function Providers({ children }: { children: React.ReactNode }) {
-  return <>{children}</>;
+  return (
+    <>
+      <CartSync />
+      {children}
+    </>
+  );
 }

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { CartSync } from "@/components/storefront/cart-sync";
 
 export function Providers({ children }: { children: React.ReactNode }) {

--- a/components/storefront/cart-sync.tsx
+++ b/components/storefront/cart-sync.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { authClient } from "@/lib/auth/client";
+import { useCartStore, useCartHydrated } from "@/stores/cart-store";
+import { syncCart } from "@/actions/cart";
+
+export function CartSync() {
+  const session = authClient.useSession();
+  const hydrated = useCartHydrated();
+  const prevUserIdRef = useRef<string | null | undefined>(undefined);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    if (session.isPending) return;
+
+    const userId = session.data?.user?.id ?? null;
+    const prevUserId = prevUserIdRef.current;
+
+    // Skip the very first render (undefined → initial value)
+    if (prevUserId === undefined) {
+      prevUserIdRef.current = userId;
+      // On first load with active session, sync cart
+      if (userId) {
+        const localItems = useCartStore.getState().items;
+        syncCart(localItems).then((merged) => {
+          useCartStore.getState().setItems(merged);
+        }).catch(() => {});
+      }
+      return;
+    }
+
+    // Login: null → userId
+    if (!prevUserId && userId) {
+      const localItems = useCartStore.getState().items;
+      syncCart(localItems).then((merged) => {
+        useCartStore.getState().setItems(merged);
+      }).catch(() => {});
+    }
+
+    // Logout: userId → null — clear local cart but keep KV for next login
+    if (prevUserId && !userId) {
+      useCartStore.getState().setItems([]);
+    }
+
+    prevUserIdRef.current = userId;
+  }, [hydrated, session.isPending, session.data?.user?.id]);
+
+  return null;
+}

--- a/stores/cart-store.ts
+++ b/stores/cart-store.ts
@@ -5,8 +5,14 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type { CartItem } from "@/lib/types/cart";
 import { cartItemKey } from "@/lib/types/cart";
+import { saveCart, clearServerCart } from "@/actions/cart";
 
 const MAX_QUANTITY = 10;
+
+function persistToServer() {
+  const items = useCartStore.getState().items;
+  saveCart(items).catch(() => {});
+}
 
 interface CartState {
   items: CartItem[];
@@ -15,6 +21,7 @@ interface CartState {
   remove: (productId: string, variantId: string | null) => void;
   updateQuantity: (productId: string, variantId: string | null, quantity: number) => void;
   clear: () => void;
+  setItems: (items: CartItem[]) => void;
   openDrawer: () => void;
   closeDrawer: () => void;
 }
@@ -29,43 +36,51 @@ export const useCartStore = create<CartState>()(
         set((state) => {
           const key = cartItemKey(item);
           const existing = state.items.find((i) => cartItemKey(i) === key);
+          let newItems: CartItem[];
           if (existing) {
-            return {
-              items: state.items.map((i) =>
-                cartItemKey(i) === key
-                  ? { ...i, quantity: Math.min(i.quantity + quantity, MAX_QUANTITY) }
-                  : i
-              ),
-              drawerOpen: true,
-            };
+            newItems = state.items.map((i) =>
+              cartItemKey(i) === key
+                ? { ...i, quantity: Math.min(i.quantity + quantity, MAX_QUANTITY) }
+                : i
+            );
+          } else {
+            newItems = [...state.items, { ...item, quantity: Math.min(quantity, MAX_QUANTITY) }];
           }
-          return {
-            items: [...state.items, { ...item, quantity: Math.min(quantity, MAX_QUANTITY) }],
-            drawerOpen: true,
-          };
+          queueMicrotask(persistToServer);
+          return { items: newItems, drawerOpen: true };
         }),
 
       remove: (productId, variantId) =>
         set((state) => {
           const key = cartItemKey({ productId, variantId });
-          return { items: state.items.filter((i) => cartItemKey(i) !== key) };
+          const newItems = state.items.filter((i) => cartItemKey(i) !== key);
+          queueMicrotask(persistToServer);
+          return { items: newItems };
         }),
 
       updateQuantity: (productId, variantId, quantity) =>
         set((state) => {
           const key = cartItemKey({ productId, variantId });
+          let newItems: CartItem[];
           if (quantity <= 0) {
-            return { items: state.items.filter((i) => cartItemKey(i) !== key) };
-          }
-          const clamped = Math.min(quantity, MAX_QUANTITY);
-          return {
-            items: state.items.map((i) =>
+            newItems = state.items.filter((i) => cartItemKey(i) !== key);
+          } else {
+            const clamped = Math.min(quantity, MAX_QUANTITY);
+            newItems = state.items.map((i) =>
               cartItemKey(i) === key ? { ...i, quantity: clamped } : i
-            ),
-          };
+            );
+          }
+          queueMicrotask(persistToServer);
+          return { items: newItems };
         }),
 
-      clear: () => set({ items: [] }),
+      clear: () => {
+        clearServerCart().catch(() => {});
+        set({ items: [] });
+      },
+
+      setItems: (items) => set({ items }),
+
       openDrawer: () => set({ drawerOpen: true }),
       closeDrawer: () => set({ drawerOpen: false }),
     }),


### PR DESCRIPTION
## Summary
- Persist cart to Cloudflare KV on every mutation (add, remove, updateQuantity) via fire-and-forget `queueMicrotask`
- On login or page load with active session, merge local cart with KV cart (additive quantities, capped at 10)
- On logout, clear local cart (localStorage) but preserve KV cart for next login
- On explicit clear (checkout), clear both local and KV

## Files
- `actions/cart.ts` — Server Actions: `syncCart()`, `saveCart()`, `clearServerCart()`
- `stores/cart-store.ts` — Added `setItems`, `persistToServer()`, KV sync on mutations
- `components/storefront/cart-sync.tsx` — Client component tracking auth state transitions
- `components/providers.tsx` — Mount `CartSync` at app root

## Test plan
- [ ] Add items to cart as guest, verify localStorage persists
- [ ] Log in, verify cart merges with any existing KV cart
- [ ] Modify cart while logged in, verify KV updates
- [ ] Log out, verify local cart clears but KV preserved
- [ ] Log back in, verify KV cart restores
- [ ] Clear cart explicitly, verify both local and KV cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)