### PR TITLE
perf(lcp): HTTP Link preload header for hero banner

### DIFF
--- a/actions/admin/banners.ts
+++ b/actions/admin/banners.ts
@@ -1,17 +1,59 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { eq } from "drizzle-orm";
+import { eq, and, or, isNull, isNotNull, lte, gt, asc } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 import { requireAdmin } from "@/lib/auth/guards";
 import { getDrizzle } from "@/lib/db/drizzle";
 import { banners, bannerGradients } from "@/lib/db/schema";
 import { uploadToR2, deleteFromR2 } from "@/lib/storage/images";
+import { getImageUrl } from "@/lib/utils/images";
+import { getKV } from "@/lib/cloudflare/context";
 import type { ActionResult } from "@/lib/utils";
 import type { BannerGradient } from "@/lib/db/types";
 
 const ALLOWED_IMAGE_EXTENSIONS = new Set(["jpg", "jpeg", "png", "webp", "avif"]);
+const KV_HERO_PRELOAD_KEY = "hero:lcp:preload-url";
+
+// Cache the first active banner's CF image URL in KV so middleware can send a
+// Link: <...>; rel=preload response header — allowing the browser to start the
+// hero image fetch at TTFB (0ms) rather than after downloading ~340KB of HTML.
+async function refreshHeroPreload(): Promise<void> {
+  try {
+    const db = await getDrizzle();
+    const now = new Date().toISOString().replace("T", " ").slice(0, 19);
+
+    const banner = await db.query.banners.findFirst({
+      where: and(
+        eq(banners.is_active, 1),
+        isNotNull(banners.image_url),
+        or(isNull(banners.starts_at), lte(banners.starts_at, now)),
+        or(isNull(banners.ends_at), gt(banners.ends_at, now))
+      ),
+      orderBy: [asc(banners.display_order)],
+      columns: { image_url: true },
+    });
+
+    const kv = await getKV();
+
+    if (!banner?.image_url) {
+      await kv.delete(KV_HERO_PRELOAD_KEY);
+      return;
+    }
+
+    const r2Url = getImageUrl(banner.image_url);
+    const path = r2Url.startsWith("/") ? r2Url.slice(1) : r2Url;
+    const cfUrl = (w: number) => `/cdn-cgi/image/width=${w},quality=75,format=auto/${path}`;
+    const srcset = [256, 384, 640, 828, 1080].map((w) => `${cfUrl(w)} ${w}w`).join(", ");
+    const sizes = "(max-width: 640px) 44vw, (max-width: 1024px) 45vw, 40vw";
+    const linkValue = `<${cfUrl(384)}>; rel=preload; as=image; fetchpriority=high; imagesrcset="${srcset}"; imagesizes="${sizes}"`;
+
+    await kv.put(KV_HERO_PRELOAD_KEY, linkValue);
+  } catch (error) {
+    console.error("[admin/banners] refreshHeroPreload error:", error);
+  }
+}
 
 const bannerSchema = z.object({
   title: z.string().min(1, "Le titre est requis").max(200),
@@ -77,6 +119,7 @@ export async function createBanner(formData: FormData): Promise<ActionResult> {
 
     revalidatePath("/banners");
     revalidatePath("/");
+    await refreshHeroPreload();
     return { success: true, id: String(inserted.id) };
   } catch (error) {
     console.error("[admin/banners] createBanner error:", error);
@@ -131,6 +174,7 @@ export async function updateBanner(
 
     revalidatePath("/banners");
     revalidatePath("/");
+    await refreshHeroPreload();
     return { success: true, id: String(id) };
   } catch (error) {
     console.error("[admin/banners] updateBanner error:", error);
@@ -198,6 +242,7 @@ export async function uploadBannerImage(
 
     revalidatePath("/banners");
     revalidatePath("/");
+    await refreshHeroPreload();
     return { success: true, url };
   } catch (error) {
     console.error("[admin/banners] uploadBannerImage error:", error);
@@ -246,6 +291,7 @@ export async function setBannerImageUrl(
 
     revalidatePath("/banners");
     revalidatePath("/");
+    await refreshHeroPreload();
     return { success: true, url: imageKey };
   } catch (error) {
     console.error("[admin/banners] setBannerImageUrl error:", error);
@@ -277,6 +323,7 @@ export async function toggleBannerActive(id: number): Promise<ActionResult> {
 
     revalidatePath("/banners");
     revalidatePath("/");
+    await refreshHeroPreload();
     return { success: true };
   } catch (error) {
     console.error("[admin/banners] toggleBannerActive error:", error);
@@ -314,6 +361,7 @@ export async function deleteBanner(id: number): Promise<ActionResult> {
 
     revalidatePath("/banners");
     revalidatePath("/");
+    await refreshHeroPreload();
     return { success: true };
   } catch (error) {
     console.error("[admin/banners] deleteBanner error:", error);

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,12 +1,14 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
 
 const PROTECTED_PATHS = ["/account", "/checkout", "/dashboard", "/products", "/orders", "/customers", "/users", "/categories", "/audit-log"];
 const AUTH_PATHS = ["/auth/"];
 const SESSION_COOKIE = "better-auth.session_token";
 const SECURE_SESSION_COOKIE = "__Secure-better-auth.session_token";
+const KV_HERO_PRELOAD_KEY = "hero:lcp:preload-url";
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   const { hostname, pathname } = request.nextUrl;
 
   // Redirect www → apex for SEO canonicalization
@@ -14,6 +16,21 @@ export function middleware(request: NextRequest) {
     const url = request.nextUrl.clone();
     url.hostname = "netereka.ci";
     return NextResponse.redirect(url, 301);
+  }
+
+  // Add Link preload header for homepage LCP — browser starts hero image fetch at TTFB
+  if (pathname === "/") {
+    try {
+      const { env } = await getCloudflareContext();
+      const linkValue = await env.KV.get(KV_HERO_PRELOAD_KEY);
+      if (linkValue) {
+        const response = NextResponse.next();
+        response.headers.set("Link", linkValue);
+        return response;
+      }
+    } catch {
+      // KV unavailable (dev without wrangler bindings) — graceful degradation
+    }
   }
 
   const isAuthPath = AUTH_PATHS.some((p) => pathname.startsWith(p));
@@ -40,6 +57,7 @@ export function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
+    "/",
     "/account/:path*",
     "/checkout/:path*",
     "/auth/:path*",


### PR DESCRIPTION
## Problem

The hero banner `<img>` tag appears at byte ~340K in the HTML (after 190KB of React RSC `<script>` payload). On throttled 4G, the browser spends ~1,400ms downloading HTML before it discovers the image. This creates a 1,400ms **Resource Load Delay** that dominates the LCP score.

Previous approaches (JSX `<link rel="preload">` in PR #101, `react-dom`'s `preload()` in PR #102) both place the preload hint at byte ~337K in `<body>` — too late. React's head-hoisting only works during synchronous render in the initial shell; async Server Components with `await` have already missed that window.

## Solution

HTTP `Link: <...>; rel=preload` **response header** — sent with the HTTP response before any HTML is downloaded. The browser starts fetching the hero image at **TTFB (0ms)** instead of at byte 340K (~1,400ms delay).

## Implementation

**`actions/admin/banners.ts`** — `refreshHeroPreload()` helper:
- Queries the first active banner with an image (same date-range conditions as `getActiveBanners()`)
- Builds a complete `Link` header value with `imagesrcset` and `imagesizes` for responsive preload
- Stores it in KV under `hero:lcp:preload-url`
- Called at the end of every banner mutation: `createBanner`, `updateBanner`, `uploadBannerImage`, `setBannerImageUrl`, `toggleBannerActive`, `deleteBanner`

**`middleware.ts`** — homepage preload header:
- Added `"/"` to the matcher
- For homepage requests: reads `hero:lcp:preload-url` from KV, attaches as `Link` response header
- Gracefully degrades (no header) if KV is unavailable (dev environment, first deploy before KV seed)

## After Deploy

Bootstrap the KV value by triggering any banner mutation in the admin, or:
```bash
npx wrangler kv key put --binding KV "hero:lcp:preload-url" '<VALUE>'
```

## Expected Impact

- Resource Load Delay: ~1,400ms → ~0ms
- Field LCP: ~1,780ms → ~350ms (TTFB + render time only)
- Lab LCP: ~4,200ms → significant improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)