### PR TITLE
fix(seo): fix sitemap 500 error and extend robots.txt AI bot rules

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,6 +1,19 @@
 import type { MetadataRoute } from "next";
 import { SITE_URL } from "@/lib/utils/constants";
 
+const AI_BOTS = [
+  "Amazonbot",
+  "Applebot-Extended",
+  "Bytespider",
+  "CCBot",
+  "ClaudeBot",
+  "Google-Extended",
+  "GPTBot",
+  "meta-externalagent",
+  "OAI-SearchBot",
+  "PerplexityBot",
+];
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
@@ -16,6 +29,7 @@ export default function robots(): MetadataRoute.Robots {
           "/auth/",
         ],
       },
+      ...AI_BOTS.map((bot) => ({ userAgent: bot, disallow: "/" })),
     ],
     sitemap: `${SITE_URL}/sitemap.xml`,
   };

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -52,28 +52,32 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
   ];
 
-  const [categories, products] = await Promise.all([
-    query<{ slug: string; updated_at: string }>(
-      "SELECT slug, updated_at FROM categories WHERE is_active = 1"
-    ),
-    query<{ slug: string; updated_at: string }>(
-      "SELECT slug, updated_at FROM products WHERE is_active = 1"
-    ),
-  ]);
+  try {
+    const [categories, products] = await Promise.all([
+      query<{ slug: string; updated_at: string }>(
+        "SELECT slug, updated_at FROM categories WHERE is_active = 1"
+      ),
+      query<{ slug: string; updated_at: string }>(
+        "SELECT slug, updated_at FROM products WHERE is_active = 1"
+      ),
+    ]);
 
-  const categoryPages: MetadataRoute.Sitemap = categories.map((cat) => ({
-    url: `${SITE_URL}/c/${cat.slug}`,
-    lastModified: new Date(cat.updated_at),
-    changeFrequency: "weekly" as const,
-    priority: 0.8,
-  }));
+    const categoryPages: MetadataRoute.Sitemap = categories.map((cat) => ({
+      url: `${SITE_URL}/c/${cat.slug}`,
+      lastModified: new Date(cat.updated_at),
+      changeFrequency: "weekly" as const,
+      priority: 0.8,
+    }));
 
-  const productPages: MetadataRoute.Sitemap = products.map((product) => ({
-    url: `${SITE_URL}/p/${product.slug}`,
-    lastModified: new Date(product.updated_at),
-    changeFrequency: "weekly" as const,
-    priority: 0.9,
-  }));
+    const productPages: MetadataRoute.Sitemap = products.map((product) => ({
+      url: `${SITE_URL}/p/${product.slug}`,
+      lastModified: new Date(product.updated_at),
+      changeFrequency: "weekly" as const,
+      priority: 0.9,
+    }));
 
-  return [...staticPages, ...categoryPages, ...productPages];
+    return [...staticPages, ...categoryPages, ...productPages];
+  } catch {
+    return staticPages;
+  }
 }


### PR DESCRIPTION
## Problèmes corrigés

### Sitemap (`app/sitemap.ts`)
Le sitemap retournait une erreur HTTP 500 en production, empêchant Google de l'indexer. Cause : une exception non gérée lors des requêtes D1 faisait crasher l'entièreté de la route.

**Fix :** Les requêtes DB sont maintenant dans un `try/catch`. En cas d'échec, le sitemap retourne les pages statiques plutôt qu'une 500.

### robots.txt (`app/robots.ts`)
Le score SEO de 92/100 était causé par "robots.txt is not valid". La source principale de l'erreur est le **Cloudflare Managed robots.txt** (directive `Content-Signal:` non standard injectée par le CDN). Ce point nécessite une action dans le Dashboard Cloudflare (Security > Bots > désactiver Managed robots.txt).

**Fix côté code :** Les règles AI bots (`GPTBot`, `ClaudeBot`, `Google-Extended`, etc.) sont désormais explicitement déclarées dans `app/robots.ts`, de sorte que si le Managed Cloudflare est désactivé, les protections restent en place.

## Action requise hors code
Dans le Cloudflare Dashboard : **Security > Bots > désactiver "Managed robots.txt"** pour supprimer la directive `Content-Signal:` invalide qui fait baisser le score SEO.

## Test plan
- [ ] Vérifier `https://netereka.ci/sitemap.xml` retourne 200 après déploiement
- [ ] Vérifier `https://netereka.ci/robots.txt` contient les règles AI bots
- [ ] Désactiver Cloudflare Managed robots.txt et re-tester avec PageSpeed Insights (SEO devrait passer de 92 → 100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)