### PR TITLE
feat(hero): increase image size on desktop

### DIFF
--- a/components/storefront/hero-banner.tsx
+++ b/components/storefront/hero-banner.tsx
@@ -164,13 +164,13 @@ export function HeroBanner({
 
                 {/* Image */}
                 {slide.image_url && (
-                  <div className="relative mx-auto aspect-square w-full max-w-xs">
+                  <div className="relative mx-auto aspect-square w-full max-w-xs lg:max-w-sm">
                     <Image
                       src={getImageUrl(slide.image_url)}
                       alt={slide.title}
                       fill
                       className="object-contain"
-                      sizes="(max-width: 640px) 80vw, 320px"
+                      sizes="(max-width: 640px) 80vw, (max-width: 1024px) 320px, 384px"
                       {...(i === 0
                         ? { priority: true, fetchPriority: "high" as const }
                         : { loading: "lazy" as const })}


### PR DESCRIPTION
## Summary
- Bumps hero banner image from `max-w-xs` (320px) to `lg:max-w-sm` (384px) on large screens
- Fills the available height (480px − 96px padding = 384px) more effectively
- Updates `sizes` hint for optimal image loading

## Test plan
- [ ] Vérifier sur desktop (≥1024px) que l'image est plus grande
- [ ] Vérifier sur mobile/tablette que le rendu reste identique
- [ ] Vérifier qu'il n'y a pas de débordement vertical

🤖 Generated with [Claude Code](https://claude.com/claude-code)