### PR TITLE
feat(ai): rebuild product creation with SSE streaming and editable preview

### DIFF
--- a/__tests__/unit/actions/admin-ai.test.ts
+++ b/__tests__/unit/actions/admin-ai.test.ts
@@ -427,7 +427,6 @@ describe("generateProductBlueprint", () => {
     variants: [
       {
         name: "128Go / Noir",
-        price: 1049000,
         stock_quantity: 5,
         attributes: { stockage: "128Go", couleur: "Noir" },
       },
@@ -508,7 +507,6 @@ describe("createProductFromBlueprint", () => {
     variants: [
       {
         name: "128Go / Noir",
-        price: 1049000,
         stock_quantity: 5,
         attributes: { stockage: "128Go", couleur: "Noir" },
       },

--- a/__tests__/unit/api/admin-ai-route.test.ts
+++ b/__tests__/unit/api/admin-ai-route.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  requireAdmin: vi.fn(),
+  searchProductSpecs: vi.fn(),
+  searchProductImages: vi.fn(),
+  callTextModel: vi.fn(),
+  getCategoryTree: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/guards", () => ({ requireAdmin: mocks.requireAdmin }));
+vi.mock("@/lib/ai/search", () => ({
+  searchProductSpecs: mocks.searchProductSpecs,
+  searchProductImages: mocks.searchProductImages,
+}));
+vi.mock("@/lib/ai", () => ({ callTextModel: mocks.callTextModel }));
+vi.mock("@/lib/db/categories", () => ({ getCategoryTree: mocks.getCategoryTree }));
+
+import { POST } from "@/app/api/admin/ai/generate-product/route";
+
+const mockCategoryTree = [
+  {
+    id: "cat-1", name: "Smartphones", slug: "smartphones",
+    parent_id: null, description: null, image_url: null,
+    sort_order: 0, is_active: 1, created_at: "",
+    children: [
+      {
+        id: "cat-1a", name: "iPhone", slug: "iphone",
+        parent_id: "cat-1", description: null, image_url: null,
+        sort_order: 0, is_active: 1, created_at: "", children: [],
+      },
+    ],
+  },
+];
+
+const mockBlueprint = {
+  name: "iPhone 16 Pro", brand: "Apple",
+  description: "Un smartphone haut de gamme.",
+  short_description: "Le meilleur iPhone.",
+  meta_title: "iPhone 16 Pro", meta_description: "Achetez sur NETEREKA.",
+  categoryId: "cat-1a",
+  variants: [{ name: "128Go / Noir", stock_quantity: 5, attributes: { couleur: "Noir" } }],
+};
+
+async function collectSSEEvents(response: Response) {
+  const text = await response.text();
+  return text.split("\n\n")
+    .filter((line) => line.startsWith("data: "))
+    .map((line) => JSON.parse(line.slice(6)));
+}
+
+function makeRequest(body: unknown) {
+  return new Request("http://localhost/api/admin/ai/generate-product", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getCategoryTree.mockResolvedValue(mockCategoryTree);
+  mocks.searchProductSpecs.mockResolvedValue("iPhone 16 Pro specs...");
+  mocks.searchProductImages.mockResolvedValue(["https://cdn.example.com/img.jpg"]);
+  mocks.callTextModel.mockResolvedValue(JSON.stringify(mockBlueprint));
+});
+
+describe("POST /api/admin/ai/generate-product", () => {
+  it("returns 401 when not authenticated", async () => {
+    mocks.requireAdmin.mockRejectedValue(
+      Object.assign(new Error("NEXT_REDIRECT: /"), { digest: "NEXT_REDIRECT;/" })
+    );
+    const res = await POST(makeRequest({ name: "iPhone 16" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when name is missing", async () => {
+    mocks.requireAdmin.mockResolvedValue(undefined);
+    const res = await POST(makeRequest({ name: "" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("streams status events then done event on success", async () => {
+    mocks.requireAdmin.mockResolvedValue(undefined);
+    const res = await POST(makeRequest({ name: "iPhone 16 Pro", brand: "Apple" }));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/event-stream");
+
+    const events = await collectSSEEvents(res);
+    const types = events.map((e) => e.type);
+    expect(types).toContain("status");
+    expect(types[types.length - 1]).toBe("done");
+
+    const doneEvent = events.find((e) => e.type === "done");
+    expect(doneEvent?.blueprint).toMatchObject({ name: "iPhone 16 Pro" });
+    expect(doneEvent?.imageUrls).toEqual(["https://cdn.example.com/img.jpg"]);
+  });
+
+  it("streams error event when categoryId is hallucinated", async () => {
+    mocks.requireAdmin.mockResolvedValue(undefined);
+    mocks.callTextModel.mockResolvedValue(
+      JSON.stringify({ ...mockBlueprint, categoryId: "fake-999" })
+    );
+    const res = await POST(makeRequest({ name: "iPhone 16 Pro" }));
+    const events = await collectSSEEvents(res);
+    const last = events[events.length - 1];
+    expect(last.type).toBe("error");
+    expect(last.message).toContain("catégorie");
+  });
+
+  it("streams error event on LLM 429", async () => {
+    mocks.requireAdmin.mockResolvedValue(undefined);
+    mocks.callTextModel.mockRejectedValue(new Error("OpenRouter API error 429: quota"));
+    const res = await POST(makeRequest({ name: "iPhone" }));
+    const events = await collectSSEEvents(res);
+    const last = events[events.length - 1];
+    expect(last.type).toBe("error");
+    expect(String(last.message)).toContain("Limite");
+  });
+
+  it("continues without specs when search fails", async () => {
+    mocks.requireAdmin.mockResolvedValue(undefined);
+    mocks.searchProductSpecs.mockRejectedValue(new Error("network"));
+    const res = await POST(makeRequest({ name: "iPhone 16 Pro" }));
+    const events = await collectSSEEvents(res);
+    expect(events[events.length - 1].type).toBe("done");
+  });
+
+  it("returns empty imageUrls when image search fails", async () => {
+    mocks.requireAdmin.mockResolvedValue(undefined);
+    mocks.searchProductImages.mockRejectedValue(new Error("timeout"));
+    const res = await POST(makeRequest({ name: "iPhone 16 Pro" }));
+    const events = await collectSSEEvents(res);
+    const done = events.find((e) => e.type === "done");
+    expect(done?.imageUrls).toEqual([]);
+  });
+});

--- a/__tests__/unit/lib/ai/stream.test.ts
+++ b/__tests__/unit/lib/ai/stream.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { encodeSSE, parseSSELine } from "@/lib/ai/stream";
+
+describe("encodeSSE", () => {
+  it("formats a status event as SSE data line", () => {
+    const bytes = encodeSSE({ type: "status", message: "Recherche..." });
+    const text = new TextDecoder().decode(bytes);
+    expect(text).toBe('data: {"type":"status","message":"Recherche..."}\n\n');
+  });
+
+  it("formats a done event with blueprint data", () => {
+    const payload = { type: "done", blueprint: { name: "Test" }, imageUrls: [] };
+    const text = new TextDecoder().decode(encodeSSE(payload));
+    expect(text).toContain('"type":"done"');
+    expect(text).toContain('"name":"Test"');
+    expect(text.endsWith("\n\n")).toBe(true);
+  });
+
+  it("formats an error event", () => {
+    const text = new TextDecoder().decode(encodeSSE({ type: "error", message: "Erreur" }));
+    expect(text).toContain('"type":"error"');
+    expect(text).toContain('"message":"Erreur"');
+  });
+});
+
+describe("parseSSELine", () => {
+  it("parses a valid data line", () => {
+    const result = parseSSELine('data: {"type":"status","message":"ok"}');
+    expect(result).toEqual({ type: "status", message: "ok" });
+  });
+
+  it("returns null for non-data lines", () => {
+    expect(parseSSELine("")).toBeNull();
+    expect(parseSSELine(": keep-alive")).toBeNull();
+    expect(parseSSELine("event: custom")).toBeNull();
+  });
+
+  it("returns null for invalid JSON", () => {
+    expect(parseSSELine("data: not-json")).toBeNull();
+  });
+});

--- a/__tests__/unit/lib/ai/stream.test.ts
+++ b/__tests__/unit/lib/ai/stream.test.ts
@@ -9,7 +9,13 @@ describe("encodeSSE", () => {
   });
 
   it("formats a done event with blueprint data", () => {
-    const payload = { type: "done", blueprint: { name: "Test" }, imageUrls: [] };
+    const payload = {
+      type: "done" as const,
+      blueprint: { name: "Test", brand: "", description: "d", short_description: "s",
+        meta_title: "t", meta_description: "m", categoryId: "cat-1", variants: [] },
+      categoryName: "Smartphones",
+      imageUrls: [],
+    };
     const text = new TextDecoder().decode(encodeSSE(payload));
     expect(text).toContain('"type":"done"');
     expect(text).toContain('"name":"Test"');

--- a/app/(admin)/products/page.tsx
+++ b/app/(admin)/products/page.tsx
@@ -75,7 +75,7 @@ export default async function ProductsPage({ searchParams }: Props) {
             categories={categories.map((c) => ({ id: c.id, name: c.name }))}
             className="flex-1"
           />
-          <ProductsPageActions />
+          <ProductsPageActions categories={categories.map((c) => ({ id: c.id, name: c.name }))} />
         </div>
       </AdminPageHeader>
 

--- a/app/(admin)/products/page.tsx
+++ b/app/(admin)/products/page.tsx
@@ -46,6 +46,7 @@ export default async function ProductsPage({ searchParams }: Props) {
   ]);
 
   const totalPages = Math.ceil(totalCount / PAGE_SIZE);
+  const categoryOptions = categories.map((c) => ({ id: c.id, name: c.name }));
 
   const productData = products.map((p) => ({
     id: p.id,
@@ -72,17 +73,17 @@ export default async function ProductsPage({ searchParams }: Props) {
         {/* Desktop filters - instant filtering */}
         <div className="hidden items-center justify-between gap-3 lg:flex">
           <ProductFilters
-            categories={categories.map((c) => ({ id: c.id, name: c.name }))}
+            categories={categoryOptions}
             className="flex-1"
           />
-          <ProductsPageActions categories={categories.map((c) => ({ id: c.id, name: c.name }))} />
+          <ProductsPageActions categories={categoryOptions} />
         </div>
       </AdminPageHeader>
 
       {/* Mobile header with filter sheet and view switcher */}
       <ProductsPageClient
         products={productData}
-        categories={categories.map((c) => ({ id: c.id, name: c.name }))}
+        categories={categoryOptions}
         totalCount={totalCount}
       />
 

--- a/app/(admin)/products/products-page-client.tsx
+++ b/app/(admin)/products/products-page-client.tsx
@@ -49,6 +49,7 @@ export function ProductsPageClient({
       <AiCreateProductModal
         open={aiModalOpen}
         onOpenChange={setAiModalOpen}
+        categories={categories}
       />
 
       {/* Mobile toolbar */}
@@ -89,7 +90,11 @@ export function ProductsPageClient({
   );
 }
 
-export function ProductsPageActions() {
+interface ProductsPageActionsProps {
+  categories: { id: string; name: string }[];
+}
+
+export function ProductsPageActions({ categories }: ProductsPageActionsProps) {
   const [aiModalOpen, setAiModalOpen] = useState(false);
 
   return (
@@ -97,6 +102,7 @@ export function ProductsPageActions() {
       <AiCreateProductModal
         open={aiModalOpen}
         onOpenChange={setAiModalOpen}
+        categories={categories}
       />
       <div className="flex items-center gap-2">
         <Button

--- a/app/api/admin/ai/generate-product/route.ts
+++ b/app/api/admin/ai/generate-product/route.ts
@@ -100,17 +100,15 @@ export async function POST(request: Request): Promise<Response> {
 
         const searchQuery = [parsed.brand, parsed.name].filter(Boolean).join(" ");
 
-        const [[specs, imageUrls], tree] = await Promise.all([
-          Promise.all([
-            searchProductSpecs(searchQuery).catch((err) => {
-              console.error("[route/generate-product] searchProductSpecs failed:", err);
-              return "";
-            }),
-            searchProductImages(searchQuery).catch((err) => {
-              console.error("[route/generate-product] searchProductImages failed:", err);
-              return [] as string[];
-            }),
-          ]),
+        const [specs, imageUrls, tree] = await Promise.all([
+          searchProductSpecs(searchQuery).catch((err) => {
+            console.error("[route/generate-product] searchProductSpecs failed:", err);
+            return "";
+          }),
+          searchProductImages(searchQuery).catch((err) => {
+            console.error("[route/generate-product] searchProductImages failed:", err);
+            return [] as string[];
+          }),
           getCategoryTree(),
         ]);
 

--- a/app/api/admin/ai/generate-product/route.ts
+++ b/app/api/admin/ai/generate-product/route.ts
@@ -1,0 +1,177 @@
+import { z } from "zod";
+import { requireAdmin } from "@/lib/auth/guards";
+import { callTextModel } from "@/lib/ai";
+import { productBlueprintPrompt } from "@/lib/ai/prompts";
+import { productBlueprintSchema } from "@/lib/ai/schemas";
+import { getCategoryTree } from "@/lib/db/categories";
+import { searchProductSpecs, searchProductImages } from "@/lib/ai/search";
+import { encodeSSE } from "@/lib/ai/stream";
+import type { CategoryNode } from "@/lib/db/types";
+
+const requestSchema = z.object({
+  name: z.string().min(1, "Le nom du produit est requis"),
+  brand: z.string().optional(),
+});
+
+function flattenCategories(
+  nodes: readonly CategoryNode[],
+  parentName?: string
+): Array<{ id: string; name: string; parentName?: string }> {
+  const result: Array<{ id: string; name: string; parentName?: string }> = [];
+  for (const node of nodes) {
+    result.push({ id: node.id, name: node.name, parentName });
+    if (node.children.length > 0) {
+      result.push(...flattenCategories(node.children, node.name));
+    }
+  }
+  return result;
+}
+
+async function runTextModel(
+  system: string,
+  user: string,
+  retryCount = 0
+): Promise<string> {
+  const raw = await callTextModel(system, user);
+  try {
+    JSON.parse(raw);
+    return raw;
+  } catch {
+    const jsonMatch = raw.match(/\{[\s\S]*\}/);
+    if (jsonMatch) {
+      try {
+        JSON.parse(jsonMatch[0]);
+        return jsonMatch[0];
+      } catch {
+        // fall through to retry
+      }
+    }
+    if (retryCount < 1) {
+      return runTextModel(
+        system +
+          "\n\nIMPORTANT: Retourne UNIQUEMENT du JSON valide. Pas de texte, pas de markdown, juste l'objet JSON.",
+        user,
+        retryCount + 1
+      );
+    }
+    throw new Error("Le modèle n'a pas retourné de JSON valide.");
+  }
+}
+
+export async function POST(request: Request): Promise<Response> {
+  // Auth check
+  try {
+    await requireAdmin();
+  } catch {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // Parse request body
+  let parsed: z.infer<typeof requestSchema>;
+  try {
+    const body = await request.json();
+    const result = requestSchema.safeParse(body);
+    if (!result.success) {
+      return new Response(
+        JSON.stringify({ error: "Le nom du produit est requis." }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+    }
+    parsed = result.data;
+  } catch {
+    return new Response(
+      JSON.stringify({ error: "Corps de requête invalide." }),
+      { status: 400, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  // SSE stream
+  const stream = new ReadableStream({
+    async start(controller) {
+      const send = (payload: Record<string, unknown>) => {
+        controller.enqueue(encodeSSE(payload));
+      };
+
+      try {
+        send({ type: "status", message: "Recherche d'informations..." });
+
+        const searchQuery = [parsed.brand, parsed.name].filter(Boolean).join(" ");
+
+        const [[specs, imageUrls], tree] = await Promise.all([
+          Promise.all([
+            searchProductSpecs(searchQuery).catch((err) => {
+              console.error("[route/generate-product] searchProductSpecs failed:", err);
+              return "";
+            }),
+            searchProductImages(searchQuery).catch((err) => {
+              console.error("[route/generate-product] searchProductImages failed:", err);
+              return [] as string[];
+            }),
+          ]),
+          getCategoryTree(),
+        ]);
+
+        const categories = flattenCategories(tree);
+
+        if (categories.length === 0) {
+          send({ type: "error", message: "Aucune catégorie disponible." });
+          controller.close();
+          return;
+        }
+
+        send({ type: "status", message: "Génération du blueprint produit..." });
+
+        const validIds = new Set(categories.map((c) => c.id));
+        const prompt = productBlueprintPrompt({ ...parsed, specs, categories });
+        const jsonStr = await runTextModel(prompt.system, prompt.user);
+        const blueprint = productBlueprintSchema.parse(JSON.parse(jsonStr));
+
+        if (!validIds.has(blueprint.categoryId)) {
+          send({
+            type: "error",
+            message:
+              "L'IA n'a pas identifié de catégorie valide. Réessayez ou sélectionnez manuellement.",
+          });
+          controller.close();
+          return;
+        }
+
+        const cat = categories.find((c) => c.id === blueprint.categoryId);
+        const categoryName = cat
+          ? cat.parentName
+            ? `${cat.parentName} > ${cat.name}`
+            : cat.name
+          : blueprint.categoryId;
+
+        send({ type: "done", blueprint, categoryName, imageUrls });
+      } catch (error) {
+        console.error("[route/generate-product] error:", error);
+        if (error instanceof Error && error.message.includes("429")) {
+          send({
+            type: "error",
+            message: "Limite IA quotidienne atteinte. Réessayez demain.",
+          });
+        } else {
+          send({
+            type: "error",
+            message: "Impossible de générer le produit. Réessayez.",
+          });
+        }
+      }
+
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/components/admin/ai-create-product-modal.tsx
+++ b/components/admin/ai-create-product-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import {
@@ -94,7 +94,7 @@ export function AiCreateProductModal({
   const [editedBlueprint, setEditedBlueprint] = useState<ProductBlueprint | null>(null);
   const [selectedCategoryId, setSelectedCategoryId] = useState("");
   const [selectedImages, setSelectedImages] = useState<Set<string>>(new Set());
-  const [isCreating, setIsCreating] = useState(false);
+  const [isPending, startTransition] = useTransition();
 
   function handleClose(open: boolean) {
     if (!open) {
@@ -155,10 +155,9 @@ export function AiCreateProductModal({
     }
   }
 
-  async function handleConfirm() {
+  function handleConfirm() {
     if (!editedBlueprint) return;
-    setIsCreating(true);
-    try {
+    startTransition(async () => {
       const result = await createProductFromBlueprint({
         blueprint: { ...editedBlueprint, categoryId: selectedCategoryId },
         imageUrls: Array.from(selectedImages),
@@ -170,9 +169,7 @@ export function AiCreateProductModal({
       } else {
         toast.error(result.error || "Erreur lors de la création");
       }
-    } finally {
-      setIsCreating(false);
-    }
+    });
   }
 
   function updateVariant(
@@ -457,17 +454,17 @@ export function AiCreateProductModal({
               <Button
                 variant="outline"
                 onClick={() => setStep("form")}
-                disabled={isCreating}
+                disabled={isPending}
                 className="flex-1"
               >
                 ← Regénérer
               </Button>
               <Button
                 onClick={handleConfirm}
-                disabled={isCreating || !selectedCategoryId}
+                disabled={isPending || !selectedCategoryId}
                 className="flex-1 gap-2"
               >
-                {isCreating ? (
+                {isPending ? (
                   <>
                     <span className="size-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
                     Création...

--- a/components/admin/ai-create-product-modal.tsx
+++ b/components/admin/ai-create-product-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import {
@@ -13,12 +13,29 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { generateProductBlueprint, createProductFromBlueprint } from "@/actions/admin/ai";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
+import { createProductFromBlueprint } from "@/actions/admin/ai";
 import type { ProductBlueprint } from "@/lib/ai/schemas";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface CategoryOption {
+  id: string;
+  name: string;
+}
 
 interface AiCreateProductModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  categories: CategoryOption[];
 }
 
 type Step = "form" | "preview";
@@ -29,17 +46,55 @@ interface GeneratedData {
   imageUrls: string[];
 }
 
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function* readSSEStream(response: Response) {
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const parts = buffer.split("\n\n");
+    buffer = parts.pop() ?? "";
+    for (const part of parts) {
+      if (part.startsWith("data: ")) {
+        try {
+          yield JSON.parse(part.slice(6));
+        } catch {
+          /* skip malformed events */
+        }
+      }
+    }
+  }
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
 export function AiCreateProductModal({
   open,
   onOpenChange,
+  categories,
 }: AiCreateProductModalProps) {
   const router = useRouter();
-  const [step, setStep] = useState<Step>("form");
+
+  // Form state
   const [name, setName] = useState("");
   const [brand, setBrand] = useState("");
+
+  // Generation state
+  const [step, setStep] = useState<Step>("form");
+  const [statusMsg, setStatusMsg] = useState("");
+  const [isGenerating, setIsGenerating] = useState(false);
+
+  // Preview/edit state
   const [generated, setGenerated] = useState<GeneratedData | null>(null);
-  const [isGenerating, startGenerating] = useTransition();
-  const [isCreating, startCreating] = useTransition();
+  const [editedBlueprint, setEditedBlueprint] = useState<ProductBlueprint | null>(null);
+  const [selectedCategoryId, setSelectedCategoryId] = useState("");
+  const [selectedImages, setSelectedImages] = useState<Set<string>>(new Set());
+  const [isCreating, setIsCreating] = useState(false);
 
   function handleClose(open: boolean) {
     if (!open) {
@@ -47,69 +102,118 @@ export function AiCreateProductModal({
       setName("");
       setBrand("");
       setGenerated(null);
+      setEditedBlueprint(null);
+      setStatusMsg("");
     }
     onOpenChange(open);
   }
 
-  function handleGenerate() {
+  async function handleGenerate() {
     if (!name.trim()) {
       toast.error("Le nom du produit est requis");
       return;
     }
-    startGenerating(async () => {
-      const result = await generateProductBlueprint({
-        name: name.trim(),
-        brand: brand.trim() || undefined,
+    setIsGenerating(true);
+    setStatusMsg("Démarrage...");
+
+    try {
+      const response = await fetch("/api/admin/ai/generate-product", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          brand: brand.trim() || undefined,
+        }),
       });
-      if (result.success && result.data) {
-        setGenerated(result.data);
-        setStep("preview");
-      } else {
-        toast.error(result.error || "Erreur lors de la génération");
+
+      if (!response.ok) {
+        toast.error("Erreur d'authentification. Reconnectez-vous.");
+        return;
       }
-    });
+
+      for await (const event of readSSEStream(response)) {
+        if (event.type === "status") {
+          setStatusMsg(event.message as string);
+        } else if (event.type === "done") {
+          const data = event as unknown as GeneratedData;
+          setGenerated(data);
+          setEditedBlueprint({ ...data.blueprint });
+          setSelectedCategoryId(data.blueprint.categoryId);
+          setSelectedImages(new Set(data.imageUrls));
+          setStep("preview");
+        } else if (event.type === "error") {
+          toast.error((event.message as string) || "Erreur lors de la génération");
+        }
+      }
+    } catch {
+      toast.error("Erreur de connexion. Réessayez.");
+    } finally {
+      setIsGenerating(false);
+      setStatusMsg("");
+    }
   }
 
-  function handleConfirm() {
-    if (!generated) return;
-    startCreating(async () => {
+  async function handleConfirm() {
+    if (!editedBlueprint) return;
+    setIsCreating(true);
+    try {
       const result = await createProductFromBlueprint({
-        blueprint: generated.blueprint,
-        imageUrls: generated.imageUrls,
+        blueprint: { ...editedBlueprint, categoryId: selectedCategoryId },
+        imageUrls: Array.from(selectedImages),
       });
       if (result.success && result.id) {
-        toast.success("Produit créé avec succès");
+        toast.success("Produit créé. Ajoutez les prix dans l'éditeur.");
         handleClose(false);
         router.push(`/products/${result.id}/edit`);
       } else {
         toast.error(result.error || "Erreur lors de la création");
       }
+    } finally {
+      setIsCreating(false);
+    }
+  }
+
+  function updateVariant(
+    idx: number,
+    field: "name" | "stock_quantity",
+    value: string | number
+  ) {
+    if (!editedBlueprint) return;
+    const variants = [...editedBlueprint.variants];
+    variants[idx] = { ...variants[idx], [field]: value };
+    setEditedBlueprint({ ...editedBlueprint, variants });
+  }
+
+  function toggleImage(url: string) {
+    setSelectedImages((prev) => {
+      const next = new Set(prev);
+      if (next.has(url)) next.delete(url);
+      else next.add(url);
+      return next;
     });
   }
 
-  const bp = generated?.blueprint;
+  const bp = editedBlueprint;
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-xl">
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
         <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <span>✨</span>
-            <span>Créer un produit avec l&apos;IA</span>
-          </DialogTitle>
+          <DialogTitle>Créer un produit avec l&apos;IA</DialogTitle>
           <DialogDescription>
             {step === "form"
-              ? "L'IA va rechercher les informations du produit et générer son contenu, ses variantes et ses images."
-              : "Vérifiez les informations générées avant de créer le produit."}
+              ? "L'IA recherche et génère le contenu. Les prix seront à saisir ensuite."
+              : "Vérifiez et ajustez les informations générées."}
           </DialogDescription>
         </DialogHeader>
 
+        {/* ── Étape 1 : Formulaire ─────────────────────────────────────────── */}
         {step === "form" && (
           <div className="space-y-4 pt-2">
             <div className="space-y-1.5">
-              <Label htmlFor="ai-product-name">Nom du produit *</Label>
+              <Label htmlFor="ai-name">Nom du produit *</Label>
               <Input
-                id="ai-product-name"
+                id="ai-name"
                 placeholder="ex: iPhone 16 Pro, Samsung Galaxy S25..."
                 value={name}
                 onChange={(e) => setName(e.target.value)}
@@ -122,13 +226,18 @@ export function AiCreateProductModal({
               <Label htmlFor="ai-brand">Marque (optionnel)</Label>
               <Input
                 id="ai-brand"
-                placeholder="ex: Apple, Samsung, Sony..."
+                placeholder="ex: Apple, Samsung..."
                 value={brand}
                 onChange={(e) => setBrand(e.target.value)}
                 onKeyDown={(e) => e.key === "Enter" && handleGenerate()}
                 disabled={isGenerating}
               />
             </div>
+            {isGenerating && (
+              <p className="animate-pulse text-center text-sm text-muted-foreground">
+                {statusMsg}
+              </p>
+            )}
             <div className="flex gap-2 pt-2">
               <Button
                 variant="outline"
@@ -149,93 +258,196 @@ export function AiCreateProductModal({
                     Génération...
                   </>
                 ) : (
-                  <>✨ Générer</>
+                  "✨ Générer"
                 )}
               </Button>
             </div>
-            {isGenerating && (
-              <p className="text-center text-sm text-muted-foreground animate-pulse">
-                Recherche des informations et génération en cours...
-              </p>
-            )}
           </div>
         )}
 
+        {/* ── Étape 2 : Preview éditable ───────────────────────────────────── */}
         {step === "preview" && bp && (
-          <div className="space-y-4 pt-2">
-            {/* Product info */}
-            <div className="rounded-lg border bg-muted/40 p-4 space-y-1.5 text-sm">
-              <div className="flex items-baseline justify-between gap-2">
-                <span className="font-semibold text-base">{bp.name}</span>
-                <span className="text-muted-foreground shrink-0">
-                  {bp.base_price.toLocaleString("fr-FR")} XOF
-                </span>
+          <div className="space-y-5 pt-2">
+            {/* Nom + Marque */}
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label>Nom</Label>
+                <Input
+                  value={bp.name}
+                  onChange={(e) =>
+                    setEditedBlueprint({ ...bp, name: e.target.value })
+                  }
+                />
               </div>
-              {bp.brand && (
-                <p className="text-muted-foreground">Marque : {bp.brand}</p>
-              )}
-              <p className="text-muted-foreground">
-                Catégorie : {generated?.categoryName}
-              </p>
-              <p className="mt-2">{bp.short_description}</p>
+              <div className="space-y-1.5">
+                <Label>Marque</Label>
+                <Input
+                  value={bp.brand ?? ""}
+                  onChange={(e) =>
+                    setEditedBlueprint({ ...bp, brand: e.target.value })
+                  }
+                />
+              </div>
             </div>
 
-            {/* Images preview */}
-            {generated && generated.imageUrls.length > 0 && (
-              <div>
-                <p className="text-sm font-medium mb-2">
-                  Images ({generated.imageUrls.length})
-                </p>
-                <div className="flex gap-2 overflow-x-auto pb-1">
-                  {generated.imageUrls.slice(0, 3).map((url, i) => (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img
-                      key={i}
-                      src={url}
-                      alt={`Image ${i + 1}`}
-                      className="h-20 w-20 shrink-0 rounded-md object-cover border"
-                      onError={(e) => {
-                        (e.target as HTMLImageElement).style.display = "none";
-                      }}
-                    />
+            {/* Catégorie */}
+            <div className="space-y-1.5">
+              <Label>Catégorie</Label>
+              <Select
+                value={selectedCategoryId}
+                onValueChange={setSelectedCategoryId}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Sélectionner une catégorie" />
+                </SelectTrigger>
+                <SelectContent>
+                  {categories.map((c) => (
+                    <SelectItem key={c.id} value={c.id}>
+                      {c.name}
+                    </SelectItem>
                   ))}
-                </div>
-              </div>
-            )}
+                </SelectContent>
+              </Select>
+            </div>
 
-            {/* Variants */}
-            {bp.variants.length > 0 ? (
+            {/* Descriptions */}
+            <div className="space-y-1.5">
+              <Label>Description courte</Label>
+              <Textarea
+                rows={2}
+                value={bp.short_description}
+                onChange={(e) =>
+                  setEditedBlueprint({
+                    ...bp,
+                    short_description: e.target.value,
+                  })
+                }
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Description</Label>
+              <Textarea
+                rows={3}
+                value={bp.description}
+                onChange={(e) =>
+                  setEditedBlueprint({ ...bp, description: e.target.value })
+                }
+              />
+            </div>
+
+            {/* SEO */}
+            <div className="grid grid-cols-1 gap-3">
+              <div className="space-y-1.5">
+                <Label>Meta title</Label>
+                <Input
+                  value={bp.meta_title}
+                  onChange={(e) =>
+                    setEditedBlueprint({ ...bp, meta_title: e.target.value })
+                  }
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Meta description</Label>
+                <Input
+                  value={bp.meta_description}
+                  onChange={(e) =>
+                    setEditedBlueprint({
+                      ...bp,
+                      meta_description: e.target.value,
+                    })
+                  }
+                />
+              </div>
+            </div>
+
+            {/* Variantes */}
+            {bp.variants.length > 0 && (
               <div>
-                <p className="text-sm font-medium mb-2">
-                  Variantes ({bp.variants.length})
-                </p>
-                <div className="rounded-md border text-sm overflow-hidden">
+                <Label className="mb-2 block">
+                  Variantes ({bp.variants.length}) — Prix à saisir dans
+                  l&apos;éditeur
+                </Label>
+                <div className="overflow-hidden rounded-md border text-sm">
                   <table className="w-full">
                     <thead>
                       <tr className="border-b bg-muted/50">
-                        <th className="text-left px-3 py-2 font-medium">Nom</th>
-                        <th className="text-right px-3 py-2 font-medium">Prix XOF</th>
-                        <th className="text-right px-3 py-2 font-medium">Stock</th>
+                        <th className="px-3 py-2 text-left font-medium">
+                          Nom
+                        </th>
+                        <th className="w-24 px-3 py-2 text-right font-medium">
+                          Stock
+                        </th>
                       </tr>
                     </thead>
                     <tbody>
                       {bp.variants.map((v, i) => (
                         <tr key={i} className="border-b last:border-0">
-                          <td className="px-3 py-2">{v.name}</td>
-                          <td className="px-3 py-2 text-right">
-                            {v.price.toLocaleString("fr-FR")}
+                          <td className="px-3 py-1.5">
+                            <Input
+                              className="h-7 text-sm"
+                              value={v.name}
+                              onChange={(e) =>
+                                updateVariant(i, "name", e.target.value)
+                              }
+                            />
                           </td>
-                          <td className="px-3 py-2 text-right">{v.stock_quantity}</td>
+                          <td className="w-24 px-3 py-1.5">
+                            <Input
+                              className="h-7 text-right text-sm"
+                              type="number"
+                              min={0}
+                              value={v.stock_quantity}
+                              onChange={(e) =>
+                                updateVariant(
+                                  i,
+                                  "stock_quantity",
+                                  Number(e.target.value)
+                                )
+                              }
+                            />
+                          </td>
                         </tr>
                       ))}
                     </tbody>
                   </table>
                 </div>
               </div>
-            ) : (
-              <p className="text-sm text-muted-foreground">
-                Aucune variante générée. Vous pourrez en ajouter dans l&apos;éditeur.
-              </p>
+            )}
+
+            {/* Images */}
+            {generated && generated.imageUrls.length > 0 && (
+              <div>
+                <Label className="mb-2 block">
+                  Images ({selectedImages.size}/{generated.imageUrls.length}{" "}
+                  sélectionnées)
+                </Label>
+                <div className="flex flex-wrap gap-3">
+                  {generated.imageUrls.map((url, i) => (
+                    <label key={i} className="group relative cursor-pointer">
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={url}
+                        alt={`Image ${i + 1}`}
+                        className={`h-20 w-20 rounded-md border-2 object-cover transition-all ${
+                          selectedImages.has(url)
+                            ? "border-primary"
+                            : "border-transparent opacity-50"
+                        }`}
+                        onError={(e) => {
+                          (
+                            e.target as HTMLImageElement
+                          ).parentElement!.style.display = "none";
+                        }}
+                      />
+                      <Checkbox
+                        className="absolute right-1 top-1"
+                        checked={selectedImages.has(url)}
+                        onCheckedChange={() => toggleImage(url)}
+                      />
+                    </label>
+                  ))}
+                </div>
+              </div>
             )}
 
             {/* Actions */}
@@ -246,11 +458,11 @@ export function AiCreateProductModal({
                 disabled={isCreating}
                 className="flex-1"
               >
-                ← Modifier
+                ← Regénérer
               </Button>
               <Button
                 onClick={handleConfirm}
-                disabled={isCreating}
+                disabled={isCreating || !selectedCategoryId}
                 className="flex-1 gap-2"
               >
                 {isCreating ? (

--- a/components/admin/ai-create-product-modal.tsx
+++ b/components/admin/ai-create-product-modal.tsx
@@ -103,6 +103,8 @@ export function AiCreateProductModal({
       setBrand("");
       setGenerated(null);
       setEditedBlueprint(null);
+      setSelectedCategoryId("");
+      setSelectedImages(new Set());
       setStatusMsg("");
     }
     onOpenChange(open);

--- a/lib/ai/helpers.ts
+++ b/lib/ai/helpers.ts
@@ -1,0 +1,50 @@
+import { callTextModel } from "@/lib/ai";
+import type { CategoryNode } from "@/lib/db/types";
+
+export function flattenCategories(
+  nodes: readonly CategoryNode[],
+  parentName?: string
+): Array<{ id: string; name: string; parentName?: string }> {
+  const result: Array<{ id: string; name: string; parentName?: string }> = [];
+  for (const node of nodes) {
+    result.push({ id: node.id, name: node.name, parentName });
+    if (node.children.length > 0) {
+      result.push(...flattenCategories(node.children, node.name));
+    }
+  }
+  return result;
+}
+
+export async function runTextModel(
+  system: string,
+  user: string,
+  retryCount = 0
+): Promise<string> {
+  const raw = await callTextModel(system, user);
+
+  try {
+    JSON.parse(raw);
+    return raw;
+  } catch {
+    console.warn("[ai/helpers] runTextModel: LLM returned non-JSON, attempting regex extraction");
+    const jsonMatch = raw.match(/\{[\s\S]*\}/);
+    if (jsonMatch) {
+      try {
+        JSON.parse(jsonMatch[0]);
+        return jsonMatch[0];
+      } catch {
+        console.error("[ai/helpers] runTextModel: regex extraction also failed, will retry if possible");
+      }
+    }
+
+    if (retryCount < 1) {
+      return runTextModel(
+        system +
+          "\n\nIMPORTANT: Retourne UNIQUEMENT du JSON valide. Pas de texte, pas de markdown, juste l'objet JSON.",
+        user,
+        retryCount + 1
+      );
+    }
+    throw new Error("Le modèle n'a pas retourné de JSON valide.");
+  }
+}

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -134,7 +134,6 @@ ${categoryList}
 Réponds UNIQUEMENT avec un objet JSON valide, sans texte avant ou après. Le JSON doit avoir exactement ces clés :
 - "name": nom exact du produit (string)
 - "brand": marque du produit (string, peut être vide)
-- "base_price": prix de base en XOF, nombre entier (ex: 1049000)
 - "description": description détaillée (2-3 phrases, max 500 caractères)
 - "short_description": résumé accrocheur en une phrase (max 150 caractères)
 - "meta_title": titre SEO (max 60 caractères)

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -142,7 +142,6 @@ Réponds UNIQUEMENT avec un objet JSON valide, sans texte avant ou après. Le JS
 - "categoryId": id de la catégorie la plus pertinente parmi la liste ci-dessus (string)
 - "variants": tableau de variantes typiques pour ce produit (max 20). Chaque variante a:
   - "name": nom de la variante (ex: "128Go / Noir Titanium")
-  - "price": prix en XOF (nombre entier)
   - "stock_quantity": quantité en stock (nombre entier, généralement 3-10)
   - "attributes": objet JSON avec les attributs (ex: {"stockage": "128Go", "couleur": "Noir Titanium"})
 

--- a/lib/ai/schemas.ts
+++ b/lib/ai/schemas.ts
@@ -35,21 +35,31 @@ export type CategorySuggestionResult = z.infer<
   typeof categorySuggestionSchema
 >;
 
+/**
+ * price is intentionally absent from variant blueprints —
+ * prices are set manually in the product editor after creation.
+ */
 export const productVariantBlueprintSchema = z.object({
-  name: z.string().min(1),
-  stock_quantity: z.coerce.number().int().min(0).default(5),
+  name: z.string().min(1).max(100),
+  stock_quantity: z.coerce.number().int().min(0).max(9999).default(5),
   attributes: z.record(z.string(), z.string()).default({}),
 });
 
+/**
+ * base_price is intentionally absent from product blueprints —
+ * prices are set manually in the product editor after creation.
+ */
 export const productBlueprintSchema = z.object({
-  name: z.string().min(1),
+  name: z.string().min(1).max(200),
   brand: z.string().optional().default(""),
-  description: z.string().max(500),
-  short_description: z.string().max(150),
+  description: z.string().min(1).max(500),
+  short_description: z.string().min(1).max(150),
   meta_title: z.string().max(60),
   meta_description: z.string().max(160),
-  categoryId: z.string(),
-  variants: z.array(productVariantBlueprintSchema).min(0).max(20),
+  // Must be a non-empty ID from the injected category list
+  categoryId: z.string().min(1),
+  // 0 variants is valid — variants can be added in the product editor
+  variants: z.array(productVariantBlueprintSchema).max(20),
 });
 
 export type ProductVariantBlueprint = z.infer<

--- a/lib/ai/schemas.ts
+++ b/lib/ai/schemas.ts
@@ -44,7 +44,6 @@ export const productVariantBlueprintSchema = z.object({
 export const productBlueprintSchema = z.object({
   name: z.string().min(1),
   brand: z.string().optional().default(""),
-  base_price: z.coerce.number().int().min(0),
   description: z.string().max(500),
   short_description: z.string().max(150),
   meta_title: z.string().max(60),

--- a/lib/ai/schemas.ts
+++ b/lib/ai/schemas.ts
@@ -37,7 +37,6 @@ export type CategorySuggestionResult = z.infer<
 
 export const productVariantBlueprintSchema = z.object({
   name: z.string().min(1),
-  price: z.coerce.number().int().min(0),
   stock_quantity: z.coerce.number().int().min(0).default(5),
   attributes: z.record(z.string(), z.string()).default({}),
 });

--- a/lib/ai/stream.ts
+++ b/lib/ai/stream.ts
@@ -1,0 +1,14 @@
+const encoder = new TextEncoder();
+
+export function encodeSSE(payload: Record<string, unknown>): Uint8Array {
+  return encoder.encode(`data: ${JSON.stringify(payload)}\n\n`);
+}
+
+export function parseSSELine(line: string): Record<string, unknown> | null {
+  if (!line.startsWith("data: ")) return null;
+  try {
+    return JSON.parse(line.slice(6)) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}

--- a/lib/ai/stream.ts
+++ b/lib/ai/stream.ts
@@ -1,13 +1,38 @@
+import type { ProductBlueprint } from "./schemas";
+
+// ── SSE event types ───────────────────────────────────────────────────────────
+
+export interface SSEStatusEvent {
+  type: "status";
+  message: string;
+}
+
+export interface SSEErrorEvent {
+  type: "error";
+  message: string;
+}
+
+export interface SSEDoneEvent {
+  type: "done";
+  blueprint: ProductBlueprint;
+  categoryName: string;
+  imageUrls: string[];
+}
+
+export type SSEEvent = SSEStatusEvent | SSEErrorEvent | SSEDoneEvent;
+
+// ── Wire utilities ────────────────────────────────────────────────────────────
+
 const encoder = new TextEncoder();
 
-export function encodeSSE(payload: Record<string, unknown>): Uint8Array {
+export function encodeSSE(payload: SSEEvent): Uint8Array {
   return encoder.encode(`data: ${JSON.stringify(payload)}\n\n`);
 }
 
-export function parseSSELine(line: string): Record<string, unknown> | null {
+export function parseSSELine(line: string): SSEEvent | null {
   if (!line.startsWith("data: ")) return null;
   try {
-    return JSON.parse(line.slice(6)) as Record<string, unknown>;
+    return JSON.parse(line.slice(6)) as SSEEvent;
   } catch {
     return null;
   }

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -356,3 +356,9 @@ export interface Banner {
   created_at: string;
   updated_at: string;
 }
+
+/** Minimal category option for UI selects — safe to pass across RSC→client boundary. */
+export interface CategoryOption {
+  id: string;
+  name: string;
+}


### PR DESCRIPTION
## Summary
- Replace Server Action blueprint generation with POST Route Handler + SSE streaming
- Remove price from AI-generated variants and blueprint (admin sets prices manually in editor)
- Add editable preview: texts, category, variants (name/stock), images selectable
- Add structured logging per step for debuggability

## Changes
- `lib/ai/schemas.ts` — remove `price` and `base_price` from blueprint schemas
- `lib/ai/prompts.ts` — remove price instruction from blueprint prompt
- `lib/ai/stream.ts` — new SSE helpers (`encodeSSE`, `parseSSELine`)
- `app/api/admin/ai/generate-product/route.ts` — new POST route handler with SSE streaming
- `actions/admin/ai.ts` — remove `generateProductBlueprint`, set prices to 0 in `createProductFromBlueprint`
- `components/admin/ai-create-product-modal.tsx` — full rewrite with SSE fetch and editable preview
- Tests: new files + updated existing

## Test plan
- [ ] Run `npm run test` — all tests pass
- [ ] Verify SSE status messages appear in real-time during generation (dev server)
- [ ] Verify editable fields update correctly before confirm
- [ ] Verify product created as draft, redirects to /products/{id}/edit
- [ ] Verify images can be toggled on/off before creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)