### PR TITLE
fix(ci): add --remote flag to KV put in hero LCP seed script

### DIFF
--- a/scripts/seed-hero-preload.js
+++ b/scripts/seed-hero-preload.js
@@ -45,7 +45,7 @@ const linkValue = `<${cfUrl(384)}>; rel=preload; as=image; fetchpriority=high; i
 try {
   execFileSync(
     wrangler,
-    ["kv", "key", "put", "--binding", "KV", "hero:lcp:preload-url", linkValue],
+    ["kv", "key", "put", "--remote", "--binding", "KV", "hero:lcp:preload-url", linkValue],
     { stdio: "inherit" }
   );
   console.log("[seed-hero-preload] KV seeded:", cfUrl(384).slice(0, 80) + "...");


### PR DESCRIPTION
## Bug

The `seed-hero-preload.js` script was writing the hero LCP preload URL to **local ephemeral KV** in CI rather than the **remote production KV namespace**.

Root cause: `wrangler kv key put --binding KV` without `--remote` defaults to local storage. The CI logs showed "Resource location: local / Use --remote if you want to access the remote instance." — confirming the KV write hit local storage (which is discarded when the job ends).

## Fix

Add `--remote` flag to the `wrangler kv key put` command:
```
wrangler kv key put --remote --binding KV hero:lcp:preload-url <value>
```

This ensures the key is written to the production `35fe4cd4dd084a629f0ebe1a795064db` namespace.

## After Merge

The next deploy will correctly seed the KV, and the middleware will return `Link: <...>; rel=preload` on homepage responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)