### PR TITLE
perf: enable ISR + edge caching on storefront

### DIFF
--- a/actions/wishlist.ts
+++ b/actions/wishlist.ts
@@ -36,7 +36,9 @@ export async function toggleWishlist(productId: string): Promise<{ success: bool
 }
 
 export async function checkWishlist(productId: string): Promise<boolean> {
+  const parsed = productIdSchema.safeParse(productId);
+  if (!parsed.success) return false;
   const session = await getOptionalSession();
   if (!session) return false;
-  return isInWishlist(session.user.id, productId);
+  return isInWishlist(session.user.id, parsed.data);
 }

--- a/actions/wishlist.ts
+++ b/actions/wishlist.ts
@@ -1,8 +1,8 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { requireAuth } from "@/lib/auth/guards";
-import { atomicToggleWishlist } from "@/lib/db/wishlist";
+import { requireAuth, getOptionalSession } from "@/lib/auth/guards";
+import { atomicToggleWishlist, isInWishlist } from "@/lib/db/wishlist";
 import { queryFirst } from "@/lib/db";
 import { z } from "zod";
 
@@ -33,4 +33,10 @@ export async function toggleWishlist(productId: string): Promise<{ success: bool
   } catch {
     return { success: false, added: false };
   }
+}
+
+export async function checkWishlist(productId: string): Promise<boolean> {
+  const session = await getOptionalSession();
+  if (!session) return false;
+  return isInWishlist(session.user.id, productId);
 }

--- a/app/(storefront)/a-propos/page.tsx
+++ b/app/(storefront)/a-propos/page.tsx
@@ -1,3 +1,5 @@
+export const revalidate = 86400;
+
 import type { Metadata } from "next";
 import Link from "next/link";
 import { SITE_NAME, SITE_URL } from "@/lib/utils/constants";

--- a/app/(storefront)/c/[slug]/page.tsx
+++ b/app/(storefront)/c/[slug]/page.tsx
@@ -21,6 +21,8 @@ import { BreadcrumbSchema } from "@/components/seo/breadcrumb-schema";
 import { JsonLd } from "@/components/seo/json-ld";
 import { SITE_NAME, SITE_URL } from "@/lib/utils/constants";
 
