### PR TITLE
fix(kysely-d1): remove deprecated numUpdatedOrDeletedRows from QueryResult

### DIFF
--- a/scripts/patch-opennext.mjs
+++ b/scripts/patch-opennext.mjs
@@ -1,23 +1,40 @@
-// Removes noisy "env.IMAGES binding is not defined" warnings from OpenNext's
-// image handler. The IMAGES binding is intentionally absent — images fall back
-// to serving the original file, which is the correct behaviour for this project.
 import { readFileSync, writeFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-const file = join(
-  __dirname,
-  "../node_modules/@opennextjs/cloudflare/dist/cli/templates/images.js"
+function patch(file, transform, label) {
+  const before = readFileSync(file, "utf8");
+  const after = transform(before);
+  if (after !== before) {
+    writeFileSync(file, after);
+    console.log(`✓ Patched ${label}`);
+  } else {
+    console.log(`✓ ${label} already patched`);
+  }
+}
+
+// 1. @opennextjs/cloudflare: remove "env.IMAGES binding is not defined" warnings.
+//    The IMAGES binding is intentionally absent — images fall back to serving
+//    the original file, which is the correct behaviour for this project.
+patch(
+  join(__dirname, "../node_modules/@opennextjs/cloudflare/dist/cli/templates/images.js"),
+  (src) => src.replace(/\s*warn\("env\.IMAGES binding is not defined"\);\n/g, "\n"),
+  "@opennextjs/cloudflare: removed env.IMAGES warnings"
 );
 
-const before = readFileSync(file, "utf8");
-const after = before.replace(/\s*warn\("env\.IMAGES binding is not defined"\);\n/g, "\n");
+// 2. kysely-d1: remove deprecated numUpdatedOrDeletedRows from QueryResult.
+//    kysely-d1 v0.4.0 still sets this field for backward compatibility with
+//    Kysely < 0.23. Kysely v0.28+ emits a warning whenever it detects it.
+//    Both CJS and ESM bundles need the fix.
+const kyselyD1Pattern =
+  /\s*\/\/ @ts-ignore deprecated in kysely.*\n\s*numUpdatedOrDeletedRows:.*\n/g;
 
-if (after !== before) {
-  writeFileSync(file, after);
-  console.log("✓ Patched @opennextjs/cloudflare: removed env.IMAGES warnings");
-} else {
-  console.log("✓ @opennextjs/cloudflare already patched");
+for (const bundle of ["index.js", "index.cjs"]) {
+  patch(
+    join(__dirname, `../node_modules/kysely-d1/dist/${bundle}`),
+    (src) => src.replace(kyselyD1Pattern, "\n"),
+    `kysely-d1/${bundle}: removed numUpdatedOrDeletedRows`
+  );
 }


### PR DESCRIPTION
## Summary

- Extends `scripts/patch-opennext.mjs` (postinstall) to also patch `kysely-d1` v0.4.0
- `kysely-d1` sets `numUpdatedOrDeletedRows` as a backward-compat alias for Kysely < 0.23; Kysely v0.28+ warns on every DB write when it detects this field
- Removes the deprecated alias from both `dist/index.js` (ESM) and `dist/index.cjs` (CJS) — `numAffectedRows` (the current API) is already set correctly and remains untouched

## Test plan

- [ ] `node scripts/patch-opennext.mjs` outputs all three `already patched` lines after a fresh `npm install`
- [ ] No `kysely:warning: outdated driver/plugin detected!` in Cloudflare Workers logs after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)