### PR TITLE
fix(admin): prevent page-level scroll caused by Radix Switch bubble inputs

### DIFF
--- a/app/(admin)/layout.tsx
+++ b/app/(admin)/layout.tsx
@@ -16,11 +16,11 @@ export default async function AdminLayout({
   return (
     <AdminUserProvider user={session.user as AdminUser}>
     <ViewProvider>
-      <div className="flex min-h-dvh">
+      <div className="flex h-dvh">
         <aside className="sticky top-0 hidden h-dvh w-64 shrink-0 overflow-y-auto border-r bg-sidebar lg:block">
           <Sidebar />
         </aside>
-        <main className="flex-1 h-dvh overflow-x-hidden overflow-y-auto p-4 sm:p-6">{children}</main>
+        <main className="relative flex-1 h-dvh overflow-x-hidden overflow-y-auto p-4 sm:p-6">{children}</main>
         <Toaster richColors position="top-right" />
       </div>
     </ViewProvider>


### PR DESCRIPTION
## Summary

- Radix UI `Switch` injects hidden `position: absolute` checkbox inputs for form integration. Without `position: relative` on `<main>`, these inputs escape the overflow container and anchor to the viewport at their natural flow offset (~1940–1988px deep), inflating `html.scrollHeight` to 2005px and making the entire document scrollable.
- Adding `relative` to `<main>` makes it the containing block — the inputs stay within the scroll area and are properly clipped by `overflow: hidden`.
- Also tightens the outer wrapper from `min-h-dvh` → `h-dvh` to strictly cap the layout at viewport height.

## Test plan

- [ ] Navigate to `/products/[id]/edit` — page should no longer scroll at document level
- [ ] Scroll to bottom of product form — only `<main>` scrolls, no blank area below
- [ ] Verify SectionNav sticky sidebar still works on desktop
- [ ] Verify sticky page header still works while scrolling
- [ ] Check other admin pages (orders, customers, dashboard) still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)