### PR TITLE
feat(security): add HTTP security headers

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,7 +3,24 @@ import { initOpenNextCloudflareForDev } from "@opennextjs/cloudflare";
 
 initOpenNextCloudflareForDev({ configPath: "wrangler.dev.jsonc" });
 
+const securityHeaders = [
+  { key: "Strict-Transport-Security", value: "max-age=31536000; includeSubDomains; preload" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "X-Frame-Options", value: "SAMEORIGIN" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+  { key: "Cross-Origin-Opener-Policy", value: "same-origin-allow-popups" },
+];
+
 const nextConfig: NextConfig = {
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders,
+      },
+    ];
+  },
   experimental: {
     inlineCss: true,
     optimizePackageImports: ["@hugeicons/core-free-icons", "@hugeicons/react"],


### PR DESCRIPTION
## Résumé

- Ajoute 6 headers de sécurité HTTP sur toutes les routes via `next.config.ts` `headers()`
- Headers ajoutés : HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy, COOP

## Headers ajoutés

| Header | Valeur |
|--------|--------|
| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains; preload` |
| `X-Content-Type-Options` | `nosniff` |
| `X-Frame-Options` | `SAMEORIGIN` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` |
| `Cross-Origin-Opener-Policy` | `same-origin-allow-popups` |

Note : COOP = `same-origin-allow-popups` (pas `same-origin`) pour ne pas casser les popups OAuth (Google, Facebook, Apple).

## Impact attendu

- Best Practices PageSpeed : 96 → 100
- Score sécurité renforcé

## Test plan

- [ ] `npm run build` passe sans erreur
- [ ] DevTools Network → réponses HTML contiennent les 6 headers
- [ ] OAuth (Google/Facebook/Apple) fonctionne toujours en prod
- [ ] Re-tester PageSpeed Insights sur netereka.ci

🤖 Generated with [Claude Code](https://claude.com/claude-code)