### PR TITLE
feat(filters): truncate brand list with expand and inline search

### DIFF
--- a/app/(storefront)/search/brand-filter.tsx
+++ b/app/(storefront)/search/brand-filter.tsx
@@ -25,8 +25,10 @@ export function BrandFilter({ brands, activeBrands, onToggle }: BrandFilterProps
   const collapsedBrands = [...top5, ...activeOutsideTop5];
   const hiddenCount = brands.length - collapsedBrands.length;
 
+  const activeBrandSet = new Set(activeBrands);
+  const searchLower = search.toLowerCase();
   const filteredBrands = expanded
-    ? brands.filter((b) => b.toLowerCase().includes(search.toLowerCase()))
+    ? brands.filter((b) => b.toLowerCase().includes(searchLower))
     : collapsedBrands;
 
   const handleExpand = () => {
@@ -77,7 +79,7 @@ export function BrandFilter({ brands, activeBrands, onToggle }: BrandFilterProps
             >
               <input
                 type="checkbox"
-                checked={activeBrands.includes(brand)}
+                checked={activeBrandSet.has(brand)}
                 onChange={() => onToggle(brand)}
                 className="size-3.5 rounded border-input accent-primary focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none"
               />

--- a/app/(storefront)/search/brand-filter.tsx
+++ b/app/(storefront)/search/brand-filter.tsx
@@ -19,10 +19,12 @@ export function BrandFilter({ brands, activeBrands, onToggle }: BrandFilterProps
 
   if (brands.length === 0) return null;
 
-  const top5 = brands.slice(0, INITIAL_VISIBLE);
-  const activeOutsideTop5 = activeBrands.filter((b) => !top5.includes(b));
+  const initialBrands = brands.slice(0, INITIAL_VISIBLE);
+  // Always show active brands that fall outside the first INITIAL_VISIBLE, so
+  // users can see and deselect their selections even while the list is collapsed.
+  const activeOutsideInitial = activeBrands.filter((b) => !initialBrands.includes(b));
 
-  const collapsedBrands = [...top5, ...activeOutsideTop5];
+  const collapsedBrands = [...initialBrands, ...activeOutsideInitial];
   const hiddenCount = brands.length - collapsedBrands.length;
 
   const activeBrandSet = new Set(activeBrands);
@@ -33,7 +35,8 @@ export function BrandFilter({ brands, activeBrands, onToggle }: BrandFilterProps
 
   const handleExpand = () => {
     setExpanded(true);
-    // Focus l'input après le rendu
+    // The input is conditionally mounted; setTimeout defers focus until after
+    // React has flushed the new render into the DOM (ref is null before that).
     setTimeout(() => searchRef.current?.focus(), 0);
   };
 
@@ -48,7 +51,6 @@ export function BrandFilter({ brands, activeBrands, onToggle }: BrandFilterProps
         Marque
       </legend>
 
-      {/* Input de recherche (visible uniquement déplié) */}
       {expanded && (
         <div className="relative mb-2">
           <HugeiconsIcon
@@ -69,7 +71,6 @@ export function BrandFilter({ brands, activeBrands, onToggle }: BrandFilterProps
         </div>
       )}
 
-      {/* Liste des marques */}
       <div className="space-y-1">
         {filteredBrands.length > 0 ? (
           filteredBrands.map((brand) => (
@@ -91,7 +92,6 @@ export function BrandFilter({ brands, activeBrands, onToggle }: BrandFilterProps
         )}
       </div>
 
-      {/* Bouton expand / collapse */}
       {!expanded && hiddenCount > 0 && (
         <button
           type="button"

--- a/app/(storefront)/search/brand-filter.tsx
+++ b/app/(storefront)/search/brand-filter.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Search01Icon } from "@hugeicons/core-free-icons";
+
+const INITIAL_VISIBLE = 5;
+
+interface BrandFilterProps {
+  brands: string[];
+  activeBrands: string[];
+  onToggle: (brand: string) => void;
+}
+
+export function BrandFilter({ brands, activeBrands, onToggle }: BrandFilterProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [search, setSearch] = useState("");
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  if (brands.length === 0) return null;
+
+  const top5 = brands.slice(0, INITIAL_VISIBLE);
+  const activeOutsideTop5 = activeBrands.filter((b) => !top5.includes(b));
+
+  const collapsedBrands = [...top5, ...activeOutsideTop5];
+  const hiddenCount = brands.length - collapsedBrands.length;
+
+  const filteredBrands = expanded
+    ? brands.filter((b) => b.toLowerCase().includes(search.toLowerCase()))
+    : collapsedBrands;
+
+  const handleExpand = () => {
+    setExpanded(true);
+    // Focus l'input après le rendu
+    setTimeout(() => searchRef.current?.focus(), 0);
+  };
+
+  const handleCollapse = () => {
+    setExpanded(false);
+    setSearch("");
+  };
+
+  return (
+    <fieldset>
+      <legend className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        Marque
+      </legend>
+
+      {/* Input de recherche (visible uniquement déplié) */}
+      {expanded && (
+        <div className="relative mb-2">
+          <HugeiconsIcon
+            icon={Search01Icon}
+            size={13}
+            className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <input
+            ref={searchRef}
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Rechercher…"
+            aria-label="Rechercher une marque"
+            className="h-8 w-full rounded-md border border-input bg-transparent pl-7 pr-3 text-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+          />
+        </div>
+      )}
+
+      {/* Liste des marques */}
+      <div className="space-y-1">
+        {filteredBrands.length > 0 ? (
+          filteredBrands.map((brand) => (
+            <label
+              key={brand}
+              className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted"
+            >
+              <input
+                type="checkbox"
+                checked={activeBrands.includes(brand)}
+                onChange={() => onToggle(brand)}
+                className="size-3.5 rounded border-input accent-primary focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none"
+              />
+              {brand}
+            </label>
+          ))
+        ) : (
+          <p className="px-2 py-1.5 text-xs text-muted-foreground">Aucune marque trouvée</p>
+        )}
+      </div>
+
+      {/* Bouton expand / collapse */}
+      {!expanded && hiddenCount > 0 && (
+        <button
+          type="button"
+          onClick={handleExpand}
+          className="mt-1.5 px-2 text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+        >
+          + {hiddenCount} marque{hiddenCount > 1 ? "s" : ""}
+        </button>
+      )}
+      {expanded && (
+        <button
+          type="button"
+          onClick={handleCollapse}
+          className="mt-1.5 px-2 text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+        >
+          Voir moins
+        </button>
+      )}
+    </fieldset>
+  );
+}

--- a/app/(storefront)/search/brand-filter.tsx
+++ b/app/(storefront)/search/brand-filter.tsx
@@ -6,6 +6,9 @@ import { Search01Icon } from "@hugeicons/core-free-icons";
 
 const INITIAL_VISIBLE = 5;
 
+const toggleBtnClass =
+  "mt-1.5 px-2 text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30";
+
 interface BrandFilterProps {
   brands: string[];
   activeBrands: string[];
@@ -20,11 +23,13 @@ export function BrandFilter({ brands, activeBrands, onToggle }: BrandFilterProps
   if (brands.length === 0) return null;
 
   const initialBrands = brands.slice(0, INITIAL_VISIBLE);
+  const initialBrandSet = new Set(initialBrands);
   // Always show active brands that fall outside the first INITIAL_VISIBLE, so
   // users can see and deselect their selections even while the list is collapsed.
-  const activeOutsideInitial = activeBrands.filter((b) => !initialBrands.includes(b));
-
-  const collapsedBrands = [...initialBrands, ...activeOutsideInitial];
+  const collapsedBrands = [
+    ...initialBrands,
+    ...activeBrands.filter((b) => !initialBrandSet.has(b)),
+  ];
   const hiddenCount = brands.length - collapsedBrands.length;
 
   const activeBrandSet = new Set(activeBrands);
@@ -33,17 +38,16 @@ export function BrandFilter({ brands, activeBrands, onToggle }: BrandFilterProps
     ? brands.filter((b) => b.toLowerCase().includes(searchLower))
     : collapsedBrands;
 
-  const handleExpand = () => {
+  function handleExpand(): void {
     setExpanded(true);
-    // The input is conditionally mounted; setTimeout defers focus until after
-    // React has flushed the new render into the DOM (ref is null before that).
+    // Defer focus until React flushes the search input into the DOM.
     setTimeout(() => searchRef.current?.focus(), 0);
-  };
+  }
 
-  const handleCollapse = () => {
+  function handleCollapse(): void {
     setExpanded(false);
     setSearch("");
-  };
+  }
 
   return (
     <fieldset>
@@ -93,20 +97,12 @@ export function BrandFilter({ brands, activeBrands, onToggle }: BrandFilterProps
       </div>
 
       {!expanded && hiddenCount > 0 && (
-        <button
-          type="button"
-          onClick={handleExpand}
-          className="mt-1.5 px-2 text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
-        >
+        <button type="button" onClick={handleExpand} className={toggleBtnClass}>
           + {hiddenCount} marque{hiddenCount > 1 ? "s" : ""}
         </button>
       )}
       {expanded && (
-        <button
-          type="button"
-          onClick={handleCollapse}
-          className="mt-1.5 px-2 text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
-        >
+        <button type="button" onClick={handleCollapse} className={toggleBtnClass}>
           Voir moins
         </button>
       )}

--- a/app/(storefront)/search/search-filters.tsx
+++ b/app/(storefront)/search/search-filters.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input";
 import { formatPrice } from "@/lib/utils/format";
 import { CategorySidebar } from "@/components/storefront/category-sidebar";
 import { useFilterData } from "./filter-context";
+import { BrandFilter } from "./brand-filter";
 
 export function SearchFilters() {
   const { categoryTree, activeCategorySlug, brands, priceRange, basePath } = useFilterData();
@@ -80,29 +81,11 @@ export function SearchFilters() {
       />
 
       {/* Brands */}
-      {brands.length > 0 && (
-        <fieldset>
-          <legend className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-            Marque
-          </legend>
-          <div className="space-y-1">
-            {brands.map((brand) => (
-              <label
-                key={brand}
-                className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted"
-              >
-                <input
-                  type="checkbox"
-                  checked={activeBrands.includes(brand)}
-                  onChange={() => handleBrandToggle(brand)}
-                  className="size-3.5 rounded border-input accent-primary focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none"
-                />
-                {brand}
-              </label>
-            ))}
-          </div>
-        </fieldset>
-      )}
+      <BrandFilter
+        brands={brands}
+        activeBrands={activeBrands}
+        onToggle={handleBrandToggle}
+      />
 
       {/* Price range */}
       <fieldset>

--- a/docs/plans/2026-02-26-brand-filter-design.md
+++ b/docs/plans/2026-02-26-brand-filter-design.md
@@ -1,0 +1,65 @@
+# Design — Filtre marques amélioré
+
+**Date :** 2026-02-26
+**Contexte :** Pages catégorie et recherche — sidebar desktop + bottom sheet mobile
+
+## Problème
+
+La liste des marques dans `SearchFilters` affiche toutes les marques sans limite. Sur des catégories avec de nombreuses marques, cela crée une sidebar très longue et une mauvaise expérience utilisateur.
+
+## Solution
+
+Tronquer la liste à 5 marques par défaut avec un bouton d'expansion qui révèle la liste complète accompagnée d'un input de recherche.
+
+## Comportement détaillé
+
+### État replié (défaut)
+- Affiche les 5 premières marques de la liste en checkboxes
+- Les marques déjà sélectionnées (actives) sont toujours visibles, même si elles sont hors du top 5
+- Si des marques supplémentaires existent → bouton `+ N marques` (N = nombre de marques cachées)
+
+### État déplié
+- Input de recherche auto-focusé pour filtrer la liste par nom (case-insensitive, contains)
+- Toutes les marques sont affichées, filtrées par la saisie
+- Bouton `Voir moins` pour replier (réinitialise aussi le champ de recherche)
+
+## Architecture
+
+### Nouveau composant
+
+`app/(storefront)/search/brand-filter.tsx` — composant client extrait
+
+**Props :**
+```ts
+interface BrandFilterProps {
+  brands: string[];
+  activeBrands: string[];
+  onToggle: (brand: string) => void;
+}
+```
+
+**State local :**
+- `expanded: boolean` — replié par défaut
+- `search: string` — vide par défaut
+
+**Logique `visibleBrands` :**
+- Replié : top 5 + actives hors top 5 (dédupliqué)
+- Déplié : toutes les marques filtrées par `search`
+
+### Modification de `SearchFilters`
+
+Remplacer le bloc `<fieldset>` marques existant par `<BrandFilter>` en lui passant `brands`, `activeBrands` et `onToggle`.
+
+## Périmètre
+
+### Inclus
+- Composant `BrandFilter`
+- Modification de `SearchFilters` pour l'utiliser
+
+### Exclus (non touchés)
+- `filter-context.tsx`
+- `active-filters.tsx`
+- `mobile-filter-sheet.tsx`
+- `search-sort.tsx`
+- Logique URL params (inchangée)
+- Page catégorie `app/(storefront)/c/[slug]/page.tsx`


### PR DESCRIPTION
## Summary
- Affiche les 5 premières marques par défaut dans la sidebar filtre
- Les marques actives hors du top 5 restent toujours visibles
- Bouton \"+ N marques\" pour révéler la liste complète avec un input de recherche inline auto-focusé
- Bouton \"Voir moins\" pour replier et réinitialiser la recherche

## Test plan
- [ ] Vérifier sur une catégorie avec > 5 marques : seules 5 s'affichent + bouton \"+ N marques\"
- [ ] Cliquer sur \"+ N marques\" : liste complète + input de recherche focusé
- [ ] Taper dans la recherche : la liste filtre en temps réel
- [ ] Sélectionner une marque hors top 5, replier : la marque reste visible
- [ ] Vérifier sur mobile (bottom sheet) : comportement identique
- [ ] Vérifier sur une catégorie avec ≤ 5 marques : aucun bouton expand affiché

🤖 Generated with [Claude Code](https://claude.com/claude-code)