### PR TITLE
feat(ai): OpenRouter Qwen3.5 397B A17B pour la génération de texte IA

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -27,4 +27,7 @@ interface CloudflareEnv {
   BRAVE_SEARCH_API_KEY?: string;
   GOOGLE_SEARCH_API_KEY?: string;    // Google Custom Search JSON API key
   GOOGLE_SEARCH_ENGINE_ID?: string;  // Programmable Search Engine cx identifier
+
+  // OpenRouter (AI text generation)
+  OPENROUTER_API_KEY?: string;
 }

--- a/lib/ai/index.ts
+++ b/lib/ai/index.ts
@@ -1,8 +1,10 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 
-export const TEXT_MODEL = "@cf/meta/llama-3.1-8b-instruct" as const;
+export const TEXT_MODEL = "qwen/qwen3.5-397b-a17b" as const;
 export const IMAGE_MODEL =
   "@cf/stabilityai/stable-diffusion-xl-base-1.0" as const;
+
+const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 
 export async function getAI() {
   const { env } = await getCloudflareContext();
@@ -10,4 +12,41 @@ export async function getAI() {
     throw new Error("Workers AI binding (AI) is not configured in wrangler.jsonc");
   }
   return env.AI;
+}
+
+export async function callTextModel(system: string, user: string): Promise<string> {
+  const { env } = await getCloudflareContext();
+  const apiKey = env.OPENROUTER_API_KEY;
+  if (!apiKey) {
+    throw new Error("OPENROUTER_API_KEY is not configured");
+  }
+
+  const response = await fetch(`${OPENROUTER_BASE_URL}/chat/completions`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+      "HTTP-Referer": "https://netereka.ci",
+      "X-Title": "NETEREKA Admin",
+    },
+    body: JSON.stringify({
+      model: TEXT_MODEL,
+      messages: [
+        { role: "system", content: system },
+        { role: "user", content: user },
+      ],
+      response_format: { type: "json_object" },
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`OpenRouter API error ${response.status}: ${errorText}`);
+  }
+
+  const data = (await response.json()) as {
+    choices: Array<{ message: { content: string } }>;
+  };
+
+  return data.choices[0].message.content;
 }


### PR DESCRIPTION
## Résumé
- Remplace \`@cf/meta/llama-3.1-8b-instruct\` (8B paramètres) par \`qwen/qwen3.5-397b-a17b\` via OpenRouter
- Nouveau helper \`callTextModel(system, user)\` — fetch direct vers l'API OpenRouter (compatible OpenAI)
- \`response_format: { type: 'json_object' }\` — JSON fiable, plus de hack regex/retry
- Workers AI conservé uniquement pour la génération d'images (Stable Diffusion)
- **Coût : $0.15/M input, $1.00/M output** (vs $0 Workers AI mais qualité bien supérieure)

## Fichiers modifiés
| Fichier | Changement |
|---|---|
| \`env.d.ts\` | Ajout \`OPENROUTER_API_KEY?: string\` |
| \`lib/ai/index.ts\` | Ajout \`callTextModel()\`, mise à jour \`TEXT_MODEL\` |
| \`actions/admin/ai.ts\` | \`runTextModel\` délègue à \`callTextModel\` |
| \`__tests__/unit/actions/admin-ai.test.ts\` | Mocks mis à jour |

## Configuration requise

**Dev local** — ajouter dans \`.dev.vars\` (gitignored) :
\`\`\`
OPENROUTER_API_KEY=sk-or-xxxx
\`\`\`

**Production** — ajouter le secret Cloudflare :
\`\`\`bash
wrangler secret put OPENROUTER_API_KEY
\`\`\`
Clé disponible sur [openrouter.ai/keys](https://openrouter.ai/keys)

## Test plan
- [x] 399/399 tests unitaires passent
- [ ] Tester manuellement la génération de texte produit en admin
- [ ] Tester la génération de blueprint complet (nom + marque → produit entier)
- [ ] Vérifier les logs sur [openrouter.ai/activity](https://openrouter.ai/activity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)