### PR TITLE
ci: add tests to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Tests
+        run: npm test
+
   deploy:
     name: Deploy to Cloudflare Workers
     needs: ci


### PR DESCRIPTION
## Summary
- Add `npm test` step to the deploy workflow's CI job, ensuring all Vitest tests pass before deploying to Cloudflare Workers
- Aligns the deploy workflow with the CI workflow which already runs tests

## Test plan
- [x] Verify tests pass locally (`npm test` — 337 tests passing)
- [ ] Confirm CI job runs tests before the deploy job

🤖 Generated with [Claude Code](https://claude.com/claude-code)