### PR TITLE
fix: remove IMAGES binding to restore image display

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -3,7 +3,6 @@ interface CloudflareEnv {
   KV: KVNamespace;
   R2: R2Bucket;
   ASSETS: Fetcher;
-  IMAGES: ImagesBinding;
   AI: Ai;
 
   // Auth (Better Auth)

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -31,9 +31,6 @@
       "bucket_name": "netereka"
     }
   ],
-  "images": {
-    "binding": "IMAGES"
-  },
   "ai": {
     "binding": "AI"
   }


### PR DESCRIPTION
## Root cause

The `IMAGES` (Cloudflare Image Transformations) binding was added in #57 to enable AVIF support. When `env.IMAGES` is defined, the OpenNext image handler calls `env.IMAGES.input().transform().output()` on **every** image request (JPEG, WEBP, PNG, GIF). This API throws a Worker exception (Cloudflare error 1101), causing all `/_next/image` requests to return 500 — breaking every image on the site.

## Fix

- Remove the `images` binding from `wrangler.jsonc`
- Remove `IMAGES: ImagesBinding` from `env.d.ts`

Without `env.IMAGES`, OpenNext falls back to serving the original image format directly — images display correctly.

## Trade-off

No AVIF conversion at the edge. Images are served in their original format (WEBP/JPEG/PNG). This is acceptable until Cloudflare Image Transformations is verified as active and working on this account.

## Test plan
- [ ] Vérifier que les images s'affichent en production après déploiement
- [ ] Vérifier le logo, les images produits et les bannières héro

🤖 Generated with [Claude Code](https://claude.com/claude-code)