### PR TITLE
feat: implement hierarchical subcategories

### DIFF
--- a/__tests__/unit/search-builder.test.ts
+++ b/__tests__/unit/search-builder.test.ts
@@ -61,6 +61,24 @@ describe("buildWhere", () => {
     expect(params).toHaveLength(7);
   });
 
+  it("ajoute un filtre par categoryIds", () => {
+    const { clause, params } = buildWhere({ categoryIds: ["id1", "id2"] });
+    expect(clause).toContain("p.category_id IN (?, ?)");
+    expect(params).toContain("id1");
+    expect(params).toContain("id2");
+  });
+
+  it("categoryIds a priorité sur category", () => {
+    const { clause } = buildWhere({ categoryIds: ["id1"], category: "smartphones" });
+    expect(clause).toContain("p.category_id IN (?)");
+    expect(clause).not.toContain("c.slug = ?");
+  });
+
+  it("ignore categoryIds si le tableau est vide", () => {
+    const { clause } = buildWhere({ categoryIds: [] });
+    expect(clause).not.toContain("p.category_id IN");
+  });
+
   it("ignore brands si le tableau est vide", () => {
     const { clause } = buildWhere({ brands: [] });
     expect(clause).not.toContain("p.brand IN");

--- a/actions/admin/categories.ts
+++ b/actions/admin/categories.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from "next/cache";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 import { requireAdmin } from "@/lib/auth/guards";
-import { execute, queryFirst } from "@/lib/db";
+import { execute, queryFirst, query } from "@/lib/db";
 import { slugify, type ActionResult } from "@/lib/utils";
 
 const idSchema = z.string().min(1, "ID requis");
@@ -13,9 +13,39 @@ const categorySchema = z.object({
   name: z.string().min(1, "Le nom est requis"),
   slug: z.string().min(1),
   description: z.string().optional().default(""),
+  parent_id: z.string().optional().default(""),
   sort_order: z.coerce.number().int().min(0).default(0),
   is_active: z.coerce.number().min(0).max(1).default(1),
 });
+
+async function getDepth(categoryId: string): Promise<number> {
+  let depth = 0;
+  let currentId: string | null = categoryId;
+  while (currentId) {
+    const cat: { parent_id: string | null } | null = await queryFirst<{ parent_id: string | null }>(
+      "SELECT parent_id FROM categories WHERE id = ?",
+      [currentId]
+    );
+    if (!cat || !cat.parent_id) break;
+    depth++;
+    currentId = cat.parent_id;
+  }
+  return depth;
+}
+
+async function isDescendantOf(categoryId: string, potentialAncestorId: string): Promise<boolean> {
+  const descendants = await query<{ id: string }>(
+    `WITH RECURSIVE descendants AS (
+      SELECT id FROM categories WHERE parent_id = ?
+      UNION ALL
+      SELECT c.id FROM categories c
+      JOIN descendants d ON c.parent_id = d.id
+    )
+    SELECT id FROM descendants`,
+    [potentialAncestorId]
+  );
+  return descendants.some((d) => d.id === categoryId);
+}
 
 export async function createCategory(formData: FormData): Promise<ActionResult> {
   await requireAdmin();
@@ -32,7 +62,23 @@ export async function createCategory(formData: FormData): Promise<ActionResult> 
   }
 
   const data = parsed.data;
+  const parentId = data.parent_id || null;
   const id = nanoid();
+
+  // Validate depth: parent must exist and result in max 2 levels
+  if (parentId) {
+    const parent = await queryFirst<{ id: string }>(
+      "SELECT id FROM categories WHERE id = ?",
+      [parentId]
+    );
+    if (!parent) {
+      return { success: false, error: "Catégorie parente introuvable" };
+    }
+    const parentDepth = await getDepth(parentId);
+    if (parentDepth >= 2) {
+      return { success: false, error: "Profondeur maximale atteinte (2 niveaux)" };
+    }
+  }
 
   const existing = await queryFirst<{ id: string }>(
     "SELECT id FROM categories WHERE slug = ?",
@@ -43,9 +89,9 @@ export async function createCategory(formData: FormData): Promise<ActionResult> 
   }
 
   await execute(
-    `INSERT INTO categories (id, name, slug, description, sort_order, is_active, created_at)
-     VALUES (?, ?, ?, ?, ?, ?, datetime('now'))`,
-    [id, data.name, data.slug, data.description || null, data.sort_order, data.is_active]
+    `INSERT INTO categories (id, name, slug, description, parent_id, sort_order, is_active, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+    [id, data.name, data.slug, data.description || null, parentId, data.sort_order, data.is_active]
   );
 
   revalidatePath("/categories");
@@ -74,6 +120,32 @@ export async function updateCategory(
   }
 
   const data = parsed.data;
+  const parentId = data.parent_id || null;
+
+  // Prevent self-reference
+  if (parentId === id) {
+    return { success: false, error: "Une catégorie ne peut pas être son propre parent" };
+  }
+
+  // Prevent circular references: new parent must not be a descendant
+  if (parentId) {
+    const parent = await queryFirst<{ id: string }>(
+      "SELECT id FROM categories WHERE id = ?",
+      [parentId]
+    );
+    if (!parent) {
+      return { success: false, error: "Catégorie parente introuvable" };
+    }
+
+    if (await isDescendantOf(parentId, id)) {
+      return { success: false, error: "Référence circulaire : le parent est un descendant de cette catégorie" };
+    }
+
+    const parentDepth = await getDepth(parentId);
+    if (parentDepth >= 2) {
+      return { success: false, error: "Profondeur maximale atteinte (2 niveaux)" };
+    }
+  }
 
   const existing = await queryFirst<{ id: string }>(
     "SELECT id FROM categories WHERE slug = ? AND id != ?",
@@ -84,9 +156,9 @@ export async function updateCategory(
   }
 
   await execute(
-    `UPDATE categories SET name = ?, slug = ?, description = ?, sort_order = ?, is_active = ?
+    `UPDATE categories SET name = ?, slug = ?, description = ?, parent_id = ?, sort_order = ?, is_active = ?
      WHERE id = ?`,
-    [data.name, data.slug, data.description || null, data.sort_order, data.is_active, id]
+    [data.name, data.slug, data.description || null, parentId, data.sort_order, data.is_active, id]
   );
 
   revalidatePath("/categories");
@@ -107,6 +179,17 @@ export async function deleteCategory(id: string): Promise<ActionResult> {
     return {
       success: false,
       error: `Impossible de supprimer: ${hasProducts.count} produit(s) dans cette catégorie`,
+    };
+  }
+
+  const hasChildren = await queryFirst<{ count: number }>(
+    "SELECT COUNT(*) as count FROM categories WHERE parent_id = ?",
+    [id]
+  );
+  if (hasChildren && hasChildren.count > 0) {
+    return {
+      success: false,
+      error: `Impossible de supprimer: ${hasChildren.count} sous-catégorie(s) liée(s)`,
     };
   }
 

--- a/app/(admin)/categories/categories-page-client.tsx
+++ b/app/(admin)/categories/categories-page-client.tsx
@@ -8,12 +8,14 @@ import { ResponsiveDataList } from "@/components/admin/responsive-data-list";
 import { ViewSwitcher } from "@/components/admin/view-switcher";
 import { CategoryCreateButton } from "./category-create-button";
 import type { CategoryWithCount } from "@/lib/db/admin/categories";
+import type { Category } from "@/lib/db/types";
 
 interface CategoriesPageClientProps {
   categories: CategoryWithCount[];
+  allCategories: Category[];
 }
 
-export function CategoriesPageClient({ categories }: CategoriesPageClientProps) {
+export function CategoriesPageClient({ categories, allCategories }: CategoriesPageClientProps) {
   const [editCategory, setEditCategory] = useState<CategoryWithCount | null>(null);
 
   return (
@@ -26,13 +28,13 @@ export function CategoriesPageClient({ categories }: CategoriesPageClientProps) 
             {categories.length} catégorie(s)
           </span>
         </div>
-        <CategoryCreateButton />
+        <CategoryCreateButton categories={allCategories} />
       </div>
 
       {/* Responsive data list */}
       <ResponsiveDataList
         data={categories}
-        renderTable={(data) => <CategoryTable categories={data} />}
+        renderTable={(data) => <CategoryTable categories={data} allCategories={allCategories} />}
         renderCard={(category) => (
           <CategoryCardMobile
             category={category}
@@ -45,6 +47,7 @@ export function CategoriesPageClient({ categories }: CategoriesPageClientProps) 
       {/* Edit form dialog */}
       <CategoryForm
         category={editCategory}
+        categories={allCategories}
         open={!!editCategory}
         onOpenChange={(open) => {
           if (!open) setEditCategory(null);

--- a/app/(admin)/categories/categories-page-client.tsx
+++ b/app/(admin)/categories/categories-page-client.tsx
@@ -46,6 +46,7 @@ export function CategoriesPageClient({ categories, allCategories }: CategoriesPa
 
       {/* Edit form dialog */}
       <CategoryForm
+        key={editCategory?.id}
         category={editCategory}
         categories={allCategories}
         open={!!editCategory}

--- a/app/(admin)/categories/category-create-button.tsx
+++ b/app/(admin)/categories/category-create-button.tsx
@@ -3,14 +3,15 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { CategoryForm } from "@/components/admin/category-form";
+import type { Category } from "@/lib/db/types";
 
-export function CategoryCreateButton() {
+export function CategoryCreateButton({ categories = [] }: { categories?: Category[] }) {
   const [open, setOpen] = useState(false);
 
   return (
     <>
       <Button onClick={() => setOpen(true)}>Nouvelle catégorie</Button>
-      <CategoryForm open={open} onOpenChange={setOpen} />
+      <CategoryForm open={open} onOpenChange={setOpen} categories={categories} />
     </>
   );
 }

--- a/app/(admin)/categories/page.tsx
+++ b/app/(admin)/categories/page.tsx
@@ -2,10 +2,14 @@ import { AdminHeader } from "@/components/admin/admin-header";
 import { AdminPageHeader } from "@/components/admin/admin-page-header";
 import { CategoryCreateButton } from "./category-create-button";
 import { getAllCategories } from "@/lib/db/admin/categories";
+import { getCategories } from "@/lib/db/categories";
 import { CategoriesPageClient } from "./categories-page-client";
 
 export default async function CategoriesPage() {
-  const categories = await getAllCategories();
+  const [categories, allCategories] = await Promise.all([
+    getAllCategories(),
+    getCategories(),
+  ]);
 
   return (
     <div>
@@ -16,12 +20,12 @@ export default async function CategoriesPage() {
           <p className="text-sm text-muted-foreground">
             {categories.length} catégorie(s)
           </p>
-          <CategoryCreateButton />
+          <CategoryCreateButton categories={allCategories} />
         </div>
       </AdminPageHeader>
 
       {/* Mobile/responsive content */}
-      <CategoriesPageClient categories={categories} />
+      <CategoriesPageClient categories={categories} allCategories={allCategories} />
     </div>
   );
 }

--- a/app/(storefront)/c/[slug]/page.tsx
+++ b/app/(storefront)/c/[slug]/page.tsx
@@ -8,6 +8,7 @@ import {
   getCategoryAncestors,
   getCategoryDescendantIds,
   getCategoryTree,
+  minifyCategoryTree,
 } from "@/lib/db/categories";
 import {
   searchProducts,
@@ -123,7 +124,7 @@ export default async function CategoryPage({ params, searchParams }: Props) {
 
   return (
     <FilterProvider
-      categoryTree={categoryTree}
+      categoryTree={minifyCategoryTree(categoryTree)}
       activeCategorySlug={slug}
       brands={brands}
       priceRange={priceRange}

--- a/app/(storefront)/c/[slug]/page.tsx
+++ b/app/(storefront)/c/[slug]/page.tsx
@@ -75,18 +75,21 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
 export default async function CategoryPage({ params, searchParams }: Props) {
   const { slug } = await params;
   const sp = await searchParams;
+  // Start category tree fetch early (doesn't depend on category.id)
+  const categoryTreePromise = getCategoryTree();
+
   const category = await getCategoryCached(slug);
   if (!category) notFound();
 
   const currentPage = Math.max(1, parseInt(sp.page ?? "1", 10) || 1);
   const limit = 20;
 
-  // Fetch subcategories, ancestors, descendant IDs, and category tree in parallel
+  // Fetch subcategories, ancestors, descendant IDs in parallel (+ await tree started above)
   const [children, ancestors, descendantIds, categoryTree] = await Promise.all([
     getCategoryChildren(category.id),
     getCategoryAncestors(category.id),
     getCategoryDescendantIds(category.id),
-    getCategoryTree(),
+    categoryTreePromise,
   ]);
 
   // Aggregate category IDs: current + all descendants

--- a/app/(storefront)/c/[slug]/page.tsx
+++ b/app/(storefront)/c/[slug]/page.tsx
@@ -2,6 +2,8 @@ import { cache } from "react";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
+import Image from "next/image";
+import { getImageUrl } from "@/lib/utils/images";
 import {
   getCategoryBySlug,
   getCategoryChildren,
@@ -186,9 +188,11 @@ export default async function CategoryPage({ params, searchParams }: Props) {
                 className="flex flex-col items-center gap-2 rounded-xl border bg-card p-4 text-center transition-colors hover:bg-muted/50"
               >
                 {child.image_url && (
-                  <img
-                    src={child.image_url}
+                  <Image
+                    src={getImageUrl(child.image_url)}
                     alt={child.name}
+                    width={48}
+                    height={48}
                     className="h-12 w-12 rounded-lg object-cover"
                   />
                 )}

--- a/app/(storefront)/c/[slug]/page.tsx
+++ b/app/(storefront)/c/[slug]/page.tsx
@@ -2,7 +2,13 @@ import { cache } from "react";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
-import { getCategoryBySlug } from "@/lib/db/categories";
+import {
+  getCategoryBySlug,
+  getCategoryChildren,
+  getCategoryAncestors,
+  getCategoryDescendantIds,
+  getCategoryTree,
+} from "@/lib/db/categories";
 import {
   searchProducts,
   countSearchResults,
@@ -75,8 +81,19 @@ export default async function CategoryPage({ params, searchParams }: Props) {
   const currentPage = Math.max(1, parseInt(sp.page ?? "1", 10) || 1);
   const limit = 20;
 
+  // Fetch subcategories, ancestors, descendant IDs, and category tree in parallel
+  const [children, ancestors, descendantIds, categoryTree] = await Promise.all([
+    getCategoryChildren(category.id),
+    getCategoryAncestors(category.id),
+    getCategoryDescendantIds(category.id),
+    getCategoryTree(),
+  ]);
+
+  // Aggregate category IDs: current + all descendants
+  const allCategoryIds = [category.id, ...descendantIds];
+
   const opts: SearchOptions = {
-    category: slug,
+    categoryIds: allCategoryIds,
     brands: sp.brand ? sp.brand.split(",").filter(Boolean) : undefined,
     minPrice: sp.min_price ? parseInt(sp.min_price, 10) : undefined,
     maxPrice: sp.max_price ? parseInt(sp.max_price, 10) : undefined,
@@ -88,27 +105,29 @@ export default async function CategoryPage({ params, searchParams }: Props) {
   const [products, total, brands, priceRange] = await Promise.all([
     searchProducts(opts),
     countSearchResults(opts),
-    getBrandsInCategory(category.id),
-    getPriceRangeInCategory(category.id),
+    getBrandsInCategory(allCategoryIds),
+    getPriceRangeInCategory(allCategoryIds),
   ]);
 
   const hasMore = (currentPage - 1) * limit + products.length < total;
 
+  // Build breadcrumb chain: Accueil > ...ancestors > current
+  const breadcrumbItems = [
+    { name: "Accueil", href: "/" },
+    ...ancestors.map((a) => ({ name: a.name, href: `/c/${a.slug}` })),
+    { name: category.name },
+  ];
+
   return (
     <FilterProvider
-      categories={[]}
+      categoryTree={categoryTree}
+      activeCategorySlug={slug}
       brands={brands}
       priceRange={priceRange}
       basePath={`/c/${slug}`}
-      hideCategory
     >
       <div className="mx-auto max-w-7xl px-4 py-6">
-        <BreadcrumbSchema
-          items={[
-            { name: "Accueil", href: "/" },
-            { name: category.name },
-          ]}
-        />
+        <BreadcrumbSchema items={breadcrumbItems} />
         <JsonLd
           data={{
             "@context": "https://schema.org",
@@ -128,6 +147,14 @@ export default async function CategoryPage({ params, searchParams }: Props) {
           <Link href="/" className="hover:text-foreground">
             Accueil
           </Link>
+          {ancestors.map((a) => (
+            <span key={a.id}>
+              <span className="mx-1.5">/</span>
+              <Link href={`/c/${a.slug}`} className="hover:text-foreground">
+                {a.name}
+              </Link>
+            </span>
+          ))}
           <span className="mx-1.5">/</span>
           <span className="text-foreground">{category.name}</span>
         </nav>
@@ -144,6 +171,28 @@ export default async function CategoryPage({ params, searchParams }: Props) {
             {total} produit{total !== 1 ? "s" : ""}
           </p>
         </div>
+
+        {/* Subcategories grid */}
+        {children.length > 0 && (
+          <div className="mb-8 grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+            {children.map((child) => (
+              <Link
+                key={child.id}
+                href={`/c/${child.slug}`}
+                className="flex flex-col items-center gap-2 rounded-xl border bg-card p-4 text-center transition-colors hover:bg-muted/50"
+              >
+                {child.image_url && (
+                  <img
+                    src={child.image_url}
+                    alt={child.name}
+                    className="h-12 w-12 rounded-lg object-cover"
+                  />
+                )}
+                <span className="text-sm font-medium">{child.name}</span>
+              </Link>
+            ))}
+          </div>
+        )}
 
         {/* Active filters + sort */}
         <div className="mb-4 flex flex-wrap items-center justify-between gap-3">

--- a/app/(storefront)/p/[slug]/page.tsx
+++ b/app/(storefront)/p/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
 import Image from "next/image";
-import { getProductBySlug, getRelatedProducts } from "@/lib/db/products";
+import { getProductBySlug, getRelatedProducts, toProductCardData } from "@/lib/db/products";
 import { ImageGallery } from "@/components/storefront/image-gallery";
 import { getImageUrl } from "@/lib/utils/images";
 import { VariantSelector } from "@/components/storefront/variant-selector";
@@ -79,7 +79,7 @@ async function RelatedProducts({
       <HorizontalSection
         title="Produits similaires"
         href={categorySlug ? `/c/${categorySlug}` : undefined}
-        products={related}
+        products={related.map(toProductCardData)}
       />
     </div>
   );

--- a/app/(storefront)/page.tsx
+++ b/app/(storefront)/page.tsx
@@ -1,7 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import type { Metadata } from "next";
-import { getCategories } from "@/lib/db/categories";
+import { getTopLevelCategories } from "@/lib/db/categories";
 import {
   getFeaturedProducts,
   getLatestProducts,
@@ -22,7 +22,7 @@ const HIGHLIGHTED_CATEGORIES = 3;
 
 export default async function HomePage() {
   const [categories, featured, latest, activeBanners] = await Promise.all([
-    getCategories(),
+    getTopLevelCategories(),
     getFeaturedProducts(10),
     getLatestProducts(10, true),
     getActiveBanners().catch((error) => {

--- a/app/(storefront)/page.tsx
+++ b/app/(storefront)/page.tsx
@@ -6,6 +6,7 @@ import {
   getFeaturedProducts,
   getLatestProducts,
   getProductsByCategorySlug,
+  toProductCardData,
 } from "@/lib/db/products";
 import type { Banner } from "@/lib/db/types";
 import { getActiveBanners } from "@/lib/db/storefront/banners";
@@ -29,7 +30,7 @@ export default async function HomePage() {
     Promise.all(
       cats.slice(0, HIGHLIGHTED_CATEGORIES).map(async (cat) => ({
         category: cat,
-        products: await getProductsByCategorySlug(cat.slug, 10),
+        products: (await getProductsByCategorySlug(cat.slug, 10)).map(toProductCardData),
       }))
     )
   );
@@ -47,21 +48,24 @@ export default async function HomePage() {
       categorySectionsPromise,
     ]);
 
+  const featuredCards = featured.map(toProductCardData);
+  const latestCards = latest.map(toProductCardData);
+
   return (
     <div className="mx-auto max-w-7xl space-y-8 px-4 py-6">
       <h1 className="sr-only">NETEREKA - Électronique &amp; High-Tech en Côte d&apos;Ivoire</h1>
-      <HeroBanner banners={activeBanners} fallbackProducts={featured.slice(0, 3)} />
+      <HeroBanner banners={activeBanners} fallbackProducts={featuredCards.slice(0, 3)} />
 
       <CategoryNav categories={categories} />
 
       <HorizontalSection
         title="Meilleures ventes"
-        products={featured}
+        products={featuredCards}
       />
 
       <HorizontalSection
         title="Nouveautés"
-        products={latest}
+        products={latestCards}
       />
 
       {categorySections.map(({ category, products }) => (

--- a/app/(storefront)/search/active-filters.tsx
+++ b/app/(storefront)/search/active-filters.tsx
@@ -2,10 +2,10 @@
 
 import { useRouter, useSearchParams } from "next/navigation";
 import { formatPrice } from "@/lib/utils/format";
-import type { CategoryNode } from "@/lib/db/types";
+import type { SidebarCategoryNode } from "@/lib/db/types";
 import { useFilterData } from "./filter-context";
 
-function findInTree(nodes: readonly CategoryNode[], slug: string): CategoryNode | undefined {
+function findInTree(nodes: readonly SidebarCategoryNode[], slug: string): SidebarCategoryNode | undefined {
   for (const node of nodes) {
     if (node.slug === slug) return node;
     const found = findInTree(node.children, slug);

--- a/app/(storefront)/search/active-filters.tsx
+++ b/app/(storefront)/search/active-filters.tsx
@@ -5,7 +5,7 @@ import { formatPrice } from "@/lib/utils/format";
 import type { CategoryNode } from "@/lib/db/types";
 import { useFilterData } from "./filter-context";
 
-function findInTree(nodes: CategoryNode[], slug: string): CategoryNode | undefined {
+function findInTree(nodes: readonly CategoryNode[], slug: string): CategoryNode | undefined {
   for (const node of nodes) {
     if (node.slug === slug) return node;
     const found = findInTree(node.children, slug);

--- a/app/(storefront)/search/active-filters.tsx
+++ b/app/(storefront)/search/active-filters.tsx
@@ -2,10 +2,20 @@
 
 import { useRouter, useSearchParams } from "next/navigation";
 import { formatPrice } from "@/lib/utils/format";
+import type { CategoryNode } from "@/lib/db/types";
 import { useFilterData } from "./filter-context";
 
+function findInTree(nodes: CategoryNode[], slug: string): CategoryNode | undefined {
+  for (const node of nodes) {
+    if (node.slug === slug) return node;
+    const found = findInTree(node.children, slug);
+    if (found) return found;
+  }
+  return undefined;
+}
+
 export function ActiveFilters() {
-  const { categories, basePath } = useFilterData();
+  const { categoryTree, basePath } = useFilterData();
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -43,7 +53,7 @@ export function ActiveFilters() {
   };
 
   const categoryName = activeCategory
-    ? categories.find((c) => c.slug === activeCategory)?.name
+    ? findInTree(categoryTree, activeCategory)?.name
     : null;
 
   return (

--- a/app/(storefront)/search/filter-context.tsx
+++ b/app/(storefront)/search/filter-context.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { createContext, useContext } from "react";
-import type { CategoryNode, PriceRange } from "@/lib/db/types";
+import type { SidebarCategoryNode, PriceRange } from "@/lib/db/types";
 
 interface FilterData {
-  categoryTree: CategoryNode[];
+  categoryTree: SidebarCategoryNode[];
   activeCategorySlug?: string;
   brands: string[];
   priceRange: PriceRange;

--- a/app/(storefront)/search/filter-context.tsx
+++ b/app/(storefront)/search/filter-context.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { createContext, useContext } from "react";
-import type { CategoryFilterItem, PriceRange } from "@/lib/db/types";
+import type { CategoryNode, PriceRange } from "@/lib/db/types";
 
 interface FilterData {
-  categories: CategoryFilterItem[];
+  categoryTree: CategoryNode[];
+  activeCategorySlug?: string;
   brands: string[];
   priceRange: PriceRange;
   basePath: string;
-  hideCategory?: boolean;
 }
 
 const FilterContext = createContext<FilterData | null>(null);

--- a/app/(storefront)/search/page.tsx
+++ b/app/(storefront)/search/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import { searchProducts, countSearchResults, getBrandsInUse, getPriceRange } from "@/lib/db/search";
-import { getCategories } from "@/lib/db/categories";
+import { getCategoryTree } from "@/lib/db/categories";
 import { ProductGrid } from "@/components/storefront/product-grid";
 import { SITE_NAME } from "@/lib/utils/constants";
-import type { SearchOptions, CategoryFilterItem } from "@/lib/db/types";
+import type { SearchOptions } from "@/lib/db/types";
 import { FilterProvider } from "./filter-context";
 import { SearchFilters } from "./search-filters";
 import { SearchSort } from "./search-sort";
@@ -53,22 +53,23 @@ export default async function SearchPage({ searchParams }: Props) {
     offset: (currentPage - 1) * limit,
   };
 
-  const [products, total, brands, categories, priceRange] = await Promise.all([
+  const [products, total, brands, categoryTree, priceRange] = await Promise.all([
     searchProducts(opts),
     countSearchResults(opts),
     getBrandsInUse(),
-    getCategories(),
+    getCategoryTree(),
     getPriceRange(),
   ]);
 
   const hasMore = (currentPage - 1) * limit + products.length < total;
 
-  const categoryFilterData = categories.map((c) => ({
-    id: c.id, name: c.name, slug: c.slug,
-  } satisfies CategoryFilterItem));
-
   return (
-    <FilterProvider categories={categoryFilterData} brands={brands} priceRange={priceRange}>
+    <FilterProvider
+      categoryTree={categoryTree}
+      activeCategorySlug={sp.category}
+      brands={brands}
+      priceRange={priceRange}
+    >
       <div className="mx-auto max-w-7xl px-4 py-6">
         {/* Header */}
         <div className="mb-6">

--- a/app/(storefront)/search/page.tsx
+++ b/app/(storefront)/search/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { searchProducts, countSearchResults, getBrandsInUse, getPriceRange } from "@/lib/db/search";
-import { getCategoryTree } from "@/lib/db/categories";
+import { getCategoryTree, minifyCategoryTree } from "@/lib/db/categories";
 import { ProductGrid } from "@/components/storefront/product-grid";
 import { SITE_NAME } from "@/lib/utils/constants";
 import type { SearchOptions } from "@/lib/db/types";
@@ -65,7 +65,7 @@ export default async function SearchPage({ searchParams }: Props) {
 
   return (
     <FilterProvider
-      categoryTree={categoryTree}
+      categoryTree={minifyCategoryTree(categoryTree)}
       activeCategorySlug={sp.category}
       brands={brands}
       priceRange={priceRange}

--- a/app/(storefront)/search/search-filters.tsx
+++ b/app/(storefront)/search/search-filters.tsx
@@ -4,14 +4,14 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useRef, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { formatPrice } from "@/lib/utils/format";
+import { CategorySidebar } from "@/components/storefront/category-sidebar";
 import { useFilterData } from "./filter-context";
 
 export function SearchFilters() {
-  const { categories, brands, priceRange, basePath, hideCategory } = useFilterData();
+  const { categoryTree, activeCategorySlug, brands, priceRange, basePath } = useFilterData();
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const activeCategory = searchParams.get("category") ?? "";
   const activeBrands = searchParams.get("brand")?.split(",").filter(Boolean) ?? [];
   const activeMinPrice = searchParams.get("min_price") ?? "";
   const activeMaxPrice = searchParams.get("max_price") ?? "";
@@ -43,10 +43,6 @@ export function SearchFilters() {
     [router, searchParams, basePath]
   );
 
-  const handleCategoryChange = (slug: string) => {
-    updateParams({ category: slug === activeCategory ? null : slug });
-  };
-
   const handleBrandToggle = (brand: string) => {
     const next = activeBrands.includes(brand)
       ? activeBrands.filter((b) => b !== brand)
@@ -73,33 +69,15 @@ export function SearchFilters() {
     router.push(`${basePath}?${params.toString()}`);
   };
 
-  const hasFilters = activeCategory || activeBrands.length > 0 || activeMinPrice || activeMaxPrice;
+  const hasFilters = activeBrands.length > 0 || activeMinPrice || activeMaxPrice;
 
   return (
     <div className="space-y-6">
-      {/* Categories */}
-      {!hideCategory && (
-        <fieldset>
-          <legend className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-            Catégorie
-          </legend>
-          <div className="space-y-1">
-            {categories.map((cat) => (
-              <button
-                key={cat.id}
-                onClick={() => handleCategoryChange(cat.slug)}
-                className={`block w-full rounded-md px-2 py-1.5 text-left text-sm transition-colors focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none ${
-                  cat.slug === activeCategory
-                    ? "bg-primary/10 font-medium text-primary"
-                    : "text-foreground hover:bg-muted"
-                }`}
-              >
-                {cat.name}
-              </button>
-            ))}
-          </div>
-        </fieldset>
-      )}
+      {/* Category tree sidebar */}
+      <CategorySidebar
+        categoryTree={categoryTree}
+        activeCategorySlug={activeCategorySlug}
+      />
 
       {/* Brands */}
       {brands.length > 0 && (

--- a/components/admin/category-card-mobile.tsx
+++ b/components/admin/category-card-mobile.tsx
@@ -70,6 +70,7 @@ export function CategoryCardMobile({
     <>
       <div
         className="flex items-center gap-3 rounded-xl border bg-card p-3 transition-colors hover:bg-muted/30"
+        style={{ marginLeft: `${category.depth * 1}rem` }}
         data-pending={isPending || undefined}
       >
         {/* Icon */}
@@ -83,8 +84,14 @@ export function CategoryCardMobile({
 
         {/* Content */}
         <div className="flex flex-1 flex-col gap-1 overflow-hidden">
-          <span className="truncate text-sm font-medium">{category.name}</span>
+          <span className="truncate text-sm font-medium">
+            {category.depth > 0 && (
+              <span className="mr-1 text-muted-foreground">↳</span>
+            )}
+            {category.name}
+          </span>
           <span className="truncate text-xs text-muted-foreground">
+            {category.parent_name ? `${category.parent_name} / ` : ""}
             {category.slug}
           </span>
           <div className="mt-1 flex items-center gap-2">

--- a/components/admin/category-form.tsx
+++ b/components/admin/category-form.tsx
@@ -1,11 +1,18 @@
 "use client";
 
-import { useRef, useTransition } from "react";
+import { useRef, useTransition, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import {
   Dialog,
   DialogContent,
@@ -17,18 +24,52 @@ import { createCategory, updateCategory } from "@/actions/admin/categories";
 
 interface CategoryFormProps {
   category?: Category | null;
+  categories?: Category[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
+function getDescendantIds(categoryId: string, allCategories: Category[]): Set<string> {
+  const ids = new Set<string>();
+  const queue = [categoryId];
+  while (queue.length > 0) {
+    const current = queue.pop()!;
+    for (const cat of allCategories) {
+      if (cat.parent_id === current && !ids.has(cat.id)) {
+        ids.add(cat.id);
+        queue.push(cat.id);
+      }
+    }
+  }
+  return ids;
+}
+
 export function CategoryForm({
   category,
+  categories = [],
   open,
   onOpenChange,
 }: CategoryFormProps) {
   const [isPending, startTransition] = useTransition();
   const isEdit = !!category;
   const isActiveRef = useRef<HTMLInputElement>(null);
+  const parentIdRef = useRef<HTMLInputElement>(null);
+  const [parentId, setParentId] = useState(category?.parent_id ?? "");
+
+  // Filter out current category and its descendants from parent options
+  const excludeIds = isEdit
+    ? new Set([category!.id, ...getDescendantIds(category!.id, categories)])
+    : new Set<string>();
+
+  const parentOptions = categories.filter((c) => !excludeIds.has(c.id));
+
+  // Build indentation for parent options
+  function getIndent(cat: Category): string {
+    if (!cat.parent_id) return "";
+    const parent = categories.find((c) => c.id === cat.parent_id);
+    if (!parent || !parent.parent_id) return "\u00A0\u00A0\u00A0\u00A0";
+    return "\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0";
+  }
 
   function handleSubmit(formData: FormData) {
     startTransition(async () => {
@@ -80,6 +121,30 @@ export function CategoryForm({
               name="description"
               defaultValue={category?.description ?? ""}
             />
+          </div>
+          <div className="space-y-2">
+            <Label>Catégorie parente</Label>
+            <input type="hidden" name="parent_id" ref={parentIdRef} value={parentId} />
+            <Select
+              value={parentId || "__none__"}
+              onValueChange={(value) => {
+                const newVal = value === "__none__" ? "" : value;
+                setParentId(newVal);
+                if (parentIdRef.current) parentIdRef.current.value = newVal;
+              }}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Aucune (catégorie principale)" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__none__">Aucune (catégorie principale)</SelectItem>
+                {parentOptions.map((cat) => (
+                  <SelectItem key={cat.id} value={cat.id}>
+                    {getIndent(cat)}{cat.parent_id ? "↳ " : ""}{cat.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
           <div className="space-y-2">
             <Label htmlFor="c-sort">Ordre d&apos;affichage</Label>

--- a/components/admin/category-form.tsx
+++ b/components/admin/category-form.tsx
@@ -20,6 +20,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import type { Category } from "@/lib/db/types";
+import { MAX_CATEGORY_DEPTH } from "@/lib/db/types";
 import { createCategory, updateCategory } from "@/actions/admin/categories";
 
 interface CategoryFormProps {
@@ -85,7 +86,9 @@ export function CategoryForm({
     ? new Set([category!.id, ...getDescendantIds(category!.id, childrenMap)])
     : new Set<string>();
 
-  const parentOptions = categories.filter((c) => !excludeIds.has(c.id));
+  const parentOptions = categories.filter(
+    (c) => !excludeIds.has(c.id) && getDepth(c, categoryById) < MAX_CATEGORY_DEPTH
+  );
 
   function handleSubmit(formData: FormData) {
     startTransition(async () => {

--- a/components/admin/category-table.tsx
+++ b/components/admin/category-table.tsx
@@ -171,6 +171,7 @@ export function CategoryTable({
       </div>
 
       <CategoryForm
+        key={editCategory?.id}
         category={editCategory}
         categories={allCategories}
         open={!!editCategory}

--- a/components/admin/category-table.tsx
+++ b/components/admin/category-table.tsx
@@ -33,13 +33,16 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { MoreVerticalIcon } from "@hugeicons/core-free-icons";
 import type { CategoryWithCount } from "@/lib/db/admin/categories";
+import type { Category } from "@/lib/db/types";
 import { deleteCategory } from "@/actions/admin/categories";
 import { CategoryForm } from "./category-form";
 
 export function CategoryTable({
   categories,
+  allCategories = [],
 }: {
   categories: CategoryWithCount[];
+  allCategories?: Category[];
 }) {
   const [editCategory, setEditCategory] = useState<CategoryWithCount | null>(
     null
@@ -55,6 +58,11 @@ export function CategoryTable({
         toast.error(result.error);
       }
     });
+  }
+
+  // Count children for delete warning
+  function childCount(id: string): number {
+    return categories.filter((c) => c.parent_id === id).length;
   }
 
   return (
@@ -79,67 +87,84 @@ export function CategoryTable({
                 </TableCell>
               </TableRow>
             ) : (
-              categories.map((cat) => (
-                <TableRow key={cat.id} data-pending={isPending || undefined}>
-                  <TableCell className="font-medium">{cat.name}</TableCell>
-                  <TableCell className="text-sm text-muted-foreground">
-                    {cat.slug}
-                  </TableCell>
-                  <TableCell>
-                    <Badge variant="secondary">{cat.product_count}</Badge>
-                  </TableCell>
-                  <TableCell>{cat.sort_order}</TableCell>
-                  <TableCell>
-                    <Badge variant={cat.is_active ? "default" : "secondary"}>
-                      {cat.is_active ? "Active" : "Inactive"}
-                    </Badge>
-                  </TableCell>
-                  <TableCell>
-                    <AlertDialog>
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <Button variant="ghost" size="icon" className="h-11 w-11">
-                            <HugeiconsIcon icon={MoreVerticalIcon} size={18} />
-                            <span className="sr-only">Actions</span>
-                          </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
-                          <DropdownMenuItem onClick={() => setEditCategory(cat)}>
-                            Modifier
-                          </DropdownMenuItem>
-                          <DropdownMenuSeparator />
-                          <AlertDialogTrigger asChild>
-                            <DropdownMenuItem className="text-destructive">
-                              Supprimer
+              categories.map((cat) => {
+                const children = childCount(cat.id);
+                return (
+                  <TableRow key={cat.id} data-pending={isPending || undefined}>
+                    <TableCell className="font-medium">
+                      <div style={{ paddingLeft: `${cat.depth * 1.5}rem` }}>
+                        <span>
+                          {cat.depth > 0 && (
+                            <span className="mr-1 text-muted-foreground">↳</span>
+                          )}
+                          {cat.name}
+                        </span>
+                        {cat.parent_name && (
+                          <p className="text-xs text-muted-foreground">{cat.parent_name}</p>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {cat.slug}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="secondary">{cat.product_count}</Badge>
+                    </TableCell>
+                    <TableCell>{cat.sort_order}</TableCell>
+                    <TableCell>
+                      <Badge variant={cat.is_active ? "default" : "secondary"}>
+                        {cat.is_active ? "Active" : "Inactive"}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <AlertDialog>
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button variant="ghost" size="icon" className="h-11 w-11">
+                              <HugeiconsIcon icon={MoreVerticalIcon} size={18} />
+                              <span className="sr-only">Actions</span>
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem onClick={() => setEditCategory(cat)}>
+                              Modifier
                             </DropdownMenuItem>
-                          </AlertDialogTrigger>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                      <AlertDialogContent>
-                        <AlertDialogHeader>
-                          <AlertDialogTitle>
-                            Supprimer cette catégorie ?
-                          </AlertDialogTitle>
-                          <AlertDialogDescription>
-                            La catégorie &quot;{cat.name}&quot; sera supprimée.
-                            {cat.product_count > 0 &&
-                              ` Elle contient ${cat.product_count} produit(s) — la suppression sera bloquée.`}
-                          </AlertDialogDescription>
-                        </AlertDialogHeader>
-                        <AlertDialogFooter>
-                          <AlertDialogCancel>Annuler</AlertDialogCancel>
-                          <AlertDialogAction
-                            onClick={() => handleDelete(cat.id)}
-                            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                          >
-                            Supprimer
-                          </AlertDialogAction>
-                        </AlertDialogFooter>
-                      </AlertDialogContent>
-                    </AlertDialog>
-                  </TableCell>
-                </TableRow>
-              ))
+                            <DropdownMenuSeparator />
+                            <AlertDialogTrigger asChild>
+                              <DropdownMenuItem className="text-destructive">
+                                Supprimer
+                              </DropdownMenuItem>
+                            </AlertDialogTrigger>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                        <AlertDialogContent>
+                          <AlertDialogHeader>
+                            <AlertDialogTitle>
+                              Supprimer cette catégorie ?
+                            </AlertDialogTitle>
+                            <AlertDialogDescription>
+                              La catégorie &quot;{cat.name}&quot; sera supprimée.
+                              {cat.product_count > 0 &&
+                                ` Elle contient ${cat.product_count} produit(s) — la suppression sera bloquée.`}
+                              {children > 0 &&
+                                ` Elle contient ${children} sous-catégorie(s) — la suppression sera bloquée.`}
+                            </AlertDialogDescription>
+                          </AlertDialogHeader>
+                          <AlertDialogFooter>
+                            <AlertDialogCancel>Annuler</AlertDialogCancel>
+                            <AlertDialogAction
+                              onClick={() => handleDelete(cat.id)}
+                              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                            >
+                              Supprimer
+                            </AlertDialogAction>
+                          </AlertDialogFooter>
+                        </AlertDialogContent>
+                      </AlertDialog>
+                    </TableCell>
+                  </TableRow>
+                );
+              })
             )}
           </TableBody>
         </Table>
@@ -147,6 +172,7 @@ export function CategoryTable({
 
       <CategoryForm
         category={editCategory}
+        categories={allCategories}
         open={!!editCategory}
         onOpenChange={(open) => {
           if (!open) setEditCategory(null);

--- a/components/storefront/category-sidebar.tsx
+++ b/components/storefront/category-sidebar.tsx
@@ -4,14 +4,14 @@ import { useState } from "react";
 import Link from "next/link";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ArrowRight01Icon, ArrowDown01Icon } from "@hugeicons/core-free-icons";
-import type { CategoryNode } from "@/lib/db/types";
+import type { SidebarCategoryNode } from "@/lib/db/types";
 
 interface CategorySidebarProps {
-  categoryTree: CategoryNode[];
+  categoryTree: SidebarCategoryNode[];
   activeCategorySlug?: string;
 }
 
-function isActiveOrAncestor(node: CategoryNode, activeSlug: string): boolean {
+function isActiveOrAncestor(node: SidebarCategoryNode, activeSlug: string): boolean {
   if (node.slug === activeSlug) return true;
   return node.children.some((child) => isActiveOrAncestor(child, activeSlug));
 }
@@ -20,7 +20,7 @@ function CategoryTreeNode({
   node,
   activeCategorySlug,
 }: {
-  node: CategoryNode;
+  node: SidebarCategoryNode;
   activeCategorySlug?: string;
 }) {
   const isActive = node.slug === activeCategorySlug;

--- a/components/storefront/category-sidebar.tsx
+++ b/components/storefront/category-sidebar.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ArrowRight01Icon, ArrowDown01Icon } from "@hugeicons/core-free-icons";
+import type { CategoryNode } from "@/lib/db/types";
+
+interface CategorySidebarProps {
+  categoryTree: CategoryNode[];
+  activeCategorySlug?: string;
+}
+
+function isActiveOrAncestor(node: CategoryNode, activeSlug: string): boolean {
+  if (node.slug === activeSlug) return true;
+  return node.children.some((child) => isActiveOrAncestor(child, activeSlug));
+}
+
+function CategoryTreeNode({
+  node,
+  activeCategorySlug,
+  depth = 0,
+}: {
+  node: CategoryNode;
+  activeCategorySlug?: string;
+  depth?: number;
+}) {
+  const isActive = node.slug === activeCategorySlug;
+  const hasChildren = node.children.length > 0;
+  const shouldAutoExpand = activeCategorySlug
+    ? isActiveOrAncestor(node, activeCategorySlug)
+    : false;
+  const [expanded, setExpanded] = useState(shouldAutoExpand);
+
+  return (
+    <div>
+      <div className="flex items-center">
+        {hasChildren && (
+          <button
+            onClick={() => setExpanded(!expanded)}
+            className="flex h-6 w-6 shrink-0 items-center justify-center rounded hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none"
+            aria-label={expanded ? "Réduire" : "Développer"}
+          >
+            <HugeiconsIcon
+              icon={expanded ? ArrowDown01Icon : ArrowRight01Icon}
+              size={14}
+              className="text-muted-foreground"
+            />
+          </button>
+        )}
+        {!hasChildren && <span className="w-6 shrink-0" />}
+        <Link
+          href={`/c/${node.slug}`}
+          className={`block flex-1 rounded-md px-2 py-1.5 text-sm transition-colors focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none ${
+            isActive
+              ? "bg-primary/10 font-medium text-primary"
+              : "text-foreground hover:bg-muted"
+          }`}
+        >
+          {node.name}
+        </Link>
+      </div>
+      {hasChildren && expanded && (
+        <div className="ml-3 border-l border-border pl-1">
+          {node.children.map((child) => (
+            <CategoryTreeNode
+              key={child.id}
+              node={child}
+              activeCategorySlug={activeCategorySlug}
+              depth={depth + 1}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function CategorySidebar({
+  categoryTree,
+  activeCategorySlug,
+}: CategorySidebarProps) {
+  if (categoryTree.length === 0) return null;
+
+  return (
+    <fieldset>
+      <legend className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        Catégories
+      </legend>
+      <div className="space-y-0.5">
+        {categoryTree.map((node) => (
+          <CategoryTreeNode
+            key={node.id}
+            node={node}
+            activeCategorySlug={activeCategorySlug}
+          />
+        ))}
+      </div>
+    </fieldset>
+  );
+}

--- a/components/storefront/category-sidebar.tsx
+++ b/components/storefront/category-sidebar.tsx
@@ -19,11 +19,9 @@ function isActiveOrAncestor(node: CategoryNode, activeSlug: string): boolean {
 function CategoryTreeNode({
   node,
   activeCategorySlug,
-  depth = 0,
 }: {
   node: CategoryNode;
   activeCategorySlug?: string;
-  depth?: number;
 }) {
   const isActive = node.slug === activeCategorySlug;
   const hasChildren = node.children.length > 0;
@@ -67,7 +65,6 @@ function CategoryTreeNode({
               key={child.id}
               node={child}
               activeCategorySlug={activeCategorySlug}
-              depth={depth + 1}
             />
           ))}
         </div>

--- a/components/storefront/hero-banner.tsx
+++ b/components/storefront/hero-banner.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import Image from "next/image";
 import useEmblaCarousel from "embla-carousel-react";
 import Autoplay from "embla-carousel-autoplay";
-import type { BadgeColor, Banner, Product } from "@/lib/db/types";
+import type { BadgeColor, Banner, ProductCardData } from "@/lib/db/types";
 import { formatPrice } from "@/lib/utils/format";
 import { getImageUrl } from "@/lib/utils/images";
 import { cn } from "@/lib/utils";
@@ -30,7 +30,7 @@ const badgeColorMap: Record<BadgeColor, string> = {
   blue: "bg-blue-500/20 text-blue-300",
 };
 
-function buildSlides(banners: Banner[], fallbackProducts: Product[]): Slide[] {
+function buildSlides(banners: Banner[], fallbackProducts: ProductCardData[]): Slide[] {
   if (banners.length > 0) {
     return banners.map((b) => ({
       title: b.title,
@@ -65,7 +65,7 @@ export function HeroBanner({
   fallbackProducts,
 }: {
   banners: Banner[];
-  fallbackProducts: Product[];
+  fallbackProducts: ProductCardData[];
 }) {
   const slides = buildSlides(banners, fallbackProducts);
 

--- a/components/storefront/horizontal-section.tsx
+++ b/components/storefront/horizontal-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import type { Product } from "@/lib/db/types";
+import type { ProductCardData } from "@/lib/db/types";
 import { ProductCard } from "@/components/storefront/product-card";
 import { useHorizontalScroll } from "@/hooks/use-horizontal-scroll";
 import { ScrollButtons } from "@/components/storefront/scroll-buttons";
@@ -13,7 +13,7 @@ export function HorizontalSection({
 }: {
   title: string;
   href?: string;
-  products: Product[];
+  products: ProductCardData[];
 }) {
   const { scrollRef, canScrollLeft, canScrollRight, scroll, dragProps } =
     useHorizontalScroll();

--- a/components/storefront/product-card.tsx
+++ b/components/storefront/product-card.tsx
@@ -1,13 +1,13 @@
 import Link from "next/link";
 import Image from "next/image";
-import type { Product } from "@/lib/db/types";
+import type { ProductCardData } from "@/lib/db/types";
 import { formatPrice } from "@/lib/utils/format";
 import { getImageUrl } from "@/lib/utils/images";
 import { WishlistButton } from "@/components/storefront/wishlist-button";
 import { cn } from "@/lib/utils";
 
 interface Props {
-  product: Product;
+  product: ProductCardData;
   isWishlisted?: boolean;
   showWishlist?: boolean;
 }

--- a/components/storefront/product-grid.tsx
+++ b/components/storefront/product-grid.tsx
@@ -1,7 +1,7 @@
-import type { Product } from "@/lib/db/types";
+import type { ProductCardData } from "@/lib/db/types";
 import { ProductCard } from "@/components/storefront/product-card";
 
-export function ProductGrid({ products }: { products: Product[] }) {
+export function ProductGrid({ products }: { products: ProductCardData[] }) {
   if (products.length === 0) {
     return (
       <div className="py-12 text-center text-muted-foreground">

--- a/lib/db/admin/categories.ts
+++ b/lib/db/admin/categories.ts
@@ -4,7 +4,7 @@ import type { Category } from "@/lib/db/types";
 export interface CategoryWithCount extends Category {
   product_count: number;
   parent_name: string | null;
-  depth: number;
+  depth: 0 | 1 | 2;
 }
 
 export async function getAllCategories(): Promise<CategoryWithCount[]> {

--- a/lib/db/admin/categories.ts
+++ b/lib/db/admin/categories.ts
@@ -3,14 +3,23 @@ import type { Category } from "@/lib/db/types";
 
 export interface CategoryWithCount extends Category {
   product_count: number;
+  parent_name: string | null;
+  depth: number;
 }
 
 export async function getAllCategories(): Promise<CategoryWithCount[]> {
   return query<CategoryWithCount>(
     `SELECT c.*,
-       (SELECT COUNT(*) FROM products p WHERE p.category_id = c.id) as product_count
+       (SELECT COUNT(*) FROM products p WHERE p.category_id = c.id) as product_count,
+       parent.name as parent_name,
+       CASE
+         WHEN c.parent_id IS NULL THEN 0
+         WHEN (SELECT parent_id FROM categories WHERE id = c.parent_id) IS NULL THEN 1
+         ELSE 2
+       END as depth
      FROM categories c
-     ORDER BY c.sort_order ASC`
+     LEFT JOIN categories parent ON parent.id = c.parent_id
+     ORDER BY COALESCE(c.parent_id, c.id), c.parent_id IS NOT NULL, c.sort_order ASC`
   );
 }
 

--- a/lib/db/categories.ts
+++ b/lib/db/categories.ts
@@ -1,5 +1,5 @@
 import { query, queryFirst } from "@/lib/db";
-import type { Category } from "@/lib/db/types";
+import type { Category, CategoryNode } from "@/lib/db/types";
 
 export async function getCategories(): Promise<Category[]> {
   return query<Category>(
@@ -12,4 +12,77 @@ export async function getCategoryBySlug(slug: string): Promise<Category | null> 
     "SELECT * FROM categories WHERE slug = ? AND is_active = 1",
     [slug]
   );
+}
+
+export async function getTopLevelCategories(): Promise<Category[]> {
+  return query<Category>(
+    "SELECT * FROM categories WHERE is_active = 1 AND parent_id IS NULL ORDER BY sort_order ASC"
+  );
+}
+
+export async function getCategoryChildren(parentId: string): Promise<Category[]> {
+  return query<Category>(
+    "SELECT * FROM categories WHERE is_active = 1 AND parent_id = ? ORDER BY sort_order ASC",
+    [parentId]
+  );
+}
+
+export async function getCategoryDescendantIds(categoryId: string): Promise<string[]> {
+  const rows = await query<{ id: string }>(
+    `WITH RECURSIVE descendants AS (
+      SELECT id FROM categories WHERE parent_id = ? AND is_active = 1
+      UNION ALL
+      SELECT c.id FROM categories c
+      JOIN descendants d ON c.parent_id = d.id
+      WHERE c.is_active = 1
+    )
+    SELECT id FROM descendants`,
+    [categoryId]
+  );
+  return rows.map((r) => r.id);
+}
+
+export async function getCategoryAncestors(categoryId: string): Promise<Category[]> {
+  const ancestors: Category[] = [];
+  let currentId: string | null = categoryId;
+
+  // Walk up the parent chain (max 2 levels, so at most 2 iterations)
+  while (currentId) {
+    const cat: Category | null = await queryFirst<Category>(
+      "SELECT * FROM categories WHERE id = ?",
+      [currentId]
+    );
+    if (!cat || !cat.parent_id) break;
+    const parent: Category | null = await queryFirst<Category>(
+      "SELECT * FROM categories WHERE id = ?",
+      [cat.parent_id]
+    );
+    if (!parent) break;
+    ancestors.unshift(parent);
+    currentId = parent.parent_id;
+  }
+
+  return ancestors;
+}
+
+export async function getCategoryTree(): Promise<CategoryNode[]> {
+  const all = await getCategories();
+
+  // Build a map of all nodes
+  const nodeMap = new Map<string, CategoryNode>();
+  for (const cat of all) {
+    nodeMap.set(cat.id, { ...cat, children: [] });
+  }
+
+  // Build tree structure
+  const roots: CategoryNode[] = [];
+  for (const node of nodeMap.values()) {
+    if (node.parent_id && nodeMap.has(node.parent_id)) {
+      nodeMap.get(node.parent_id)!.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+
+  return roots;
 }

--- a/lib/db/categories.ts
+++ b/lib/db/categories.ts
@@ -1,5 +1,5 @@
 import { query, queryFirst } from "@/lib/db";
-import type { Category, CategoryNode } from "@/lib/db/types";
+import type { Category, CategoryNode, SidebarCategoryNode } from "@/lib/db/types";
 import { MAX_CATEGORY_DEPTH } from "@/lib/db/types";
 
 export async function getCategories(): Promise<Category[]> {
@@ -85,4 +85,14 @@ export async function getCategoryTree(): Promise<CategoryNode[]> {
   }
 
   return roots;
+}
+
+/** Strip a category tree to only the fields needed by client-side sidebar. */
+export function minifyCategoryTree(nodes: readonly CategoryNode[]): SidebarCategoryNode[] {
+  return nodes.map((n) => ({
+    id: n.id,
+    slug: n.slug,
+    name: n.name,
+    children: minifyCategoryTree(n.children),
+  }));
 }

--- a/lib/db/products.ts
+++ b/lib/db/products.ts
@@ -1,5 +1,5 @@
 import { query, queryFirst } from "@/lib/db";
-import type { Product, ProductAttribute, ProductDetail, ProductImage, ProductVariant } from "@/lib/db/types";
+import type { Product, ProductCardData, ProductAttribute, ProductDetail, ProductImage, ProductVariant } from "@/lib/db/types";
 
 export async function getProductsByCategory(
   categoryId: string,
@@ -104,6 +104,23 @@ export async function getProductsByCategorySlug(
      LIMIT ?`,
     [categorySlug, limit]
   );
+}
+
+/** Strip a Product to only the fields needed by client-side cards. */
+export function toProductCardData(p: Product): ProductCardData {
+  return {
+    id: p.id,
+    slug: p.slug,
+    name: p.name,
+    base_price: p.base_price,
+    compare_price: p.compare_price,
+    brand: p.brand,
+    is_featured: p.is_featured,
+    stock_quantity: p.stock_quantity,
+    image_url: p.image_url,
+    category_name: p.category_name,
+    variant_count: p.variant_count,
+  };
 }
 
 export async function getRelatedProducts(

--- a/lib/db/search.ts
+++ b/lib/db/search.ts
@@ -18,7 +18,11 @@ export function buildWhere(opts: SearchOptions): { clause: string; params: unkno
     params.push(like, like, like);
   }
 
-  if (opts.category) {
+  if (opts.categoryIds && opts.categoryIds.length > 0) {
+    const placeholders = opts.categoryIds.map(() => "?").join(", ");
+    conditions.push(`p.category_id IN (${placeholders})`);
+    params.push(...opts.categoryIds);
+  } else if (opts.category) {
     conditions.push("c.slug = ?");
     params.push(opts.category);
   }
@@ -76,18 +80,22 @@ export async function countSearchResults(opts: SearchOptions): Promise<number> {
   return result?.count ?? 0;
 }
 
-export async function getBrandsInCategory(categoryId: string): Promise<string[]> {
+export async function getBrandsInCategory(categoryIds: string | string[]): Promise<string[]> {
+  const ids = Array.isArray(categoryIds) ? categoryIds : [categoryIds];
+  const placeholders = ids.map(() => "?").join(", ");
   const rows = await query<{ brand: string }>(
-    "SELECT DISTINCT brand FROM products WHERE is_active = 1 AND brand IS NOT NULL AND category_id = ? ORDER BY brand",
-    [categoryId]
+    `SELECT DISTINCT brand FROM products WHERE is_active = 1 AND brand IS NOT NULL AND category_id IN (${placeholders}) ORDER BY brand`,
+    ids
   );
   return rows.map((r) => r.brand);
 }
 
-export async function getPriceRangeInCategory(categoryId: string): Promise<PriceRange> {
+export async function getPriceRangeInCategory(categoryIds: string | string[]): Promise<PriceRange> {
+  const ids = Array.isArray(categoryIds) ? categoryIds : [categoryIds];
+  const placeholders = ids.map(() => "?").join(", ");
   const result = await queryFirst<{ min_price: number; max_price: number }>(
-    "SELECT MIN(base_price) as min_price, MAX(base_price) as max_price FROM products WHERE is_active = 1 AND category_id = ?",
-    [categoryId]
+    `SELECT MIN(base_price) as min_price, MAX(base_price) as max_price FROM products WHERE is_active = 1 AND category_id IN (${placeholders})`,
+    ids
   );
   return { min: result?.min_price ?? 0, max: result?.max_price ?? 0 };
 }

--- a/lib/db/search.ts
+++ b/lib/db/search.ts
@@ -82,6 +82,7 @@ export async function countSearchResults(opts: SearchOptions): Promise<number> {
 
 export async function getBrandsInCategory(categoryIds: string | string[]): Promise<string[]> {
   const ids = Array.isArray(categoryIds) ? categoryIds : [categoryIds];
+  if (ids.length === 0) return [];
   const placeholders = ids.map(() => "?").join(", ");
   const rows = await query<{ brand: string }>(
     `SELECT DISTINCT brand FROM products WHERE is_active = 1 AND brand IS NOT NULL AND category_id IN (${placeholders}) ORDER BY brand`,
@@ -92,6 +93,7 @@ export async function getBrandsInCategory(categoryIds: string | string[]): Promi
 
 export async function getPriceRangeInCategory(categoryIds: string | string[]): Promise<PriceRange> {
   const ids = Array.isArray(categoryIds) ? categoryIds : [categoryIds];
+  if (ids.length === 0) return { min: 0, max: 0 };
   const placeholders = ids.map(() => "?").join(", ");
   const result = await queryFirst<{ min_price: number; max_price: number }>(
     `SELECT MIN(base_price) as min_price, MAX(base_price) as max_price FROM products WHERE is_active = 1 AND category_id IN (${placeholders})`,

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -33,6 +33,22 @@ export interface Product {
   variant_count?: number;
 }
 
+/** Minimal product fields for client-side cards (server-serialization optimization). */
+export type ProductCardData = Pick<
+  Product,
+  | "id"
+  | "slug"
+  | "name"
+  | "base_price"
+  | "compare_price"
+  | "brand"
+  | "is_featured"
+  | "stock_quantity"
+  | "image_url"
+  | "category_name"
+  | "variant_count"
+>;
+
 export interface ProductVariant {
   id: string;
   product_id: string;
@@ -147,6 +163,14 @@ export const MAX_CATEGORY_DEPTH = 2;
 
 export interface CategoryNode extends Category {
   readonly children: readonly CategoryNode[];
+}
+
+/** Minimal category node for client-side sidebar (server-serialization optimization). */
+export interface SidebarCategoryNode {
+  readonly id: string;
+  readonly slug: string;
+  readonly name: string;
+  readonly children: readonly SidebarCategoryNode[];
 }
 
 export interface SearchOptions {

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -142,8 +142,11 @@ export interface OrderItem {
   total_price: number;
 }
 
+/** Maximum category hierarchy depth (0-indexed). Root = 0, max child depth = MAX_CATEGORY_DEPTH. */
+export const MAX_CATEGORY_DEPTH = 2;
+
 export interface CategoryNode extends Category {
-  children: CategoryNode[];
+  readonly children: readonly CategoryNode[];
 }
 
 export interface SearchOptions {

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -142,9 +142,14 @@ export interface OrderItem {
   total_price: number;
 }
 
+export interface CategoryNode extends Category {
+  children: CategoryNode[];
+}
+
 export interface SearchOptions {
   query?: string;
   category?: string; // category slug
+  categoryIds?: string[]; // category IDs for aggregated search (parent + descendants)
   brands?: string[]; // brand names
   minPrice?: number;
   maxPrice?: number;
@@ -280,9 +285,6 @@ export type CustomerSidebarData = Pick<
   AdminCustomerDetail,
   'id' | 'order_count' | 'total_spent' | 'createdAt' | 'role' | 'is_active'
 >;
-
-/** Category data for filter/picker UIs. */
-export type CategoryFilterItem = Pick<Category, 'id' | 'name' | 'slug'>;
 
 // Audit Log Types
 export type AuditAction =


### PR DESCRIPTION
## Summary

- Activate the existing `parent_id` field in categories to support up to 2 levels of depth (parent > child > grandchild)
- Add 5 hierarchical query functions: `getTopLevelCategories`, `getCategoryChildren`, `getCategoryDescendantIds`, `getCategoryAncestors`, `getCategoryTree`
- Aggregate products across a category and all its descendants on category pages and search
- Admin: parent selector in category form, depth validation, circular reference prevention, hierarchical table/card display with indentation
- Storefront: subcategory cards on category pages, hierarchical breadcrumbs, new `CategorySidebar` component with recursive expand/collapse tree
- Search: replace flat category filter list with tree sidebar navigation
- Homepage: show only top-level categories in `CategoryNav`

## Files changed (18)

| Area | Files |
|------|-------|
| Types & DB | `lib/db/types.ts`, `lib/db/categories.ts`, `lib/db/search.ts`, `lib/db/admin/categories.ts` |
| Admin actions | `actions/admin/categories.ts` |
| Admin UI | `category-form.tsx`, `category-table.tsx`, `category-card-mobile.tsx`, `page.tsx`, `categories-page-client.tsx`, `category-create-button.tsx` |
| Storefront | `c/[slug]/page.tsx`, `page.tsx` (homepage), `category-sidebar.tsx` (new) |
| Search/Filters | `filter-context.tsx`, `search-filters.tsx`, `active-filters.tsx`, `search/page.tsx` |

## Test plan

- [ ] `npm run build` — no TypeScript errors
- [ ] `npm run test` — 337 tests pass
- [ ] Admin: create parent category, child, grandchild — verify parent selector, depth validation
- [ ] Admin: attempt to create a 3rd-level child — should be blocked
- [ ] Admin: attempt to delete a parent with children — should be blocked
- [ ] Storefront `/c/smartphones` (parent) — subcategory cards + aggregated products from descendants
- [ ] Storefront `/c/iphone` (child) — breadcrumb `Accueil > Smartphones > iPhone`
- [ ] Storefront `/search` — sidebar with hierarchical tree, expand/collapse works
- [ ] Homepage — only root categories in CategoryNav

🤖 Generated with [Claude Code](https://claude.com/claude-code)