### PR TITLE
revert(images): restore /_next/image loader — CF Image Resizing quota exhausted

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,8 +12,26 @@ const nextConfig: NextConfig = {
     },
   },
   images: {
-    loader: "custom",
-    loaderFile: "./lib/utils/cloudflare-image-loader.ts",
+    formats: ["image/avif", "image/webp"],
+    minimumCacheTTL: 2592000,
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "*.r2.cloudflarestorage.com",
+      },
+      {
+        protocol: "https",
+        hostname: "netereka.ci",
+      },
+      {
+        protocol: "https",
+        hostname: "*.netereka.ci",
+      },
+      {
+        protocol: "https",
+        hostname: "pub-*.r2.dev",
+      },
+    ],
   },
 };
 


### PR DESCRIPTION
## Pourquoi ce revert

Après déploiement de la PR #97, toutes les images du site retournent :
```
ERROR 9422: Free unique transformations by account has been exhausted
```

Cloudflare Image Resizing a un quota de transformations gratuites qui a été épuisé immédiatement. Le loader `/cdn-cgi/image/` est donc inutilisable en l'état.

## Ce qui est restauré

`next.config.ts` reprend la configuration originale avec `formats`, `minimumCacheTTL` et `remotePatterns`.

## Prochaines étapes

Pour optimiser les images sans ce problème, les options viables sont :
1. **Activer le module payant Cloudflare Image Resizing** (add-on sur le plan Cloudflare) et réactiver le loader PR #97
2. **Optimiser les images à l'upload** (conversion WebP via WASM dans le Server Action)
3. **Cloudflare Images** (produit distinct, $5/mois, 100K images)

🤖 Generated with [Claude Code](https://claude.com/claude-code)