### PR TITLE
fix(admin): fix SectionNav not highlighting SEO and Visibilité sections

### DIFF
--- a/components/admin/section-nav.tsx
+++ b/components/admin/section-nav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 
@@ -17,6 +17,7 @@ interface SectionNavProps {
 
 export function SectionNav({ sections, submitLabel, isPending }: SectionNavProps) {
   const [activeSection, setActiveSection] = useState(sections[0]?.id ?? "");
+  const intersectingRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     const elements = sections
@@ -25,16 +26,23 @@ export function SectionNav({ sections, submitLabel, isPending }: SectionNavProps
 
     if (elements.length === 0) return;
 
+    const scrollContainer = document.querySelector("main");
+
     const observer = new IntersectionObserver(
       (entries) => {
         for (const entry of entries) {
           if (entry.isIntersecting) {
-            setActiveSection(entry.target.id);
-            break;
+            intersectingRef.current.add(entry.target.id);
+          } else {
+            intersectingRef.current.delete(entry.target.id);
           }
         }
+        // Among all visible sections, pick the last one in document order
+        // (the one furthest down = most recently scrolled into view)
+        const last = sections.findLast((s) => intersectingRef.current.has(s.id));
+        if (last) setActiveSection(last.id);
       },
-      { rootMargin: "-80px 0px -60% 0px", threshold: 0 }
+      { root: scrollContainer, rootMargin: "-80px 0px -20% 0px", threshold: 0 }
     );
 
     for (const el of elements) observer.observe(el);
@@ -42,6 +50,7 @@ export function SectionNav({ sections, submitLabel, isPending }: SectionNavProps
   }, [sections]);
 
   function scrollToSection(id: string) {
+    setActiveSection(id);
     const el = document.getElementById(id);
     if (el) {
       el.scrollIntoView({ behavior: "smooth", block: "start" });


### PR DESCRIPTION
## Summary

- At max scroll, SEO appeared at 328px and Visibilité at 604px in the viewport. The `IntersectionObserver` with `rootMargin: "-60%"` capped the active zone at 320px — both sections were permanently outside the zone and never highlighted.
- Use `<main>` as the `IntersectionObserver` root (instead of viewport) for accurate in-container detection.
- Expand the bottom `rootMargin` from `-60%` to `-20%` (zone: 80px → 640px), covering SEO (328px) and Visibilité (604px).
- Track all currently-intersecting sections in a `Set` and pick the **last in document order** (`findLast`) — when multiple sections are simultaneously visible at the bottom, the bottommost one is highlighted, matching scroll intent.
- Clicking a section now immediately highlights it via `setActiveSection(id)`.

## Test plan

- [ ] Scroll slowly from top to bottom — all 8 steps should progressively highlight as they become visible
- [ ] At max scroll: **Visibilité** should be the active step
- [ ] Click **SEO** → SEO highlights immediately and content scrolls to it
- [ ] Click **Visibilité** → Visibilité highlights immediately
- [ ] Scroll back up → steps de-highlight in reverse order correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)