### PR TITLE
fix(image-loader): revert accidental http/https bypass

### DIFF
--- a/lib/utils/cloudflare-image-loader.ts
+++ b/lib/utils/cloudflare-image-loader.ts
@@ -7,7 +7,7 @@ export default function cloudflareImageLoader({
   width: number;
   quality?: number;
 }): string {
-  if (process.env.NODE_ENV === "development" || src.startsWith("http://") || src.startsWith("https://")) {
+  if (process.env.NODE_ENV === "development") {
     return src;
   }
 


### PR DESCRIPTION
## Summary

- Reverts the accidental `http://`/`https://` bypass in `cloudflare-image-loader.ts` that was mistakenly included in PR #108
- R2 absolute URLs (`https://r2.netereka.ci/...`) must continue to go through Cloudflare Image Resizing
- The OAuth avatar fix (PR #108) correctly uses `unoptimized` on the `<Image>` component instead

## Root cause

The loader change was staged from a failed commit attempt and inadvertently included in the final commit of #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)