### PR TITLE
feat: automate D1 migrations in deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,12 @@ jobs:
 
       - run: npm ci
 
+      - name: Run D1 migrations
+        run: bash scripts/migrate.sh --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
       - name: Build worker
         run: npm run build:worker
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,8 @@ npm run test:watch         # Watch mode
 # Database (Drizzle ORM + local D1)
 npm run db:generate        # Generate SQL migrations from schema changes
 npm run db:studio          # Open Drizzle Studio (visual DB browser)
-npm run db:migrate:legacy  # Run legacy SQL migrations (initial setup)
+npm run db:migrate         # Run all pending migrations locally (auto-tracks)
+npm run db:migrate:remote  # Run all pending migrations on remote D1
 npm run db:seed            # Seed initial data
 npm run db:seed-catalogue  # Seed product catalogue
 ```
@@ -125,7 +126,9 @@ Two DB access patterns coexist (gradual migration in progress):
 - **Raw SQL** (legacy): `query<T>()`, `queryFirst<T>()`, `execute()`, `batch()` in `lib/db/index.ts`
 - **Drizzle ORM** (new code): `getDrizzle()` from `lib/db/drizzle.ts`
 
-Schema changes workflow: edit `lib/db/schema.ts` → run `npm run db:generate` → apply generated SQL via `wrangler d1 execute`.
+Schema changes workflow: edit `lib/db/schema.ts` → run `npm run db:generate` → place generated SQL in `db/migrations/` → run `npm run db:migrate` locally. Remote migrations run automatically on deploy via GitHub Actions.
+
+**Migration tracking:** `scripts/migrate.sh` maintains a `_migrations` table in D1. On first run against an existing DB, it bootstraps by recording all current migration filenames without re-running them. Subsequent runs only apply new migrations.
 
 ### Environment Variables
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test:coverage": "vitest run --coverage",
     "db:generate": "drizzle-kit generate",
     "db:studio": "drizzle-kit studio",
-    "db:migrate:legacy": "npx wrangler d1 execute netereka-db --local --file=db/migrations/0001_initial.sql",
+    "db:migrate": "bash scripts/migrate.sh --local",
+    "db:migrate:remote": "bash scripts/migrate.sh --remote",
     "db:seed": "npx wrangler d1 execute netereka-db --local --file=db/seeds/seed.sql",
     "db:seed-catalogue": "npx wrangler d1 execute netereka-db --local --file=db/seeds/catalogue.sql",
     "prepare": "husky"

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -14,6 +14,18 @@ if [[ "$TARGET" != "--local" && "$TARGET" != "--remote" ]]; then
   exit 1
 fi
 
+# Validate required env vars for remote mode
+if [[ "$TARGET" == "--remote" ]]; then
+  if [[ -z "${CLOUDFLARE_API_TOKEN:-}" ]]; then
+    echo "ERROR: CLOUDFLARE_API_TOKEN is not set. Required for --remote migrations."
+    exit 1
+  fi
+  if [[ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
+    echo "ERROR: CLOUDFLARE_ACCOUNT_ID is not set. Required for --remote migrations."
+    exit 1
+  fi
+fi
+
 echo "==> Running migrations ($TARGET) on $DB_NAME"
 
 # 1. Ensure _migrations tracking table exists
@@ -26,34 +38,46 @@ npx wrangler d1 execute "$DB_NAME" "$TARGET" --command \
 # 2. Get list of already-applied migrations
 APPLIED=$(npx wrangler d1 execute "$DB_NAME" "$TARGET" --command \
   "SELECT filename FROM _migrations ORDER BY filename;" --json \
-  | node -e "
-    const input = require('fs').readFileSync('/dev/stdin','utf8');
-    const rows = JSON.parse(input)[0].results;
-    rows.forEach(r => console.log(r.filename));
-  " 2>/dev/null || true)
+  | node -p "JSON.parse(require('fs').readFileSync(0,'utf8'))[0].results.map(r=>r.filename).join('\n')")
 
-# 3. Get sorted list of migration files
-MIGRATION_FILES=($(ls "$MIGRATIONS_DIR"/*.sql 2>/dev/null | sort))
+# 3. Get sorted list of migration files (glob is already lexicographic)
+if [[ ! -d "$MIGRATIONS_DIR" ]]; then
+  echo "ERROR: Migrations directory not found: $MIGRATIONS_DIR"
+  echo "Working directory: $(pwd)"
+  exit 1
+fi
+
+shopt -s nullglob
+MIGRATION_FILES=("$MIGRATIONS_DIR"/*.sql)
+shopt -u nullglob
 
 if [[ ${#MIGRATION_FILES[@]} -eq 0 ]]; then
   echo "==> No migration files found in $MIGRATIONS_DIR"
   exit 0
 fi
 
+# Helper: validate migration filename contains only safe characters
+validate_filename() {
+  local fname="$1"
+  if [[ ! "$fname" =~ ^[0-9a-zA-Z_.-]+\.sql$ ]]; then
+    echo "ERROR: Invalid migration filename: $fname"
+    exit 1
+  fi
+}
+
 # 4. Bootstrap: if _migrations is empty but DB has tables, seed all filenames
 if [[ -z "$APPLIED" ]]; then
   HAS_TABLES=$(npx wrangler d1 execute "$DB_NAME" "$TARGET" --command \
     "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE '\_%' ESCAPE '\\' LIMIT 1;" --json \
-    | node -e "
-      const input = require('fs').readFileSync('/dev/stdin','utf8');
-      const rows = JSON.parse(input)[0].results;
-      console.log(rows.length > 0 ? 'yes' : 'no');
-    " 2>/dev/null || echo "no")
+    | node -p "JSON.parse(require('fs').readFileSync(0,'utf8'))[0].results.length > 0 ? 'yes' : 'no'")
 
   if [[ "$HAS_TABLES" == "yes" ]]; then
     echo "==> Bootstrap: existing DB detected, seeding migration history"
+    echo "    WARNING: All ${#MIGRATION_FILES[@]} migration files will be marked as applied."
     for file in "${MIGRATION_FILES[@]}"; do
       fname=$(basename "$file")
+      validate_filename "$fname"
+      echo "    Recording: $fname"
       npx wrangler d1 execute "$DB_NAME" "$TARGET" --command \
         "INSERT OR IGNORE INTO _migrations (filename) VALUES ('$fname');"
     done
@@ -66,15 +90,20 @@ fi
 PENDING=0
 for file in "${MIGRATION_FILES[@]}"; do
   fname=$(basename "$file")
+  validate_filename "$fname"
 
-  if echo "$APPLIED" | grep -qxF "$fname"; then
+  if [[ -n "$APPLIED" ]] && echo "$APPLIED" | grep -qxF "$fname"; then
     continue
   fi
 
   echo "==> Applying: $fname"
-  npx wrangler d1 execute "$DB_NAME" "$TARGET" --file="$file"
-  npx wrangler d1 execute "$DB_NAME" "$TARGET" --command \
-    "INSERT INTO _migrations (filename) VALUES ('$fname');"
+  # Combine migration SQL + tracking record into a single D1 execution for atomicity
+  TMPFILE=$(mktemp)
+  trap "rm -f '$TMPFILE'" EXIT
+  cat "$file" > "$TMPFILE"
+  printf '\nINSERT INTO _migrations (filename) VALUES ('\''%s'\'');\n' "$fname" >> "$TMPFILE"
+  npx wrangler d1 execute "$DB_NAME" "$TARGET" --file="$TMPFILE"
+  rm -f "$TMPFILE"
   echo "    Done: $fname"
   PENDING=$((PENDING + 1))
 done

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# D1 Migration Runner
+# Tracks applied migrations in a _migrations table and runs pending ones.
+# Usage: bash scripts/migrate.sh [--local|--remote]
+
+DB_NAME="netereka-db"
+MIGRATIONS_DIR="db/migrations"
+TARGET="${1:---remote}"
+
+if [[ "$TARGET" != "--local" && "$TARGET" != "--remote" ]]; then
+  echo "Usage: bash scripts/migrate.sh [--local|--remote]"
+  exit 1
+fi
+
+echo "==> Running migrations ($TARGET) on $DB_NAME"
+
+# 1. Ensure _migrations tracking table exists
+npx wrangler d1 execute "$DB_NAME" "$TARGET" --command \
+  "CREATE TABLE IF NOT EXISTS _migrations (
+    filename TEXT PRIMARY KEY,
+    applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );"
+
+# 2. Get list of already-applied migrations
+APPLIED=$(npx wrangler d1 execute "$DB_NAME" "$TARGET" --command \
+  "SELECT filename FROM _migrations ORDER BY filename;" --json \
+  | node -e "
+    const input = require('fs').readFileSync('/dev/stdin','utf8');
+    const rows = JSON.parse(input)[0].results;
+    rows.forEach(r => console.log(r.filename));
+  " 2>/dev/null || true)
+
+# 3. Get sorted list of migration files
+MIGRATION_FILES=($(ls "$MIGRATIONS_DIR"/*.sql 2>/dev/null | sort))
+
+if [[ ${#MIGRATION_FILES[@]} -eq 0 ]]; then
+  echo "==> No migration files found in $MIGRATIONS_DIR"
+  exit 0
+fi
+
+# 4. Bootstrap: if _migrations is empty but DB has tables, seed all filenames
+if [[ -z "$APPLIED" ]]; then
+  HAS_TABLES=$(npx wrangler d1 execute "$DB_NAME" "$TARGET" --command \
+    "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE '\_%' ESCAPE '\\' LIMIT 1;" --json \
+    | node -e "
+      const input = require('fs').readFileSync('/dev/stdin','utf8');
+      const rows = JSON.parse(input)[0].results;
+      console.log(rows.length > 0 ? 'yes' : 'no');
+    " 2>/dev/null || echo "no")
+
+  if [[ "$HAS_TABLES" == "yes" ]]; then
+    echo "==> Bootstrap: existing DB detected, seeding migration history"
+    for file in "${MIGRATION_FILES[@]}"; do
+      fname=$(basename "$file")
+      npx wrangler d1 execute "$DB_NAME" "$TARGET" --command \
+        "INSERT OR IGNORE INTO _migrations (filename) VALUES ('$fname');"
+    done
+    echo "==> Bootstrap complete (${#MIGRATION_FILES[@]} migrations recorded)"
+    exit 0
+  fi
+fi
+
+# 5. Run pending migrations
+PENDING=0
+for file in "${MIGRATION_FILES[@]}"; do
+  fname=$(basename "$file")
+
+  if echo "$APPLIED" | grep -qxF "$fname"; then
+    continue
+  fi
+
+  echo "==> Applying: $fname"
+  npx wrangler d1 execute "$DB_NAME" "$TARGET" --file="$file"
+  npx wrangler d1 execute "$DB_NAME" "$TARGET" --command \
+    "INSERT INTO _migrations (filename) VALUES ('$fname');"
+  echo "    Done: $fname"
+  PENDING=$((PENDING + 1))
+done
+
+if [[ $PENDING -eq 0 ]]; then
+  echo "==> No pending migrations"
+else
+  echo "==> Applied $PENDING migration(s)"
+fi


### PR DESCRIPTION
## Summary

- **New `scripts/migrate.sh`** — tracks applied migrations in a `_migrations` table, runs only pending ones. Bootstraps existing DBs (like production) by recording all current filenames without re-executing them.
- **GitHub Actions** — migrations now run automatically before build/deploy on push to main.
- **New npm scripts** — `db:migrate` (local) and `db:migrate:remote` replace the old `db:migrate:legacy`.

## Context

Migrations were applied manually via `wrangler d1 execute --remote`, which caused a production incident where migrations 0009 and 0010 were forgotten. This automates the process with idempotent tracking.

## How it works

1. Creates `_migrations` table if missing
2. Queries already-applied migrations
3. **Bootstrap**: if `_migrations` is empty but DB has tables (existing prod), seeds all filenames without re-running them
4. Loops `db/migrations/*.sql` sorted alphabetically, runs pending ones, records each

## Test plan

- [x] `npm run db:migrate` on existing local DB → bootstraps (records 9 migrations, runs 0)
- [x] Run again → reports "No pending migrations"
- [ ] Push to main → GitHub Actions deploy runs migrations then deploys
- [ ] Check Actions log for "Bootstrap complete" or "No pending migrations"

🤖 Generated with [Claude Code](https://claude.com/claude-code)