### PR TITLE
feat: add expandable rows to admin categories table

### DIFF
--- a/app/(admin)/categories/categories-page-client.tsx
+++ b/app/(admin)/categories/categories-page-client.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState, useCallback } from "react";
 import { CategoryTable } from "@/components/admin/category-table";
 import { CategoryCardMobile } from "@/components/admin/category-card-mobile";
 import { CategoryForm } from "@/components/admin/category-form";
 import { ResponsiveDataList } from "@/components/admin/responsive-data-list";
 import { ViewSwitcher } from "@/components/admin/view-switcher";
+import { Button } from "@/components/ui/button";
 import { CategoryCreateButton } from "./category-create-button";
 import type { CategoryWithCount } from "@/lib/db/admin/categories";
 import type { Category } from "@/lib/db/types";
@@ -15,8 +16,72 @@ interface CategoriesPageClientProps {
   allCategories: Category[];
 }
 
+function getVisibleCategories(
+  categories: CategoryWithCount[],
+  expandedIds: Set<string>
+): CategoryWithCount[] {
+  return categories.filter((cat) => {
+    // Root categories are always visible
+    if (!cat.parent_id) return true;
+    // Direct children: visible if parent is expanded
+    return expandedIds.has(cat.parent_id);
+  });
+}
+
 export function CategoriesPageClient({ categories, allCategories }: CategoriesPageClientProps) {
   const [editCategory, setEditCategory] = useState<CategoryWithCount | null>(null);
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+
+  // Build a map of parent_id -> count for O(1) lookups
+  const childCountMap = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const cat of categories) {
+      if (cat.parent_id) {
+        map.set(cat.parent_id, (map.get(cat.parent_id) ?? 0) + 1);
+      }
+    }
+    return map;
+  }, [categories]);
+
+  const childCount = useCallback(
+    (id: string) => childCountMap.get(id) ?? 0,
+    [childCountMap]
+  );
+
+  const hasAnyChildren = childCountMap.size > 0;
+
+  // IDs of all categories that have children (for expand all)
+  const parentIds = useMemo(
+    () => [...childCountMap.keys()],
+    [childCountMap]
+  );
+
+  const isAllExpanded = parentIds.length > 0 && parentIds.every((id) => expandedIds.has(id));
+
+  function toggleExpand(id: string) {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
+  function expandAll() {
+    setExpandedIds(new Set(parentIds));
+  }
+
+  function collapseAll() {
+    setExpandedIds(new Set());
+  }
+
+  const visibleCategories = useMemo(
+    () => getVisibleCategories(categories, expandedIds),
+    [categories, expandedIds]
+  );
 
   return (
     <>
@@ -27,18 +92,51 @@ export function CategoriesPageClient({ categories, allCategories }: CategoriesPa
           <span className="text-sm text-muted-foreground">
             {categories.length} catégorie(s)
           </span>
+          {hasAnyChildren && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={isAllExpanded ? collapseAll : expandAll}
+            >
+              {isAllExpanded ? "Tout réduire" : "Tout développer"}
+            </Button>
+          )}
         </div>
         <CategoryCreateButton categories={allCategories} />
       </div>
 
+      {/* Desktop expand/collapse toolbar */}
+      {hasAnyChildren && (
+        <div className="mb-2 hidden lg:flex">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={isAllExpanded ? collapseAll : expandAll}
+          >
+            {isAllExpanded ? "Tout réduire" : "Tout développer"}
+          </Button>
+        </div>
+      )}
+
       {/* Responsive data list */}
       <ResponsiveDataList
-        data={categories}
-        renderTable={(data) => <CategoryTable categories={data} allCategories={allCategories} />}
+        data={visibleCategories}
+        renderTable={(data) => (
+          <CategoryTable
+            categories={data}
+            allCategories={allCategories}
+            expandedIds={expandedIds}
+            onToggleExpand={toggleExpand}
+            childCount={childCount}
+          />
+        )}
         renderCard={(category) => (
           <CategoryCardMobile
             category={category}
             onEdit={(cat) => setEditCategory(cat)}
+            isExpanded={expandedIds.has(category.id)}
+            onToggleExpand={toggleExpand}
+            childCount={childCount(category.id)}
           />
         )}
         emptyMessage="Aucune catégorie"

--- a/components/admin/category-card-mobile.tsx
+++ b/components/admin/category-card-mobile.tsx
@@ -77,7 +77,7 @@ export function CategoryCardMobile({
   return (
     <>
       <div
-        className="flex items-center gap-3 rounded-xl border bg-card p-3"
+        className={`flex items-center gap-3 rounded-xl border p-3 ${category.depth > 0 ? "bg-muted/50" : "bg-card"}`}
         style={{ marginLeft: `${category.depth * 1}rem` }}
         data-pending={isPending || undefined}
       >

--- a/components/admin/category-card-mobile.tsx
+++ b/components/admin/category-card-mobile.tsx
@@ -8,6 +8,8 @@ import {
   Edit02Icon,
   Delete02Icon,
   Folder01Icon,
+  ArrowRight01Icon,
+  ArrowDown01Icon,
 } from "@hugeicons/core-free-icons";
 import { Badge } from "@/components/ui/badge";
 import { ActionSheet, type ActionSheetItem } from "./action-sheet";
@@ -17,11 +19,17 @@ import { deleteCategory } from "@/actions/admin/categories";
 interface CategoryCardMobileProps {
   category: CategoryWithCount;
   onEdit: (category: CategoryWithCount) => void;
+  isExpanded: boolean;
+  onToggleExpand: (id: string) => void;
+  childCount: number;
 }
 
 export function CategoryCardMobile({
   category,
   onEdit,
+  isExpanded,
+  onToggleExpand,
+  childCount,
 }: CategoryCardMobileProps) {
   const [actionSheetOpen, setActionSheetOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
@@ -73,14 +81,30 @@ export function CategoryCardMobile({
         style={{ marginLeft: `${category.depth * 1}rem` }}
         data-pending={isPending || undefined}
       >
-        {/* Icon */}
-        <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-lg bg-muted">
-          <HugeiconsIcon
-            icon={Folder01Icon}
-            size={24}
-            className="text-muted-foreground"
-          />
-        </div>
+        {/* Icon / Chevron */}
+        {childCount > 0 ? (
+          <button
+            onClick={() => onToggleExpand(category.id)}
+            className="flex h-14 w-14 shrink-0 items-center justify-center rounded-lg bg-muted hover:bg-muted/80 focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none"
+            aria-expanded={isExpanded}
+            aria-label={isExpanded ? `Replier ${category.name}` : `Déplier ${category.name}`}
+          >
+            <HugeiconsIcon
+              icon={isExpanded ? ArrowDown01Icon : ArrowRight01Icon}
+              size={24}
+              className="text-muted-foreground"
+              aria-hidden="true"
+            />
+          </button>
+        ) : (
+          <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-lg bg-muted">
+            <HugeiconsIcon
+              icon={Folder01Icon}
+              size={24}
+              className="text-muted-foreground"
+            />
+          </div>
+        )}
 
         {/* Content */}
         <div className="flex flex-1 flex-col gap-1 overflow-hidden">
@@ -105,6 +129,11 @@ export function CategoryCardMobile({
             <span className="text-xs text-muted-foreground">
               Ordre: {category.sort_order}
             </span>
+            {childCount > 0 && !isExpanded && (
+              <Badge variant="outline" className="text-xs">
+                {childCount} sous-cat.
+              </Badge>
+            )}
           </div>
         </div>
 

--- a/components/admin/category-card-mobile.tsx
+++ b/components/admin/category-card-mobile.tsx
@@ -77,7 +77,7 @@ export function CategoryCardMobile({
   return (
     <>
       <div
-        className={`flex items-center gap-3 rounded-xl border p-3 ${category.depth > 0 ? "bg-muted/50" : "bg-card"}`}
+        className={`flex items-center gap-3 rounded-xl border p-3 ${category.depth > 0 ? "bg-muted" : "bg-card"}`}
         style={{ marginLeft: `${category.depth * 1}rem` }}
         data-pending={isPending || undefined}
       >

--- a/components/admin/category-table.tsx
+++ b/components/admin/category-table.tsx
@@ -100,7 +100,7 @@ export function CategoryTable({
                     key={cat.id}
                     data-pending={isPending || undefined}
                     data-expanded={children > 0 && isExpanded ? "" : undefined}
-                    className={`data-[expanded]:bg-muted/30${cat.depth > 0 ? " bg-muted/50" : ""}`}
+                    className={`data-[expanded]:bg-muted/50${cat.depth > 0 ? " bg-muted" : ""}`}
                   >
                     <TableCell className="font-medium">
                       <div className="flex items-center gap-1" style={{ paddingLeft: `${cat.depth * 1.5}rem` }}>

--- a/components/admin/category-table.tsx
+++ b/components/admin/category-table.tsx
@@ -31,7 +31,11 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { MoreVerticalIcon } from "@hugeicons/core-free-icons";
+import {
+  MoreVerticalIcon,
+  ArrowRight01Icon,
+  ArrowDown01Icon,
+} from "@hugeicons/core-free-icons";
 import type { CategoryWithCount } from "@/lib/db/admin/categories";
 import type { Category } from "@/lib/db/types";
 import { deleteCategory } from "@/actions/admin/categories";
@@ -40,9 +44,15 @@ import { CategoryForm } from "./category-form";
 export function CategoryTable({
   categories,
   allCategories = [],
+  expandedIds,
+  onToggleExpand,
+  childCount,
 }: {
   categories: CategoryWithCount[];
   allCategories?: Category[];
+  expandedIds: Set<string>;
+  onToggleExpand: (id: string) => void;
+  childCount: (id: string) => number;
 }) {
   const [editCategory, setEditCategory] = useState<CategoryWithCount | null>(
     null
@@ -58,11 +68,6 @@ export function CategoryTable({
         toast.error(result.error);
       }
     });
-  }
-
-  // Count children for delete warning
-  function childCount(id: string): number {
-    return categories.filter((c) => c.parent_id === id).length;
   }
 
   return (
@@ -89,19 +94,48 @@ export function CategoryTable({
             ) : (
               categories.map((cat) => {
                 const children = childCount(cat.id);
+                const isExpanded = expandedIds.has(cat.id);
                 return (
-                  <TableRow key={cat.id} data-pending={isPending || undefined}>
+                  <TableRow
+                    key={cat.id}
+                    data-pending={isPending || undefined}
+                    data-expanded={children > 0 && isExpanded ? "" : undefined}
+                    className="data-[expanded]:bg-muted/30"
+                  >
                     <TableCell className="font-medium">
-                      <div style={{ paddingLeft: `${cat.depth * 1.5}rem` }}>
-                        <span>
-                          {cat.depth > 0 && (
-                            <span className="mr-1 text-muted-foreground">↳</span>
-                          )}
-                          {cat.name}
-                        </span>
-                        {cat.parent_name && (
-                          <p className="text-xs text-muted-foreground">{cat.parent_name}</p>
+                      <div className="flex items-center gap-1" style={{ paddingLeft: `${cat.depth * 1.5}rem` }}>
+                        {children > 0 ? (
+                          <button
+                            onClick={() => onToggleExpand(cat.id)}
+                            className="flex h-6 w-6 shrink-0 items-center justify-center rounded hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none"
+                            aria-expanded={isExpanded}
+                            aria-label={isExpanded ? `Replier ${cat.name}` : `Déplier ${cat.name}`}
+                          >
+                            <HugeiconsIcon
+                              icon={isExpanded ? ArrowDown01Icon : ArrowRight01Icon}
+                              size={16}
+                              aria-hidden="true"
+                            />
+                          </button>
+                        ) : (
+                          <span className="w-6 shrink-0" />
                         )}
+                        <div>
+                          <span>
+                            {cat.depth > 0 && (
+                              <span className="mr-1 text-muted-foreground">↳</span>
+                            )}
+                            {cat.name}
+                          </span>
+                          {children > 0 && !isExpanded && (
+                            <Badge variant="outline" className="ml-2 text-xs">
+                              {children} sous-cat.
+                            </Badge>
+                          )}
+                          {cat.parent_name && (
+                            <p className="text-xs text-muted-foreground">{cat.parent_name}</p>
+                          )}
+                        </div>
                       </div>
                     </TableCell>
                     <TableCell className="text-sm text-muted-foreground">

--- a/components/admin/category-table.tsx
+++ b/components/admin/category-table.tsx
@@ -100,7 +100,7 @@ export function CategoryTable({
                     key={cat.id}
                     data-pending={isPending || undefined}
                     data-expanded={children > 0 && isExpanded ? "" : undefined}
-                    className="data-[expanded]:bg-muted/30"
+                    className={`data-[expanded]:bg-muted/30${cat.depth > 0 ? " bg-muted/50" : ""}`}
                   >
                     <TableCell className="font-medium">
                       <div className="flex items-center gap-1" style={{ paddingLeft: `${cat.depth * 1.5}rem` }}>


### PR DESCRIPTION
## Summary
- Show only root categories by default; chevron toggles expand/collapse children and grandchildren
- "Tout développer" / "Tout réduire" toolbar buttons on both mobile and desktop
- "N sous-cat." badge on collapsed parent rows for quick scanning
- Proper ARIA attributes (`aria-expanded`, `aria-label`) on all toggle controls
- Works in both desktop table view and mobile card view

## Test plan
- [ ] Verify only root categories are visible by default
- [ ] Click chevron on a root category → children appear; click again → children collapse
- [ ] Grandchildren only appear when their direct parent is also expanded
- [ ] "Tout développer" expands all; "Tout réduire" collapses all
- [ ] Badge "N sous-cat." visible when collapsed, hidden when expanded
- [ ] Edit/delete actions still work on expanded children
- [ ] Test in mobile card view (same expand/collapse behavior)
- [ ] `tsc --noEmit` passes, `vitest run` passes (340/340 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)