### PR TITLE
fix(admin): remove AI generation and add inline color picker

### DIFF
--- a/components/admin/banner-form.tsx
+++ b/components/admin/banner-form.tsx
@@ -23,16 +23,9 @@ import {
   createBanner,
   updateBanner,
   uploadBannerImage,
-  setBannerImageUrl,
 } from "@/actions/admin/banners";
-import dynamic from "next/dynamic";
-import type { BannerTextResult } from "@/lib/ai/schemas";
-import { AiGenerateButton } from "./ai-generate-button";
-import { generateBannerText } from "@/actions/admin/ai";
 import { GradientPicker } from "./gradient-picker";
 import { BannerPreview } from "./banner-preview";
-
-const AiImageDialog = dynamic(() => import("./ai-image-dialog").then((m) => m.AiImageDialog));
 
 interface BannerFormProps {
   banner?: Banner | null;
@@ -109,20 +102,8 @@ export function BannerForm({ banner, savedGradients: initialGradients = [] }: Ba
         <div className="lg:col-span-2 space-y-6">
           {/* Informations */}
           <Card>
-            <CardHeader className="flex-row items-center justify-between space-y-0">
+            <CardHeader>
               <CardTitle>Informations</CardTitle>
-              <AiGenerateButton<BannerTextResult>
-                label="Générer les textes"
-                onGenerate={() =>
-                  generateBannerText({ productName: title || undefined })
-                }
-                onResult={(data) => {
-                  setTitle(data.title);
-                  setSubtitle(data.subtitle);
-                  setCtaText(data.ctaText);
-                  setBadgeText(data.badgeText ?? "");
-                }}
-              />
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="space-y-2">
@@ -263,33 +244,14 @@ export function BannerForm({ banner, savedGradients: initialGradients = [] }: Ba
                     className="hidden"
                     onChange={handleImageUpload}
                   />
-                  <div className="flex gap-2">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      disabled={isPending}
-                      onClick={() => fileInputRef.current?.click()}
-                    >
-                      {imagePreview ? "Changer l'image" : "Ajouter une image"}
-                    </Button>
-                    <AiImageDialog
-                      onImageGenerated={(url) => {
-                        startTransition(async () => {
-                          try {
-                            const result = await setBannerImageUrl(banner!.id, url);
-                            if (result.success) {
-                              setImagePreview(url);
-                              toast.success("Image IA enregistrée");
-                            } else {
-                              toast.error(result.error || "Erreur lors de l'enregistrement de l'image");
-                            }
-                          } catch {
-                            toast.error("Erreur de connexion au serveur. Veuillez réessayer.");
-                          }
-                        });
-                      }}
-                    />
-                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={isPending}
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    {imagePreview ? "Changer l'image" : "Ajouter une image"}
+                  </Button>
                 </>
               ) : (
                 <p className="text-sm text-muted-foreground">

--- a/components/admin/color-picker.tsx
+++ b/components/admin/color-picker.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Popover as PopoverPrimitive } from "radix-ui";
+import { HexColorPicker, HexColorInput } from "react-colorful";
+import { cn } from "@/lib/utils";
+
+interface ColorPickerProps {
+  id?: string;
+  name?: string;
+  value: string;
+  onChange: (value: string) => void;
+  className?: string;
+}
+
+export function ColorPicker({ id, name, value, onChange, className }: ColorPickerProps) {
+  return (
+    <PopoverPrimitive.Root>
+      {name && <input type="hidden" name={name} value={value} />}
+      <PopoverPrimitive.Trigger asChild>
+        <button
+          type="button"
+          id={id}
+          className={cn(
+            "flex h-10 w-full cursor-pointer items-center gap-2 rounded-md border px-2 hover:bg-accent",
+            className
+          )}
+        >
+          <span
+            className="h-6 w-6 shrink-0 rounded border border-black/10"
+            style={{ backgroundColor: value }}
+          />
+          <span className="font-mono text-sm">{value.toUpperCase()}</span>
+        </button>
+      </PopoverPrimitive.Trigger>
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Content
+          align="start"
+          sideOffset={4}
+          className="z-50 w-[200px] rounded-xl border bg-popover p-3 shadow-lg"
+        >
+          <HexColorPicker
+            color={value}
+            onChange={onChange}
+            style={{ width: "100%" }}
+          />
+          <div className="mt-2 flex items-center gap-1.5">
+            <span className="text-sm text-muted-foreground">#</span>
+            <HexColorInput
+              color={value}
+              onChange={onChange}
+              className="h-8 flex-1 rounded-md border bg-background px-2 text-sm font-mono uppercase focus:outline-none focus:ring-1 focus:ring-ring"
+            />
+          </div>
+          <PopoverPrimitive.Arrow className="fill-border" />
+        </PopoverPrimitive.Content>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
+  );
+}

--- a/components/admin/gradient-picker.tsx
+++ b/components/admin/gradient-picker.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/dialog";
 import { createBannerGradient, deleteBannerGradient } from "@/actions/admin/banners";
 import type { BannerGradient } from "@/lib/db/types";
+import { ColorPicker } from "./color-picker";
 
 interface GradientPickerProps {
   colorFrom: string;
@@ -176,24 +177,20 @@ export function GradientPicker({
         <div className="grid grid-cols-2 gap-3">
           <div className="space-y-1">
             <label htmlFor="color-from" className="text-xs text-muted-foreground">Début</label>
-            <input
+            <ColorPicker
               id="color-from"
-              type="color"
               name="bg_gradient_from"
               value={colorFrom}
-              onChange={(e) => onChange(e.target.value, colorTo)}
-              className="h-10 w-full cursor-pointer rounded-md border"
+              onChange={(v) => onChange(v, colorTo)}
             />
           </div>
           <div className="space-y-1">
             <label htmlFor="color-to" className="text-xs text-muted-foreground">Fin</label>
-            <input
+            <ColorPicker
               id="color-to"
-              type="color"
               name="bg_gradient_to"
               value={colorTo}
-              onChange={(e) => onChange(colorFrom, e.target.value)}
-              className="h-10 w-full cursor-pointer rounded-md border"
+              onChange={(v) => onChange(colorFrom, v)}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- **Remove AI generation** from the banner form: "Générer les textes" button and "Générer une image IA" button
- **Replace OS color picker** (`<input type="color">`) with `react-colorful` rendered inline in a Radix Popover — no more OS system dialog

## Details

**AI removal:**
- Removed `AiGenerateButton`, `generateBannerText`, `AiImageDialog`, `setBannerImageUrl` from `banner-form.tsx`
- Manual input only

**Inline color picker:**
- New reusable `ColorPicker` component (`components/admin/color-picker.tsx`)
- Trigger button shows colored swatch + hex code at all times
- Popover contains HSB picker + editable hex input (react-colorful)
- Hidden `<input name="...">` preserves form submission
- Connects to live preview (gradient updates in real time)

## Test plan
- [x] Banner form loads without AI buttons
- [x] Click color button → popover opens inline (no OS dialog)
- [x] Change color via picker → preview updates live
- [x] Edit hex field → picker and preview update
- [x] 459 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)