### PR TITLE
feat: cookie consent banner with GA4 conditional loading

### DIFF
--- a/app/(storefront)/politique-confidentialite/page.tsx
+++ b/app/(storefront)/politique-confidentialite/page.tsx
@@ -133,6 +133,10 @@ export default function PolitiqueConfidentialitePage() {
               <strong>Resend</strong> — envoi des emails transactionnels (confirmations de
               commande, notifications)
             </li>
+            <li>
+              <strong>Google Analytics</strong> — mesure d&apos;audience anonymisée
+              (uniquement si vous avez donné votre consentement via le bandeau cookies)
+            </li>
           </ul>
           <p>
             Ces prestataires n&apos;ont accès qu&apos;aux données strictement nécessaires à

--- a/app/(storefront)/politique-confidentialite/page.tsx
+++ b/app/(storefront)/politique-confidentialite/page.tsx
@@ -200,10 +200,10 @@ export default function PolitiqueConfidentialitePage() {
 
         <section>
           <h2 className="text-xl font-semibold">8. Cookies</h2>
-          <p>
-            Notre site utilise uniquement des cookies techniques strictement nécessaires au
-            fonctionnement du service :
-          </p>
+          <p>Notre site utilise deux catégories de cookies :</p>
+          <h3 className="mt-3 text-base font-medium">
+            Cookies nécessaires (toujours actifs)
+          </h3>
           <ul className="list-disc space-y-1 pl-6">
             <li>
               <strong>Cookie de session</strong> — maintient votre connexion active (durée :
@@ -214,9 +214,24 @@ export default function PolitiqueConfidentialitePage() {
               du panier
             </li>
           </ul>
+          <p className="text-sm text-muted-foreground">
+            Ces cookies sont indispensables au fonctionnement du site et ne peuvent pas être
+            désactivés.
+          </p>
+          <h3 className="mt-3 text-base font-medium">
+            Cookies analytiques (soumis à votre consentement)
+          </h3>
+          <ul className="list-disc space-y-1 pl-6">
+            <li>
+              <strong>Google Analytics 4</strong> — nous aide à comprendre comment vous utilisez
+              le site afin de l&apos;améliorer. Ces cookies collectent des données anonymisées
+              sur les pages visitées et les interactions.
+            </li>
+          </ul>
           <p>
-            Ces cookies ne collectent aucune donnée à des fins publicitaires ou de profilage.
-            Aucun cookie tiers n&apos;est déposé sans votre consentement préalable.
+            Les cookies analytiques ne sont déposés qu&apos;après votre consentement explicite
+            via le bandeau affiché lors de votre première visite. Vous pouvez modifier votre
+            choix à tout moment depuis le lien « Gérer les cookies » en pied de page.
           </p>
         </section>
 

--- a/components/analytics/google-analytics.tsx
+++ b/components/analytics/google-analytics.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import Script from "next/script";
+import { useConsentStore, useConsentHydrated } from "@/stores/consent-store";
+
+const GA_ID = process.env.NEXT_PUBLIC_GA4_ID;
+
+export function GoogleAnalytics() {
+  const consent = useConsentStore((s) => s.consent);
+  const hydrated = useConsentHydrated();
+
+  if (!GA_ID) return null;
+  if (!hydrated) return null;
+  if (!consent?.analytics) return null;
+
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+        strategy="afterInteractive"
+      />
+      <Script id="ga4-config" strategy="afterInteractive">
+        {`window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','${GA_ID}');`}
+      </Script>
+    </>
+  );
+}

--- a/components/analytics/google-analytics.tsx
+++ b/components/analytics/google-analytics.tsx
@@ -1,16 +1,19 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Script from "next/script";
-import { useConsentStore, useConsentHydrated } from "@/stores/consent-store";
+import { useConsentStore } from "@/stores/consent-store";
 
 const GA_ID = process.env.NEXT_PUBLIC_GA4_ID;
 
 export function GoogleAnalytics() {
   const consent = useConsentStore((s) => s.consent);
-  const hydrated = useConsentHydrated();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
 
   if (!GA_ID) return null;
-  if (!hydrated) return null;
+  if (!mounted) return null;
   if (!consent?.analytics) return null;
 
   return (

--- a/components/analytics/google-analytics.tsx
+++ b/components/analytics/google-analytics.tsx
@@ -1,29 +1,27 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import Script from "next/script";
 import { useConsentStore } from "@/stores/consent-store";
+import { useMounted } from "@/hooks/use-mounted";
 
+const GA_ID_RE = /^G-[A-Z0-9]+$/;
 const GA_ID = process.env.NEXT_PUBLIC_GA4_ID;
+const validGaId = GA_ID && GA_ID_RE.test(GA_ID) ? GA_ID : null;
 
 export function GoogleAnalytics() {
   const consent = useConsentStore((s) => s.consent);
-  const [mounted, setMounted] = useState(false);
+  const mounted = useMounted();
 
-  useEffect(() => setMounted(true), []);
-
-  if (!GA_ID) return null;
-  if (!mounted) return null;
-  if (!consent?.analytics) return null;
+  if (!validGaId || !mounted || !consent?.analytics) return null;
 
   return (
     <>
       <Script
-        src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+        src={`https://www.googletagmanager.com/gtag/js?id=${validGaId}`}
         strategy="afterInteractive"
       />
       <Script id="ga4-config" strategy="afterInteractive">
-        {`window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','${GA_ID}');`}
+        {`window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','${validGaId}');`}
       </Script>
     </>
   );

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -1,12 +1,16 @@
 "use client";
 
 import { CartSync } from "@/components/storefront/cart-sync";
+import { CookieBanner } from "@/components/storefront/cookie-banner";
+import { GoogleAnalytics } from "@/components/analytics/google-analytics";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <>
       <CartSync />
+      <GoogleAnalytics />
       {children}
+      <CookieBanner />
     </>
   );
 }

--- a/components/storefront/cookie-banner.tsx
+++ b/components/storefront/cookie-banner.tsx
@@ -1,19 +1,21 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
-import { useConsentStore, useConsentHydrated } from "@/stores/consent-store";
+import { useConsentStore } from "@/stores/consent-store";
 import { Button } from "@/components/ui/button";
 
 export function CookieBanner() {
   const consent = useConsentStore((s) => s.consent);
   const { acceptAll, rejectAll, updateConsent } = useConsentStore();
-  const hydrated = useConsentHydrated();
+  const [mounted, setMounted] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [analyticsToggle, setAnalyticsToggle] = useState(false);
 
-  // Don't render until hydrated or if user already consented
-  if (!hydrated || consent !== null) return null;
+  useEffect(() => setMounted(true), []);
+
+  // Don't render until mounted (avoids hydration mismatch) or if already consented
+  if (!mounted || consent !== null) return null;
 
   if (showSettings) {
     return (

--- a/components/storefront/cookie-banner.tsx
+++ b/components/storefront/cookie-banner.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useConsentStore, useConsentHydrated } from "@/stores/consent-store";
+import { Button } from "@/components/ui/button";
+
+export function CookieBanner() {
+  const consent = useConsentStore((s) => s.consent);
+  const { acceptAll, rejectAll, updateConsent } = useConsentStore();
+  const hydrated = useConsentHydrated();
+  const [showSettings, setShowSettings] = useState(false);
+  const [analyticsToggle, setAnalyticsToggle] = useState(false);
+
+  // Don't render until hydrated or if user already consented
+  if (!hydrated || consent !== null) return null;
+
+  if (showSettings) {
+    return (
+      <div
+        role="dialog"
+        aria-label="Paramètres des cookies"
+        className="fixed inset-x-0 bottom-0 z-50 border-t bg-background p-4 shadow-lg sm:p-6"
+      >
+        <div className="mx-auto max-w-3xl space-y-4">
+          <h2 className="text-base font-semibold">Paramètres des cookies</h2>
+
+          <div className="space-y-3">
+            {/* Necessary cookies — always on */}
+            <div className="flex items-center justify-between rounded-lg border p-3">
+              <div>
+                <p className="text-sm font-medium">Cookies nécessaires</p>
+                <p className="text-xs text-muted-foreground">
+                  Session, panier, préférences d&apos;affichage. Indispensables
+                  au fonctionnement du site.
+                </p>
+              </div>
+              <span className="shrink-0 text-xs font-medium text-muted-foreground">
+                Toujours actif
+              </span>
+            </div>
+
+            {/* Analytics cookies — toggleable */}
+            <div className="flex items-center justify-between rounded-lg border p-3">
+              <div>
+                <p className="text-sm font-medium">Cookies analytiques</p>
+                <p className="text-xs text-muted-foreground">
+                  Google Analytics — nous aident à comprendre comment vous
+                  utilisez le site pour l&apos;améliorer.
+                </p>
+              </div>
+              <button
+                role="switch"
+                aria-checked={analyticsToggle}
+                onClick={() => setAnalyticsToggle(!analyticsToggle)}
+                className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 ${
+                  analyticsToggle ? "bg-primary" : "bg-muted"
+                }`}
+              >
+                <span
+                  className={`pointer-events-none inline-block size-5 rounded-full bg-background shadow-sm ring-0 transition-transform ${
+                    analyticsToggle ? "translate-x-5" : "translate-x-0"
+                  }`}
+                />
+              </button>
+            </div>
+          </div>
+
+          <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-between sm:items-center">
+            <Link
+              href="/politique-confidentialite"
+              className="text-xs text-muted-foreground underline underline-offset-4 hover:text-foreground"
+            >
+              Politique de confidentialité
+            </Link>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setShowSettings(false)}
+              >
+                Retour
+              </Button>
+              <Button
+                size="sm"
+                onClick={() => updateConsent("analytics", analyticsToggle)}
+              >
+                Enregistrer mes choix
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Consentement cookies"
+      className="fixed inset-x-0 bottom-0 z-50 border-t bg-background p-4 shadow-lg sm:p-6"
+    >
+      <div className="mx-auto flex max-w-3xl flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm text-muted-foreground">
+          Nous utilisons des cookies analytiques pour améliorer votre
+          expérience.{" "}
+          <Link
+            href="/politique-confidentialite"
+            className="underline underline-offset-4 hover:text-foreground"
+          >
+            En savoir plus
+          </Link>
+        </p>
+        <div className="flex shrink-0 gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setShowSettings(true)}
+          >
+            Personnaliser
+          </Button>
+          <Button variant="outline" size="sm" onClick={rejectAll}>
+            Tout refuser
+          </Button>
+          <Button size="sm" onClick={acceptAll}>
+            Tout accepter
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/storefront/cookie-banner.tsx
+++ b/components/storefront/cookie-banner.tsx
@@ -1,18 +1,18 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import { useConsentStore } from "@/stores/consent-store";
+import { useMounted } from "@/hooks/use-mounted";
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
 
 export function CookieBanner() {
   const consent = useConsentStore((s) => s.consent);
   const { acceptAll, rejectAll, updateConsent } = useConsentStore();
-  const [mounted, setMounted] = useState(false);
+  const mounted = useMounted();
   const [showSettings, setShowSettings] = useState(false);
   const [analyticsToggle, setAnalyticsToggle] = useState(false);
-
-  useEffect(() => setMounted(true), []);
 
   // Don't render until mounted (avoids hydration mismatch) or if already consented
   if (!mounted || consent !== null) return null;
@@ -51,20 +51,10 @@ export function CookieBanner() {
                   utilisez le site pour l&apos;améliorer.
                 </p>
               </div>
-              <button
-                role="switch"
-                aria-checked={analyticsToggle}
-                onClick={() => setAnalyticsToggle(!analyticsToggle)}
-                className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 ${
-                  analyticsToggle ? "bg-primary" : "bg-muted"
-                }`}
-              >
-                <span
-                  className={`pointer-events-none inline-block size-5 rounded-full bg-background shadow-sm ring-0 transition-transform ${
-                    analyticsToggle ? "translate-x-5" : "translate-x-0"
-                  }`}
-                />
-              </button>
+              <Switch
+                checked={analyticsToggle}
+                onCheckedChange={setAnalyticsToggle}
+              />
             </div>
           </div>
 

--- a/components/storefront/cookie-settings-button.tsx
+++ b/components/storefront/cookie-settings-button.tsx
@@ -3,9 +3,10 @@
 import { useConsentStore } from "@/stores/consent-store";
 
 export function CookieSettingsButton() {
+  const resetConsent = useConsentStore((s) => s.resetConsent);
   return (
     <button
-      onClick={() => useConsentStore.setState({ consent: null })}
+      onClick={resetConsent}
       className="text-sm text-muted-foreground hover:text-foreground"
     >
       Gérer les cookies

--- a/components/storefront/cookie-settings-button.tsx
+++ b/components/storefront/cookie-settings-button.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useConsentStore } from "@/stores/consent-store";
+
+export function CookieSettingsButton() {
+  return (
+    <button
+      onClick={() => useConsentStore.setState({ consent: null })}
+      className="text-sm text-muted-foreground hover:text-foreground"
+    >
+      Gérer les cookies
+    </button>
+  );
+}

--- a/components/storefront/footer.tsx
+++ b/components/storefront/footer.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import { SITE_NAME } from "@/lib/utils/constants";
+import { CookieSettingsButton } from "@/components/storefront/cookie-settings-button";
 
 const footerLinks = {
   boutique: {
@@ -75,6 +76,9 @@ export function Footer() {
             &copy; {new Date().getFullYear()} {SITE_NAME}. Tous droits
             réservés. Paiement à la livraison uniquement.
           </p>
+          <div className="mt-2">
+            <CookieSettingsButton />
+          </div>
         </div>
       </div>
     </footer>

--- a/docs/plans/2026-02-13-cookie-consent-design.md
+++ b/docs/plans/2026-02-13-cookie-consent-design.md
@@ -1,0 +1,46 @@
+# Design — Bandeau consentement cookies
+
+## Contexte
+
+NETEREKA utilise actuellement des cookies techniques (session better-auth, localStorage pour panier et theme). GA4 sera ajouté prochainement. La loi ivoirienne (n2013-450) exige un consentement prealable pour les cookies non essentiels.
+
+## Categories
+
+| Categorie | Cookies | Consentement |
+|-----------|---------|-------------|
+| Necessaires | Session better-auth, panier localStorage, theme | Toujours actif |
+| Analytiques | GA4 (`_ga`, `_ga_*`) | Opt-in requis |
+
+## Architecture
+
+### Store consentement (`stores/consent-store.ts`)
+
+Zustand + persist middleware, cle `netereka-consent:v1` dans localStorage.
+
+- `consent: { analytics: boolean } | null` — null = pas encore choisi
+- `acceptAll()`, `rejectAll()`, `updateConsent(category, value)`
+
+### Bandeau (`components/storefront/cookie-banner.tsx`)
+
+- Fixed bottom, affiche si `consent === null`
+- 3 actions : Tout accepter (primaire), Tout refuser (secondaire), Personnaliser
+- Panneau personnalisation avec toggles par categorie
+- Lien vers `/politique-confidentialite`
+
+### GA4 (`components/analytics/google-analytics.tsx`)
+
+- Lit `consent.analytics` du store
+- Si true : injecte gtag.js via `next/script` (afterInteractive)
+- Measurement ID via `NEXT_PUBLIC_GA4_ID`
+
+### Montage
+
+Dans `components/providers.tsx` : `<CookieBanner />` + `<GoogleAnalytics />`.
+
+## Fichiers impactes
+
+- `stores/consent-store.ts` — nouveau
+- `components/storefront/cookie-banner.tsx` — nouveau
+- `components/analytics/google-analytics.tsx` — nouveau
+- `components/providers.tsx` — modifie
+- `app/(storefront)/politique-confidentialite/page.tsx` — modifie (section cookies)

--- a/hooks/use-mounted.ts
+++ b/hooks/use-mounted.ts
@@ -1,0 +1,12 @@
+import { useSyncExternalStore } from "react";
+
+const subscribe = () => () => {};
+
+/**
+ * Returns false during SSR / first render and true after hydration.
+ * Uses useSyncExternalStore to avoid the ESLint react-hooks/set-state-in-effect
+ * rule that flags the common useState+useEffect "mounted" pattern.
+ */
+export function useMounted() {
+  return useSyncExternalStore(subscribe, () => true, () => false);
+}

--- a/stores/cart-store.ts
+++ b/stores/cart-store.ts
@@ -98,16 +98,17 @@ export const useCartStore = create<CartState>()(
 );
 
 export function useCartHydrated() {
-  const [hydrated, setHydrated] = useState(() => useCartStore.persist.hasHydrated());
+  const [hydrated, setHydrated] = useState(
+    () => useCartStore.persist?.hasHydrated?.() ?? false
+  );
 
-  // Catch hydration that completed between useState init and effect setup
-  if (!hydrated && useCartStore.persist.hasHydrated()) {
+  if (!hydrated && (useCartStore.persist?.hasHydrated?.() ?? false)) {
     setHydrated(true);
   }
 
   useEffect(() => {
-    const unsub = useCartStore.persist.onFinishHydration(() => setHydrated(true));
-    return unsub;
+    const unsub = useCartStore.persist?.onFinishHydration?.(() => setHydrated(true));
+    return () => unsub?.();
   }, []);
   return hydrated;
 }

--- a/stores/consent-store.ts
+++ b/stores/consent-store.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface ConsentState {
+  consent: { analytics: boolean } | null;
+  acceptAll: () => void;
+  rejectAll: () => void;
+  updateConsent: (category: "analytics", value: boolean) => void;
+}
+
+export const useConsentStore = create<ConsentState>()(
+  persist(
+    (set) => ({
+      consent: null,
+
+      acceptAll: () => set({ consent: { analytics: true } }),
+
+      rejectAll: () => set({ consent: { analytics: false } }),
+
+      updateConsent: (_category, value) =>
+        set(() => ({
+          consent: { analytics: value },
+        })),
+    }),
+    {
+      name: "netereka-consent:v1",
+      partialize: (state) => ({ consent: state.consent }),
+    }
+  )
+);
+
+export function useConsentHydrated() {
+  const [hydrated, setHydrated] = useState(() =>
+    useConsentStore.persist.hasHydrated()
+  );
+
+  if (!hydrated && useConsentStore.persist.hasHydrated()) {
+    setHydrated(true);
+  }
+
+  useEffect(() => {
+    const unsub = useConsentStore.persist.onFinishHydration(() =>
+      setHydrated(true)
+    );
+    return unsub;
+  }, []);
+
+  return hydrated;
+}

--- a/stores/consent-store.ts
+++ b/stores/consent-store.ts
@@ -33,19 +33,19 @@ export const useConsentStore = create<ConsentState>()(
 );
 
 export function useConsentHydrated() {
-  const [hydrated, setHydrated] = useState(() =>
-    useConsentStore.persist.hasHydrated()
+  const [hydrated, setHydrated] = useState(
+    () => useConsentStore.persist?.hasHydrated?.() ?? false
   );
 
-  if (!hydrated && useConsentStore.persist.hasHydrated()) {
+  if (!hydrated && (useConsentStore.persist?.hasHydrated?.() ?? false)) {
     setHydrated(true);
   }
 
   useEffect(() => {
-    const unsub = useConsentStore.persist.onFinishHydration(() =>
+    const unsub = useConsentStore.persist?.onFinishHydration?.(() =>
       setHydrated(true)
     );
-    return unsub;
+    return () => unsub?.();
   }, []);
 
   return hydrated;

--- a/stores/consent-store.ts
+++ b/stores/consent-store.ts
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
@@ -8,6 +7,7 @@ interface ConsentState {
   consent: { analytics: boolean } | null;
   acceptAll: () => void;
   rejectAll: () => void;
+  resetConsent: () => void;
   updateConsent: (category: "analytics", value: boolean) => void;
 }
 
@@ -20,6 +20,8 @@ export const useConsentStore = create<ConsentState>()(
 
       rejectAll: () => set({ consent: { analytics: false } }),
 
+      resetConsent: () => set({ consent: null }),
+
       updateConsent: (_category, value) =>
         set(() => ({
           consent: { analytics: value },
@@ -31,22 +33,3 @@ export const useConsentStore = create<ConsentState>()(
     }
   )
 );
-
-export function useConsentHydrated() {
-  const [hydrated, setHydrated] = useState(
-    () => useConsentStore.persist?.hasHydrated?.() ?? false
-  );
-
-  if (!hydrated && (useConsentStore.persist?.hasHydrated?.() ?? false)) {
-    setHydrated(true);
-  }
-
-  useEffect(() => {
-    const unsub = useConsentStore.persist?.onFinishHydration?.(() =>
-      setHydrated(true)
-    );
-    return () => unsub?.();
-  }, []);
-
-  return hydrated;
-}


### PR DESCRIPTION
## Summary
- Cookie consent banner (fixed bottom) with 3 actions: accept all, reject all, customize
- Settings panel with per-category toggles (necessary = always on, analytics = opt-in)
- GA4 script (`next/script`) loads only when analytics consent is granted
- Consent stored in localStorage via Zustand persist (`netereka-consent:v1`)
- "Gérer les cookies" link in footer to reopen the banner
- Privacy policy updated with analytics cookies section

## Files
- `stores/consent-store.ts` — Zustand consent store
- `components/storefront/cookie-banner.tsx` — Banner + settings panel
- `components/storefront/cookie-settings-button.tsx` — Footer link (client component)
- `components/analytics/google-analytics.tsx` — Conditional GA4 injection
- `components/providers.tsx` — Mounts banner + GA4
- `components/storefront/footer.tsx` — Added cookie settings link
- `app/(storefront)/politique-confidentialite/page.tsx` — Updated cookies section
- `docs/plans/2026-02-13-cookie-consent-design.md` — Design doc

## Configuration
Set `NEXT_PUBLIC_GA4_ID` env var to enable GA4 (e.g. `G-XXXXXXXXXX`). Without it, no analytics scripts are loaded regardless of consent.

## Test plan
- [ ] First visit: banner appears at bottom
- [ ] Click "Tout accepter": banner disappears, consent stored
- [ ] Reload: banner does not reappear
- [ ] Click "Tout refuser": banner disappears, no GA4 loaded
- [ ] Click "Personnaliser": settings panel with toggles
- [ ] Toggle analytics on + "Enregistrer": GA4 loads
- [ ] Footer "Gérer les cookies": reopens banner
- [ ] Without `NEXT_PUBLIC_GA4_ID`: no analytics scripts regardless

🤖 Generated with [Claude Code](https://claude.com/claude-code)