+export const revalidate = 300;
+
 const getCategoryCached = cache(getCategoryBySlug);
 
 interface Props {

--- a/app/(storefront)/conditions-generales/page.tsx
+++ b/app/(storefront)/conditions-generales/page.tsx
@@ -1,3 +1,5 @@
+export const revalidate = 86400;
+
 import type { Metadata } from "next";
 import Link from "next/link";
 import { SITE_NAME, SITE_URL } from "@/lib/utils/constants";

--- a/app/(storefront)/contact/page.tsx
+++ b/app/(storefront)/contact/page.tsx
@@ -1,3 +1,5 @@
+export const revalidate = 86400;
+
 import Link from "next/link";
 
 export default function ContactPage() {

--- a/app/(storefront)/faq/page.tsx
+++ b/app/(storefront)/faq/page.tsx
@@ -1,3 +1,5 @@
+export const revalidate = 86400;
+
 import type { Metadata } from "next";
 import Link from "next/link";
 import { SITE_NAME } from "@/lib/utils/constants";

--- a/app/(storefront)/layout.tsx
+++ b/app/(storefront)/layout.tsx
@@ -2,8 +2,6 @@ import { Header } from "@/components/storefront/header";
 import { Footer } from "@/components/storefront/footer";
 import { CartDrawer } from "@/components/storefront/cart-drawer";
 
-export const dynamic = "force-dynamic";
-
 export default function StorefrontLayout({
   children,
 }: {

--- a/app/(storefront)/livraison/page.tsx
+++ b/app/(storefront)/livraison/page.tsx
@@ -1,3 +1,5 @@
+export const revalidate = 86400;
+
 import type { Metadata } from "next";
 import Link from "next/link";
 import { SITE_NAME } from "@/lib/utils/constants";

--- a/app/(storefront)/politique-confidentialite/page.tsx
+++ b/app/(storefront)/politique-confidentialite/page.tsx
@@ -1,3 +1,5 @@
+export const revalidate = 86400;
+
 import type { Metadata } from "next";
 import Link from "next/link";
 import { SITE_NAME, SITE_URL } from "@/lib/utils/constants";

--- a/components/storefront/header-auth.tsx
+++ b/components/storefront/header-auth.tsx
@@ -7,7 +7,7 @@ export function HeaderAuth() {
   const session = authClient.useSession();
 
   if (session.isPending) {
-    return <div className="size-8 animate-pulse rounded-full bg-muted" />;
+    return <div className="h-8 w-20 animate-pulse rounded-md bg-muted" />;
   }
 
   const user = session.data?.user

--- a/components/storefront/header-auth.tsx
+++ b/components/storefront/header-auth.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { authClient } from "@/lib/auth/client";
+import { HeaderUserMenu } from "@/components/storefront/header-user-menu";
+
+export function HeaderAuth() {
+  const session = authClient.useSession();
+
+  if (session.isPending) {
+    return <div className="size-8 animate-pulse rounded-full bg-muted" />;
+  }
+
+  const user = session.data?.user
+    ? {
+        id: session.data.user.id,
+        name: session.data.user.name,
+        email: session.data.user.email,
+        image: session.data.user.image ?? undefined,
+        role: session.data.user.role ?? undefined,
+      }
+    : null;
+
+  return <HeaderUserMenu user={user} />;
+}

--- a/components/storefront/header.tsx
+++ b/components/storefront/header.tsx
@@ -1,18 +1,11 @@
 import Link from "next/link";
 import Image from "next/image";
 import { SITE_NAME } from "@/lib/utils/constants";
-import { getOptionalSession } from "@/lib/auth/guards";
-import { HeaderUserMenu } from "@/components/storefront/header-user-menu";
+import { HeaderAuth } from "@/components/storefront/header-auth";
 import { CartIcon } from "@/components/storefront/cart-icon";
 import { SearchAutocomplete } from "@/components/storefront/search-autocomplete";
 
-export async function Header() {
-  const session = await getOptionalSession();
-
-  const userForMenu = session?.user
-    ? { id: session.user.id, name: session.user.name, email: session.user.email, image: session.user.image ?? undefined, role: session.user.role ?? undefined }
-    : null;
-
+export function Header() {
   return (
     <header className="sticky top-0 z-50 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="relative mx-auto flex h-16 max-w-7xl items-center justify-between px-4">
@@ -29,7 +22,7 @@ export async function Header() {
         <nav className="flex items-center gap-1">
           <SearchAutocomplete />
           <CartIcon />
-          <HeaderUserMenu user={userForMenu} />
+          <HeaderAuth />
         </nav>
       </div>
     </header>

--- a/components/storefront/wishlist-button-dynamic.tsx
+++ b/components/storefront/wishlist-button-dynamic.tsx
@@ -11,11 +11,17 @@ export function WishlistButtonDynamic({ productId }: { productId: string }) {
 
   useEffect(() => {
     if (session.data?.user) {
-      checkWishlist(productId).then(setIsWishlisted).catch(() => {});
+      checkWishlist(productId).then(setIsWishlisted).catch(console.error);
     }
   }, [session.data?.user, productId]);
 
   if (!session.data?.user) return null;
 
-  return <WishlistButton productId={productId} isWishlisted={isWishlisted} />;
+  return (
+    <WishlistButton
+      productId={productId}
+      isWishlisted={isWishlisted}
+      onToggled={setIsWishlisted}
+    />
+  );
 }

--- a/components/storefront/wishlist-button-dynamic.tsx
+++ b/components/storefront/wishlist-button-dynamic.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { authClient } from "@/lib/auth/client";
+import { WishlistButton } from "@/components/storefront/wishlist-button";
+import { checkWishlist } from "@/actions/wishlist";
+
+export function WishlistButtonDynamic({ productId }: { productId: string }) {
+  const session = authClient.useSession();
+  const [isWishlisted, setIsWishlisted] = useState(false);
+
+  useEffect(() => {
+    if (session.data?.user) {
+      checkWishlist(productId).then(setIsWishlisted).catch(() => {});
+    }
+  }, [session.data?.user, productId]);
+
+  if (!session.data?.user) return null;
+
+  return <WishlistButton productId={productId} isWishlisted={isWishlisted} />;
+}

--- a/components/storefront/wishlist-button.tsx
+++ b/components/storefront/wishlist-button.tsx
@@ -7,10 +7,11 @@ import { cn } from "@/lib/utils";
 interface Props {
   productId: string;
   isWishlisted: boolean;
+  onToggled?: (added: boolean) => void;
   className?: string;
 }
 
-export function WishlistButton({ productId, isWishlisted, className }: Props) {
+export function WishlistButton({ productId, isWishlisted, onToggled, className }: Props) {
   const [pending, startTransition] = useTransition();
   const [optimistic, setOptimistic] = useOptimistic(isWishlisted);
 
@@ -19,7 +20,8 @@ export function WishlistButton({ productId, isWishlisted, className }: Props) {
     e.stopPropagation();
     startTransition(async () => {
       setOptimistic(!optimistic);
-      await toggleWishlist(productId);
+      const result = await toggleWishlist(productId);
+      onToggled?.(result.added);
     });
   }
 


### PR DESCRIPTION
## Summary

- **Move session from SSR to client-side** — `Header` no longer calls `getOptionalSession()` server-side. New `HeaderAuth` client component uses `authClient.useSession()` (same pattern as `CartSync`)
- **Remove `force-dynamic` from storefront layout** — unlocks ISR with `stale-while-revalidate` for all public pages via the R2 incremental cache already configured in `open-next.config.ts`
- **Move wishlist check to client-side** — New `WishlistButtonDynamic` component + `checkWishlist` server action replaces server-side `isInWishlist()` call on product page

### Revalidate timers

| Page | Revalidate |
|------|-----------|
| Homepage | `60s` (already in place) |
| Product `/p/[slug]` | `3600s` (1h) |
| Category `/c/[slug]` | `300s` (5min) |
| Static pages (FAQ, about, etc.) | `86400s` (1d) |
| Search, account, checkout | Dynamic (unchanged) |

### Expected impact

- **TTFB:** ~750ms → <100ms (pages served from Cloudflare edge cache)
- **LCP:** ~4.2s → ~2.5-3s (~650ms TTFB reduction)
- **No UX regression:** session loaded client-side with skeleton loader

## Test plan

- [ ] Verify header shows login button for guests, user menu for authenticated users
- [ ] Verify wishlist button appears on product page after login
- [ ] Verify account pages still redirect unauthenticated users
- [ ] Verify checkout flow still works (auth guard)
- [ ] Check response headers for `stale-while-revalidate` on public pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)