### PR TITLE
fix(ci): remove synchronous setState in useEffect in WishlistButtonDynamic

### DIFF
--- a/components/storefront/wishlist-button-dynamic.tsx
+++ b/components/storefront/wishlist-button-dynamic.tsx
@@ -12,8 +12,6 @@ export function WishlistButtonDynamic({ productId }: { productId: string }) {
   useEffect(() => {
     if (session.data?.user) {
       checkWishlist(productId).then(setIsWishlisted).catch(console.error);
-    } else {
-      setIsWishlisted(undefined);
     }
   }, [session.data?.user, productId]);
 


### PR DESCRIPTION
## Summary

- Fixes CI/CD failure on `main` caused by ESLint error `react-hooks/set-state-in-effect`
- `setIsWishlisted(undefined)` was called synchronously in the `useEffect` body (else branch)
- The else branch is unnecessary: when `session.data?.user` is falsy, the component already returns `null` (line 20), so resetting state serves no purpose

## Test plan
- [ ] ESLint passes (`npm run lint`)
- [ ] Wishlist button still appears/hides correctly on login/logout

🤖 Generated with [Claude Code](https://claude.com/claude-code)