### PR TITLE
fix(ci): remove per-variant price field to fix TypeScript errors

### DIFF
--- a/__tests__/unit/actions/admin-ai.test.ts
+++ b/__tests__/unit/actions/admin-ai.test.ts
@@ -507,7 +507,6 @@ describe("createProductFromBlueprint", () => {
     variants: [
       {
         name: "128Go / Noir",
-        price: 1049000,
         stock_quantity: 5,
         attributes: { stockage: "128Go", couleur: "Noir" },
       },

--- a/actions/admin/ai.ts
+++ b/actions/admin/ai.ts
@@ -439,7 +439,7 @@ export async function createProductFromBlueprint(
              attributes, is_active, sort_order)
            VALUES (?, ?, ?, NULL, ?, ?, ?, 1, ?)`
         )
-        .bind(nanoid(), id, v.name, v.price, v.stock_quantity, JSON.stringify(v.attributes), i)
+        .bind(nanoid(), id, v.name, blueprint.base_price, v.stock_quantity, JSON.stringify(v.attributes), i)
     );
 
     await db.batch([productStmt, ...variantStmts]);

--- a/components/admin/ai-create-product-modal.tsx
+++ b/components/admin/ai-create-product-modal.tsx
@@ -214,7 +214,6 @@ export function AiCreateProductModal({
                     <thead>
                       <tr className="border-b bg-muted/50">
                         <th className="text-left px-3 py-2 font-medium">Nom</th>
-                        <th className="text-right px-3 py-2 font-medium">Prix XOF</th>
                         <th className="text-right px-3 py-2 font-medium">Stock</th>
                       </tr>
                     </thead>
@@ -222,9 +221,6 @@ export function AiCreateProductModal({
                       {bp.variants.map((v, i) => (
                         <tr key={i} className="border-b last:border-0">
                           <td className="px-3 py-2">{v.name}</td>
-                          <td className="px-3 py-2 text-right">
-                            {v.price.toLocaleString("fr-FR")}
-                          </td>
                           <td className="px-3 py-2 text-right">{v.stock_quantity}</td>
                         </tr>
                       ))}


### PR DESCRIPTION
## Summary

- `actions/admin/ai.ts`: `createProductFromBlueprint` now passes `blueprint.base_price` when inserting variants instead of the removed `v.price` field
- `components/admin/ai-create-product-modal.tsx`: removed the "Prix XOF" per-variant column — price is displayed once at the product level
- `__tests__/unit/actions/admin-ai.test.ts`: removed `price: 1049000` from the variant fixture in the `createProductFromBlueprint` block (incorrectly added by #79)

## Root cause

`productVariantBlueprintSchema` intentionally dropped `price` (moved to `blueprint.base_price`), but two production code references and one test fixture still used `v.price`, causing `tsc` to fail in CI.

## Test plan

- [x] `npx tsc --noEmit` — no errors
- [x] `npm run test` — 437 tests passing (28 test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)