### PR TITLE
feat: enable Cloudflare Image Transformations for AVIF

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -3,6 +3,7 @@ interface CloudflareEnv {
   KV: KVNamespace;
   R2: R2Bucket;
   ASSETS: Fetcher;
+  IMAGES: ImagesBinding;
 
   // Auth (Better Auth)
   BETTER_AUTH_SECRET: string;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -30,5 +30,8 @@
       "binding": "R2",
       "bucket_name": "netereka"
     }
-  ]
+  ],
+  "images": {
+    "binding": "IMAGES"
+  }
 }


### PR DESCRIPTION
## Summary

- Add `IMAGES` binding to `wrangler.jsonc` for Cloudflare Image Transformations API
- Add `ImagesBinding` type to `env.d.ts`

## Context

The `formats: ["image/avif", "image/webp"]` config in `next.config.ts` (added in #55) had no effect because the OpenNext handler checks for `env.IMAGES` at runtime. When undefined, it short-circuits and returns the original image without any format conversion.

With this binding + Image Transformations enabled in the Cloudflare dashboard (Pro plan), the worker will now convert images to AVIF/WebP on the edge via `/_next/image`.

## Expected impact

- ~50% smaller image payloads (AVIF vs JPEG/WebP)
- Significant LCP improvement on mobile (estimated -500ms to -1.5s)

## Test plan

- [ ] `npm run build` passes
- [ ] `npm run deploy` succeeds
- [ ] Request `/_next/image?url=...&w=640&q=75` with `Accept: image/avif` header → response `Content-Type: image/avif`
- [ ] PageSpeed Insights: "Improve image delivery" opportunity should disappear or reduce significantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)