### PR TITLE
fix(ci): pass Cloudflare credentials to build worker step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,8 @@ jobs:
         env:
           NEXT_PUBLIC_R2_URL: ${{ vars.NEXT_PUBLIC_R2_URL }}
           NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ vars.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Deploy
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
## Summary

- Le binding `ai` ajouté en PR #69 pousse `opennextjs-cloudflare build` à initier une session `wrangler dev --remote`
- Cette session nécessite une authentification Cloudflare, absente du step "Build worker"
- Le deploy échoue depuis PR #69 et PR #70 — la prod est bloquée sur PR #68

## Fix

Ajout de `CLOUDFLARE_API_TOKEN` et `CLOUDFLARE_ACCOUNT_ID` dans l'env du step "Build worker".

## Test plan

- [ ] Le workflow Deploy passe sur ce PR
- [ ] La prod est mise à jour avec les features des PR #69 et #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)