### PR TITLE
feat: add Vitest test framework with 121 unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,6 @@ jobs:
 
       - name: Lint
         run: npm run lint
+
+      - name: Tests
+        run: npm test

--- a/__tests__/unit/cart.test.ts
+++ b/__tests__/unit/cart.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { cartItemKey } from "@/lib/types/cart";
+
+describe("cartItemKey", () => {
+  it("génère la clé avec un variantId", () => {
+    expect(
+      cartItemKey({ productId: "prod-1", variantId: "var-1" })
+    ).toBe("prod-1:var-1");
+  });
+
+  it("utilise 'default' quand variantId est null", () => {
+    expect(
+      cartItemKey({ productId: "prod-1", variantId: null })
+    ).toBe("prod-1:default");
+  });
+
+  it("génère des clés différentes pour des variantes différentes", () => {
+    const key1 = cartItemKey({ productId: "prod-1", variantId: "var-1" });
+    const key2 = cartItemKey({ productId: "prod-1", variantId: "var-2" });
+    expect(key1).not.toBe(key2);
+  });
+
+  it("génère des clés différentes pour des produits différents", () => {
+    const key1 = cartItemKey({ productId: "prod-1", variantId: null });
+    const key2 = cartItemKey({ productId: "prod-2", variantId: null });
+    expect(key1).not.toBe(key2);
+  });
+});

--- a/__tests__/unit/csv.test.ts
+++ b/__tests__/unit/csv.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { ordersToCSV } from "@/lib/csv/orders";
+import type { AdminOrder } from "@/lib/db/types";
+
+function makeOrder(overrides: Partial<AdminOrder> = {}): AdminOrder {
+  return {
+    id: "order-1",
+    order_number: "ORD-ABC123",
+    user_id: "user-1",
+    user_name: "Koné Amadou",
+    user_email: "kone@example.com",
+    status: "pending",
+    subtotal: 50000,
+    delivery_fee: 2000,
+    discount_amount: 0,
+    total: 52000,
+    delivery_phone: "0102030405",
+    delivery_commune: "Cocody",
+    delivery_address: "Rue des Jardins",
+    delivery_instructions: null,
+    promo_code_id: null,
+    promo_code: null,
+    estimated_delivery: null,
+    cancellation_reason: null,
+    item_count: 2,
+    created_at: "2024-01-15T10:30:00Z",
+    updated_at: "2024-01-15T10:30:00Z",
+    confirmed_at: null,
+    preparing_at: null,
+    shipping_at: null,
+    delivered_at: null,
+    cancelled_at: null,
+    returned_at: null,
+    ...overrides,
+  } as AdminOrder;
+}
+
+describe("ordersToCSV", () => {
+  it("génère un CSV avec les en-têtes corrects", () => {
+    const csv = ordersToCSV([]);
+    const headers = csv.split("\n")[0];
+    expect(headers).toContain("Numéro");
+    expect(headers).toContain("Client");
+    expect(headers).toContain("Total");
+    expect(headers).toContain("Statut");
+  });
+
+  it("génère une ligne par commande", () => {
+    const csv = ordersToCSV([makeOrder(), makeOrder({ id: "order-2" })]);
+    const lines = csv.split("\n");
+    expect(lines).toHaveLength(3); // 1 header + 2 rows
+  });
+
+  it("inclut le numéro de commande", () => {
+    const csv = ordersToCSV([makeOrder()]);
+    expect(csv).toContain("ORD-ABC123");
+  });
+
+  it("traduit le statut en français", () => {
+    const csv = ordersToCSV([makeOrder({ status: "delivered" })]);
+    expect(csv).toContain("Livrée");
+  });
+
+  it("échappe les valeurs contenant des virgules", () => {
+    const csv = ordersToCSV([
+      makeOrder({ delivery_address: "Rue 12, Cocody, Abidjan" }),
+    ]);
+    // La valeur avec virgules doit être entourée de guillemets
+    expect(csv).toContain('"Rue 12, Cocody, Abidjan"');
+  });
+
+  it("échappe les valeurs contenant des guillemets", () => {
+    const csv = ordersToCSV([
+      makeOrder({ user_name: 'Amadou "Le Grand"' }),
+    ]);
+    // Les guillemets doivent être doublés
+    expect(csv).toContain('"Amadou ""Le Grand"""');
+  });
+
+  it("inclut les montants numériques", () => {
+    const csv = ordersToCSV([
+      makeOrder({ subtotal: 75000, delivery_fee: 3000, total: 78000 }),
+    ]);
+    expect(csv).toContain("75000");
+    expect(csv).toContain("3000");
+    expect(csv).toContain("78000");
+  });
+
+  it("retourne uniquement les en-têtes pour un tableau vide", () => {
+    const csv = ordersToCSV([]);
+    const lines = csv.split("\n");
+    expect(lines).toHaveLength(1);
+  });
+});

