### PR TITLE
fix: correct robots.txt and optimize mobile LCP

### DIFF
--- a/__tests__/unit/actions/admin-customers.test.ts
+++ b/__tests__/unit/actions/admin-customers.test.ts
@@ -77,7 +77,8 @@ describe("updateCustomerRole", () => {
   });
 
   it("rejette un rôle invalide", async () => {
-    const result = await updateCustomerRole("user-target", "invalid_role" as any);
+    // @ts-expect-error -- testing invalid role on purpose
+    const result = await updateCustomerRole("user-target", "invalid_role");
     expect(result.success).toBe(false);
   });
 

--- a/__tests__/unit/validations/address.test.ts
+++ b/__tests__/unit/validations/address.test.ts
@@ -17,6 +17,7 @@ describe("addressSchema", () => {
   });
 
   it("utilise Abidjan comme ville par défaut", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { city, ...withoutCity } = validAddress;
     const result = addressSchema.safeParse(withoutCity);
     expect(result.success).toBe(true);

--- a/app/(admin-auth)/admin/login/page.tsx
+++ b/app/(admin-auth)/admin/login/page.tsx
@@ -120,7 +120,7 @@ export default function AdminLoginPage() {
                 <Input
                   id="email"
                   type="email"
-                  placeholder="admin@netereka.com"
+                  placeholder="admin@netereka.ci"
                   className="h-11"
                   {...register("email")}
                 />

--- a/app/(storefront)/contact/page.tsx
+++ b/app/(storefront)/contact/page.tsx
@@ -22,10 +22,10 @@ export default function ContactPage() {
               <div>
                 <p className="font-medium text-foreground">Email</p>
                 <a
-                  href="mailto:contact@netereka.com"
+                  href="mailto:contact@netereka.ci"
                   className="text-primary hover:underline"
                 >
-                  contact@netereka.com
+                  contact@netereka.ci
                 </a>
               </div>
               <div>
@@ -64,7 +64,7 @@ export default function ContactPage() {
           </p>
 
           <a
-            href="mailto:contact@netereka.com"
+            href="mailto:contact@netereka.ci"
             className="flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-medium text-primary-foreground hover:bg-primary/90"
           >
             Envoyer un email
@@ -74,10 +74,10 @@ export default function ContactPage() {
             <p>
               Vous pouvez aussi nous écrire directement à{" "}
               <a
-                href="mailto:contact@netereka.com"
+                href="mailto:contact@netereka.ci"
                 className="font-medium text-primary hover:underline"
               >
-                contact@netereka.com
+                contact@netereka.ci
               </a>
             </p>
           </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -108,6 +108,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="fr" className={inter.variable}>
+      <head>
+        <link rel="preconnect" href="https://r2.netereka.ci" crossOrigin="anonymous" />
+        <link rel="dns-prefetch" href="https://r2.netereka.ci" />
+      </head>
       <body className="antialiased">
         <JsonLd data={organizationSchema} />
         <JsonLd data={websiteSchema} />

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -14,8 +14,6 @@ export default function robots(): MetadataRoute.Robots {
           "/checkout/",
           "/cart/",
           "/auth/",
-          "/*?*sort=",
-          "/*?*filter=",
         ],
       },
     ],

--- a/components/storefront/auth/turnstile-captcha.tsx
+++ b/components/storefront/auth/turnstile-captcha.tsx
@@ -27,8 +27,11 @@ export function TurnstileCaptcha({ onVerify, onError }: TurnstileCaptchaProps) {
   const widgetIdRef = useRef<string | null>(null);
   const onVerifyRef = useRef(onVerify);
   const onErrorRef = useRef(onError);
-  onVerifyRef.current = onVerify;
-  onErrorRef.current = onError;
+
+  useEffect(() => {
+    onVerifyRef.current = onVerify;
+    onErrorRef.current = onError;
+  }, [onVerify, onError]);
 
   const renderWidget = () => {
     if (!containerRef.current || !window.turnstile || widgetIdRef.current || !TURNSTILE_SITE_KEY)
@@ -43,7 +46,6 @@ export function TurnstileCaptcha({ onVerify, onError }: TurnstileCaptchaProps) {
 
   useEffect(() => {
     renderWidget();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   if (!TURNSTILE_SITE_KEY) return null;

--- a/components/storefront/hero-banner.tsx
+++ b/components/storefront/hero-banner.tsx
@@ -32,7 +32,7 @@ export function HeroBanner({ product }: { product: Product }) {
             src={getImageUrl(product.image_url)}
             alt={product.name}
             fill
-            className="object-contain drop-shadow-2xl"
+            className="object-contain"
             sizes="(max-width: 640px) 80vw, 320px"
             priority
           />

--- a/lib/storage/images.ts
+++ b/lib/storage/images.ts
@@ -10,7 +10,10 @@ export async function uploadToR2(
   }
   const buffer = await file.arrayBuffer();
   await r2.put(key, buffer, {
-    httpMetadata: { contentType: file.type },
+    httpMetadata: {
+      contentType: file.type,
+      cacheControl: "public, max-age=31536000, immutable",
+    },
   });
   return key;
 }

--- a/lib/utils/constants.ts
+++ b/lib/utils/constants.ts
@@ -1,6 +1,6 @@
 export const SITE_NAME = "NETEREKA";
 export const SITE_DESCRIPTION = "Votre boutique électronique en Côte d'Ivoire";
-export const SITE_URL = "https://netereka.com";
+export const SITE_URL = "https://netereka.ci";
 
 export const ORDER_STATUSES = {
   pending: "En attente",

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,8 @@ const nextConfig: NextConfig = {
     optimizePackageImports: ["@hugeicons/core-free-icons"],
   },
   images: {
+    formats: ["image/avif", "image/webp"],
+    minimumCacheTTL: 2592000,
     remotePatterns: [
       {
         protocol: "https",
@@ -15,7 +17,11 @@ const nextConfig: NextConfig = {
       },
       {
         protocol: "https",
-        hostname: "netereka.com",
+        hostname: "netereka.ci",
+      },
+      {
+        protocol: "https",
+        hostname: "*.netereka.ci",
       },
       {
         protocol: "https",


### PR DESCRIPTION
## Summary

- **Fix SITE_URL** (`netereka.com` → `netereka.ci`): corrige le sitemap dans robots.txt, metadataBase, openGraph, JSON-LD
- **Remove invalid robots.txt patterns**: supprime les disallow `/*?*sort=` et `/*?*filter=` (syntaxe non-standard, erreur PageSpeed SEO)
- **Preconnect R2**: ajoute `<link rel="preconnect">` et `dns-prefetch` pour `r2.netereka.ci`
- **AVIF + cache**: active le format AVIF, `minimumCacheTTL: 30j`, corrige les hostnames images
- **Remove hero drop-shadow**: supprime `drop-shadow-2xl` sur l'image LCP hero (coûteux en paint sur mobile)
- **R2 Cache-Control**: ajoute `Cache-Control: public, max-age=31536000, immutable` aux uploads R2

## Impact estimé (PageSpeed mobile)

| Optimisation | Gain estimé |
|---|---|
| Preconnect R2 | -100 à -300ms |
| AVIF + cache TTL | -500ms à -1.5s |
| Remove drop-shadow | -50 à -200ms |
| R2 Cache-Control | -200 à -500ms (revisites) |

## Test plan

- [ ] `npm run build` passe sans erreur
- [ ] Visiter `/robots.txt` — sitemap pointe vers `netereka.ci`
- [ ] Relancer PageSpeed Insights mobile après déploiement
- [ ] Vérifier `Content-Type: image/avif` sur `/_next/image` (browsers supportés)
- [ ] Vérifier `Cache-Control: immutable` sur images R2 re-uploadées

🤖 Generated with [Claude Code](https://claude.com/claude-code)