### PR TITLE
perf(lcp): add server-side preload for hero banner image

### DIFF
--- a/app/(storefront)/page.tsx
+++ b/app/(storefront)/page.tsx
@@ -10,10 +10,18 @@ import {
 } from "@/lib/db/products";
 import type { Banner } from "@/lib/db/types";
 import { getActiveBanners } from "@/lib/db/storefront/banners";
+import { getImageUrl } from "@/lib/utils/images";
 import { CategoryNav } from "@/components/storefront/category-nav";
 import { HeroBanner } from "@/components/storefront/hero-banner";
 import { HorizontalSection } from "@/components/storefront/horizontal-section";
 import { TrustBadges } from "@/components/storefront/trust-badges";
+
+function heroCfSrcSet(src: string): string {
+  const path = src.startsWith("/") ? src.slice(1) : src;
+  return [256, 384, 640, 828, 1080]
+    .map((w) => `/cdn-cgi/image/width=${w},quality=75,format=auto/${path} ${w}w`)
+    .join(", ");
+}
 
 export const metadata: Metadata = {
   alternates: { canonical: "/" },
@@ -51,33 +59,50 @@ export default async function HomePage() {
   const featuredCards = featured.map(toProductCardData);
   const latestCards = latest.map(toProductCardData);
 
+  const firstBannerSrc = activeBanners[0]?.image_url
+    ? getImageUrl(activeBanners[0].image_url)
+    : featuredCards[0]?.image_url
+      ? getImageUrl(featuredCards[0].image_url)
+      : null;
+
   return (
-    <div className="mx-auto max-w-7xl space-y-8 px-4 py-6">
-      <h1 className="sr-only">NETEREKA - Électronique &amp; High-Tech en Côte d&apos;Ivoire</h1>
-      <HeroBanner banners={activeBanners} fallbackProducts={featuredCards.slice(0, 3)} />
-
-      <CategoryNav categories={categories} />
-
-      <HorizontalSection
-        title="Meilleures ventes"
-        products={featuredCards}
-      />
-
-      <HorizontalSection
-        title="Nouveautés"
-        products={latestCards}
-      />
-
-      {categorySections.map(({ category, products }) => (
-        <HorizontalSection
-          key={category.id}
-          title={category.name}
-          href={`/c/${category.slug}`}
-          products={products}
+    <>
+      {firstBannerSrc && (
+        <link
+          rel="preload"
+          as="image"
+          imageSrcSet={heroCfSrcSet(firstBannerSrc)}
+          imageSizes="(max-width: 640px) 44vw, (max-width: 1024px) 45vw, 40vw"
+          fetchPriority="high"
         />
-      ))}
+      )}
+      <div className="mx-auto max-w-7xl space-y-8 px-4 py-6">
+        <h1 className="sr-only">NETEREKA - Électronique &amp; High-Tech en Côte d&apos;Ivoire</h1>
+        <HeroBanner banners={activeBanners} fallbackProducts={featuredCards.slice(0, 3)} />
 
-      <TrustBadges />
-    </div>
+        <CategoryNav categories={categories} />
+
+        <HorizontalSection
+          title="Meilleures ventes"
+          products={featuredCards}
+        />
+
+        <HorizontalSection
+          title="Nouveautés"
+          products={latestCards}
+        />
+
+        {categorySections.map(({ category, products }) => (
+          <HorizontalSection
+            key={category.id}
+            title={category.name}
+            href={`/c/${category.slug}`}
+            products={products}
+          />
+        ))}
+
+        <TrustBadges />
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## Problème

Le custom `loaderFile` Cloudflare (`cloudflare-image-loader.ts`) s'exécute côté client. Next.js ne peut donc pas générer de `<link rel="preload">` dans le `<head>` SSR pour les images prioritaires : le navigateur ne découvre l'image hero qu'après avoir parsé le body et exécuté le bundle JS, causant un LCP de 3.9–5.0s.

## Solution

Dans le Server Component `page.tsx`, on calcule l'URL CF Image Resizing côté serveur (on connaît la formule : `/cdn-cgi/image/width=W,quality=75,format=auto/{src}`) et on émet un `<link rel="preload" as="image" imageSrcSet=...>` que React 19 hisse automatiquement dans `<head>`.

Le navigateur commence à fetcher l'image hero dès la réception du HTML, avant tout JS.

## Changements

- `app/(storefront)/page.tsx` — calcul de `firstBannerSrc`, helper `heroCfSrcSet()`, `<link rel="preload">` conditionnel avec `imageSrcSet` (256w→1080w) et `imageSizes` identiques à ceux du composant `<Image>`

## Impact attendu

- LCP mobile : 3.9–5.0s → < 2.5s (objectif)
- Performance score : 81–90 → 90+

## Test plan

- [ ] `npm run build` passe sans erreur
- [ ] DevTools → Network → vérifier `<link rel="preload" as="image">` dans le head HTML de la homepage
- [ ] DevTools → Network → l'image hero a `Initiator: Other` (preload) et non `Initiator: img`
- [ ] Re-tester PageSpeed Insights sur netereka.ci après déploiement

🤖 Generated with [Claude Code](https://claude.com/claude-code)