--- a/__tests__/unit/format.test.ts
+++ b/__tests__/unit/format.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { formatPrice, formatDate, formatDateTime } from "@/lib/utils/format";
+
+describe("formatPrice (XOF currency)", () => {
+  it("formate un prix en XOF", () => {
+    const result = formatPrice(25000);
+    // XOF format varie selon la locale mais doit contenir le montant
+    expect(result).toMatch(/25/);
+    expect(result).toMatch(/000/);
+  });
+
+  it("formate zéro", () => {
+    const result = formatPrice(0);
+    expect(result).toMatch(/0/);
+  });
+
+  it("n'affiche pas de décimales pour le XOF", () => {
+    const result = formatPrice(1500);
+    // Le XOF n'a pas de sous-unités
+    expect(result).not.toMatch(/[.,]\d{2}$/);
+  });
+
+  it("formate les grands montants", () => {
+    const result = formatPrice(2500000);
+    expect(result).toMatch(/2.*500.*000/);
+  });
+});
+
+describe("formatDate", () => {
+  it("formate une date string", () => {
+    const result = formatDate("2024-01-15");
+    expect(result).toMatch(/15/);
+    expect(result).toMatch(/2024/);
+  });
+
+  it("formate un objet Date", () => {
+    const result = formatDate(new Date("2024-06-20T10:00:00Z"));
+    expect(result).toMatch(/20/);
+    expect(result).toMatch(/2024/);
+  });
+});
+
+describe("formatDateTime", () => {
+  it("inclut l'heure dans le format", () => {
+    const result = formatDateTime("2024-01-15T14:30:00Z");
+    expect(result).toMatch(/15/);
+    expect(result).toMatch(/2024/);
+    // Doit contenir une indication d'heure
+    expect(result).toMatch(/\d{2}:\d{2}/);
+  });
+});

--- a/__tests__/unit/images.test.ts
+++ b/__tests__/unit/images.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getImageUrl } from "@/lib/utils/images";
+
+describe("getImageUrl", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("retourne le placeholder pour null", () => {
+    expect(getImageUrl(null)).toBe("/images/placeholder.webp");
+  });
+
+  it("retourne le placeholder pour undefined", () => {
+    expect(getImageUrl(undefined)).toBe("/images/placeholder.webp");
+  });
+
+  it("retourne le placeholder pour une chaîne vide", () => {
+    expect(getImageUrl("")).toBe("/images/placeholder.webp");
+  });
+
+  it("retourne l'URL absolue telle quelle (http)", () => {
+    const url = "http://example.com/image.jpg";
+    expect(getImageUrl(url)).toBe(url);
+  });
+
+  it("retourne l'URL absolue telle quelle (https)", () => {
+    const url = "https://cdn.example.com/image.png";
+    expect(getImageUrl(url)).toBe(url);
+  });
+
+  it("retourne les chemins root-relatifs tels quels", () => {
+    expect(getImageUrl("/images/product.jpg")).toBe("/images/product.jpg");
+  });
+
+  it("préfixe avec R2_URL si défini", () => {
+    vi.stubEnv("NEXT_PUBLIC_R2_URL", "https://r2.netereka.ci");
+    expect(getImageUrl("products/phone.jpg")).toBe(
+      "https://r2.netereka.ci/products/phone.jpg"
+    );
+  });
+
+  it("utilise /images comme fallback sans R2_URL", () => {
+    delete process.env.NEXT_PUBLIC_R2_URL;
+    expect(getImageUrl("products/phone.jpg")).toBe("/images/products/phone.jpg");
+  });
+});

--- a/__tests__/unit/order-number.test.ts
+++ b/__tests__/unit/order-number.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { generateOrderNumber } from "@/lib/db/orders";
+
+describe("generateOrderNumber", () => {
+  it("commence par ORD-", () => {
+    const num = generateOrderNumber();
+    expect(num).toMatch(/^ORD-/);
+  });
+
+  it("a exactement 10 caractères (ORD- + 6)", () => {
+    const num = generateOrderNumber();
+    expect(num).toHaveLength(10);
+  });
+
+  it("ne contient que des caractères alphanumériques après ORD-", () => {
+    const num = generateOrderNumber();
+    const suffix = num.slice(4);
+    expect(suffix).toMatch(/^[A-Z0-9]{6}$/);
+  });
+
+  it("génère des numéros différents (probabiliste)", () => {
+    const numbers = new Set(Array.from({ length: 100 }, () => generateOrderNumber()));
+    // 36^6 = ~2 milliards de combinaisons, 100 devraient toutes être uniques
+    expect(numbers.size).toBe(100);
+  });
+});

