### PR TITLE
feat(images): use Cloudflare Image Resizing to fix LCP

### DIFF
--- a/__tests__/unit/cloudflare-image-loader.test.ts
+++ b/__tests__/unit/cloudflare-image-loader.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import cloudflareImageLoader from "@/lib/utils/cloudflare-image-loader";
+
+describe("cloudflareImageLoader", () => {
+  describe("en développement (NODE_ENV=development)", () => {
+    beforeEach(() => {
+      vi.stubEnv("NODE_ENV", "development");
+    });
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it("retourne src inchangé pour une URL absolue", () => {
+      expect(
+        cloudflareImageLoader({
+          src: "https://r2.netereka.ci/products/iphone.jpg",
+          width: 640,
+          quality: 75,
+        })
+      ).toBe("https://r2.netereka.ci/products/iphone.jpg");
+    });
+
+    it("retourne src inchangé pour un chemin relatif", () => {
+      expect(
+        cloudflareImageLoader({ src: "/images/placeholder.webp", width: 40 })
+      ).toBe("/images/placeholder.webp");
+    });
+  });
+
+  describe("en production (NODE_ENV=production)", () => {
+    beforeEach(() => {
+      vi.stubEnv("NODE_ENV", "production");
+    });
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it("génère une URL CF pour une URL R2 absolue", () => {
+      expect(
+        cloudflareImageLoader({
+          src: "https://r2.netereka.ci/products/iphone.jpg",
+          width: 640,
+          quality: 75,
+        })
+      ).toBe(
+        "/cdn-cgi/image/width=640,quality=75,format=auto/https://r2.netereka.ci/products/iphone.jpg"
+      );
+    });
+
+    it("utilise quality=75 par défaut", () => {
+      expect(
+        cloudflareImageLoader({
+          src: "https://r2.netereka.ci/products/img.jpg",
+          width: 320,
+        })
+      ).toBe(
+        "/cdn-cgi/image/width=320,quality=75,format=auto/https://r2.netereka.ci/products/img.jpg"
+      );
+    });
+
+    it("génère une URL CF pour un chemin relatif (supprime le slash initial)", () => {
+      expect(
+        cloudflareImageLoader({
+          src: "/images/placeholder.webp",
+          width: 40,
+          quality: 75,
+        })
+      ).toBe("/cdn-cgi/image/width=40,quality=75,format=auto/images/placeholder.webp");
+    });
+
+    it("respecte la quality passée en paramètre", () => {
+      expect(
+        cloudflareImageLoader({
+          src: "https://r2.netereka.ci/banners/hero.jpg",
+          width: 1200,
+          quality: 90,
+        })
+      ).toBe(
+        "/cdn-cgi/image/width=1200,quality=90,format=auto/https://r2.netereka.ci/banners/hero.jpg"
+      );
+    });
+
+    it("gère les chemins relatifs sans slash initial", () => {
+      expect(
+        cloudflareImageLoader({
+          src: "images/logo.png",
+          width: 140,
+          quality: 75,
+        })
+      ).toBe("/cdn-cgi/image/width=140,quality=75,format=auto/images/logo.png");
+    });
+  });
+});

