### PR TITLE
perf: eliminate render-blocking CSS and optimize LCP image

### DIFF
--- a/components/storefront/hero-banner.tsx
+++ b/components/storefront/hero-banner.tsx
@@ -35,6 +35,7 @@ export function HeroBanner({ product }: { product: Product }) {
             className="object-contain"
             sizes="(max-width: 640px) 80vw, 320px"
             priority
+            fetchPriority="high"
           />
         </div>
       </div>

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,7 @@ initOpenNextCloudflareForDev();
 
 const nextConfig: NextConfig = {
   experimental: {
+    inlineCss: true,
     optimizePackageImports: ["@hugeicons/core-free-icons"],
   },
   images: {


### PR DESCRIPTION
## Summary

- **Inline CSS** (`experimental.inlineCss: true`): CSS is inlined in `<head>` as `<style>` tags instead of render-blocking `<link>` tags. Eliminates the 590ms render-blocking delay identified by PageSpeed.
- **`fetchPriority="high"` on hero image**: Explicit hint for the browser to prioritize the LCP image download.
- **`NEXT_PUBLIC_R2_URL` migrated** to `https://r2.netereka.ci` (GitHub Actions variable updated) so the preconnect hint added in #55 is effective.

## Context

After PR #55 (SEO + perf) and #57 (AVIF), the remaining bottleneck was render-blocking CSS (2 stylesheets, 21.4 KiB, 590ms on Slow 4G). The LCP breakdown also showed 340ms of resource load delay partly due to fetchPriority not being set and preconnect targeting the wrong R2 domain.

## Expected impact

| Fix | Estimated gain |
|---|---|
| Inline CSS (no render-blocking) | -590ms |
| fetchPriority="high" | -100 to -300ms |
| Preconnect to correct R2 domain | -100 to -200ms |

## Test plan

- [ ] `npm run build` passes (confirm `✓ inlineCss` in experiments)
- [ ] View page source → CSS should be inlined as `<style>` tags, not `<link>` tags
- [ ] Hero image HTML includes `fetchpriority="high"` attribute
- [ ] Image URLs use `r2.netereka.ci` instead of `pub-*.r2.dev`
- [ ] PageSpeed mobile: render blocking requests should disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)