### PR TITLE
feat: add quick action buttons on product cards

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,6 +3,7 @@
 @import "shadcn/tailwind.css";
 
 @custom-variant dark (&:is(.dark *));
+@custom-variant touch (@media (pointer: coarse));
 
 @theme inline {
   --color-hero-bg: var(--hero-bg);

--- a/components/storefront/product-card-actions.tsx
+++ b/components/storefront/product-card-actions.tsx
@@ -63,7 +63,7 @@ export function ProductCardActions({
         productId={product.id}
         isWishlisted={isWishlisted}
         className={cn(
-          "pointer-events-auto absolute right-0.5 top-0.5 size-11",
+          "pointer-events-auto absolute right-1 top-1 size-8",
           "opacity-0 translate-y-(-1) group-hover:opacity-100 group-hover:translate-y-0",
           "touch:opacity-100 touch:translate-y-0",
           "focus-visible:opacity-100 focus-visible:translate-y-0",

--- a/components/storefront/product-card-actions.tsx
+++ b/components/storefront/product-card-actions.tsx
@@ -47,7 +47,7 @@ export function ProductCardActions({
       name: product.name,
       variantName: null,
       price: product.base_price,
-      imageUrl: product.image_url,
+      imageUrl: product.image_url ?? null,
       slug: product.slug,
     });
 

--- a/components/storefront/product-card-actions.tsx
+++ b/components/storefront/product-card-actions.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ShoppingBag, Tick02Icon } from "@hugeicons/core-free-icons";
+import { useCartStore } from "@/stores/cart-store";
+import { WishlistButton } from "@/components/storefront/wishlist-button";
+import type { Product } from "@/lib/db/types";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  product: Product;
+  isWishlisted?: boolean;
+  showWishlist?: boolean;
+}
+
+export function ProductCardActions({
+  product,
+  isWishlisted = false,
+  showWishlist = false,
+}: Props) {
+  const router = useRouter();
+  const add = useCartStore((s) => s.add);
+  const [added, setAdded] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
+
+  const hasVariants = (product.variant_count ?? 0) > 1;
+  const isOutOfStock = product.stock_quantity <= 0;
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  function handleCartClick(e: React.MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (hasVariants) {
+      router.push(`/p/${product.slug}`);
+      return;
+    }
+
+    add({
+      productId: product.id,
+      variantId: null,
+      name: product.name,
+      variantName: null,
+      price: product.base_price,
+      imageUrl: product.image_url,
+      slug: product.slug,
+    });
+
+    setAdded(true);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setAdded(false), 1500);
+  }
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-10">
+      {/* Wishlist — top-right */}
+      {showWishlist && (
+        <WishlistButton
+          productId={product.id}
+          isWishlisted={isWishlisted}
+          className="pointer-events-auto absolute right-2 top-2 size-11"
+        />
+      )}
+
+      {/* Cart — bottom-right, hover-reveal */}
+      {!isOutOfStock && (
+        <button
+          onClick={handleCartClick}
+          className={cn(
+            "pointer-events-auto absolute bottom-2 right-2",
+            "flex size-10 items-center justify-center rounded-full",
+            "bg-primary text-primary-foreground shadow-md",
+            "transition-all duration-200",
+            "opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0",
+            "touch:opacity-100 touch:translate-y-0",
+            "hover:bg-primary/90 active:scale-95",
+            "focus-visible:opacity-100 focus-visible:translate-y-0",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+            added && "bg-emerald-600 hover:bg-emerald-600",
+          )}
+          aria-label={
+            hasVariants ? "Choisir les options" : "Ajouter au panier"
+          }
+        >
+          <HugeiconsIcon
+            icon={added ? Tick02Icon : ShoppingBag}
+            size={18}
+            strokeWidth={2}
+          />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/components/storefront/product-card-actions.tsx
+++ b/components/storefront/product-card-actions.tsx
@@ -63,7 +63,7 @@ export function ProductCardActions({
         productId={product.id}
         isWishlisted={isWishlisted}
         className={cn(
-          "pointer-events-auto absolute right-2 top-2 size-11",
+          "pointer-events-auto absolute right-0.5 top-0.5 size-11",
           "opacity-0 translate-y-(-1) group-hover:opacity-100 group-hover:translate-y-0",
           "touch:opacity-100 touch:translate-y-0",
           "focus-visible:opacity-100 focus-visible:translate-y-0",

--- a/components/storefront/product-card-actions.tsx
+++ b/components/storefront/product-card-actions.tsx
@@ -12,13 +12,11 @@ import { cn } from "@/lib/utils";
 interface Props {
   product: Product;
   isWishlisted?: boolean;
-  showWishlist?: boolean;
 }
 
 export function ProductCardActions({
   product,
   isWishlisted = false,
-  showWishlist = false,
 }: Props) {
   const router = useRouter();
   const add = useCartStore((s) => s.add);
@@ -61,13 +59,17 @@ export function ProductCardActions({
   return (
     <div className="pointer-events-none absolute inset-0 z-10">
       {/* Wishlist — top-right */}
-      {showWishlist && (
-        <WishlistButton
-          productId={product.id}
-          isWishlisted={isWishlisted}
-          className="pointer-events-auto absolute right-2 top-2 size-11"
-        />
-      )}
+      <WishlistButton
+        productId={product.id}
+        isWishlisted={isWishlisted}
+        className={cn(
+          "pointer-events-auto absolute right-2 top-2 size-11",
+          "opacity-0 translate-y-(-1) group-hover:opacity-100 group-hover:translate-y-0",
+          "touch:opacity-100 touch:translate-y-0",
+          "focus-visible:opacity-100 focus-visible:translate-y-0",
+          "transition-all duration-200",
+        )}
+      />
 
       {/* Cart — bottom-right, hover-reveal */}
       {!isOutOfStock && (

--- a/components/storefront/product-card.tsx
+++ b/components/storefront/product-card.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 import type { Product } from "@/lib/db/types";
 import { formatPrice } from "@/lib/utils/format";
 import { getImageUrl } from "@/lib/utils/images";
-import { WishlistButton } from "@/components/storefront/wishlist-button";
+import { ProductCardActions } from "@/components/storefront/product-card-actions";
 import { cn } from "@/lib/utils";
 
 interface Props {
@@ -46,28 +46,19 @@ export function ProductCard({ product, isWishlisted = false, showWishlist = fals
           sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
         />
 
-        {/* Top row: category + discount + wishlist */}
-        <div className="absolute inset-x-0 top-0 flex items-start justify-between p-2">
-          <div className="flex items-center gap-1.5">
-            {product.category_name && (
-              <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
-                {product.category_name}
-              </span>
-            )}
-            {hasDiscount && (
-              <span className="rounded-md bg-destructive px-1.5 py-0.5 text-[10px] font-bold leading-tight text-white">
-                -{discountPercent}%
-              </span>
-            )}
-          </div>
-          {showWishlist && (
-            <WishlistButton
-              productId={product.id}
-              isWishlisted={isWishlisted}
-              className="size-11"
-            />
-          )}
-        </div>
+        {/* Category badge */}
+        {product.category_name && (
+          <span className="absolute left-2 top-2 z-10 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
+            {product.category_name}
+          </span>
+        )}
+
+        {/* Quick action buttons */}
+        <ProductCardActions
+          product={product}
+          isWishlisted={isWishlisted}
+          showWishlist={showWishlist}
+        />
 
         {/* Out of stock overlay */}
         {isOutOfStock && (
@@ -93,8 +84,13 @@ export function ProductCard({ product, isWishlisted = false, showWishlist = fals
           <span className={cn("text-[11px]", hasVariants ? "text-muted-foreground" : "invisible")}>
             {hasVariants ? "À partir de" : "\u00A0"}
           </span>
-          <p className="text-sm font-bold tabular-nums text-foreground">
+          <p className="flex items-center gap-1.5 text-sm font-bold tabular-nums text-foreground">
             {formatPrice(product.base_price)}
+            {hasDiscount && (
+              <span className="rounded-md bg-destructive px-1.5 py-0.5 text-[10px] font-bold leading-tight text-white">
+                -{discountPercent}%
+              </span>
+            )}
           </p>
           {/* Compare price — always reserve one line */}
           <p className={cn("text-[10px] tabular-nums line-through", hasDiscount ? "text-muted-foreground" : "invisible")}>

--- a/components/storefront/product-card.tsx
+++ b/components/storefront/product-card.tsx
@@ -9,10 +9,9 @@ import { cn } from "@/lib/utils";
 interface Props {
   product: Product;
   isWishlisted?: boolean;
-  showWishlist?: boolean;
 }
 
-export function ProductCard({ product, isWishlisted = false, showWishlist = false }: Props) {
+export function ProductCard({ product, isWishlisted = false }: Props) {
   const hasVariants = (product.variant_count ?? 0) > 1;
   const isOutOfStock = product.stock_quantity <= 0;
   const comparePrice = product.compare_price;
@@ -57,7 +56,6 @@ export function ProductCard({ product, isWishlisted = false, showWishlist = fals
         <ProductCardActions
           product={product}
           isWishlisted={isWishlisted}
-          showWishlist={showWishlist}
         />
 
         {/* Out of stock overlay */}

--- a/components/storefront/wishlist-button.tsx
+++ b/components/storefront/wishlist-button.tsx
@@ -37,7 +37,7 @@ export function WishlistButton({ productId, isWishlisted, className }: Props) {
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"
-        className="size-[65%]"
+        className="size-[50%]"
         fill={optimistic ? "currentColor" : "none"}
         stroke="currentColor"
         strokeWidth={2}

--- a/components/storefront/wishlist-button.tsx
+++ b/components/storefront/wishlist-button.tsx
@@ -37,7 +37,7 @@ export function WishlistButton({ productId, isWishlisted, className }: Props) {
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"
-        className="size-[45%]"
+        className="size-[65%]"
         fill={optimistic ? "currentColor" : "none"}
         stroke="currentColor"
         strokeWidth={2}

--- a/components/storefront/wishlist-button.tsx
+++ b/components/storefront/wishlist-button.tsx
@@ -28,7 +28,7 @@ export function WishlistButton({ productId, isWishlisted, className }: Props) {
       onClick={handleClick}
       disabled={pending}
       className={cn(
-        "flex size-8 items-center justify-center rounded-full bg-background/80 text-muted-foreground backdrop-blur-sm transition-colors hover:text-destructive",
+        "flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-destructive",
         optimistic && "text-destructive",
         className
       )}


### PR DESCRIPTION
## Summary

- **Quick add-to-cart button**: bouton panier en overlay sur les cartes produit, ajoute directement au panier (ou redirige vers la page produit si variantes)
- **Wishlist button**: bouton wishlist en haut à droite de chaque carte produit
- **UI polish**: positionnement, taille d'icône, suppression du fond pour ne pas masquer l'image

## Test plan

- [ ] `npm run build` passe sans erreur
- [ ] Hover sur une carte produit → boutons quick-action visibles
- [ ] Clic panier sur produit sans variante → ajout au cart
- [ ] Clic panier sur produit avec variantes → redirection vers page produit
- [ ] Bouton wishlist visible et fonctionnel sur toutes les cartes

🤖 Generated with [Claude Code](https://claude.com/claude-code)