### PR TITLE
feat(admin): banner live preview, gradient presets and saved gradients

### DIFF
--- a/__tests__/unit/actions/admin-banners.test.ts
+++ b/__tests__/unit/actions/admin-banners.test.ts
@@ -407,7 +407,7 @@ describe("createBannerGradient", () => {
     const valuesMock = vi.fn().mockReturnValue({ returning: returningMock });
     mocks.dbInsert.mockReturnValue({ values: valuesMock });
     mocks.getDrizzle.mockResolvedValue({ insert: mocks.dbInsert });
-    return row;
+    return { row, valuesMock };
   }
 
   it("redirige si non admin", async () => {
@@ -436,13 +436,16 @@ describe("createBannerGradient", () => {
   });
 
   it("crée le gradient et retourne l'objet créé", async () => {
-    const row = mockInsertSuccess({ name: "Violet Coucher", color_from: "#7C3AED", color_to: "#EC4899" });
+    const { row, valuesMock } = mockInsertSuccess({ name: "Violet Coucher", color_from: "#7C3AED", color_to: "#EC4899" });
     const result = await createBannerGradient({
       name: "Violet Coucher",
       color_from: "#7C3AED",
       color_to: "#EC4899",
     });
     expect(result.success).toBe(true);
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Violet Coucher", color_from: "#7C3AED", color_to: "#EC4899" })
+    );
     expect(result.gradient).toMatchObject({
       id: row.id,
       name: row.name,
@@ -509,10 +512,11 @@ describe("deleteBannerGradient", () => {
   });
 
   it("supprime le gradient avec succès", async () => {
-    mockDeleteSuccess();
+    const { whereMock } = mockDeleteSuccess();
     const result = await deleteBannerGradient(5);
     expect(result.success).toBe(true);
     expect(mocks.dbDelete).toHaveBeenCalled();
+    expect(whereMock).toHaveBeenCalled();
   });
 
   it("retourne une erreur si le gradient est introuvable (returning vide)", async () => {

--- a/__tests__/unit/actions/admin-banners.test.ts
+++ b/__tests__/unit/actions/admin-banners.test.ts
@@ -426,13 +426,13 @@ describe("createBannerGradient", () => {
   it("rejette une couleur invalide (color_from)", async () => {
     const result = await createBannerGradient({ name: "Test", color_from: "not-a-color", color_to: "#ffffff" });
     expect(result.success).toBe(false);
-    expect(result.error).toContain("couleur");
+    expect(result.error).toContain("Couleur");
   });
 
   it("rejette une couleur invalide (color_to)", async () => {
     const result = await createBannerGradient({ name: "Test", color_from: "#000000", color_to: "rgb(0,0,0)" });
     expect(result.success).toBe(false);
-    expect(result.error).toContain("couleur");
+    expect(result.error).toContain("Couleur");
   });
 
   it("crée le gradient et retourne l'objet créé", async () => {
@@ -449,6 +449,16 @@ describe("createBannerGradient", () => {
       color_from: row.color_from,
       color_to: row.color_to,
     });
+  });
+
+  it("retourne une erreur si l'insertion retourne un tableau vide", async () => {
+    const returningMock = vi.fn().mockResolvedValue([]);
+    const valuesMock = vi.fn().mockReturnValue({ returning: returningMock });
+    mocks.dbInsert.mockReturnValue({ values: valuesMock });
+    mocks.getDrizzle.mockResolvedValue({ insert: mocks.dbInsert });
+    const result = await createBannerGradient({ name: "Test", color_from: "#000000", color_to: "#ffffff" });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Échec");
   });
 
   it("retourne une erreur si l'insertion DB échoue", async () => {

--- a/__tests__/unit/actions/admin-banners.test.ts
+++ b/__tests__/unit/actions/admin-banners.test.ts
@@ -483,11 +483,12 @@ describe("deleteBannerGradient", () => {
     mocks.getSession.mockResolvedValue(mockAdminSession);
   });
 
-  function mockDeleteSuccess() {
-    const whereMock = vi.fn().mockResolvedValue(undefined);
+  function mockDeleteSuccess(returning: object[] = [{ id: 5 }]) {
+    const returningMock = vi.fn().mockResolvedValue(returning);
+    const whereMock = vi.fn().mockReturnValue({ returning: returningMock });
     mocks.dbDelete.mockReturnValue({ where: whereMock });
     mocks.getDrizzle.mockResolvedValue({ delete: mocks.dbDelete });
-    return whereMock;
+    return { whereMock, returningMock };
   }
 
   it("redirige si non admin", async () => {
@@ -514,9 +515,18 @@ describe("deleteBannerGradient", () => {
     expect(mocks.dbDelete).toHaveBeenCalled();
   });
 
+  it("retourne une erreur si le gradient est introuvable (returning vide)", async () => {
+    mockDeleteSuccess([]);
+    const result = await deleteBannerGradient(99);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("introuvable");
+  });
+
   it("retourne une erreur si la suppression DB échoue", async () => {
     mocks.dbDelete.mockReturnValue({
-      where: vi.fn().mockRejectedValue(new Error("D1 delete error")),
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockRejectedValue(new Error("D1 delete error")),
+      }),
     });
     mocks.getDrizzle.mockResolvedValue({ delete: mocks.dbDelete });
     const result = await deleteBannerGradient(5);

--- a/__tests__/unit/actions/admin-banners.test.ts
+++ b/__tests__/unit/actions/admin-banners.test.ts
@@ -12,6 +12,8 @@ const mocks = vi.hoisted(() => ({
   deleteFromR2: vi.fn(),
   findFirst: vi.fn(),
   dbUpdate: vi.fn(),
+  dbInsert: vi.fn(),
+  dbDelete: vi.fn(),
   getDrizzle: vi.fn(),
 }));
 
@@ -30,7 +32,12 @@ vi.mock("@/lib/storage/images", () => ({
 vi.mock("nanoid", () => ({ nanoid: vi.fn().mockReturnValue("mockuid8") }));
 vi.mock("@/lib/db/drizzle", () => ({ getDrizzle: mocks.getDrizzle }));
 
-import { uploadBannerImage, setBannerImageUrl } from "@/actions/admin/banners";
+import {
+  uploadBannerImage,
+  setBannerImageUrl,
+  createBannerGradient,
+  deleteBannerGradient,
+} from "@/actions/admin/banners";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -376,5 +383,134 @@ describe("setBannerImageUrl", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain("mise à jour de l'image");
+  });
+});
+
+// ─── createBannerGradient ─────────────────────────────────────────────────────
+
+describe("createBannerGradient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue(mockAdminSession);
+  });
+
+  function mockInsertSuccess(overrides: Partial<{ id: number; name: string; color_from: string; color_to: string }> = {}) {
+    const row = {
+      id: 1,
+      name: "Mon dégradé",
+      color_from: "#7C3AED",
+      color_to: "#EC4899",
+      created_at: "2026-02-24 00:00:00",
+      ...overrides,
+    };
+    const returningMock = vi.fn().mockResolvedValue([row]);
+    const valuesMock = vi.fn().mockReturnValue({ returning: returningMock });
+    mocks.dbInsert.mockReturnValue({ values: valuesMock });
+    mocks.getDrizzle.mockResolvedValue({ insert: mocks.dbInsert });
+    return row;
+  }
+
+  it("redirige si non admin", async () => {
+    mocks.getSession.mockResolvedValue(mockCustomerSession);
+    await expect(
+      createBannerGradient({ name: "Test", color_from: "#000000", color_to: "#ffffff" })
+    ).rejects.toThrow("NEXT_REDIRECT");
+  });
+
+  it("rejette un name vide", async () => {
+    const result = await createBannerGradient({ name: "", color_from: "#000000", color_to: "#ffffff" });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("nom");
+  });
+
+  it("rejette une couleur invalide (color_from)", async () => {
+    const result = await createBannerGradient({ name: "Test", color_from: "not-a-color", color_to: "#ffffff" });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("couleur");
+  });
+
+  it("rejette une couleur invalide (color_to)", async () => {
+    const result = await createBannerGradient({ name: "Test", color_from: "#000000", color_to: "rgb(0,0,0)" });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("couleur");
+  });
+
+  it("crée le gradient et retourne l'objet créé", async () => {
+    const row = mockInsertSuccess({ name: "Violet Coucher", color_from: "#7C3AED", color_to: "#EC4899" });
+    const result = await createBannerGradient({
+      name: "Violet Coucher",
+      color_from: "#7C3AED",
+      color_to: "#EC4899",
+    });
+    expect(result.success).toBe(true);
+    expect(result.gradient).toMatchObject({
+      id: row.id,
+      name: row.name,
+      color_from: row.color_from,
+      color_to: row.color_to,
+    });
+  });
+
+  it("retourne une erreur si l'insertion DB échoue", async () => {
+    mocks.getDrizzle.mockResolvedValue({
+      insert: vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockRejectedValue(new Error("D1 error")),
+        }),
+      }),
+    });
+    const result = await createBannerGradient({ name: "Test", color_from: "#000000", color_to: "#ffffff" });
+    expect(result.success).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+});
+
+// ─── deleteBannerGradient ─────────────────────────────────────────────────────
+
+describe("deleteBannerGradient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue(mockAdminSession);
+  });
+
+  function mockDeleteSuccess() {
+    const whereMock = vi.fn().mockResolvedValue(undefined);
+    mocks.dbDelete.mockReturnValue({ where: whereMock });
+    mocks.getDrizzle.mockResolvedValue({ delete: mocks.dbDelete });
+    return whereMock;
+  }
+
+  it("redirige si non admin", async () => {
+    mocks.getSession.mockResolvedValue(mockCustomerSession);
+    await expect(deleteBannerGradient(1)).rejects.toThrow("NEXT_REDIRECT");
+  });
+
+  it("rejette id = 0", async () => {
+    const result = await deleteBannerGradient(0);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("ID");
+  });
+
+  it("rejette id négatif", async () => {
+    const result = await deleteBannerGradient(-3);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("ID");
+  });
+
+  it("supprime le gradient avec succès", async () => {
+    mockDeleteSuccess();
+    const result = await deleteBannerGradient(5);
+    expect(result.success).toBe(true);
+    expect(mocks.dbDelete).toHaveBeenCalled();
+  });
+
+  it("retourne une erreur si la suppression DB échoue", async () => {
+    mocks.dbDelete.mockReturnValue({
+      where: vi.fn().mockRejectedValue(new Error("D1 delete error")),
+    });
+    mocks.getDrizzle.mockResolvedValue({ delete: mocks.dbDelete });
+    const result = await deleteBannerGradient(5);
+    expect(result.success).toBe(false);
+    expect(result.error).toBeTruthy();
   });
 });

--- a/actions/admin/banners.ts
+++ b/actions/admin/banners.ts
@@ -323,8 +323,8 @@ export async function deleteBanner(id: number): Promise<ActionResult> {
 
 const gradientSchema = z.object({
   name: z.string().min(1, "Le nom est requis").max(100),
-  color_from: z.string().regex(/^#[0-9a-fA-F]{6}$/, "couleur invalide (format: #RRGGBB)"),
-  color_to: z.string().regex(/^#[0-9a-fA-F]{6}$/, "couleur invalide (format: #RRGGBB)"),
+  color_from: z.string().regex(/^#[0-9a-fA-F]{6}$/, "Couleur invalide (format: #RRGGBB)"),
+  color_to: z.string().regex(/^#[0-9a-fA-F]{6}$/, "Couleur invalide (format: #RRGGBB)"),
 });
 
 export async function createBannerGradient(
@@ -334,7 +334,7 @@ export async function createBannerGradient(
 
   const parsed = gradientSchema.safeParse(input);
   if (!parsed.success) {
-    const msg = parsed.error.issues.map((e) => e.message).join(", ");
+    const msg = parsed.error.issues.map((e: { message: string }) => e.message).join(", ");
     return { success: false, error: msg };
   }
 
@@ -357,6 +357,7 @@ export async function createBannerGradient(
       return { success: false, error: "Échec de la création du dégradé" };
     }
 
+    revalidatePath("/banners");
     return { success: true, gradient: gradient as BannerGradient };
   } catch (error) {
     console.error("[admin/banners] createBannerGradient error:", error);
@@ -372,6 +373,7 @@ export async function deleteBannerGradient(id: number): Promise<ActionResult> {
   try {
     const db = await getDrizzle();
     await db.delete(bannerGradients).where(eq(bannerGradients.id, id));
+    revalidatePath("/banners");
     return { success: true };
   } catch (error) {
     console.error("[admin/banners] deleteBannerGradient error:", error);

--- a/actions/admin/banners.ts
+++ b/actions/admin/banners.ts
@@ -372,7 +372,13 @@ export async function deleteBannerGradient(id: number): Promise<ActionResult> {
 
   try {
     const db = await getDrizzle();
-    await db.delete(bannerGradients).where(eq(bannerGradients.id, id));
+    const deleted = await db.delete(bannerGradients)
+      .where(eq(bannerGradients.id, id))
+      .returning({ id: bannerGradients.id });
+
+    if (deleted.length === 0) {
+      return { success: false, error: "Dégradé introuvable" };
+    }
     revalidatePath("/banners");
     return { success: true };
   } catch (error) {

--- a/actions/admin/banners.ts
+++ b/actions/admin/banners.ts
@@ -6,9 +6,10 @@ import { nanoid } from "nanoid";
 import { z } from "zod";
 import { requireAdmin } from "@/lib/auth/guards";
 import { getDrizzle } from "@/lib/db/drizzle";
-import { banners } from "@/lib/db/schema";
+import { banners, bannerGradients } from "@/lib/db/schema";
 import { uploadToR2, deleteFromR2 } from "@/lib/storage/images";
 import type { ActionResult } from "@/lib/utils";
+import type { BannerGradient } from "@/lib/db/types";
 
 const ALLOWED_IMAGE_EXTENSIONS = new Set(["jpg", "jpeg", "png", "webp", "avif"]);
 
@@ -317,5 +318,63 @@ export async function deleteBanner(id: number): Promise<ActionResult> {
   } catch (error) {
     console.error("[admin/banners] deleteBanner error:", error);
     return { success: false, error: "Erreur lors de la suppression de la bannière" };
+  }
+}
+
+const gradientSchema = z.object({
+  name: z.string().min(1, "Le nom est requis").max(100),
+  color_from: z.string().regex(/^#[0-9a-fA-F]{6}$/, "couleur invalide (format: #RRGGBB)"),
+  color_to: z.string().regex(/^#[0-9a-fA-F]{6}$/, "couleur invalide (format: #RRGGBB)"),
+});
+
+export async function createBannerGradient(
+  input: { name: string; color_from: string; color_to: string }
+): Promise<ActionResult & { gradient?: BannerGradient }> {
+  await requireAdmin();
+
+  const parsed = gradientSchema.safeParse(input);
+  if (!parsed.success) {
+    const msg = parsed.error.issues.map((e) => e.message).join(", ");
+    return { success: false, error: msg };
+  }
+
+  try {
+    const db = await getDrizzle();
+    const rows = await db.insert(bannerGradients).values({
+      name: parsed.data.name,
+      color_from: parsed.data.color_from,
+      color_to: parsed.data.color_to,
+    }).returning({
+      id: bannerGradients.id,
+      name: bannerGradients.name,
+      color_from: bannerGradients.color_from,
+      color_to: bannerGradients.color_to,
+      created_at: bannerGradients.created_at,
+    });
+
+    const gradient = rows[0];
+    if (!gradient) {
+      return { success: false, error: "Échec de la création du dégradé" };
+    }
+
+    return { success: true, gradient: gradient as BannerGradient };
+  } catch (error) {
+    console.error("[admin/banners] createBannerGradient error:", error);
+    return { success: false, error: "Erreur lors de la création du dégradé" };
+  }
+}
+
+export async function deleteBannerGradient(id: number): Promise<ActionResult> {
+  await requireAdmin();
+
+  if (!id || id <= 0) return { success: false, error: "ID de dégradé invalide" };
+
+  try {
+    const db = await getDrizzle();
+    await db.delete(bannerGradients).where(eq(bannerGradients.id, id));
+    return { success: true };
+  } catch (error) {
+    console.error("[admin/banners] deleteBannerGradient error:", error);
+    return { success: false, error: "Erreur lors de la suppression du dégradé" };
   }
 }

--- a/app/(admin)/banners/[id]/edit/page.tsx
+++ b/app/(admin)/banners/[id]/edit/page.tsx
@@ -5,7 +5,7 @@ import { ArrowLeft02Icon } from "@hugeicons/core-free-icons";
 import { Button } from "@/components/ui/button";
 import { AdminPageHeader } from "@/components/admin/admin-page-header";
 import { BannerForm } from "@/components/admin/banner-form";
-import { getBannerById } from "@/lib/db/admin/banners";
+import { getBannerById, getSavedGradients } from "@/lib/db/admin/banners";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -13,7 +13,10 @@ interface Props {
 
 export default async function EditBannerPage({ params }: Props) {
   const { id } = await params;
-  const banner = await getBannerById(Number(id));
+  const [banner, savedGradients] = await Promise.all([
+    getBannerById(Number(id)),
+    getSavedGradients(),
+  ]);
 
   if (!banner) notFound();
 
@@ -42,7 +45,7 @@ export default async function EditBannerPage({ params }: Props) {
           </div>
         </header>
       </AdminPageHeader>
-      <BannerForm banner={banner} />
+      <BannerForm banner={banner} savedGradients={savedGradients} />
     </div>
   );
 }

--- a/app/(admin)/banners/new/page.tsx
+++ b/app/(admin)/banners/new/page.tsx
@@ -4,8 +4,11 @@ import { ArrowLeft02Icon } from "@hugeicons/core-free-icons";
 import { Button } from "@/components/ui/button";
 import { AdminPageHeader } from "@/components/admin/admin-page-header";
 import { BannerForm } from "@/components/admin/banner-form";
+import { getSavedGradients } from "@/lib/db/admin/banners";
 
-export default function NewBannerPage() {
+export default async function NewBannerPage() {
+  const savedGradients = await getSavedGradients();
+
   return (
     <div>
       <AdminPageHeader>
@@ -31,7 +34,7 @@ export default function NewBannerPage() {
           </div>
         </header>
       </AdminPageHeader>
-      <BannerForm />
+      <BannerForm savedGradients={savedGradients} />
     </div>
   );
 }

--- a/components/admin/banner-form.tsx
+++ b/components/admin/banner-form.tsx
@@ -26,13 +26,13 @@ import {
   setBannerImageUrl,
 } from "@/actions/admin/banners";
 import dynamic from "next/dynamic";
+import type { BannerTextResult } from "@/lib/ai/schemas";
 import { AiGenerateButton } from "./ai-generate-button";
 import { generateBannerText } from "@/actions/admin/ai";
 import { GradientPicker } from "./gradient-picker";
 import { BannerPreview } from "./banner-preview";
 
 const AiImageDialog = dynamic(() => import("./ai-image-dialog").then((m) => m.AiImageDialog));
-import type { BannerTextResult } from "@/lib/ai/schemas";
 
 interface BannerFormProps {
   banner?: Banner | null;

--- a/components/admin/banner-form.tsx
+++ b/components/admin/banner-form.tsx
@@ -17,7 +17,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import type { Banner } from "@/lib/db/types";
+import type { BadgeColor, Banner, BannerGradient } from "@/lib/db/types";
 import { getImageUrl } from "@/lib/utils/images";
 import {
   createBanner,
@@ -28,27 +28,37 @@ import {
 import dynamic from "next/dynamic";
 import { AiGenerateButton } from "./ai-generate-button";
 import { generateBannerText } from "@/actions/admin/ai";
+import { GradientPicker } from "./gradient-picker";
+import { BannerPreview } from "./banner-preview";
 
 const AiImageDialog = dynamic(() => import("./ai-image-dialog").then((m) => m.AiImageDialog));
 import type { BannerTextResult } from "@/lib/ai/schemas";
 
 interface BannerFormProps {
   banner?: Banner | null;
+  savedGradients?: BannerGradient[];
 }
 
-export function BannerForm({ banner }: BannerFormProps) {
+export function BannerForm({ banner, savedGradients: initialGradients = [] }: BannerFormProps) {
   const [isPending, startTransition] = useTransition();
   const router = useRouter();
   const isEdit = !!banner;
   const isActiveRef = useRef<HTMLInputElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const titleRef = useRef<HTMLInputElement>(null);
-  const subtitleRef = useRef<HTMLTextAreaElement>(null);
-  const ctaTextRef = useRef<HTMLInputElement>(null);
-  const badgeTextRef = useRef<HTMLInputElement>(null);
-  const [imagePreview, setImagePreview] = useState<string | null>(
-    banner?.image_url ?? null
-  );
+
+  // Controlled visual state (feeds the live preview)
+  const [title, setTitle] = useState(banner?.title ?? "");
+  const [subtitle, setSubtitle] = useState(banner?.subtitle ?? "");
+  const [ctaText, setCtaText] = useState(banner?.cta_text ?? "Découvrir");
+  const [badgeText, setBadgeText] = useState(banner?.badge_text ?? "");
+  const [badgeColor, setBadgeColor] = useState<BadgeColor>(banner?.badge_color ?? "mint");
+  const [bgFrom, setBgFrom] = useState(banner?.bg_gradient_from ?? "#183C78");
+  const [bgTo, setBgTo] = useState(banner?.bg_gradient_to ?? "#1E4A8F");
+  const [price, setPrice] = useState<string>(banner?.price != null ? String(banner.price) : "");
+  const [imagePreview, setImagePreview] = useState<string | null>(banner?.image_url ?? null);
+
+  // Saved gradients with optimistic updates
+  const [savedGradients, setSavedGradients] = useState<BannerGradient[]>(initialGradients);
 
   function handleSubmit(formData: FormData) {
     startTransition(async () => {
@@ -103,17 +113,14 @@ export function BannerForm({ banner }: BannerFormProps) {
               <CardTitle>Informations</CardTitle>
               <AiGenerateButton<BannerTextResult>
                 label="Générer les textes"
-                onGenerate={() => {
-                  const title = titleRef.current?.value;
-                  return generateBannerText({
-                    productName: title || undefined,
-                  });
-                }}
+                onGenerate={() =>
+                  generateBannerText({ productName: title || undefined })
+                }
                 onResult={(data) => {
-                  if (titleRef.current) titleRef.current.value = data.title;
-                  if (subtitleRef.current) subtitleRef.current.value = data.subtitle;
-                  if (ctaTextRef.current) ctaTextRef.current.value = data.ctaText;
-                  if (badgeTextRef.current) badgeTextRef.current.value = data.badgeText ?? "";
+                  setTitle(data.title);
+                  setSubtitle(data.subtitle);
+                  setCtaText(data.ctaText);
+                  setBadgeText(data.badgeText ?? "");
                 }}
               />
             </CardHeader>
@@ -123,9 +130,9 @@ export function BannerForm({ banner }: BannerFormProps) {
                 <Input
                   id="title"
                   name="title"
-                  ref={titleRef}
                   required
-                  defaultValue={banner?.title ?? ""}
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
                   placeholder="Ex: PlayStation 5 - Offre spéciale"
                 />
               </div>
@@ -134,9 +141,9 @@ export function BannerForm({ banner }: BannerFormProps) {
                 <Textarea
                   id="subtitle"
                   name="subtitle"
-                  ref={subtitleRef}
                   rows={2}
-                  defaultValue={banner?.subtitle ?? ""}
+                  value={subtitle}
+                  onChange={(e) => setSubtitle(e.target.value)}
                   placeholder="Description courte de la bannière"
                 />
               </div>
@@ -156,8 +163,8 @@ export function BannerForm({ banner }: BannerFormProps) {
                   <Input
                     id="cta_text"
                     name="cta_text"
-                    ref={ctaTextRef}
-                    defaultValue={banner?.cta_text ?? "Découvrir"}
+                    value={ctaText}
+                    onChange={(e) => setCtaText(e.target.value)}
                     placeholder="Découvrir"
                   />
                 </div>
@@ -177,8 +184,8 @@ export function BannerForm({ banner }: BannerFormProps) {
                   <Input
                     id="badge_text"
                     name="badge_text"
-                    ref={badgeTextRef}
-                    defaultValue={banner?.badge_text ?? ""}
+                    value={badgeText}
+                    onChange={(e) => setBadgeText(e.target.value)}
                     placeholder="Ex: Nouveau, Promo"
                   />
                 </div>
@@ -186,7 +193,8 @@ export function BannerForm({ banner }: BannerFormProps) {
                   <Label htmlFor="badge_color">Couleur du badge</Label>
                   <Select
                     name="badge_color"
-                    defaultValue={banner?.badge_color ?? "mint"}
+                    value={badgeColor}
+                    onValueChange={(v) => setBadgeColor(v as BadgeColor)}
                   >
                     <SelectTrigger>
                       <SelectValue placeholder="Choisir..." />
@@ -200,28 +208,21 @@ export function BannerForm({ banner }: BannerFormProps) {
                   </Select>
                 </div>
               </div>
-              <div className="grid gap-4 sm:grid-cols-2">
-                <div className="space-y-2">
-                  <Label htmlFor="bg_gradient_from">Dégradé - Début</Label>
-                  <input
-                    type="color"
-                    id="bg_gradient_from"
-                    name="bg_gradient_from"
-                    defaultValue={banner?.bg_gradient_from ?? "#183C78"}
-                    className="h-10 w-full cursor-pointer rounded-md border"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="bg_gradient_to">Dégradé - Fin</Label>
-                  <input
-                    type="color"
-                    id="bg_gradient_to"
-                    name="bg_gradient_to"
-                    defaultValue={banner?.bg_gradient_to ?? "#1E4A8F"}
-                    className="h-10 w-full cursor-pointer rounded-md border"
-                  />
-                </div>
-              </div>
+
+              <GradientPicker
+                colorFrom={bgFrom}
+                colorTo={bgTo}
+                savedGradients={savedGradients}
+                onChange={(from, to) => {
+                  setBgFrom(from);
+                  setBgTo(to);
+                }}
+                onGradientSaved={(g) => setSavedGradients((prev) => [...prev, g])}
+                onGradientDeleted={(id) =>
+                  setSavedGradients((prev) => prev.filter((g) => g.id !== id))
+                }
+              />
+
               <div className="space-y-2">
                 <Label htmlFor="price">Prix (FCFA)</Label>
                 <Input
@@ -229,7 +230,8 @@ export function BannerForm({ banner }: BannerFormProps) {
                   name="price"
                   type="number"
                   min={0}
-                  defaultValue={banner?.price ?? ""}
+                  value={price}
+                  onChange={(e) => setPrice(e.target.value)}
                   placeholder="Optionnel"
                 />
               </div>
@@ -360,6 +362,21 @@ export function BannerForm({ banner }: BannerFormProps) {
               </div>
             </CardContent>
           </Card>
+
+          {/* Live preview — sticky */}
+          <div className="lg:sticky lg:top-6">
+            <BannerPreview
+              title={title}
+              subtitle={subtitle}
+              badgeText={badgeText}
+              badgeColor={badgeColor}
+              price={price !== "" ? Number(price) : null}
+              imageUrl={imagePreview}
+              bgFrom={bgFrom}
+              bgTo={bgTo}
+              ctaText={ctaText}
+            />
+          </div>
 
           <Button type="submit" className="w-full" disabled={isPending}>
             {isPending

--- a/components/admin/banner-form.tsx
+++ b/components/admin/banner-form.tsx
@@ -275,12 +275,16 @@ export function BannerForm({ banner, savedGradients: initialGradients = [] }: Ba
                     <AiImageDialog
                       onImageGenerated={(url) => {
                         startTransition(async () => {
-                          const result = await setBannerImageUrl(banner!.id, url);
-                          if (result.success) {
-                            setImagePreview(url);
-                            toast.success("Image IA enregistrée");
-                          } else {
-                            toast.error(result.error || "Erreur lors de l'enregistrement de l'image");
+                          try {
+                            const result = await setBannerImageUrl(banner!.id, url);
+                            if (result.success) {
+                              setImagePreview(url);
+                              toast.success("Image IA enregistrée");
+                            } else {
+                              toast.error(result.error || "Erreur lors de l'enregistrement de l'image");
+                            }
+                          } catch {
+                            toast.error("Erreur de connexion au serveur. Veuillez réessayer.");
                           }
                         });
                       }}

--- a/components/admin/banner-preview.tsx
+++ b/components/admin/banner-preview.tsx
@@ -1,0 +1,104 @@
+import Image from "next/image";
+import { cn } from "@/lib/utils";
+import { formatPrice } from "@/lib/utils/format";
+import { getImageUrl } from "@/lib/utils/images";
+import type { BadgeColor } from "@/lib/db/types";
+
+interface BannerPreviewProps {
+  title: string;
+  subtitle: string;
+  badgeText: string;
+  badgeColor: BadgeColor;
+  price: number | null;
+  imageUrl: string | null;
+  bgFrom: string;
+  bgTo: string;
+  ctaText: string;
+}
+
+const badgeColorMap: Record<BadgeColor, string> = {
+  mint: "bg-emerald-500/20 text-emerald-300",
+  red: "bg-red-500/20 text-red-300",
+  orange: "bg-orange-500/20 text-orange-300",
+  blue: "bg-blue-500/20 text-blue-300",
+};
+
+export function BannerPreview({
+  title,
+  subtitle,
+  badgeText,
+  badgeColor,
+  price,
+  imageUrl,
+  bgFrom,
+  bgTo,
+  ctaText,
+}: BannerPreviewProps) {
+  return (
+    <div className="space-y-1">
+      <p className="text-xs text-muted-foreground font-medium uppercase tracking-wide">
+        Prévisualisation
+      </p>
+      <div
+        className="relative h-[170px] overflow-hidden rounded-xl"
+        style={{ background: `linear-gradient(135deg, ${bgFrom}, ${bgTo})` }}
+      >
+        {/* Decorative orbs */}
+        <div className="pointer-events-none absolute -right-10 -top-10 h-32 w-32 rounded-full bg-[#00FF9C]/10 blur-2xl" />
+        <div className="pointer-events-none absolute -bottom-8 -left-8 h-24 w-24 rounded-full bg-white/5 blur-xl" />
+
+        <div className="grid h-full grid-cols-2 items-center gap-2 px-3 py-3">
+          {/* Text glass card */}
+          <div className="rounded-lg border border-white/20 bg-white/10 p-2 shadow-xl backdrop-blur-xl">
+            {badgeText && (
+              <span
+                className={cn(
+                  "mb-1 inline-block rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
+                  badgeColorMap[badgeColor]
+                )}
+              >
+                {badgeText}
+              </span>
+            )}
+            <p className="text-xs font-bold leading-tight text-white line-clamp-2">
+              {title || "Titre de la bannière"}
+            </p>
+            {subtitle && (
+              <p className="mt-0.5 text-[10px] text-white/70 line-clamp-1">
+                {subtitle}
+              </p>
+            )}
+            {price != null && (
+              <p className="mt-0.5 text-[10px] font-semibold text-emerald-300">
+                {formatPrice(price)}
+              </p>
+            )}
+            <span
+              className="mt-1 inline-block rounded-full bg-white px-2 py-0.5 text-[10px] font-semibold"
+              style={{ color: bgFrom }}
+            >
+              {ctaText || "Découvrir"}
+            </span>
+          </div>
+
+          {/* Product image */}
+          {imageUrl ? (
+            <div className="relative h-[120px] w-full">
+              <Image
+                src={getImageUrl(imageUrl)}
+                alt={title}
+                fill
+                className="object-contain"
+                sizes="100px"
+              />
+            </div>
+          ) : (
+            <div className="flex h-[120px] items-center justify-center rounded-lg border border-white/10 bg-white/5">
+              <span className="text-[10px] text-white/40">Image produit</span>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/banner-preview.tsx
+++ b/components/admin/banner-preview.tsx
@@ -16,6 +16,13 @@ interface BannerPreviewProps {
   ctaText: string;
 }
 
+const decorativeOrbs = (
+  <>
+    <div className="pointer-events-none absolute -right-10 -top-10 h-32 w-32 rounded-full bg-[#00FF9C]/10 blur-2xl" />
+    <div className="pointer-events-none absolute -bottom-8 -left-8 h-24 w-24 rounded-full bg-white/5 blur-xl" />
+  </>
+);
+
 const badgeColorMap: Record<BadgeColor, string> = {
   mint: "bg-emerald-500/20 text-emerald-300",
   red: "bg-red-500/20 text-red-300",
@@ -44,8 +51,7 @@ export function BannerPreview({
         style={{ background: `linear-gradient(135deg, ${bgFrom}, ${bgTo})` }}
       >
         {/* Decorative orbs */}
-        <div className="pointer-events-none absolute -right-10 -top-10 h-32 w-32 rounded-full bg-[#00FF9C]/10 blur-2xl" />
-        <div className="pointer-events-none absolute -bottom-8 -left-8 h-24 w-24 rounded-full bg-white/5 blur-xl" />
+        {decorativeOrbs}
 
         <div className="grid h-full grid-cols-2 items-center gap-2 px-3 py-3">
           {/* Text glass card */}

--- a/components/admin/banner-preview.tsx
+++ b/components/admin/banner-preview.tsx
@@ -86,10 +86,10 @@ export function BannerPreview({
             <div className="relative h-[120px] w-full">
               <Image
                 src={getImageUrl(imageUrl)}
-                alt={title}
+                alt={title || "Bannière"}
                 fill
                 className="object-contain"
-                sizes="100px"
+                sizes="120px"
               />
             </div>
           ) : (

--- a/components/admin/gradient-picker.tsx
+++ b/components/admin/gradient-picker.tsx
@@ -169,8 +169,9 @@ export function GradientPicker({
         <Label>Couleur libre</Label>
         <div className="grid grid-cols-2 gap-3">
           <div className="space-y-1">
-            <span className="text-xs text-muted-foreground">Début</span>
+            <label htmlFor="color-from" className="text-xs text-muted-foreground">Début</label>
             <input
+              id="color-from"
               type="color"
               name="bg_gradient_from"
               value={colorFrom}
@@ -179,8 +180,9 @@ export function GradientPicker({
             />
           </div>
           <div className="space-y-1">
-            <span className="text-xs text-muted-foreground">Fin</span>
+            <label htmlFor="color-to" className="text-xs text-muted-foreground">Fin</label>
             <input
+              id="color-to"
               type="color"
               name="bg_gradient_to"
               value={colorTo}

--- a/components/admin/gradient-picker.tsx
+++ b/components/admin/gradient-picker.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useTransition } from "react";
 import { toast } from "sonner";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Cancel01Icon } from "@hugeicons/core-free-icons";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -46,6 +48,7 @@ export function GradientPicker({
   const [saveDialogOpen, setSaveDialogOpen] = useState(false);
   const [gradientName, setGradientName] = useState("");
   const [isSaving, startSaveTransition] = useTransition();
+  const [, startDeleteTransition] = useTransition();
   const [deletingId, setDeletingId] = useState<number | null>(null);
 
   function isActive(from: string, to: string) {
@@ -71,19 +74,21 @@ export function GradientPicker({
     });
   }
 
-  async function handleDelete(id: number) {
+  function handleDelete(id: number) {
     setDeletingId(id);
-    try {
-      const result = await deleteBannerGradient(id);
-      if (result.success) {
-        onGradientDeleted(id);
-        toast.success("Dégradé supprimé");
-      } else {
-        toast.error(result.error || "Erreur lors de la suppression");
+    startDeleteTransition(async () => {
+      try {
+        const result = await deleteBannerGradient(id);
+        if (result.success) {
+          onGradientDeleted(id);
+          toast.success("Dégradé supprimé");
+        } else {
+          toast.error(result.error || "Erreur lors de la suppression");
+        }
+      } finally {
+        setDeletingId(null);
       }
-    } finally {
-      setDeletingId(null);
-    }
+    });
   }
 
   return (
@@ -151,7 +156,7 @@ export function GradientPicker({
                   aria-label={`Supprimer ${g.name}`}
                   className="shrink-0 text-muted-foreground hover:text-destructive"
                 >
-                  ×
+                  <HugeiconsIcon icon={Cancel01Icon} size={12} />
                 </Button>
               </div>
             ))}

--- a/components/admin/gradient-picker.tsx
+++ b/components/admin/gradient-picker.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { createBannerGradient, deleteBannerGradient } from "@/actions/admin/banners";
+import type { BannerGradient } from "@/lib/db/types";
+
+interface GradientPickerProps {
+  colorFrom: string;
+  colorTo: string;
+  savedGradients: BannerGradient[];
+  onChange: (from: string, to: string) => void;
+  onGradientSaved: (gradient: BannerGradient) => void;
+  onGradientDeleted: (id: number) => void;
+}
+
+const BUILTIN_PRESETS = [
+  { label: "Navy", from: "#183C78", to: "#1E4A8F" },
+  { label: "Violet", from: "#7C3AED", to: "#EC4899" },
+  { label: "Vert tropical", from: "#059669", to: "#0891B2" },
+  { label: "Orange feu", from: "#EA580C", to: "#DC2626" },
+  { label: "Nuit", from: "#111827", to: "#374151" },
+  { label: "Menthe", from: "#00C47A", to: "#183C78" },
+] as const;
+
+export function GradientPicker({
+  colorFrom,
+  colorTo,
+  savedGradients,
+  onChange,
+  onGradientSaved,
+  onGradientDeleted,
+}: GradientPickerProps) {
+  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const [gradientName, setGradientName] = useState("");
+  const [isSaving, startSaveTransition] = useTransition();
+  const [isDeleting, startDeleteTransition] = useTransition();
+
+  function isActive(from: string, to: string) {
+    return colorFrom.toLowerCase() === from.toLowerCase() &&
+      colorTo.toLowerCase() === to.toLowerCase();
+  }
+
+  function handleSave() {
+    startSaveTransition(async () => {
+      const result = await createBannerGradient({
+        name: gradientName.trim(),
+        color_from: colorFrom,
+        color_to: colorTo,
+      });
+      if (result.success && result.gradient) {
+        onGradientSaved(result.gradient);
+        toast.success("Dégradé sauvegardé");
+        setSaveDialogOpen(false);
+        setGradientName("");
+      } else {
+        toast.error(result.error || "Erreur lors de la sauvegarde");
+      }
+    });
+  }
+
+  function handleDelete(id: number) {
+    startDeleteTransition(async () => {
+      const result = await deleteBannerGradient(id);
+      if (result.success) {
+        onGradientDeleted(id);
+        toast.success("Dégradé supprimé");
+      } else {
+        toast.error(result.error || "Erreur lors de la suppression");
+      }
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Built-in presets */}
+      <div className="space-y-2">
+        <Label>Prédégradés</Label>
+        <div className="grid grid-cols-3 gap-2">
+          {BUILTIN_PRESETS.map((preset) => (
+            <button
+              key={preset.label}
+              type="button"
+              title={preset.label}
+              onClick={() => onChange(preset.from, preset.to)}
+              className={cn(
+                "h-8 w-full rounded-md border-2 transition-all",
+                isActive(preset.from, preset.to)
+                  ? "border-primary ring-2 ring-primary/30"
+                  : "border-transparent hover:border-border"
+              )}
+              style={{
+                background: `linear-gradient(135deg, ${preset.from}, ${preset.to})`,
+              }}
+              aria-label={preset.label}
+              aria-pressed={isActive(preset.from, preset.to)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Saved gradients */}
+      {savedGradients.length > 0 && (
+        <div className="space-y-2">
+          <Label>Mes dégradés</Label>
+          <div className="space-y-1">
+            {savedGradients.map((g) => (
+              <div
+                key={g.id}
+                className="flex items-center gap-2"
+              >
+                <button
+                  type="button"
+                  onClick={() => onChange(g.color_from, g.color_to)}
+                  className={cn(
+                    "h-7 flex-1 rounded border-2 text-left transition-all",
+                    isActive(g.color_from, g.color_to)
+                      ? "border-primary ring-2 ring-primary/30"
+                      : "border-transparent hover:border-border"
+                  )}
+                  style={{
+                    background: `linear-gradient(135deg, ${g.color_from}, ${g.color_to})`,
+                  }}
+                  aria-label={g.name}
+                  aria-pressed={isActive(g.color_from, g.color_to)}
+                />
+                <span className="w-24 truncate text-xs text-muted-foreground">
+                  {g.name}
+                </span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  disabled={isDeleting}
+                  onClick={() => handleDelete(g.id)}
+                  aria-label={`Supprimer ${g.name}`}
+                  className="shrink-0 text-muted-foreground hover:text-destructive"
+                >
+                  ×
+                </Button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Free color pickers */}
+      <div className="space-y-2">
+        <Label>Couleur libre</Label>
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1">
+            <span className="text-xs text-muted-foreground">Début</span>
+            <input
+              type="color"
+              name="bg_gradient_from"
+              value={colorFrom}
+              onChange={(e) => onChange(e.target.value, colorTo)}
+              className="h-10 w-full cursor-pointer rounded-md border"
+            />
+          </div>
+          <div className="space-y-1">
+            <span className="text-xs text-muted-foreground">Fin</span>
+            <input
+              type="color"
+              name="bg_gradient_to"
+              value={colorTo}
+              onChange={(e) => onChange(colorFrom, e.target.value)}
+              className="h-10 w-full cursor-pointer rounded-md border"
+            />
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="w-full"
+          onClick={() => {
+            setGradientName("");
+            setSaveDialogOpen(true);
+          }}
+        >
+          Sauvegarder ce dégradé
+        </Button>
+      </div>
+
+      {/* Save dialog */}
+      <Dialog open={saveDialogOpen} onOpenChange={setSaveDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Nommer ce dégradé</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div
+              className="h-12 w-full rounded-lg"
+              style={{ background: `linear-gradient(135deg, ${colorFrom}, ${colorTo})` }}
+            />
+            <Input
+              value={gradientName}
+              onChange={(e) => setGradientName(e.target.value)}
+              placeholder="Ex: Violet Coucher de soleil"
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleSave();
+              }}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setSaveDialogOpen(false)}
+            >
+              Annuler
+            </Button>
+            <Button
+              type="button"
+              disabled={isSaving || !gradientName.trim()}
+              onClick={handleSave}
+            >
+              {isSaving ? "Enregistrement..." : "Sauvegarder"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/components/admin/gradient-picker.tsx
+++ b/components/admin/gradient-picker.tsx
@@ -58,18 +58,22 @@ export function GradientPicker({
 
   function handleSave() {
     startSaveTransition(async () => {
-      const result = await createBannerGradient({
-        name: gradientName.trim(),
-        color_from: colorFrom,
-        color_to: colorTo,
-      });
-      if (result.success && result.gradient) {
-        onGradientSaved(result.gradient);
-        toast.success("Dégradé sauvegardé");
-        setSaveDialogOpen(false);
-        setGradientName("");
-      } else {
-        toast.error(result.error || "Erreur lors de la sauvegarde");
+      try {
+        const result = await createBannerGradient({
+          name: gradientName.trim(),
+          color_from: colorFrom,
+          color_to: colorTo,
+        });
+        if (result.success && result.gradient) {
+          onGradientSaved(result.gradient);
+          toast.success("Dégradé sauvegardé");
+          setSaveDialogOpen(false);
+          setGradientName("");
+        } else {
+          toast.error(result.error || "Erreur lors de la sauvegarde");
+        }
+      } catch {
+        toast.error("Erreur de connexion au serveur. Veuillez réessayer.");
       }
     });
   }
@@ -85,6 +89,8 @@ export function GradientPicker({
         } else {
           toast.error(result.error || "Erreur lors de la suppression");
         }
+      } catch {
+        toast.error("Erreur de connexion au serveur. Veuillez réessayer.");
       } finally {
         setDeletingId(null);
       }

--- a/components/admin/gradient-picker.tsx
+++ b/components/admin/gradient-picker.tsx
@@ -9,6 +9,7 @@ import { Label } from "@/components/ui/label";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -45,7 +46,7 @@ export function GradientPicker({
   const [saveDialogOpen, setSaveDialogOpen] = useState(false);
   const [gradientName, setGradientName] = useState("");
   const [isSaving, startSaveTransition] = useTransition();
-  const [isDeleting, startDeleteTransition] = useTransition();
+  const [deletingId, setDeletingId] = useState<number | null>(null);
 
   function isActive(from: string, to: string) {
     return colorFrom.toLowerCase() === from.toLowerCase() &&
@@ -70,8 +71,9 @@ export function GradientPicker({
     });
   }
 
-  function handleDelete(id: number) {
-    startDeleteTransition(async () => {
+  async function handleDelete(id: number) {
+    setDeletingId(id);
+    try {
       const result = await deleteBannerGradient(id);
       if (result.success) {
         onGradientDeleted(id);
@@ -79,7 +81,9 @@ export function GradientPicker({
       } else {
         toast.error(result.error || "Erreur lors de la suppression");
       }
-    });
+    } finally {
+      setDeletingId(null);
+    }
   }
 
   return (
@@ -142,7 +146,7 @@ export function GradientPicker({
                   type="button"
                   variant="ghost"
                   size="icon-xs"
-                  disabled={isDeleting}
+                  disabled={deletingId === g.id}
                   onClick={() => handleDelete(g.id)}
                   aria-label={`Supprimer ${g.name}`}
                   className="shrink-0 text-muted-foreground hover:text-destructive"
@@ -199,6 +203,9 @@ export function GradientPicker({
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Nommer ce dégradé</DialogTitle>
+            <DialogDescription>
+              Choisissez un nom pour réutiliser ce dégradé
+            </DialogDescription>
           </DialogHeader>
           <div className="space-y-3">
             <div

--- a/docs/plans/2026-02-24-banner-gradient-preview-design.md
+++ b/docs/plans/2026-02-24-banner-gradient-preview-design.md
@@ -1,0 +1,180 @@
+# Design: Amélioration Création de Bannière — Prévisualisation, Prédégradés & Sauvegarde
+
+**Date:** 2026-02-24
+**Statut:** Approuvé
+
+## Contexte
+
+Le formulaire de création/édition de bannière (`components/admin/banner-form.tsx`) dispose actuellement de deux color pickers HTML natifs basiques pour le dégradé de fond. Il n'y a pas de prévisualisation temps réel et pas de prédégradés.
+
+Le rendu réel est dans `components/storefront/hero-banner.tsx` avec `linear-gradient(135deg, from, to)` + orbes décoratifs + glassmorphisme.
+
+## Objectifs
+
+1. **Prévisualisation temps réel** dans le formulaire admin (panel latéral sticky)
+2. **6 prédégradés codés en dur** sélectionnables d'un clic
+3. **Sauvegarde de dégradés personnalisés** en D1 (table dédiée), partagés entre tous les admins
+
+## Approche retenue : État React contrôlé + table `banner_gradients`
+
+`BannerForm` devient entièrement contrôlé (React state pour tous les champs d'apparence). Un composant `BannerPreview` reçoit les valeurs en props et se met à jour en temps réel. Un composant `GradientPicker` gère présets + sauvegarde.
+
+## Schéma DB — table `banner_gradients`
+
+```sql
+CREATE TABLE banner_gradients (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  color_from TEXT NOT NULL,   -- ex: "#7C3AED"
+  color_to TEXT NOT NULL,     -- ex: "#EC4899"
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+```
+
+Aucune FK, table autonome. Accessible à tous les admins.
+
+Migration Drizzle : ajout dans `lib/db/schema.ts` → `npm run db:generate` → `npm run db:migrate`.
+
+## Composants
+
+### `GradientPicker` (nouveau — `components/admin/gradient-picker.tsx`)
+
+Props :
+```ts
+interface GradientPickerProps {
+  colorFrom: string;
+  colorTo: string;
+  savedGradients: BannerGradient[];
+  onChange: (from: string, to: string) => void;
+  onGradientSaved: (gradient: BannerGradient) => void;
+  onGradientDeleted: (id: number) => void;
+}
+```
+
+Structure UI :
+- **Présets intégrés** : grille 3×2 de swatches visuels (mini dégradés 40×24px cliquables)
+- **Mes dégradés** : liste des dégradés sauvegardés en D1, chacun avec bouton supprimer
+- **Couleur libre** : 2 `<input type="color">` + bouton "Sauvegarder ce dégradé"
+- Sauvegarder → `<Dialog>` pour nommer le dégradé → Server Action `createBannerGradient`
+
+6 présets codés en dur :
+| Nom | From | To |
+|-----|------|----|
+| Navy (défaut) | #183C78 | #1E4A8F |
+| Violet Coucher | #7C3AED | #EC4899 |
+| Vert Tropical | #059669 | #0891B2 |
+| Orange Feu | #EA580C | #DC2626 |
+| Nuit | #111827 | #374151 |
+| Menthe Netereka | #00C47A | #183C78 |
+
+### `BannerPreview` (nouveau — `components/admin/banner-preview.tsx`)
+
+Props :
+```ts
+interface BannerPreviewProps {
+  title: string;
+  subtitle: string;
+  badgeText: string;
+  badgeColor: BadgeColor;
+  price: number | null;
+  imageUrl: string | null;
+  bgFrom: string;
+  bgTo: string;
+  ctaText: string;
+}
+```
+
+Reprend exactement le markup d'un slide `HeroBanner` (orbes, glassmorphisme, layout 2 colonnes). Affiché dans la sidebar sticky du formulaire, sous la Card "Publication". Ratio fixe `aspect-[16/9]` ou hauteur fixe `h-[200px]` pour ne pas écraser la sidebar.
+
+### `BannerForm` refactorisé (`components/admin/banner-form.tsx`)
+
+Conversion en formulaire contrôlé :
+```ts
+const [title, setTitle] = useState(banner?.title ?? "");
+const [subtitle, setSubtitle] = useState(banner?.subtitle ?? "");
+const [ctaText, setCtaText] = useState(banner?.cta_text ?? "Découvrir");
+const [badgeText, setBadgeText] = useState(banner?.badge_text ?? "");
+const [badgeColor, setBadgeColor] = useState<BadgeColor>(banner?.badge_color ?? "mint");
+const [bgFrom, setBgFrom] = useState(banner?.bg_gradient_from ?? "#183C78");
+const [bgTo, setBgTo] = useState(banner?.bg_gradient_to ?? "#1E4A8F");
+const [price, setPrice] = useState<number | null>(banner?.price ?? null);
+```
+
+Les champs non visuels (`link_url`, `display_order`, `is_active`, dates) restent non contrôlés (refs ou FormData natif) car ils n'alimentent pas la prévisualisation.
+
+L'image reste gérée comme actuellement (upload séparé, `imagePreview` state).
+
+Modifications layout sidebar :
+```
+Sidebar droite :
+  [Card Publication]
+  [BannerPreview — sticky]  ← nouveau
+  [Button Enregistrer]
+```
+
+## Server Actions
+
+### `createBannerGradient` (`actions/admin/banners.ts`)
+
+```ts
+export async function createBannerGradient(input: {
+  name: string;
+  color_from: string;
+  color_to: string;
+}): Promise<ActionResult & { gradient?: BannerGradient }>
+```
+
+Validation : name non vide, couleurs format hex 6 chars. Requiert `requireAdmin()`.
+
+### `deleteBannerGradient` (`actions/admin/banners.ts`)
+
+```ts
+export async function deleteBannerGradient(id: number): Promise<ActionResult>
+```
+
+Requiert `requireAdmin()`.
+
+## Page bannière — chargement des dégradés sauvegardés
+
+Les pages `/banners/new` et `/banners/[id]/edit` chargent les gradients depuis D1 côté serveur (RSC) et les passent à `BannerForm` en props :
+
+```ts
+// app/(admin)/banners/new/page.tsx
+const savedGradients = await getSavedGradients(); // lib/db/admin/banners.ts
+return <BannerForm savedGradients={savedGradients} />;
+```
+
+`BannerForm` reçoit un nouveau prop `savedGradients: BannerGradient[]` et le passe à `GradientPicker`. Les mises à jour optimistes (après save/delete gradient) se font via `useState` local dans `BannerForm` pour éviter un refresh complet.
+
+## Types
+
+Nouveau type dans `lib/db/types.ts` :
+```ts
+export interface BannerGradient {
+  id: number;
+  name: string;
+  color_from: string;
+  color_to: string;
+  created_at: string;
+}
+```
+
+## Tests
+
+- `__tests__/unit/actions/admin-banners.test.ts` : ajouter tests pour `createBannerGradient` et `deleteBannerGradient` (validation, erreurs, succès)
+
+## Fichiers modifiés/créés
+
+| Fichier | Action |
+|---------|--------|
+| `lib/db/schema.ts` | Ajouter table `banner_gradients` |
+| `drizzle/` | Nouvelle migration générée |
+| `lib/db/types.ts` | Ajouter `BannerGradient` interface |
+| `lib/db/admin/banners.ts` | Ajouter `getSavedGradients()` |
+| `actions/admin/banners.ts` | Ajouter `createBannerGradient`, `deleteBannerGradient` |
+| `components/admin/gradient-picker.tsx` | Nouveau composant |
+| `components/admin/banner-preview.tsx` | Nouveau composant |
+| `components/admin/banner-form.tsx` | Refactoriser en contrôlé + intégrer les deux nouveaux composants |
+| `app/(admin)/banners/new/page.tsx` | Passer `savedGradients` |
+| `app/(admin)/banners/[id]/edit/page.tsx` | Passer `savedGradients` |
+| `__tests__/unit/actions/admin-banners.test.ts` | Ajouter tests |

--- a/docs/plans/2026-02-24-banner-gradient-preview.md
+++ b/docs/plans/2026-02-24-banner-gradient-preview.md
@@ -1,0 +1,1374 @@
+# Banner Gradient Preview — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Ajouter prévisualisation temps réel, 6 prédégradés codés en dur et sauvegarde de dégradés personnalisés (table D1) dans le formulaire de création/édition de bannières admin.
+
+**Architecture:** `BannerForm` devient contrôlé (React state pour les champs visuels). Un composant `GradientPicker` remplace les deux color pickers natifs et gère présets + sauvegarde. Un composant `BannerPreview` dans la sidebar sticky affiche le rendu live. Les dégradés personnalisés sont stockés en D1 via deux nouvelles Server Actions et chargés côté serveur (RSC) avant d'être passés en props.
+
+**Tech Stack:** Next.js App Router, Drizzle ORM + D1 SQLite, Zod, Vitest, shadcn/ui (Dialog, Input, Button), React `useTransition`, Tailwind CSS 4
+
+---
+
+## Task 1: Ajouter la table `banner_gradients` en DB
+
+**Files:**
+- Modify: `lib/db/schema.ts` (après le bloc `banners`, ligne ~372)
+
+**Step 1: Ajouter la définition de table dans le schéma Drizzle**
+
+Ouvrir `lib/db/schema.ts`. Après la fermeture de la table `banners` (ligne ~372), ajouter :
+
+```ts
+// =============================================================================
+// Banner Gradients (saved presets)
+// =============================================================================
+export const bannerGradients = sqliteTable("banner_gradients", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  name: text("name").notNull(),
+  color_from: text("color_from").notNull(),
+  color_to: text("color_to").notNull(),
+  created_at: text("created_at").notNull().default(sql`(datetime('now'))`),
+});
+```
+
+**Step 2: Générer la migration SQL**
+
+```bash
+npm run db:generate
+```
+
+Expected: un nouveau fichier `drizzle/XXXX_add_banner_gradients.sql` est créé.
+
+**Step 3: Vérifier le contenu du fichier SQL généré**
+
+Il doit contenir :
+```sql
+CREATE TABLE `banner_gradients` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `name` text NOT NULL,
+  `color_from` text NOT NULL,
+  `color_to` text NOT NULL,
+  `created_at` text DEFAULT (datetime('now')) NOT NULL
+);
+```
+
+**Step 4: Appliquer la migration localement**
+
+```bash
+npm run db:migrate
+```
+
+Expected: `Applied migration: XXXX_add_banner_gradients.sql`
+
+**Step 5: Commit**
+
+```bash
+git add lib/db/schema.ts drizzle/
+git commit -m "feat(db): add banner_gradients table for saved gradient presets"
+```
+
+---
+
+## Task 2: Ajouter le type `BannerGradient` et le helper DB
+
+**Files:**
+- Modify: `lib/db/types.ts` (après l'interface `Banner`, ligne ~358)
+- Modify: `lib/db/admin/banners.ts`
+
+**Step 1: Ajouter l'interface dans `lib/db/types.ts`**
+
+Après la fermeture de l'interface `Banner` (ligne ~358), ajouter :
+
+```ts
+export interface BannerGradient {
+  id: number;
+  name: string;
+  color_from: string;
+  color_to: string;
+  created_at: string;
+}
+```
+
+**Step 2: Ajouter `getSavedGradients()` dans `lib/db/admin/banners.ts`**
+
+Ajouter en haut du fichier l'import :
+```ts
+import { bannerGradients } from "@/lib/db/schema";
+import type { Banner, BannerGradient } from "@/lib/db/types";
+```
+(remplace le `import type { Banner }` existant)
+
+Ajouter en bas du fichier :
+```ts
+export async function getSavedGradients(): Promise<BannerGradient[]> {
+  const db = await getDrizzle();
+  return db.select().from(bannerGradients).orderBy(asc(bannerGradients.id)) as unknown as BannerGradient[];
+}
+```
+
+**Step 3: Vérifier la compilation TypeScript**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors
+
+**Step 4: Commit**
+
+```bash
+git add lib/db/types.ts lib/db/admin/banners.ts
+git commit -m "feat(types): add BannerGradient type and getSavedGradients DB helper"
+```
+
+---
+
+## Task 3: Server Actions `createBannerGradient` et `deleteBannerGradient` (TDD)
+
+**Files:**
+- Modify: `__tests__/unit/actions/admin-banners.test.ts`
+- Modify: `actions/admin/banners.ts`
+
+**Step 1: Étendre le fichier de tests**
+
+Dans `__tests__/unit/actions/admin-banners.test.ts`, modifier le bloc `vi.hoisted` pour ajouter `dbInsert` et `dbDelete` :
+
+```ts
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  redirect: vi.fn((url: string): never => {
+    const error = new Error(`NEXT_REDIRECT: ${url}`) as Error & { digest: string };
+    error.digest = `NEXT_REDIRECT;${url}`;
+    throw error;
+  }),
+  uploadToR2: vi.fn(),
+  deleteFromR2: vi.fn(),
+  findFirst: vi.fn(),
+  dbUpdate: vi.fn(),
+  dbInsert: vi.fn(),
+  dbDelete: vi.fn(),
+  getDrizzle: vi.fn(),
+}));
+```
+
+Modifier la ligne d'import des actions en bas du bloc de mocks :
+```ts
+import {
+  uploadBannerImage,
+  setBannerImageUrl,
+  createBannerGradient,
+  deleteBannerGradient,
+} from "@/actions/admin/banners";
+```
+
+Ajouter à la fin du fichier les deux nouveaux blocs `describe` :
+
+```ts
+// ─── createBannerGradient ─────────────────────────────────────────────────────
+
+describe("createBannerGradient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue(mockAdminSession);
+  });
+
+  function mockInsertSuccess(overrides: Partial<{ id: number; name: string; color_from: string; color_to: string }> = {}) {
+    const row = {
+      id: 1,
+      name: "Mon dégradé",
+      color_from: "#7C3AED",
+      color_to: "#EC4899",
+      created_at: "2026-02-24 00:00:00",
+      ...overrides,
+    };
+    const returningMock = vi.fn().mockResolvedValue([row]);
+    const valuesMock = vi.fn().mockReturnValue({ returning: returningMock });
+    mocks.dbInsert.mockReturnValue({ values: valuesMock });
+    mocks.getDrizzle.mockResolvedValue({ insert: mocks.dbInsert });
+    return row;
+  }
+
+  it("redirige si non admin", async () => {
+    mocks.getSession.mockResolvedValue(mockCustomerSession);
+    await expect(
+      createBannerGradient({ name: "Test", color_from: "#000000", color_to: "#ffffff" })
+    ).rejects.toThrow("NEXT_REDIRECT");
+  });
+
+  it("rejette un name vide", async () => {
+    const result = await createBannerGradient({ name: "", color_from: "#000000", color_to: "#ffffff" });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("nom");
+  });
+
+  it("rejette une couleur invalide (color_from)", async () => {
+    const result = await createBannerGradient({ name: "Test", color_from: "not-a-color", color_to: "#ffffff" });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("couleur");
+  });
+
+  it("rejette une couleur invalide (color_to)", async () => {
+    const result = await createBannerGradient({ name: "Test", color_from: "#000000", color_to: "rgb(0,0,0)" });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("couleur");
+  });
+
+  it("crée le gradient et retourne l'objet créé", async () => {
+    const row = mockInsertSuccess({ name: "Violet Coucher", color_from: "#7C3AED", color_to: "#EC4899" });
+    const result = await createBannerGradient({
+      name: "Violet Coucher",
+      color_from: "#7C3AED",
+      color_to: "#EC4899",
+    });
+    expect(result.success).toBe(true);
+    expect(result.gradient).toMatchObject({
+      id: row.id,
+      name: row.name,
+      color_from: row.color_from,
+      color_to: row.color_to,
+    });
+  });
+
+  it("retourne une erreur si l'insertion DB échoue", async () => {
+    mocks.getDrizzle.mockResolvedValue({
+      insert: vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockRejectedValue(new Error("D1 error")),
+        }),
+      }),
+    });
+    const result = await createBannerGradient({ name: "Test", color_from: "#000000", color_to: "#ffffff" });
+    expect(result.success).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+});
+
+// ─── deleteBannerGradient ─────────────────────────────────────────────────────
+
+describe("deleteBannerGradient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue(mockAdminSession);
+  });
+
+  function mockDeleteSuccess() {
+    const whereMock = vi.fn().mockResolvedValue(undefined);
+    mocks.dbDelete.mockReturnValue({ where: whereMock });
+    mocks.getDrizzle.mockResolvedValue({ delete: mocks.dbDelete });
+    return whereMock;
+  }
+
+  it("redirige si non admin", async () => {
+    mocks.getSession.mockResolvedValue(mockCustomerSession);
+    await expect(deleteBannerGradient(1)).rejects.toThrow("NEXT_REDIRECT");
+  });
+
+  it("rejette id = 0", async () => {
+    const result = await deleteBannerGradient(0);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("ID");
+  });
+
+  it("rejette id négatif", async () => {
+    const result = await deleteBannerGradient(-3);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("ID");
+  });
+
+  it("supprime le gradient avec succès", async () => {
+    mockDeleteSuccess();
+    const result = await deleteBannerGradient(5);
+    expect(result.success).toBe(true);
+    expect(mocks.dbDelete).toHaveBeenCalled();
+  });
+
+  it("retourne une erreur si la suppression DB échoue", async () => {
+    mocks.dbDelete.mockReturnValue({
+      where: vi.fn().mockRejectedValue(new Error("D1 delete error")),
+    });
+    mocks.getDrizzle.mockResolvedValue({ delete: mocks.dbDelete });
+    const result = await deleteBannerGradient(5);
+    expect(result.success).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+});
+```
+
+**Step 2: Lancer les tests pour vérifier qu'ils échouent**
+
+```bash
+npm run test -- --reporter=verbose __tests__/unit/actions/admin-banners.test.ts
+```
+
+Expected: les `describe` blocks `createBannerGradient` et `deleteBannerGradient` échouent avec "not a function" ou import error.
+
+**Step 3: Implémenter les deux actions dans `actions/admin/banners.ts`**
+
+Ajouter en haut du fichier l'import :
+```ts
+import { banners, bannerGradients } from "@/lib/db/schema";
+```
+(remplace `import { banners } from "@/lib/db/schema"`)
+
+Ajouter l'import du type :
+```ts
+import type { ActionResult } from "@/lib/utils";
+import type { BannerGradient } from "@/lib/db/types";
+```
+
+Ajouter à la fin du fichier :
+
+```ts
+const gradientSchema = z.object({
+  name: z.string().min(1, "Le nom est requis").max(100),
+  color_from: z.string().regex(/^#[0-9a-fA-F]{6}$/, "Couleur invalide (format: #RRGGBB)"),
+  color_to: z.string().regex(/^#[0-9a-fA-F]{6}$/, "Couleur invalide (format: #RRGGBB)"),
+});
+
+export async function createBannerGradient(
+  input: { name: string; color_from: string; color_to: string }
+): Promise<ActionResult & { gradient?: BannerGradient }> {
+  await requireAdmin();
+
+  const parsed = gradientSchema.safeParse(input);
+  if (!parsed.success) {
+    const msg = parsed.error.issues.map((e) => e.message).join(", ");
+    return { success: false, error: msg };
+  }
+
+  try {
+    const db = await getDrizzle();
+    const rows = await db.insert(bannerGradients).values({
+      name: parsed.data.name,
+      color_from: parsed.data.color_from,
+      color_to: parsed.data.color_to,
+    }).returning({
+      id: bannerGradients.id,
+      name: bannerGradients.name,
+      color_from: bannerGradients.color_from,
+      color_to: bannerGradients.color_to,
+      created_at: bannerGradients.created_at,
+    });
+
+    const gradient = rows[0];
+    if (!gradient) {
+      return { success: false, error: "Échec de la création du dégradé" };
+    }
+
+    return { success: true, gradient: gradient as BannerGradient };
+  } catch (error) {
+    console.error("[admin/banners] createBannerGradient error:", error);
+    return { success: false, error: "Erreur lors de la création du dégradé" };
+  }
+}
+
+export async function deleteBannerGradient(id: number): Promise<ActionResult> {
+  await requireAdmin();
+
+  if (!id || id <= 0) return { success: false, error: "ID de dégradé invalide" };
+
+  try {
+    const db = await getDrizzle();
+    await db.delete(bannerGradients).where(eq(bannerGradients.id, id));
+    return { success: true };
+  } catch (error) {
+    console.error("[admin/banners] deleteBannerGradient error:", error);
+    return { success: false, error: "Erreur lors de la suppression du dégradé" };
+  }
+}
+```
+
+**Step 4: Lancer les tests**
+
+```bash
+npm run test -- --reporter=verbose __tests__/unit/actions/admin-banners.test.ts
+```
+
+Expected: tous les tests passent.
+
+**Step 5: Commit**
+
+```bash
+git add actions/admin/banners.ts "__tests__/unit/actions/admin-banners.test.ts"
+git commit -m "feat(actions): add createBannerGradient and deleteBannerGradient server actions"
+```
+
+---
+
+## Task 4: Composant `BannerPreview`
+
+**Files:**
+- Create: `components/admin/banner-preview.tsx`
+
+**Step 1: Créer le composant**
+
+Créer `components/admin/banner-preview.tsx` :
+
+```tsx
+import Image from "next/image";
+import { cn } from "@/lib/utils";
+import { formatPrice } from "@/lib/utils/format";
+import { getImageUrl } from "@/lib/utils/images";
+import type { BadgeColor } from "@/lib/db/types";
+
+interface BannerPreviewProps {
+  title: string;
+  subtitle: string;
+  badgeText: string;
+  badgeColor: BadgeColor;
+  price: number | null;
+  imageUrl: string | null;
+  bgFrom: string;
+  bgTo: string;
+  ctaText: string;
+}
+
+const badgeColorMap: Record<BadgeColor, string> = {
+  mint: "bg-emerald-500/20 text-emerald-300",
+  red: "bg-red-500/20 text-red-300",
+  orange: "bg-orange-500/20 text-orange-300",
+  blue: "bg-blue-500/20 text-blue-300",
+};
+
+export function BannerPreview({
+  title,
+  subtitle,
+  badgeText,
+  badgeColor,
+  price,
+  imageUrl,
+  bgFrom,
+  bgTo,
+  ctaText,
+}: BannerPreviewProps) {
+  return (
+    <div className="space-y-1">
+      <p className="text-xs text-muted-foreground font-medium uppercase tracking-wide">
+        Prévisualisation
+      </p>
+      <div
+        className="relative h-[170px] overflow-hidden rounded-xl"
+        style={{ background: `linear-gradient(135deg, ${bgFrom}, ${bgTo})` }}
+      >
+        {/* Decorative orbs */}
+        <div className="pointer-events-none absolute -right-10 -top-10 h-32 w-32 rounded-full bg-[#00FF9C]/10 blur-2xl" />
+        <div className="pointer-events-none absolute -bottom-8 -left-8 h-24 w-24 rounded-full bg-white/5 blur-xl" />
+
+        <div className="grid h-full grid-cols-2 items-center gap-2 px-3 py-3">
+          {/* Text glass card */}
+          <div className="rounded-lg border border-white/20 bg-white/10 p-2 shadow-xl backdrop-blur-xl">
+            {badgeText && (
+              <span
+                className={cn(
+                  "mb-1 inline-block rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
+                  badgeColorMap[badgeColor]
+                )}
+              >
+                {badgeText}
+              </span>
+            )}
+            <p className="text-xs font-bold leading-tight text-white line-clamp-2">
+              {title || "Titre de la bannière"}
+            </p>
+            {subtitle && (
+              <p className="mt-0.5 text-[10px] text-white/70 line-clamp-1">
+                {subtitle}
+              </p>
+            )}
+            {price != null && (
+              <p className="mt-0.5 text-[10px] font-semibold text-emerald-300">
+                {formatPrice(price)}
+              </p>
+            )}
+            <span
+              className="mt-1 inline-block rounded-full bg-white px-2 py-0.5 text-[10px] font-semibold"
+              style={{ color: bgFrom }}
+            >
+              {ctaText || "Découvrir"}
+            </span>
+          </div>
+
+          {/* Product image */}
+          {imageUrl ? (
+            <div className="relative h-[120px] w-full">
+              <Image
+                src={getImageUrl(imageUrl)}
+                alt={title}
+                fill
+                className="object-contain"
+                sizes="100px"
+              />
+            </div>
+          ) : (
+            <div className="flex h-[120px] items-center justify-center rounded-lg border border-white/10 bg-white/5">
+              <span className="text-[10px] text-white/40">Image produit</span>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+**Step 2: Vérifier la compilation**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+**Step 3: Commit**
+
+```bash
+git add components/admin/banner-preview.tsx
+git commit -m "feat(admin): add BannerPreview component for live banner rendering"
+```
+
+---
+
+## Task 5: Composant `GradientPicker`
+
+**Files:**
+- Create: `components/admin/gradient-picker.tsx`
+
+**Step 1: Créer le composant**
+
+Créer `components/admin/gradient-picker.tsx` :
+
+```tsx
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { createBannerGradient, deleteBannerGradient } from "@/actions/admin/banners";
+import type { BannerGradient } from "@/lib/db/types";
+
+interface GradientPickerProps {
+  colorFrom: string;
+  colorTo: string;
+  savedGradients: BannerGradient[];
+  onChange: (from: string, to: string) => void;
+  onGradientSaved: (gradient: BannerGradient) => void;
+  onGradientDeleted: (id: number) => void;
+}
+
+const BUILTIN_PRESETS = [
+  { label: "Navy", from: "#183C78", to: "#1E4A8F" },
+  { label: "Violet", from: "#7C3AED", to: "#EC4899" },
+  { label: "Vert tropical", from: "#059669", to: "#0891B2" },
+  { label: "Orange feu", from: "#EA580C", to: "#DC2626" },
+  { label: "Nuit", from: "#111827", to: "#374151" },
+  { label: "Menthe", from: "#00C47A", to: "#183C78" },
+] as const;
+
+export function GradientPicker({
+  colorFrom,
+  colorTo,
+  savedGradients,
+  onChange,
+  onGradientSaved,
+  onGradientDeleted,
+}: GradientPickerProps) {
+  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const [gradientName, setGradientName] = useState("");
+  const [isSaving, startSaveTransition] = useTransition();
+  const [isDeleting, startDeleteTransition] = useTransition();
+
+  function isActive(from: string, to: string) {
+    return colorFrom.toLowerCase() === from.toLowerCase() &&
+      colorTo.toLowerCase() === to.toLowerCase();
+  }
+
+  function handleSave() {
+    startSaveTransition(async () => {
+      const result = await createBannerGradient({
+        name: gradientName.trim(),
+        color_from: colorFrom,
+        color_to: colorTo,
+      });
+      if (result.success && result.gradient) {
+        onGradientSaved(result.gradient);
+        toast.success("Dégradé sauvegardé");
+        setSaveDialogOpen(false);
+        setGradientName("");
+      } else {
+        toast.error(result.error || "Erreur lors de la sauvegarde");
+      }
+    });
+  }
+
+  function handleDelete(id: number) {
+    startDeleteTransition(async () => {
+      const result = await deleteBannerGradient(id);
+      if (result.success) {
+        onGradientDeleted(id);
+        toast.success("Dégradé supprimé");
+      } else {
+        toast.error(result.error || "Erreur lors de la suppression");
+      }
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Built-in presets */}
+      <div className="space-y-2">
+        <Label>Prédégradés</Label>
+        <div className="grid grid-cols-3 gap-2">
+          {BUILTIN_PRESETS.map((preset) => (
+            <button
+              key={preset.label}
+              type="button"
+              title={preset.label}
+              onClick={() => onChange(preset.from, preset.to)}
+              className={cn(
+                "h-8 w-full rounded-md border-2 transition-all",
+                isActive(preset.from, preset.to)
+                  ? "border-primary ring-2 ring-primary/30"
+                  : "border-transparent hover:border-border"
+              )}
+              style={{
+                background: `linear-gradient(135deg, ${preset.from}, ${preset.to})`,
+              }}
+              aria-label={preset.label}
+              aria-pressed={isActive(preset.from, preset.to)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Saved gradients */}
+      {savedGradients.length > 0 && (
+        <div className="space-y-2">
+          <Label>Mes dégradés</Label>
+          <div className="space-y-1">
+            {savedGradients.map((g) => (
+              <div
+                key={g.id}
+                className="flex items-center gap-2"
+              >
+                <button
+                  type="button"
+                  onClick={() => onChange(g.color_from, g.color_to)}
+                  className={cn(
+                    "h-7 flex-1 rounded border-2 text-left transition-all",
+                    isActive(g.color_from, g.color_to)
+                      ? "border-primary ring-2 ring-primary/30"
+                      : "border-transparent hover:border-border"
+                  )}
+                  style={{
+                    background: `linear-gradient(135deg, ${g.color_from}, ${g.color_to})`,
+                  }}
+                  aria-label={g.name}
+                  aria-pressed={isActive(g.color_from, g.color_to)}
+                />
+                <span className="w-24 truncate text-xs text-muted-foreground">
+                  {g.name}
+                </span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  disabled={isDeleting}
+                  onClick={() => handleDelete(g.id)}
+                  aria-label={`Supprimer ${g.name}`}
+                  className="shrink-0 text-muted-foreground hover:text-destructive"
+                >
+                  ×
+                </Button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Free color pickers */}
+      <div className="space-y-2">
+        <Label>Couleur libre</Label>
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-1">
+            <span className="text-xs text-muted-foreground">Début</span>
+            <input
+              type="color"
+              name="bg_gradient_from"
+              value={colorFrom}
+              onChange={(e) => onChange(e.target.value, colorTo)}
+              className="h-10 w-full cursor-pointer rounded-md border"
+            />
+          </div>
+          <div className="space-y-1">
+            <span className="text-xs text-muted-foreground">Fin</span>
+            <input
+              type="color"
+              name="bg_gradient_to"
+              value={colorTo}
+              onChange={(e) => onChange(colorFrom, e.target.value)}
+              className="h-10 w-full cursor-pointer rounded-md border"
+            />
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="w-full"
+          onClick={() => {
+            setGradientName("");
+            setSaveDialogOpen(true);
+          }}
+        >
+          Sauvegarder ce dégradé
+        </Button>
+      </div>
+
+      {/* Save dialog */}
+      <Dialog open={saveDialogOpen} onOpenChange={setSaveDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Nommer ce dégradé</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div
+              className="h-12 w-full rounded-lg"
+              style={{ background: `linear-gradient(135deg, ${colorFrom}, ${colorTo})` }}
+            />
+            <Input
+              value={gradientName}
+              onChange={(e) => setGradientName(e.target.value)}
+              placeholder="Ex: Violet Coucher de soleil"
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleSave();
+              }}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setSaveDialogOpen(false)}
+            >
+              Annuler
+            </Button>
+            <Button
+              type="button"
+              disabled={isSaving || !gradientName.trim()}
+              onClick={handleSave}
+            >
+              {isSaving ? "Enregistrement..." : "Sauvegarder"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+```
+
+**Step 2: Vérifier la compilation**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+**Step 3: Commit**
+
+```bash
+git add components/admin/gradient-picker.tsx
+git commit -m "feat(admin): add GradientPicker component with presets and save/delete"
+```
+
+---
+
+## Task 6: Refactoriser `BannerForm` + mettre à jour les pages
+
+**Files:**
+- Modify: `components/admin/banner-form.tsx`
+- Modify: `app/(admin)/banners/new/page.tsx`
+- Modify: `app/(admin)/banners/[id]/edit/page.tsx`
+
+**Step 1: Réécrire `BannerForm`**
+
+Remplacer l'intégralité de `components/admin/banner-form.tsx` par :
+
+```tsx
+"use client";
+
+import { useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { BadgeColor, Banner, BannerGradient } from "@/lib/db/types";
+import { getImageUrl } from "@/lib/utils/images";
+import {
+  createBanner,
+  updateBanner,
+  uploadBannerImage,
+  setBannerImageUrl,
+} from "@/actions/admin/banners";
+import dynamic from "next/dynamic";
+import { AiGenerateButton } from "./ai-generate-button";
+import { generateBannerText } from "@/actions/admin/ai";
+import { GradientPicker } from "./gradient-picker";
+import { BannerPreview } from "./banner-preview";
+
+const AiImageDialog = dynamic(() => import("./ai-image-dialog").then((m) => m.AiImageDialog));
+import type { BannerTextResult } from "@/lib/ai/schemas";
+
+interface BannerFormProps {
+  banner?: Banner | null;
+  savedGradients?: BannerGradient[];
+}
+
+export function BannerForm({ banner, savedGradients: initialGradients = [] }: BannerFormProps) {
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+  const isEdit = !!banner;
+  const isActiveRef = useRef<HTMLInputElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Controlled visual state (feeds the live preview)
+  const [title, setTitle] = useState(banner?.title ?? "");
+  const [subtitle, setSubtitle] = useState(banner?.subtitle ?? "");
+  const [ctaText, setCtaText] = useState(banner?.cta_text ?? "Découvrir");
+  const [badgeText, setBadgeText] = useState(banner?.badge_text ?? "");
+  const [badgeColor, setBadgeColor] = useState<BadgeColor>(banner?.badge_color ?? "mint");
+  const [bgFrom, setBgFrom] = useState(banner?.bg_gradient_from ?? "#183C78");
+  const [bgTo, setBgTo] = useState(banner?.bg_gradient_to ?? "#1E4A8F");
+  const [price, setPrice] = useState<string>(banner?.price != null ? String(banner.price) : "");
+  const [imagePreview, setImagePreview] = useState<string | null>(banner?.image_url ?? null);
+
+  // Saved gradients with optimistic updates
+  const [savedGradients, setSavedGradients] = useState<BannerGradient[]>(initialGradients);
+
+  function handleSubmit(formData: FormData) {
+    startTransition(async () => {
+      try {
+        const result = isEdit
+          ? await updateBanner(banner!.id, formData)
+          : await createBanner(formData);
+
+        if (result.success) {
+          toast.success(isEdit ? "Bannière mise à jour" : "Bannière créée");
+          if (!isEdit && result.id) {
+            router.push(`/banners/${result.id}/edit`);
+          }
+        } else {
+          toast.error(result.error || "Une erreur est survenue");
+        }
+      } catch {
+        toast.error("Erreur de connexion au serveur. Veuillez réessayer.");
+      }
+    });
+  }
+
+  function handleImageUpload(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    startTransition(async () => {
+      try {
+        const formData = new FormData();
+        formData.append("file", file);
+        const result = await uploadBannerImage(banner!.id, formData);
+
+        if (result.success) {
+          toast.success("Image mise à jour");
+          setImagePreview(result.url ?? null);
+        } else {
+          toast.error(result.error || "Une erreur est survenue");
+        }
+      } catch {
+        toast.error("Erreur de connexion au serveur. Veuillez réessayer.");
+      }
+    });
+  }
+
+  return (
+    <form action={handleSubmit}>
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="lg:col-span-2 space-y-6">
+          {/* Informations */}
+          <Card>
+            <CardHeader className="flex-row items-center justify-between space-y-0">
+              <CardTitle>Informations</CardTitle>
+              <AiGenerateButton<BannerTextResult>
+                label="Générer les textes"
+                onGenerate={() =>
+                  generateBannerText({ productName: title || undefined })
+                }
+                onResult={(data) => {
+                  setTitle(data.title);
+                  setSubtitle(data.subtitle);
+                  setCtaText(data.ctaText);
+                  setBadgeText(data.badgeText ?? "");
+                }}
+              />
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="title">Titre</Label>
+                <Input
+                  id="title"
+                  name="title"
+                  required
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  placeholder="Ex: PlayStation 5 - Offre spéciale"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="subtitle">Sous-titre</Label>
+                <Textarea
+                  id="subtitle"
+                  name="subtitle"
+                  rows={2}
+                  value={subtitle}
+                  onChange={(e) => setSubtitle(e.target.value)}
+                  placeholder="Description courte de la bannière"
+                />
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="link_url">Lien (URL)</Label>
+                  <Input
+                    id="link_url"
+                    name="link_url"
+                    required
+                    defaultValue={banner?.link_url ?? ""}
+                    placeholder="Ex: /p/playstation-5"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="cta_text">Texte du bouton</Label>
+                  <Input
+                    id="cta_text"
+                    name="cta_text"
+                    value={ctaText}
+                    onChange={(e) => setCtaText(e.target.value)}
+                    placeholder="Découvrir"
+                  />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Apparence */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Apparence</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="badge_text">Texte du badge</Label>
+                  <Input
+                    id="badge_text"
+                    name="badge_text"
+                    value={badgeText}
+                    onChange={(e) => setBadgeText(e.target.value)}
+                    placeholder="Ex: Nouveau, Promo"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="badge_color">Couleur du badge</Label>
+                  <Select
+                    name="badge_color"
+                    value={badgeColor}
+                    onValueChange={(v) => setBadgeColor(v as BadgeColor)}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Choisir..." />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="mint">Vert menthe</SelectItem>
+                      <SelectItem value="red">Rouge</SelectItem>
+                      <SelectItem value="orange">Orange</SelectItem>
+                      <SelectItem value="blue">Bleu</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <GradientPicker
+                colorFrom={bgFrom}
+                colorTo={bgTo}
+                savedGradients={savedGradients}
+                onChange={(from, to) => {
+                  setBgFrom(from);
+                  setBgTo(to);
+                }}
+                onGradientSaved={(g) => setSavedGradients((prev) => [...prev, g])}
+                onGradientDeleted={(id) =>
+                  setSavedGradients((prev) => prev.filter((g) => g.id !== id))
+                }
+              />
+
+              <div className="space-y-2">
+                <Label htmlFor="price">Prix (FCFA)</Label>
+                <Input
+                  id="price"
+                  name="price"
+                  type="number"
+                  min={0}
+                  value={price}
+                  onChange={(e) => setPrice(e.target.value)}
+                  placeholder="Optionnel"
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Image */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Image</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {isEdit ? (
+                <>
+                  {imagePreview && (
+                    <div className="relative aspect-[16/9] w-full overflow-hidden rounded-lg border">
+                      <Image
+                        src={getImageUrl(imagePreview)}
+                        alt={banner?.title ?? "Banner"}
+                        fill
+                        className="object-contain"
+                      />
+                    </div>
+                  )}
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/*"
+                    className="hidden"
+                    onChange={handleImageUpload}
+                  />
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      disabled={isPending}
+                      onClick={() => fileInputRef.current?.click()}
+                    >
+                      {imagePreview ? "Changer l'image" : "Ajouter une image"}
+                    </Button>
+                    <AiImageDialog
+                      onImageGenerated={(url) => {
+                        startTransition(async () => {
+                          const result = await setBannerImageUrl(banner!.id, url);
+                          if (result.success) {
+                            setImagePreview(url);
+                            toast.success("Image IA enregistrée");
+                          } else {
+                            toast.error(result.error || "Erreur lors de l'enregistrement de l'image");
+                          }
+                        });
+                      }}
+                    />
+                  </div>
+                </>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  Enregistrez d&apos;abord la bannière pour ajouter une image.
+                </p>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Programmation */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Programmation</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="starts_at">Date de début</Label>
+                  <input
+                    type="datetime-local"
+                    id="starts_at"
+                    name="starts_at"
+                    defaultValue={banner?.starts_at?.replace(" ", "T").slice(0, 16) ?? ""}
+                    className="border-input bg-background flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="ends_at">Date de fin</Label>
+                  <input
+                    type="datetime-local"
+                    id="ends_at"
+                    name="ends_at"
+                    defaultValue={banner?.ends_at?.replace(" ", "T").slice(0, 16) ?? ""}
+                    className="border-input bg-background flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs"
+                  />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Sidebar */}
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Publication</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex items-center justify-between">
+                <Label>Active</Label>
+                <input
+                  type="hidden"
+                  name="is_active"
+                  ref={isActiveRef}
+                  defaultValue={banner?.is_active ?? 1}
+                />
+                <Switch
+                  defaultChecked={banner ? banner.is_active === 1 : true}
+                  onCheckedChange={(checked) => {
+                    if (isActiveRef.current)
+                      isActiveRef.current.value = checked ? "1" : "0";
+                  }}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="display_order">Ordre d&apos;affichage</Label>
+                <Input
+                  id="display_order"
+                  name="display_order"
+                  type="number"
+                  min={0}
+                  defaultValue={banner?.display_order ?? 0}
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Live preview — sticky */}
+          <div className="lg:sticky lg:top-6">
+            <BannerPreview
+              title={title}
+              subtitle={subtitle}
+              badgeText={badgeText}
+              badgeColor={badgeColor}
+              price={price !== "" ? Number(price) : null}
+              imageUrl={imagePreview}
+              bgFrom={bgFrom}
+              bgTo={bgTo}
+              ctaText={ctaText}
+            />
+          </div>
+
+          <Button type="submit" className="w-full" disabled={isPending}>
+            {isPending
+              ? "Enregistrement..."
+              : isEdit
+                ? "Mettre à jour"
+                : "Créer la bannière"}
+          </Button>
+        </div>
+      </div>
+    </form>
+  );
+}
+```
+
+**Step 2: Mettre à jour `app/(admin)/banners/new/page.tsx`**
+
+```tsx
+import Link from "next/link";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ArrowLeft02Icon } from "@hugeicons/core-free-icons";
+import { Button } from "@/components/ui/button";
+import { AdminPageHeader } from "@/components/admin/admin-page-header";
+import { BannerForm } from "@/components/admin/banner-form";
+import { getSavedGradients } from "@/lib/db/admin/banners";
+
+export default async function NewBannerPage() {
+  const savedGradients = await getSavedGradients();
+
+  return (
+    <div>
+      <AdminPageHeader>
+        <header className="flex items-center gap-3">
+          <Button
+            variant="ghost"
+            size="icon"
+            asChild
+            className="h-11 w-11 shrink-0"
+            aria-label="Retour aux bannières"
+          >
+            <Link href="/banners">
+              <HugeiconsIcon icon={ArrowLeft02Icon} size={20} />
+            </Link>
+          </Button>
+          <div className="min-w-0">
+            <h1 className="text-lg font-bold sm:text-2xl">
+              Nouvelle bannière
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              Créer une bannière
+            </p>
+          </div>
+        </header>
+      </AdminPageHeader>
+      <BannerForm savedGradients={savedGradients} />
+    </div>
+  );
+}
+```
+
+**Step 3: Mettre à jour `app/(admin)/banners/[id]/edit/page.tsx`**
+
+```tsx
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ArrowLeft02Icon } from "@hugeicons/core-free-icons";
+import { Button } from "@/components/ui/button";
+import { AdminPageHeader } from "@/components/admin/admin-page-header";
+import { BannerForm } from "@/components/admin/banner-form";
+import { getBannerById, getSavedGradients } from "@/lib/db/admin/banners";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+export default async function EditBannerPage({ params }: Props) {
+  const { id } = await params;
+  const [banner, savedGradients] = await Promise.all([
+    getBannerById(Number(id)),
+    getSavedGradients(),
+  ]);
+
+  if (!banner) notFound();
+
+  return (
+    <div>
+      <AdminPageHeader>
+        <header className="flex items-center gap-3">
+          <Button
+            variant="ghost"
+            size="icon"
+            asChild
+            className="h-11 w-11 shrink-0"
+            aria-label="Retour aux bannières"
+          >
+            <Link href="/banners">
+              <HugeiconsIcon icon={ArrowLeft02Icon} size={20} />
+            </Link>
+          </Button>
+          <div className="min-w-0">
+            <h1 className="truncate text-lg font-bold sm:text-2xl">
+              {banner.title}
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              Modifier la bannière
+            </p>
+          </div>
+        </header>
+      </AdminPageHeader>
+      <BannerForm banner={banner} savedGradients={savedGradients} />
+    </div>
+  );
+}
+```
+
+**Step 4: Lancer tous les tests**
+
+```bash
+npm run test
+```
+
+Expected: tous les tests passent.
+
+**Step 5: Vérifier la compilation TypeScript et le lint**
+
+```bash
+npx tsc --noEmit && npm run lint
+```
+
+Expected: no errors (1 warning existant sur `ProductBlueprint` est hors scope).
+
+**Step 6: Commit final**
+
+```bash
+git add components/admin/banner-form.tsx "app/(admin)/banners/new/page.tsx" "app/(admin)/banners/[id]/edit/page.tsx"
+git commit -m "feat(admin): refactor BannerForm with live preview, gradient picker and saved presets"
+```
+
+---
+
+## Task 7: Vérification finale
+
+**Step 1: Lancer le serveur de dev et tester manuellement**
+
+```bash
+npm run dev
+```
+
+Ouvrir http://localhost:3000/banners/new
+
+Vérifier :
+- [ ] La prévisualisation se met à jour en tapant le titre
+- [ ] Cliquer un preset met à jour preview + color pickers
+- [ ] Modifier les color pickers met à jour la preview
+- [ ] "Sauvegarder ce dégradé" ouvre le dialog, nommer et sauvegarder fonctionne
+- [ ] Le gradient sauvegardé apparaît dans "Mes dégradés"
+- [ ] Le bouton × supprime le gradient sauvegardé
+- [ ] Le formulaire de création/édition soumet correctement la bannière
+- [ ] L'IA "Générer les textes" met à jour les champs contrôlés
+
+**Step 2: Créer la PR**
+
+```bash
+git push -u origin feat/banner-gradient-preview
+gh pr create --title "feat(admin): banner live preview, gradient presets and saved gradients" \
+  --body "$(cat <<'EOF'
+## Summary
+- Prévisualisation temps réel dans la sidebar sticky du formulaire bannière
+- 6 prédégradés codés en dur sélectionnables en un clic
+- Sauvegarde/suppression de dégradés personnalisés (table D1 `banner_gradients`)
+- `BannerForm` converti en composant contrôlé
+- Nouveaux composants : `BannerPreview`, `GradientPicker`
+- 2 nouvelles Server Actions : `createBannerGradient`, `deleteBannerGradient`
+
+## Test plan
+- [ ] Tests unitaires passent (`npm run test`)
+- [ ] TypeScript compile sans erreur (`npx tsc --noEmit`)
+- [ ] Lint propre (`npm run lint`)
+- [ ] Prévisualisation mise à jour en temps réel sur /banners/new et /banners/[id]/edit
+- [ ] Sauvegarde et suppression de dégradés fonctionnent
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/drizzle/0002_mute_lightspeed.sql
+++ b/drizzle/0002_mute_lightspeed.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `banner_gradients` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`color_from` text NOT NULL,
+	`color_to` text NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL
+);

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,2353 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f67b8dd7-92e2-4289-80a8-8e04f1685ad8",
+  "prevId": "a1f693ae-4a7c-48fa-8983-991f1a3bd7c1",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_account_userId": {
+          "name": "idx_account_userId",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "idx_account_provider": {
+          "name": "idx_account_provider",
+          "columns": [
+            "providerId",
+            "accountId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "addresses": {
+      "name": "addresses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Domicile'"
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "street": {
+          "name": "street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commune": {
+          "name": "commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Abidjan'"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_addresses_user": {
+          "name": "idx_addresses_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "addresses_user_id_user_id_fk": {
+          "name": "addresses_user_id_user_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "addresses_zone_id_delivery_zones_id_fk": {
+          "name": "addresses_zone_id_delivery_zones_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "delivery_zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_audit_log_actor": {
+          "name": "idx_audit_log_actor",
+          "columns": [
+            "actor_id"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_log_action": {
+          "name": "idx_audit_log_action",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_log_created": {
+          "name": "idx_audit_log_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "banner_gradients": {
+      "name": "banner_gradients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_from": {
+          "name": "color_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_to": {
+          "name": "color_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "banners": {
+      "name": "banners",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "badge_text": {
+          "name": "badge_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "badge_color": {
+          "name": "badge_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'mint'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cta_text": {
+          "name": "cta_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Découvrir'"
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bg_gradient_from": {
+          "name": "bg_gradient_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#183C78'"
+        },
+        "bg_gradient_to": {
+          "name": "bg_gradient_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#1E4A8F'"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_banners_active_order": {
+          "name": "idx_banners_active_order",
+          "columns": [
+            "is_active",
+            "display_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "idx_categories_slug": {
+          "name": "idx_categories_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "idx_categories_parent": {
+          "name": "idx_categories_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "categories_parent_id_categories_id_fk": {
+          "name": "categories_parent_id_categories_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "delivery_zones": {
+      "name": "delivery_zones",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commune": {
+          "name": "commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fee": {
+          "name": "fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimated_hours": {
+          "name": "estimated_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 24
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "order_items": {
+      "name": "order_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_name": {
+          "name": "variant_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_order_items_order": {
+          "name": "idx_order_items_order",
+          "columns": [
+            "order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "order_items_order_id_orders_id_fk": {
+          "name": "order_items_order_id_orders_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_items_product_id_products_id_fk": {
+          "name": "order_items_product_id_products_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_items_variant_id_product_variants_id_fk": {
+          "name": "order_items_variant_id_product_variants_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "order_status_history": {
+      "name": "order_status_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_order_status_history_order": {
+          "name": "idx_order_status_history_order",
+          "columns": [
+            "order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "order_status_history_order_id_orders_id_fk": {
+          "name": "order_status_history_order_id_orders_id_fk",
+          "tableFrom": "order_status_history",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "orders": {
+      "name": "orders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_number": {
+          "name": "order_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_fee": {
+          "name": "delivery_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "promo_code_id": {
+          "name": "promo_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivery_address": {
+          "name": "delivery_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_commune": {
+          "name": "delivery_commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_phone": {
+          "name": "delivery_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_instructions": {
+          "name": "delivery_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "estimated_delivery": {
+          "name": "estimated_delivery",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "internal_notes": {
+          "name": "internal_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivery_person_id": {
+          "name": "delivery_person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivery_person_name": {
+          "name": "delivery_person_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preparing_at": {
+          "name": "preparing_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_at": {
+          "name": "shipping_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "returned_at": {
+          "name": "returned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "return_reason": {
+          "name": "return_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "orders_order_number_unique": {
+          "name": "orders_order_number_unique",
+          "columns": [
+            "order_number"
+          ],
+          "isUnique": true
+        },
+        "idx_orders_user": {
+          "name": "idx_orders_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_orders_status": {
+          "name": "idx_orders_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_orders_number": {
+          "name": "idx_orders_number",
+          "columns": [
+            "order_number"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "orders_user_id_user_id_fk": {
+          "name": "orders_user_id_user_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "orders_promo_code_id_promo_codes_id_fk": {
+          "name": "orders_promo_code_id_promo_codes_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "promo_codes",
+          "columnsFrom": [
+            "promo_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product_attributes": {
+      "name": "product_attributes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_product_attributes_product": {
+          "name": "idx_product_attributes_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "product_attributes_product_id_products_id_fk": {
+          "name": "product_attributes_product_id_products_id_fk",
+          "tableFrom": "product_attributes",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product_images": {
+      "name": "product_images",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_product_images_product": {
+          "name": "idx_product_images_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "product_images_product_id_products_id_fk": {
+          "name": "product_images_product_id_products_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product_variants": {
+      "name": "product_variants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compare_price": {
+          "name": "compare_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "product_variants_sku_unique": {
+          "name": "product_variants_sku_unique",
+          "columns": [
+            "sku"
+          ],
+          "isUnique": true
+        },
+        "idx_product_variants_product": {
+          "name": "idx_product_variants_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "product_variants_product_id_products_id_fk": {
+          "name": "product_variants_product_id_products_id_fk",
+          "tableFrom": "product_variants",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "products": {
+      "name": "products",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "short_description": {
+          "name": "short_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_price": {
+          "name": "base_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compare_price": {
+          "name": "compare_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "low_stock_threshold": {
+          "name": "low_stock_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        },
+        "weight_grams": {
+          "name": "weight_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta_title": {
+          "name": "meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "products_slug_unique": {
+          "name": "products_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "products_sku_unique": {
+          "name": "products_sku_unique",
+          "columns": [
+            "sku"
+          ],
+          "isUnique": true
+        },
+        "idx_products_slug": {
+          "name": "idx_products_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "idx_products_category": {
+          "name": "idx_products_category",
+          "columns": [
+            "category_id"
+          ],
+          "isUnique": false
+        },
+        "idx_products_active": {
+          "name": "idx_products_active",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        },
+        "idx_products_featured": {
+          "name": "idx_products_featured",
+          "columns": [
+            "is_featured"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "products_category_id_categories_id_fk": {
+          "name": "products_category_id_categories_id_fk",
+          "tableFrom": "products",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "promo_codes": {
+      "name": "promo_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discount_value": {
+          "name": "discount_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "min_order_amount": {
+          "name": "min_order_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "promo_codes_code_unique": {
+          "name": "promo_codes_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reviews": {
+      "name": "reviews",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_verified_purchase": {
+          "name": "is_verified_purchase",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_reviews_product": {
+          "name": "idx_reviews_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        },
+        "idx_reviews_user": {
+          "name": "idx_reviews_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reviews_product_id_products_id_fk": {
+          "name": "reviews_product_id_products_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_user_id_user_id_fk": {
+          "name": "reviews_user_id_user_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "rating_range": {
+          "name": "rating_range",
+          "value": "\"reviews\".\"rating\" BETWEEN 1 AND 5"
+        }
+      }
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_session_userId": {
+          "name": "idx_session_userId",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'customer'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'customer'"
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'email'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_phone_unique": {
+          "name": "users_phone_unique",
+          "columns": [
+            "phone"
+          ],
+          "isUnique": true
+        },
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "idx_users_phone": {
+          "name": "idx_users_phone",
+          "columns": [
+            "phone"
+          ],
+          "isUnique": false
+        },
+        "idx_users_is_active": {
+          "name": "idx_users_is_active",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wishlist": {
+      "name": "wishlist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "wishlist_user_product_unique": {
+          "name": "wishlist_user_product_unique",
+          "columns": [
+            "user_id",
+            "product_id"
+          ],
+          "isUnique": true
+        },
+        "idx_wishlist_user": {
+          "name": "idx_wishlist_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_wishlist_product": {
+          "name": "idx_wishlist_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wishlist_user_id_user_id_fk": {
+          "name": "wishlist_user_id_user_id_fk",
+          "tableFrom": "wishlist",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wishlist_product_id_products_id_fk": {
+          "name": "wishlist_product_id_products_id_fk",
+          "tableFrom": "wishlist",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1771424867283,
       "tag": "0001_0001_add_banners",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1771928212203,
+      "tag": "0002_mute_lightspeed",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/admin/banners.ts
+++ b/lib/db/admin/banners.ts
@@ -1,7 +1,7 @@
 import { getDrizzle } from "@/lib/db/drizzle";
-import { banners } from "@/lib/db/schema";
+import { banners, bannerGradients } from "@/lib/db/schema";
 import { eq, asc } from "drizzle-orm";
-import type { Banner } from "@/lib/db/types";
+import type { Banner, BannerGradient } from "@/lib/db/types";
 
 export async function getAllBanners(): Promise<Banner[]> {
   const db = await getDrizzle();
@@ -12,4 +12,9 @@ export async function getBannerById(id: number): Promise<Banner | undefined> {
   const db = await getDrizzle();
   const rows = await db.select().from(banners).where(eq(banners.id, id)).limit(1);
   return rows[0] as unknown as Banner | undefined;
+}
+
+export async function getSavedGradients(): Promise<BannerGradient[]> {
+  const db = await getDrizzle();
+  return db.select().from(bannerGradients).orderBy(asc(bannerGradients.id)) as unknown as BannerGradient[];
 }

--- a/lib/db/admin/banners.ts
+++ b/lib/db/admin/banners.ts
@@ -16,5 +16,5 @@ export async function getBannerById(id: number): Promise<Banner | undefined> {
 
 export async function getSavedGradients(): Promise<BannerGradient[]> {
   const db = await getDrizzle();
-  return db.select().from(bannerGradients).orderBy(asc(bannerGradients.id)) as unknown as BannerGradient[];
+  return db.select().from(bannerGradients).orderBy(asc(bannerGradients.id)).limit(50) as unknown as BannerGradient[];
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -370,3 +370,14 @@ export const banners = sqliteTable("banners", {
 }, (table) => [
   index("idx_banners_active_order").on(table.is_active, table.display_order),
 ]);
+
+// =============================================================================
+// Banner Gradients (saved presets)
+// =============================================================================
+export const bannerGradients = sqliteTable("banner_gradients", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  name: text("name").notNull(),
+  color_from: text("color_from").notNull(),
+  color_to: text("color_to").notNull(),
+  created_at: text("created_at").notNull().default(sql`(datetime('now'))`),
+});

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -357,6 +357,14 @@ export interface Banner {
   updated_at: string;
 }
 
+export interface BannerGradient {
+  id: number;
+  name: string;
+  color_from: string;
+  color_to: string;
+  created_at: string;
+}
+
 /** Minimal category option for UI selects — safe to pass across RSC→client boundary. */
 export interface CategoryOption {
   id: string;

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,7 +6,7 @@ initOpenNextCloudflareForDev({ configPath: "wrangler.dev.jsonc" });
 const nextConfig: NextConfig = {
   experimental: {
     inlineCss: true,
-    optimizePackageImports: ["@hugeicons/core-free-icons"],
+    optimizePackageImports: ["@hugeicons/core-free-icons", "@hugeicons/react"],
     serverActions: {
       bodySizeLimit: "6mb",
     },


### PR DESCRIPTION
## Summary

- **Prévisualisation temps réel** : panel sticky dans la sidebar du formulaire bannière, mis à jour instantanément à chaque frappe
- **6 prédégradés intégrés** : Navy, Violet, Vert tropical, Orange feu, Nuit, Menthe — sélectionnables en un clic
- **Sauvegarde de dégradés personnalisés** : nouvelle table D1 `banner_gradients`, partageée entre tous les admins, avec nommage, réutilisation et suppression
- `BannerForm` converti en composant contrôlé ; nouveaux composants `BannerPreview` et `GradientPicker`
- 2 nouvelles Server Actions (`createBannerGradient`, `deleteBannerGradient`) avec validation Zod et couverture TDD complète (45 tests)

## Test Plan

- [ ] `npm run test` — 459 tests passent
- [ ] `npx tsc --noEmit` — zéro erreur TypeScript
- [ ] Ouvrir `/banners/new` — la prévisualisation se met à jour en temps réel (titre, badge, dégradé, prix)
- [ ] Cliquer un prédégradé — les color pickers et la preview changent instantanément
- [ ] Modifier les color pickers librement — la preview suit
- [ ] "Sauvegarder ce dégradé" → nommer → enregistré dans "Mes dégradés"
- [ ] Supprimer un dégradé sauvegardé — disparaît immédiatement (optimistic update)
- [ ] Ouvrir `/banners/[id]/edit` — les valeurs existantes pré-remplissent le formulaire et la preview
- [ ] Soumettre le formulaire — bannière créée/mise à jour avec le bon dégradé

🤖 Generated with [Claude Code](https://claude.com/claude-code)