--- a/docs/plans/2026-02-24-cloudflare-image-loader-design.md
+++ b/docs/plans/2026-02-24-cloudflare-image-loader-design.md
@@ -1,0 +1,41 @@
+# Design — Cloudflare Image Resizing Loader
+
+**Date :** 2026-02-24
+**Contexte :** PageSpeed Insights signale 6 691 KiB d'économies potentielles sur les images. Le LCP atteint 8,4 s sur mobile.
+
+## Diagnostic
+
+`next/image` route les requêtes vers `/_next/image` qui utilise Sharp pour optimiser les images. Sharp ne tourne pas dans le runtime Cloudflare Workers — les images sont donc servies à leur taille d'origine depuis R2, sans redimensionnement ni conversion AVIF/WebP.
+
+## Solution retenue : custom loader Cloudflare Image Resizing
+
+Next.js expose un `loaderFile` : une fonction `(src, width, quality) → url` appliquée à chaque `<Image>`. On génère des URLs `/cdn-cgi/image/...` que Cloudflare intercepte pour :
+- redimensionner au `width` exact demandé par le `sizes` prop
+- convertir en AVIF (si supporté) ou WebP
+- mettre en cache au CDN edge
+
+## Fichiers impactés
+
+| Fichier | Action |
+|---|---|
+| `lib/utils/cloudflare-image-loader.ts` | Nouveau — fonction loader |
+| `next.config.ts` | Modifier — ajouter `loaderFile` |
+
+Aucun composant modifié.
+
+## Format URL généré
+
+```
+/cdn-cgi/image/width={w},quality={q},format=auto/{src}
+```
+
+Exemples :
+- `https://r2.netereka.ci/products/img.jpg` → `/cdn-cgi/image/width=640,quality=75,format=auto/https://r2.netereka.ci/products/img.jpg`
+- `/images/placeholder.webp` → `/cdn-cgi/image/width=40,quality=75,format=auto/images/placeholder.webp`
+
+## Comportement attendu
+
+- LCP image (premier slide hero) : `priority={true}` génère toujours un `<link rel="preload">` avec l'URL CF
+- Toutes les images existantes bénéficient du fix sans re-upload
+- Cache CDN Cloudflare sur les images redimensionnées
+- `sizes` props existants déjà corrects — pas de changement nécessaire

--- a/lib/utils/cloudflare-image-loader.ts
+++ b/lib/utils/cloudflare-image-loader.ts
@@ -1,0 +1,17 @@
+export default function cloudflareImageLoader({
+  src,
+  width,
+  quality,
+}: {
+  src: string;
+  width: number;
+  quality?: number;
+}): string {
+  if (process.env.NODE_ENV === "development") {
+    return src;
+  }
+
+  const params = `width=${width},quality=${quality ?? 75},format=auto`;
+  const path = src.startsWith("/") ? src.slice(1) : src;
+  return `/cdn-cgi/image/${params}/${path}`;
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -12,26 +12,8 @@ const nextConfig: NextConfig = {
     },
   },
   images: {
-    formats: ["image/avif", "image/webp"],
-    minimumCacheTTL: 2592000,
-    remotePatterns: [
-      {
-        protocol: "https",
-        hostname: "*.r2.cloudflarestorage.com",
-      },
-      {
-        protocol: "https",
-        hostname: "netereka.ci",
-      },
-      {
-        protocol: "https",
-        hostname: "*.netereka.ci",
-      },
-      {
-        protocol: "https",
-        hostname: "pub-*.r2.dev",
-      },
-    ],
+    loader: "custom",
+    loaderFile: "./lib/utils/cloudflare-image-loader.ts",
   },
 };
 


### PR DESCRIPTION
## Problème
Next.js `/_next/image` utilise Sharp (binaire natif) qui ne tourne pas dans Cloudflare Workers. Les images étaient servies sans redimensionnement ni conversion, causant ~6,7 MB de gaspillage et un LCP de 8,4 s sur mobile.

## Solution
Custom loader Next.js → URLs `/cdn-cgi/image/width=W,quality=Q,format=auto/src` traitées par Cloudflare Image Resizing à l'edge.

- En **développement** : loader passthrough (src inchangé), aucune dépendance CF locale
- En **production** : toutes les images passent par CF Image Resizing → AVIF/WebP auto, redimensionnement exact au `width` du `sizes` prop

## Fichiers
- `lib/utils/cloudflare-image-loader.ts` — nouveau loader (17 lignes)
- `next.config.ts` — `loaderFile` ajouté, `formats`/`remotePatterns` supprimés (ignorés avec custom loader)
- `__tests__/unit/cloudflare-image-loader.test.ts` — 7 tests couvrant dev/prod, URL absolues, chemins relatifs, quality par défaut

## Impact attendu
- LCP : 8,4 s → < 2,5 s
- Score Performance : 67 → ~85+
- Payload images : ~6 691 KiB de moins par page

## Test plan
- [ ] `npm run build` passe sans erreur ✅
- [ ] 392 tests passent ✅
- [ ] Après déploiement : DevTools Network → images servies depuis `/cdn-cgi/image/...` en AVIF/WebP
- [ ] Re-tester PageSpeed Insights sur netereka.ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)