--- a/__tests__/unit/order-number.test.ts
+++ b/__tests__/unit/order-number.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { generateOrderNumber } from "@/lib/db/orders";
+import { generateOrderNumber } from "@/lib/utils/order-number";
 
 describe("generateOrderNumber", () => {
   it("commence par ORD-", () => {

--- a/__tests__/unit/orders.test.ts
+++ b/__tests__/unit/orders.test.ts
@@ -49,6 +49,14 @@ describe("isValidStatusTransition", () => {
     expect(isValidStatusTransition("confirmed", "preparing")).toBe(true);
   });
 
+  it("permet confirmed → cancelled", () => {
+    expect(isValidStatusTransition("confirmed", "cancelled")).toBe(true);
+  });
+
+  it("permet preparing → cancelled", () => {
+    expect(isValidStatusTransition("preparing", "cancelled")).toBe(true);
+  });
+
   it("permet preparing → shipping", () => {
     expect(isValidStatusTransition("preparing", "shipping")).toBe(true);
   });

--- a/__tests__/unit/orders.test.ts
+++ b/__tests__/unit/orders.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import {
+  ORDER_STATUS_TRANSITIONS,
+  ORDER_STATUS_LABELS,
+  ORDER_STATUSES,
+  isOrderStatus,
+  getOrderStatus,
+  isValidStatusTransition,
+  getStatusTimestampField,
+} from "@/lib/constants/orders";
+
+describe("isOrderStatus", () => {
+  it("reconnaît tous les statuts valides", () => {
+    for (const status of ORDER_STATUSES) {
+      expect(isOrderStatus(status)).toBe(true);
+    }
+  });
+
+  it("rejette les statuts invalides", () => {
+    expect(isOrderStatus("invalid")).toBe(false);
+    expect(isOrderStatus("")).toBe(false);
+    expect(isOrderStatus("PENDING")).toBe(false); // case-sensitive
+  });
+});
+
+describe("getOrderStatus", () => {
+  it("retourne le statut s'il est valide", () => {
+    expect(getOrderStatus("pending")).toBe("pending");
+    expect(getOrderStatus("delivered")).toBe("delivered");
+  });
+
+  it("retourne 'pending' comme fallback pour un statut invalide", () => {
+    expect(getOrderStatus("invalid")).toBe("pending");
+    expect(getOrderStatus("")).toBe("pending");
+  });
+});
+
+describe("isValidStatusTransition", () => {
+  // Transitions valides
+  it("permet pending → confirmed", () => {
+    expect(isValidStatusTransition("pending", "confirmed")).toBe(true);
+  });
+
+  it("permet pending → cancelled", () => {
+    expect(isValidStatusTransition("pending", "cancelled")).toBe(true);
+  });
+
+  it("permet confirmed → preparing", () => {
+    expect(isValidStatusTransition("confirmed", "preparing")).toBe(true);
+  });
+
+  it("permet preparing → shipping", () => {
+    expect(isValidStatusTransition("preparing", "shipping")).toBe(true);
+  });
+
+  it("permet shipping → delivered", () => {
+    expect(isValidStatusTransition("shipping", "delivered")).toBe(true);
+  });
+
+  it("permet shipping → returned", () => {
+    expect(isValidStatusTransition("shipping", "returned")).toBe(true);
+  });
+
+  it("permet delivered → returned", () => {
+    expect(isValidStatusTransition("delivered", "returned")).toBe(true);
+  });
+
+  // Transitions invalides
+  it("interdit pending → delivered (saut d'étape)", () => {
+    expect(isValidStatusTransition("pending", "delivered")).toBe(false);
+  });
+
+  it("interdit delivered → pending (retour arrière)", () => {
+    expect(isValidStatusTransition("delivered", "pending")).toBe(false);
+  });
+
+  it("interdit cancelled → * (état terminal)", () => {
+    for (const status of ORDER_STATUSES) {
+      expect(isValidStatusTransition("cancelled", status)).toBe(false);
+    }
+  });
+
+  it("interdit returned → * (état terminal)", () => {
+    for (const status of ORDER_STATUSES) {
+      expect(isValidStatusTransition("returned", status)).toBe(false);
+    }
+  });
+});
+
+describe("getStatusTimestampField", () => {
+  it("retourne le champ timestamp pour chaque statut avec timestamp", () => {
+    expect(getStatusTimestampField("confirmed")).toBe("confirmed_at");
+    expect(getStatusTimestampField("preparing")).toBe("preparing_at");
+    expect(getStatusTimestampField("shipping")).toBe("shipping_at");
+    expect(getStatusTimestampField("delivered")).toBe("delivered_at");
+    expect(getStatusTimestampField("cancelled")).toBe("cancelled_at");
+    expect(getStatusTimestampField("returned")).toBe("returned_at");
+  });
+
+  it("retourne null pour pending (pas de timestamp)", () => {
+    expect(getStatusTimestampField("pending")).toBeNull();
+  });
+});
+
+describe("ORDER_STATUS_LABELS", () => {
+  it("a un label pour chaque statut", () => {
+    for (const status of ORDER_STATUSES) {
+      expect(ORDER_STATUS_LABELS[status]).toBeDefined();
+      expect(typeof ORDER_STATUS_LABELS[status]).toBe("string");
+    }
+  });
+
+  it("les labels sont en français", () => {
+    expect(ORDER_STATUS_LABELS.pending).toBe("En attente");
+    expect(ORDER_STATUS_LABELS.delivered).toBe("Livrée");
+    expect(ORDER_STATUS_LABELS.cancelled).toBe("Annulée");
+  });
+});
+
+describe("ORDER_STATUS_TRANSITIONS", () => {
+  it("chaque statut a un tableau de transitions (même vide)", () => {
+    for (const status of ORDER_STATUSES) {
+      expect(Array.isArray(ORDER_STATUS_TRANSITIONS[status])).toBe(true);
+    }
+  });
+
+  it("les états terminaux n'ont aucune transition", () => {
+    expect(ORDER_STATUS_TRANSITIONS.cancelled).toHaveLength(0);
+    expect(ORDER_STATUS_TRANSITIONS.returned).toHaveLength(0);
+  });
+});

--- a/__tests__/unit/utils.test.ts
+++ b/__tests__/unit/utils.test.ts
@@ -41,23 +41,23 @@ describe("slugify", () => {
 });
 
 describe("formatPrice", () => {
-  it("formate un prix avec le suffixe FCFA", () => {
+  it("formate un prix en XOF avec indicateur CFA", () => {
     const result = formatPrice(15000);
     expect(result).toContain("15");
     expect(result).toContain("000");
-    expect(result).toContain("FCFA");
+    // Re-exported from lib/utils/format — uses Intl currency format (F CFA)
+    expect(result).toMatch(/CFA/);
   });
 
   it("formate zéro", () => {
     const result = formatPrice(0);
     expect(result).toContain("0");
-    expect(result).toContain("FCFA");
+    expect(result).toMatch(/CFA/);
   });
 
   it("formate un grand nombre avec séparateurs", () => {
     const result = formatPrice(1500000);
-    expect(result).toContain("FCFA");
-    // Le séparateur de milliers est présent (espace ou point selon locale)
+    expect(result).toMatch(/CFA/);
     expect(result).toMatch(/1.*500.*000/);
   });
 });

--- a/__tests__/unit/utils.test.ts
+++ b/__tests__/unit/utils.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { slugify, formatPrice, cn, formatOrderDate, formatDateShort, formatDateLong } from "@/lib/utils";
+
+describe("slugify", () => {
+  it("convertit un texte simple en slug", () => {
+    expect(slugify("Hello World")).toBe("hello-world");
+  });
+
+  it("supprime les accents français", () => {
+    expect(slugify("Écouteurs Bluetooth")).toBe("ecouteurs-bluetooth");
+    expect(slugify("Téléphone à écran")).toBe("telephone-a-ecran");
+    expect(slugify("Caméra réseau")).toBe("camera-reseau");
+  });
+
+  it("gère les caractères spéciaux", () => {
+    expect(slugify("Prix: 50,000 FCFA!")).toBe("prix-50-000-fcfa");
+    expect(slugify("TV 4K (65 pouces)")).toBe("tv-4k-65-pouces");
+  });
+
+  it("supprime les tirets en début/fin", () => {
+    expect(slugify("--hello--")).toBe("hello");
+    expect(slugify("  test  ")).toBe("test");
+  });
+
+  it("gère les espaces multiples", () => {
+    expect(slugify("mot   un   deux")).toBe("mot-un-deux");
+  });
+
+  it("retourne une chaîne vide pour une entrée vide", () => {
+    expect(slugify("")).toBe("");
+  });
+
+  it("gère les chiffres", () => {
+    expect(slugify("iPhone 15 Pro Max")).toBe("iphone-15-pro-max");
+  });
+
+  it("gère le cédille et autres diacritiques", () => {
+    expect(slugify("Façade")).toBe("facade");
+    expect(slugify("naïve")).toBe("naive");
+  });
+});
+
+describe("formatPrice", () => {
+  it("formate un prix avec le suffixe FCFA", () => {
+    const result = formatPrice(15000);
+    expect(result).toContain("15");
+    expect(result).toContain("000");
+    expect(result).toContain("FCFA");
+  });
+
+  it("formate zéro", () => {
+    const result = formatPrice(0);
+    expect(result).toContain("0");
+    expect(result).toContain("FCFA");
+  });
+
+  it("formate un grand nombre avec séparateurs", () => {
+    const result = formatPrice(1500000);
+    expect(result).toContain("FCFA");
+    // Le séparateur de milliers est présent (espace ou point selon locale)
+    expect(result).toMatch(/1.*500.*000/);
+  });
+});
+
+describe("cn", () => {
+  it("fusionne des classes simples", () => {
+    expect(cn("foo", "bar")).toBe("foo bar");
+  });
+
+  it("résout les conflits Tailwind", () => {
+    expect(cn("px-2", "px-4")).toBe("px-4");
+    expect(cn("text-red-500", "text-blue-500")).toBe("text-blue-500");
+  });
+
+  it("gère les valeurs conditionnelles", () => {
+    expect(cn("base", false && "hidden", "extra")).toBe("base extra");
+    expect(cn("base", true && "visible")).toBe("base visible");
+  });
+
+  it("gère undefined et null", () => {
+    expect(cn("foo", undefined, null, "bar")).toBe("foo bar");
+  });
+});
+
+describe("formatOrderDate", () => {
+  it("formate une date ISO en format court français", () => {
+    const result = formatOrderDate("2024-01-25T14:30:00Z");
+    expect(result).toMatch(/25/);
+    expect(result).toMatch(/janv/i);
+  });
+});
+
+describe("formatDateShort", () => {
+  it("formate en format court avec année", () => {
+    const result = formatDateShort("2024-06-15T10:00:00Z");
+    expect(result).toMatch(/15/);
+    expect(result).toMatch(/2024/);
+  });
+});
+
+describe("formatDateLong", () => {
+  it("formate en format long avec mois complet", () => {
+    const result = formatDateLong("2024-03-08T10:00:00Z");
+    expect(result).toMatch(/08/);
+    expect(result).toMatch(/mars/i);
+    expect(result).toMatch(/2024/);
+  });
+});

--- a/__tests__/unit/validations/account.test.ts
+++ b/__tests__/unit/validations/account.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { profileSchema, changePasswordSchema } from "@/lib/validations/account";
+
+describe("profileSchema", () => {
+  it("accepte un profil valide", () => {
+    const result = profileSchema.safeParse({
+      name: "Koné Amadou",
+      phone: "0102030405",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejette un nom trop court", () => {
+    const result = profileSchema.safeParse({ name: "A", phone: "0102030405" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejette un nom trop long (>100)", () => {
+    const result = profileSchema.safeParse({
+      name: "a".repeat(101),
+      phone: "0102030405",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepte un téléphone avec +225", () => {
+    const result = profileSchema.safeParse({
+      name: "Amadou",
+      phone: "+2250102030405",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("nettoie les espaces dans le téléphone", () => {
+    const result = profileSchema.safeParse({
+      name: "Amadou",
+      phone: "01 02 03 04 05",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.phone).toBe("0102030405");
+    }
+  });
+
+  it("rejette un numéro invalide", () => {
+    const result = profileSchema.safeParse({
+      name: "Amadou",
+      phone: "12345",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("changePasswordSchema", () => {
+  const validPasswords = {
+    currentPassword: "ancienMotDePasse",
+    newPassword: "nouveauMotDePasse123",
+    confirmPassword: "nouveauMotDePasse123",
+  };
+
+  it("accepte des mots de passe valides qui correspondent", () => {
+    const result = changePasswordSchema.safeParse(validPasswords);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejette si les mots de passe ne correspondent pas", () => {
+    const result = changePasswordSchema.safeParse({
+      ...validPasswords,
+      confirmPassword: "different",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const errors = result.error.flatten();
+      expect(errors.fieldErrors.confirmPassword).toBeDefined();
+    }
+  });
+
+  it("rejette un nouveau mot de passe trop court (<8)", () => {
+    const result = changePasswordSchema.safeParse({
+      ...validPasswords,
+      newPassword: "court",
+      confirmPassword: "court",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejette un mot de passe actuel vide", () => {
+    const result = changePasswordSchema.safeParse({
+      ...validPasswords,
+      currentPassword: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejette une confirmation vide", () => {
+    const result = changePasswordSchema.safeParse({
+      ...validPasswords,
+      confirmPassword: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepte un mot de passe de exactement 8 caractères", () => {
+    const result = changePasswordSchema.safeParse({
+      currentPassword: "ancien",
+      newPassword: "12345678",
+      confirmPassword: "12345678",
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/__tests__/unit/validations/address.test.ts
+++ b/__tests__/unit/validations/address.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { addressSchema } from "@/lib/validations/address";
+
+const validAddress = {
+  label: "Maison",
+  fullName: "Koné Amadou",
+  phone: "0102030405",
+  street: "Rue des Jardins, Cocody",
+  commune: "Cocody",
+  city: "Abidjan",
+};
+
+describe("addressSchema", () => {
+  it("accepte une adresse valide", () => {
+    const result = addressSchema.safeParse(validAddress);
+    expect(result.success).toBe(true);
+  });
+
+  it("utilise Abidjan comme ville par défaut", () => {
+    const { city, ...withoutCity } = validAddress;
+    const result = addressSchema.safeParse(withoutCity);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.city).toBe("Abidjan");
+    }
+  });
+
+  // --- Téléphone ivoirien ---
+
+  it("accepte un numéro à 10 chiffres", () => {
+    const result = addressSchema.safeParse({ ...validAddress, phone: "0708091011" });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepte un numéro avec préfixe +225", () => {
+    const result = addressSchema.safeParse({ ...validAddress, phone: "+2250102030405" });
+    expect(result.success).toBe(true);
+  });
+
+  it("nettoie les espaces et tirets du numéro", () => {
+    const result = addressSchema.safeParse({ ...validAddress, phone: "01 02 03-04-05" });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.phone).toBe("0102030405");
+    }
+  });
+
+  it("rejette un numéro trop court", () => {
+    const result = addressSchema.safeParse({ ...validAddress, phone: "01020304" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejette un numéro trop long", () => {
+    const result = addressSchema.safeParse({ ...validAddress, phone: "010203040506" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejette un numéro avec des lettres", () => {
+    const result = addressSchema.safeParse({ ...validAddress, phone: "01020304ab" });
+    expect(result.success).toBe(false);
+  });
+
+  // --- Champs requis ---
+
+  it("rejette un label vide", () => {
+    const result = addressSchema.safeParse({ ...validAddress, label: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejette un nom trop court", () => {
+    const result = addressSchema.safeParse({ ...validAddress, fullName: "A" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejette une adresse rue trop courte", () => {
+    const result = addressSchema.safeParse({ ...validAddress, street: "AB" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejette une commune vide", () => {
+    const result = addressSchema.safeParse({ ...validAddress, commune: "" });
+    expect(result.success).toBe(false);
+  });
+
+  // --- Limites de longueur ---
+
+  it("rejette un label trop long (>50)", () => {
+    const result = addressSchema.safeParse({ ...validAddress, label: "a".repeat(51) });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejette un nom trop long (>100)", () => {
+    const result = addressSchema.safeParse({ ...validAddress, fullName: "a".repeat(101) });
+    expect(result.success).toBe(false);
+  });
+
+  // --- Champ optionnel ---
+
+  it("accepte les instructions optionnelles", () => {
+    const result = addressSchema.safeParse({
+      ...validAddress,
+      instructions: "Sonner 2 fois",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejette des instructions trop longues (>500)", () => {
+    const result = addressSchema.safeParse({
+      ...validAddress,
+      instructions: "a".repeat(501),
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/__tests__/unit/validations/checkout.test.ts
+++ b/__tests__/unit/validations/checkout.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import { checkoutSchema } from "@/lib/validations/checkout";
+
+const validItem = { productId: "prod-1", variantId: null, quantity: 2 };
+
+const validCheckoutWithSavedAddress = {
+  savedAddressId: "addr-1",
+  commune: "Cocody",
+  items: [validItem],
+};
+
+const validCheckoutWithNewAddress = {
+  fullName: "Koné Amadou",
+  phone: "0102030405",
+  street: "Rue des Jardins, Cocody",
+  commune: "Cocody",
+  items: [validItem],
+};
+
+describe("checkoutSchema", () => {
+  // --- Cas valides ---
+
+  it("accepte un checkout avec adresse enregistrée", () => {
+    const result = checkoutSchema.safeParse(validCheckoutWithSavedAddress);
+    expect(result.success).toBe(true);
+  });
+
+  it("accepte un checkout avec nouvelle adresse complète", () => {
+    const result = checkoutSchema.safeParse(validCheckoutWithNewAddress);
+    expect(result.success).toBe(true);
+  });
+
+  it("saveAddress est false par défaut", () => {
+    const result = checkoutSchema.safeParse(validCheckoutWithNewAddress);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.saveAddress).toBe(false);
+    }
+  });
+
+  // --- Validation du panier ---
+
+  it("rejette un panier vide", () => {
+    const result = checkoutSchema.safeParse({
+      ...validCheckoutWithSavedAddress,
+      items: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejette une quantité à 0", () => {
+    const result = checkoutSchema.safeParse({
+      ...validCheckoutWithSavedAddress,
+      items: [{ ...validItem, quantity: 0 }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejette une quantité > 10", () => {
+    const result = checkoutSchema.safeParse({
+      ...validCheckoutWithSavedAddress,
+      items: [{ ...validItem, quantity: 11 }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepte quantité de 1 à 10", () => {
+    for (const q of [1, 5, 10]) {
+      const result = checkoutSchema.safeParse({
+        ...validCheckoutWithSavedAddress,
+        items: [{ ...validItem, quantity: q }],
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  // --- Validation conditionnelle d'adresse ---
+
+  it("rejette sans adresse enregistrée ET sans adresse complète", () => {
+    const result = checkoutSchema.safeParse({
+      commune: "Cocody",
+      items: [validItem],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejette si nouvelle adresse incomplète (manque fullName)", () => {
+    const result = checkoutSchema.safeParse({
+      phone: "0102030405",
+      street: "Rue test",
+      commune: "Cocody",
+      items: [validItem],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejette si nouvelle adresse incomplète (manque phone)", () => {
+    const result = checkoutSchema.safeParse({
+      fullName: "Koné Amadou",
+      street: "Rue test",
+      commune: "Cocody",
+      items: [validItem],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejette si nouvelle adresse incomplète (manque street)", () => {
+    const result = checkoutSchema.safeParse({
+      fullName: "Koné Amadou",
+      phone: "0102030405",
+      commune: "Cocody",
+      items: [validItem],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  // --- Commune toujours requise ---
+
+  it("rejette sans commune", () => {
+    const result = checkoutSchema.safeParse({
+      savedAddressId: "addr-1",
+      items: [validItem],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  // --- Champs optionnels ---
+
+  it("accepte un code promo", () => {
+    const result = checkoutSchema.safeParse({
+      ...validCheckoutWithSavedAddress,
+      promoCode: "NOEL2024",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepte des instructions de livraison", () => {
+    const result = checkoutSchema.safeParse({
+      ...validCheckoutWithSavedAddress,
+      instructions: "Appeler en arrivant",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  // --- Téléphone avec nettoyage ---
+
+  it("nettoie les espaces et tirets du téléphone", () => {
+    const result = checkoutSchema.safeParse({
+      ...validCheckoutWithNewAddress,
+      phone: "01 02-03 04-05",
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/__tests__/unit/validations/review.test.ts
+++ b/__tests__/unit/validations/review.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { reviewSchema } from "@/lib/validations/review";
+
+describe("reviewSchema", () => {
+  it("accepte un avis valide", () => {
+    const result = reviewSchema.safeParse({
+      productId: "prod-1",
+      rating: 4,
+      comment: "Très bon produit",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepte un avis sans commentaire", () => {
+    const result = reviewSchema.safeParse({
+      productId: "prod-1",
+      rating: 5,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejette une note à 0", () => {
+    const result = reviewSchema.safeParse({
+      productId: "prod-1",
+      rating: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejette une note > 5", () => {
+    const result = reviewSchema.safeParse({
+      productId: "prod-1",
+      rating: 6,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejette une note décimale", () => {
+    const result = reviewSchema.safeParse({
+      productId: "prod-1",
+      rating: 3.5,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepte les notes de 1 à 5", () => {
+    for (let rating = 1; rating <= 5; rating++) {
+      const result = reviewSchema.safeParse({ productId: "prod-1", rating });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("rejette un productId vide", () => {
+    const result = reviewSchema.safeParse({
+      productId: "",
+      rating: 3,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejette un commentaire trop long (>1000)", () => {
+    const result = reviewSchema.safeParse({
+      productId: "prod-1",
+      rating: 3,
+      comment: "a".repeat(1001),
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/actions/checkout.ts
+++ b/actions/checkout.ts
@@ -5,7 +5,8 @@ import { checkoutSchema, type CheckoutInput, type CheckoutOutput } from "@/lib/v
 import { query, queryFirst } from "@/lib/db";
 import { getDeliveryZoneByCommune } from "@/lib/db/delivery-zones";
 import { getAddressById, createAddress } from "@/lib/db/addresses";
-import { createOrderWithItems, generateOrderNumber } from "@/lib/db/orders";
+import { createOrderWithItems } from "@/lib/db/orders";
+import { generateOrderNumber } from "@/lib/utils/order-number";
 import type { Product, ProductVariant, PromoCode } from "@/lib/db/types";
 import { notifyOrderConfirmation } from "@/lib/notifications";
 

--- a/components/admin/order-filter-sheet.tsx
+++ b/components/admin/order-filter-sheet.tsx
@@ -5,7 +5,8 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Cancel01Icon, FilterIcon, Search01Icon } from "@hugeicons/core-free-icons";
 import { cn } from "@/lib/utils";
-import { ORDER_STATUS_LABELS, ORDER_STATUS_ICONS } from "@/lib/constants/orders";
+import { ORDER_STATUS_LABELS } from "@/lib/constants/orders";
+import { ORDER_STATUS_ICONS } from "@/lib/constants/order-icons";
 import type { OrderStatus } from "@/lib/db/types";
 
 interface OrderFilterSheetProps {

--- a/components/ui/status-badge.tsx
+++ b/components/ui/status-badge.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Badge, type badgeVariants } from "./badge";
-import { ORDER_STATUS_ICONS } from "@/lib/constants/orders";
+import { ORDER_STATUS_ICONS } from "@/lib/constants/order-icons";
 import type { VariantProps } from "class-variance-authority";
 import type { OrderStatus } from "@/lib/db/types";
 

--- a/lib/constants/order-icons.ts
+++ b/lib/constants/order-icons.ts
@@ -1,0 +1,25 @@
+import {
+  Time02Icon,
+  CheckmarkCircle02Icon,
+  Package02Icon,
+  DeliveryTruck01Icon,
+  CheckmarkSquare02Icon,
+  Cancel01Icon,
+  ArrowTurnBackwardIcon,
+} from "@hugeicons/core-free-icons";
+
+/**
+ * Icons for each order status.
+ * Provides visual differentiation beyond color alone (accessibility).
+ *
+ * Separated from orders.ts to keep pure logic free of UI imports.
+ */
+export const ORDER_STATUS_ICONS = {
+  pending: Time02Icon,
+  confirmed: CheckmarkCircle02Icon,
+  preparing: Package02Icon,
+  shipping: DeliveryTruck01Icon,
+  delivered: CheckmarkSquare02Icon,
+  cancelled: Cancel01Icon,
+  returned: ArrowTurnBackwardIcon,
+} as const;

--- a/lib/constants/orders.ts
+++ b/lib/constants/orders.ts
@@ -1,27 +1,4 @@
-import {
-  Time02Icon,
-  CheckmarkCircle02Icon,
-  Package02Icon,
-  DeliveryTruck01Icon,
-  CheckmarkSquare02Icon,
-  Cancel01Icon,
-  ArrowTurnBackwardIcon,
-} from "@hugeicons/core-free-icons";
 import type { OrderStatus } from "@/lib/db/types";
-
-/**
- * Icons for each order status.
- * Provides visual differentiation beyond color alone (accessibility).
- */
-export const ORDER_STATUS_ICONS = {
-  pending: Time02Icon,
-  confirmed: CheckmarkCircle02Icon,
-  preparing: Package02Icon,
-  shipping: DeliveryTruck01Icon,
-  delivered: CheckmarkSquare02Icon,
-  cancelled: Cancel01Icon,
-  returned: ArrowTurnBackwardIcon,
-} as const;
 
 /**
  * Valid status transitions for orders.

--- a/lib/db/orders.ts
+++ b/lib/db/orders.ts
@@ -4,15 +4,6 @@ import { nanoid } from "nanoid";
 import type { Order, OrderItem } from "@/lib/db/types";
 export type { Order, OrderItem };
 
-export function generateOrderNumber(): string {
-  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-  let result = "ORD-";
-  for (let i = 0; i < 6; i++) {
-    result += chars.charAt(Math.floor(Math.random() * chars.length));
-  }
-  return result;
-}
-
 interface CreateOrderData {
   userId: string;
   orderNumber: string;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,6 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
+export { formatPrice } from "@/lib/utils/format";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -12,10 +13,6 @@ export function slugify(text: string): string {
     .replace(/[\u0300-\u036f]/g, "")
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-|-$/g, "");
-}
-
-export function formatPrice(price: number): string {
-  return new Intl.NumberFormat("fr-CI", { style: "decimal" }).format(price) + " FCFA";
 }
 
 // Date formatting options for order lists (shared across components)

--- a/lib/utils/order-number.ts
+++ b/lib/utils/order-number.ts
@@ -1,0 +1,8 @@
+export function generateOrderNumber(): string {
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  let result = "ORD-";
+  for (let i = 0; i < 6; i++) {
+    result += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return result;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "netereka",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "netereka",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "@base-ui/react": "^1.1.0",
         "@hookform/resolvers": "^5.2.2",
@@ -50,6 +50,7 @@
         "shadcn": "^3.8.1",
         "tailwindcss": "^4",
         "typescript": "5.9.3",
+        "vitest": "^4.0.18",
         "wrangler": "^4.61.1",
         "xlsx": "^0.18.5"
       }
@@ -1506,6 +1507,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1975,6 +1977,7 @@
       "version": "1.4.18",
       "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.4.18.tgz",
       "integrity": "sha512-q+awYgC7nkLEBdx2sW0iJjkzgSHlIxGnOpsN1r/O1+a4m7osJNHtfK2mKJSL1I+GfNyIlxJF8WvD/NLuYMpmcg==",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "zod": "^4.3.5"
@@ -2004,12 +2007,14 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@better-fetch/fetch": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
-      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
+      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==",
+      "peer": true
     },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.4.2",
@@ -2120,7 +2125,8 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260131.0.tgz",
       "integrity": "sha512-ELgvb2mp68Al50p+FmpgCO2hgU5o4tmz8pi7kShN+cRXc0UZoEdxpDIikR0CeT7b3tV7wlnEnsUzd0UoJLS0oQ==",
       "devOptional": true,
-      "license": "MIT OR Apache-2.0"
+      "license": "MIT OR Apache-2.0",
+      "peer": true
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -2301,6 +2307,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2414,6 +2421,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2430,6 +2438,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2446,6 +2455,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2462,6 +2472,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2478,6 +2489,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2494,6 +2506,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2510,6 +2523,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2526,6 +2540,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2542,6 +2557,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2558,6 +2574,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2574,6 +2591,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2590,6 +2608,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2606,6 +2625,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2622,6 +2642,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2638,6 +2659,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2654,6 +2676,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2670,6 +2693,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2686,6 +2710,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2702,6 +2727,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2718,6 +2744,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2734,6 +2761,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2750,6 +2778,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4436,6 +4465,7 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -4929,6 +4959,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6545,6 +6576,356 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -7714,15 +8095,34 @@
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -7764,6 +8164,7 @@
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7774,6 +8175,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -7837,6 +8239,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -8330,6 +8733,117 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "devOptional": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@zone-eu/mailsplit": {
       "version": "5.4.8",
       "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.8.tgz",
@@ -8371,6 +8885,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8714,6 +9229,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
@@ -8957,6 +9482,7 @@
       "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.1.8.tgz",
       "integrity": "sha512-XMQ2rs6FNXasGNfMjzbyroSwKwYbZ/T3IxruSS6U2MJRsSYh3wYtG3o6H00ZlKZ/C/UPOAD97tqgQJNsxyeTXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@better-auth/utils": "^0.3.0",
         "@better-fetch/fetch": "^1.1.4",
@@ -8979,6 +9505,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -9089,6 +9616,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9249,6 +9777,16 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -10032,6 +10570,7 @@
       "integrity": "sha512-O9EC/miwdnRDY10qRxM8P3Pg8hXe3LyU4ZipReKOgTwn4OqANmftj8XJz1UPUAS6NMHf0E2htjsbQujUTkncCg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@drizzle-team/brocli": "^0.10.2",
         "@esbuild-kit/esm-loader": "^2.5.5",
@@ -10047,6 +10586,7 @@
       "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.1.tgz",
       "integrity": "sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@aws-sdk/client-rds-data": ">=3",
         "@cloudflare/workers-types": ">=4",
@@ -10461,6 +11001,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -10525,6 +11072,7 @@
       "integrity": "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -10606,6 +11154,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10791,6 +11340,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -11028,6 +11578,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -11116,11 +11676,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/express": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -12919,6 +13490,7 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
       "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -13057,6 +13629,7 @@
       "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.11.tgz",
       "integrity": "sha512-zpGIFg0HuoC893rIjYX1BETkVWdDnzTzF5e0kWXJFg5lE0k1/LfNWBejrcnOFu8Q2Rfq/hTDTU7XLUM8QOrpzg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -13519,7 +14092,7 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -13863,6 +14436,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }
@@ -13911,6 +14485,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
       "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.1.6",
         "@swc/helpers": "0.5.15",
@@ -14300,6 +14875,17 @@
       "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "devOptional": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -14672,7 +15258,7 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -14715,7 +15301,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -15043,6 +15629,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15062,6 +15649,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15074,6 +15662,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
       "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -15358,6 +15947,51 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/rou3": {
@@ -15895,6 +16529,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "devOptional": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -16019,6 +16660,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/standardwebhooks": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
@@ -16037,6 +16685,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -16546,11 +17201,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
       "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -16560,7 +17222,7 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -16577,7 +17239,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -16595,13 +17257,24 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tlds": {
@@ -16885,6 +17558,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16962,6 +17636,7 @@
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -17168,6 +17843,689 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -17298,6 +18656,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wmf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
@@ -17334,6 +18709,7 @@
       "integrity": "sha512-EhLJGptSGFi8AEErLiamO3PoGpbRqL+v4Ve36H2B38VxmDgFOSmDhfepBnA14sCQzGf1AEaoZX2DCwZsmO74yQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -17353,6 +18729,7 @@
       "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.61.1.tgz",
       "integrity": "sha512-hfYQ16VLPkNi8xE1/V3052S2stM5e+vq3Idpt83sXoDC3R7R1CLgMkK6M6+Qp3G+9GVDNyHCkvohMPdfFTaD4Q==",
       "license": "MIT OR Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.4.2",
         "@cloudflare/unenv-preset": "2.12.0",
@@ -18193,6 +19570,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "deploy": "npm run build:worker && npx wrangler deploy",
     "start": "next start",
     "lint": "eslint",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "db:generate": "drizzle-kit generate",
     "db:studio": "drizzle-kit studio",
     "db:migrate:legacy": "npx wrangler d1 execute netereka-db --local --file=db/migrations/0001_initial.sql",
@@ -60,6 +63,7 @@
     "shadcn": "^3.8.1",
     "tailwindcss": "^4",
     "typescript": "5.9.3",
+    "vitest": "^4.0.18",
     "wrangler": "^4.61.1",
     "xlsx": "^0.18.5"
   }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "."),
+    },
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,6 @@ import path from "path";
 
 export default defineConfig({
   test: {
-    globals: true,
     environment: "node",
   },
   resolve: {


### PR DESCRIPTION
## Summary

- Install and configure **Vitest** as the project's test framework with path alias support (`@/`)
- Add `test`, `test:watch`, and `test:coverage` npm scripts
- Write **121 unit tests** across 11 test files covering the core business logic

## Tests added

| File | Tests | What's tested |
|------|-------|---------------|
| `utils.test.ts` | 18 | `slugify` (accents, special chars), `formatPrice`, `cn`, date formatting |
| `format.test.ts` | 7 | XOF currency formatting, `formatDate`, `formatDateTime` |
| `images.test.ts` | 8 | `getImageUrl` (null, http, R2 prefix, fallback) |
| `cart.test.ts` | 4 | `cartItemKey` with/without variant |
| `order-number.test.ts` | 4 | `generateOrderNumber` format and uniqueness |
| `validations/address.test.ts` | 16 | Ivorian phone validation (+225), required fields, length limits |
| `validations/checkout.test.ts` | 15 | Cart items, conditional address logic, quantity bounds |
| `validations/account.test.ts` | 12 | Profile schema, password change refinement |
| `validations/review.test.ts` | 8 | Rating 1-5 integers, optional comment |
| `orders.test.ts` | 21 | Status transitions, terminal states, type guards, timestamps |
| `csv.test.ts` | 8 | CSV escaping (quotes, commas), status translation, export |

## Test plan

- [x] `npm test` — all 121 tests pass
- [ ] Verify CI picks up the new test script

🤖 Generated with [Claude Code](https://claude.com/claude-code)