### PR TITLE
fix(uploads): increase Server Action body size limit to 6mb

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,9 @@ const nextConfig: NextConfig = {
   experimental: {
     inlineCss: true,
     optimizePackageImports: ["@hugeicons/core-free-icons"],
+    serverActions: {
+      bodySizeLimit: "6mb",
+    },
   },
   images: {
     formats: ["image/avif", "image/webp"],


### PR DESCRIPTION
## Summary

- Next.js defaults Server Action request bodies to **1MB**
- Banner (and product) image uploads were silently rejected with HTTP 413 before the action code even ran, causing `"Erreur de connexion au serveur"` in the UI
- Added `experimental.serverActions.bodySizeLimit: '6mb'` in `next.config.ts`, consistent with the 5MB file size cap already enforced inside the upload actions

## Root cause

```
Client FormData (file ≤ 5MB) → POST /_next/action
  → Next.js body parser: 413 Payload Too Large (limit was 1MB)
  → Server Action never runs
  → Client catch block: "Erreur de connexion au serveur"
```

## Test plan

- [ ] Upload a banner image between 1MB and 5MB → should succeed
- [ ] Upload a banner image > 5MB → should show "L'image ne doit pas dépasser 5 Mo" (validation inside the action)
- [ ] Upload a product image > 1MB → should also succeed now

🤖 Generated with [Claude Code](https://claude.com/claude-code)