### PR TITLE
feat(images): re-enable Cloudflare Image Resizing loader

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,26 +12,8 @@ const nextConfig: NextConfig = {
     },
   },
   images: {
-    formats: ["image/avif", "image/webp"],
-    minimumCacheTTL: 2592000,
-    remotePatterns: [
-      {
-        protocol: "https",
-        hostname: "*.r2.cloudflarestorage.com",
-      },
-      {
-        protocol: "https",
-        hostname: "netereka.ci",
-      },
-      {
-        protocol: "https",
-        hostname: "*.netereka.ci",
-      },
-      {
-        protocol: "https",
-        hostname: "pub-*.r2.dev",
-      },
-    ],
+    loader: "custom",
+    loaderFile: "./lib/utils/cloudflare-image-loader.ts",
   },
 };
 


### PR DESCRIPTION
## Contexte

Suite à l'activation de Cloudflare Images ($5/mois) sur le compte, le quota de transformations n'est plus un obstacle. Réactivation du custom loader qui avait été revert en urgence (PR #98) après l'erreur 9422.

## Changement

- `next.config.ts` : `loader: "custom"`, `loaderFile: "./lib/utils/cloudflare-image-loader.ts"` — suppression de `formats`/`remotePatterns` (ignorés avec un custom loader)

Le fichier loader (`lib/utils/cloudflare-image-loader.ts`) et ses 7 tests étaient déjà présents depuis PR #97.

## Impact attendu

- Toutes les images servies via `/cdn-cgi/image/width=W,quality=75,format=auto/...`
- AVIF/WebP automatique selon le navigateur
- Redimensionnement au `width` exact demandé par le `sizes` prop
- LCP : de ~4s actuellement vers < 2.5s cible

## Test plan

- [x] 7 tests unitaires passent
- [x] `npm run build` OK
- [ ] En prod : images servies depuis `/cdn-cgi/image/...` (vérifier DevTools Network)
- [ ] Re-tester PageSpeed Insights sur netereka.ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)