### PR TITLE
ci: add tests to pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -9,7 +9,12 @@ echo "🔍 Vérification du linting ESLint..."
 npm run lint
 LINT_EXIT=$?
 
-if [ $TSC_EXIT -ne 0 ] || [ $LINT_EXIT -ne 0 ]; then
+echo ""
+echo "🧪 Exécution des tests..."
+npm test
+TEST_EXIT=$?
+
+if [ $TSC_EXIT -ne 0 ] || [ $LINT_EXIT -ne 0 ] || [ $TEST_EXIT -ne 0 ]; then
   echo ""
   echo "❌ =============================================="
   echo "❌  COMMIT BLOQUÉ"
@@ -21,6 +26,9 @@ if [ $TSC_EXIT -ne 0 ] || [ $LINT_EXIT -ne 0 ]; then
   if [ $LINT_EXIT -ne 0 ]; then
     echo "  → Des erreurs ESLint ont été détectées."
   fi
+  if [ $TEST_EXIT -ne 0 ]; then
+    echo "  → Des tests ont échoué."
+  fi
   echo ""
   echo "  Corrigez ces erreurs avant de commit."
   echo "  NE PAS utiliser --no-verify pour bypasser."
@@ -29,4 +37,4 @@ if [ $TSC_EXIT -ne 0 ] || [ $LINT_EXIT -ne 0 ]; then
 fi
 
 echo ""
-echo "✅ Types et lint OK — commit autorisé."
+echo "✅ Types, lint et tests OK — commit autorisé."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ Wrangler config: `wrangler.jsonc` (not `.toml`).
 
 ## Gotchas
 
-- **Pre-commit hook (Husky):** Runs `tsc --noEmit` + `eslint` before every commit. Fix all type and lint errors before committing — the hook blocks commits on failure.
+- **Pre-commit hook (Husky):** Runs `tsc --noEmit` + `eslint` + `vitest run` before every commit. Fix all type, lint, and test errors before committing — the hook blocks commits on failure.
 - **Local D1 bootstrap:** Before `npm run db:studio` works, you must initialize the local D1 SQLite file first: `npx wrangler d1 execute netereka-db --local --command "SELECT 1"`. Then run the legacy migration and seed scripts.
 - **SEO files:** `app/robots.ts` and `app/sitemap.ts` generate SEO metadata dynamically.
 - **Drizzle remote mode:** To use `drizzle-kit` against remote D1, set `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_DATABASE_ID`, and `CLOUDFLARE_D1_TOKEN` env vars.


### PR DESCRIPTION
## Summary
- Add `npm test` (vitest) to the Husky pre-commit hook, running after type check and lint
- Update CLAUDE.md to document the new pre-commit behavior

## Test plan
- [x] Verify tests pass locally (`npm test` — 337 tests passing)
- [ ] Confirm pre-commit hook blocks commits when tests fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)