### PR TITLE
feat(filters): replace price inputs with dual-handle slider + inputs

### DIFF
--- a/app/(storefront)/search/price-filter.tsx
+++ b/app/(storefront)/search/price-filter.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Slider } from "@/components/ui/slider";
+import { Input } from "@/components/ui/input";
+import { formatPrice } from "@/lib/utils/format";
+
+interface PriceFilterProps {
+  priceRange: { min: number; max: number };
+  activeMin: string;
+  activeMax: string;
+  onUpdate: (min: string | null, max: string | null) => void;
+}
+
+function parsePrice(value: string, fallback: number): number {
+  const parsed = parseInt(value, 10);
+  return isNaN(parsed) ? fallback : parsed;
+}
+
+export function PriceFilter({ priceRange, activeMin, activeMax, onUpdate }: PriceFilterProps) {
+  const initMin = parsePrice(activeMin, priceRange.min);
+  const initMax = parsePrice(activeMax, priceRange.max);
+
+  const [localMin, setLocalMin] = useState(initMin);
+  const [localMax, setLocalMax] = useState(initMax);
+  // Separate string state allows free typing in inputs without clamping mid-entry.
+  const [minInput, setMinInput] = useState(String(initMin));
+  const [maxInput, setMaxInput] = useState(String(initMax));
+  // Track last URL values to detect external resets (e.g. "Réinitialiser les filtres").
+  const [prevActive, setPrevActive] = useState({ min: activeMin, max: activeMax });
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  // Sync when URL changes externally without user interaction.
+  // Called during render (not useEffect) to avoid a one-frame flash of stale values.
+  if (prevActive.min !== activeMin || prevActive.max !== activeMax) {
+    const newMin = parsePrice(activeMin, priceRange.min);
+    const newMax = parsePrice(activeMax, priceRange.max);
+    setPrevActive({ min: activeMin, max: activeMax });
+    setLocalMin(newMin);
+    setLocalMax(newMax);
+    setMinInput(String(newMin));
+    setMaxInput(String(newMax));
+  }
+
+  function scheduleUpdate(min: number, max: number) {
+    clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      onUpdate(
+        min !== priceRange.min ? String(min) : null,
+        max !== priceRange.max ? String(max) : null,
+      );
+    }, 500);
+  }
+
+  function handleSliderChange([min, max]: number[]) {
+    setLocalMin(min);
+    setLocalMax(max);
+    setMinInput(String(min));
+    setMaxInput(String(max));
+    scheduleUpdate(min, max);
+  }
+
+  function handleMinBlur() {
+    const clamped = Math.max(priceRange.min, Math.min(parsePrice(minInput, priceRange.min), localMax));
+    setLocalMin(clamped);
+    setMinInput(String(clamped));
+    scheduleUpdate(clamped, localMax);
+  }
+
+  function handleMaxBlur() {
+    const clamped = Math.min(priceRange.max, Math.max(parsePrice(maxInput, priceRange.max), localMin));
+    setLocalMax(clamped);
+    setMaxInput(String(clamped));
+    scheduleUpdate(localMin, clamped);
+  }
+
+  return (
+    <fieldset>
+      <legend className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        Prix
+      </legend>
+      <Slider
+        min={priceRange.min}
+        max={priceRange.max}
+        step={500}
+        value={[localMin, localMax]}
+        onValueChange={handleSliderChange}
+        className="mb-4"
+      />
+      <div className="flex items-center gap-2">
+        <Input
+          type="number"
+          aria-label="Prix minimum"
+          value={minInput}
+          onChange={(e) => setMinInput(e.target.value)}
+          onBlur={handleMinBlur}
+          min={priceRange.min}
+          max={priceRange.max}
+          className="h-8 text-xs"
+        />
+        <span className="shrink-0 text-muted-foreground" aria-hidden="true">—</span>
+        <Input
+          type="number"
+          aria-label="Prix maximum"
+          value={maxInput}
+          onChange={(e) => setMaxInput(e.target.value)}
+          onBlur={handleMaxBlur}
+          min={priceRange.min}
+          max={priceRange.max}
+          className="h-8 text-xs"
+        />
+      </div>
+      <p className="mt-1.5 text-[10px] text-muted-foreground">
+        {formatPrice(priceRange.min)} — {formatPrice(priceRange.max)}
+      </p>
+    </fieldset>
+  );
+}

--- a/app/(storefront)/search/price-filter.tsx
+++ b/app/(storefront)/search/price-filter.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { Slider } from "@/components/ui/slider";
 import { Input } from "@/components/ui/input";
+import { Slider } from "@/components/ui/slider";
 import { formatPrice } from "@/lib/utils/format";
+
+const DEBOUNCE_MS = 500;
 
 interface PriceFilterProps {
   priceRange: { min: number; max: number };
@@ -26,57 +28,59 @@ export function PriceFilter({ priceRange, activeMin, activeMax, onUpdate }: Pric
   // Separate string state allows free typing in inputs without clamping mid-entry.
   const [minInput, setMinInput] = useState(String(initMin));
   const [maxInput, setMaxInput] = useState(String(initMax));
-  // Track last URL values to detect any external change to price params — full resets
+  // Track last URL values to detect external changes — full resets
   // ("Réinitialiser les filtres", "Tout effacer") or individual chip removals.
   const [prevActive, setPrevActive] = useState({ min: activeMin, max: activeMax });
-  // ReturnType<typeof setTimeout> avoids the number vs NodeJS.Timeout environment split.
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  // Applies a min/max pair to all local state at once.
+  function applyValues(min: number, max: number): void {
+    setLocalMin(min);
+    setLocalMax(max);
+    setMinInput(String(min));
+    setMaxInput(String(max));
+  }
 
   // Sync when URL changes externally without user interaction.
   // Called during render (not useEffect) to avoid a one-frame flash of stale values.
   // React's getDerivedStateFromProps replacement pattern: calling setState during render
   // is safe only because the condition prevents re-triggering on the resulting re-render.
   if (prevActive.min !== activeMin || prevActive.max !== activeMax) {
-    const newMin = parsePrice(activeMin, priceRange.min);
-    const newMax = parsePrice(activeMax, priceRange.max);
     setPrevActive({ min: activeMin, max: activeMax });
-    setLocalMin(newMin);
-    setLocalMax(newMax);
-    setMinInput(String(newMin));
-    setMaxInput(String(newMax));
+    applyValues(
+      parsePrice(activeMin, priceRange.min),
+      parsePrice(activeMax, priceRange.max),
+    );
   }
 
-  // Debounces the URL update by 500 ms to avoid pushing a history entry on every
-  // slider tick. Passes null for params at the range boundary so the URL stays clean
+  // Debounces the URL update to avoid pushing a history entry on every slider tick.
+  // Passes null for params at the range boundary so the URL stays clean
   // (e.g., no ?min_price=0 when the range starts at 0).
-  function scheduleUpdate(min: number, max: number) {
+  function scheduleUpdate(min: number, max: number): void {
     clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => {
       onUpdate(
         min !== priceRange.min ? String(min) : null,
         max !== priceRange.max ? String(max) : null,
       );
-    }, 500);
+    }, DEBOUNCE_MS);
   }
 
   useEffect(() => () => clearTimeout(timerRef.current), []);
 
-  function handleSliderChange([min, max]: [number, number]) {
-    setLocalMin(min);
-    setLocalMax(max);
-    setMinInput(String(min));
-    setMaxInput(String(max));
+  function handleSliderChange([min, max]: [number, number]): void {
+    applyValues(min, max);
     scheduleUpdate(min, max);
   }
 
-  function handleMinBlur() {
+  function handleMinBlur(): void {
     const clamped = Math.max(priceRange.min, Math.min(parsePrice(minInput, priceRange.min), localMax));
     setLocalMin(clamped);
     setMinInput(String(clamped));
     scheduleUpdate(clamped, localMax);
   }
 
-  function handleMaxBlur() {
+  function handleMaxBlur(): void {
     const clamped = Math.min(priceRange.max, Math.max(parsePrice(maxInput, priceRange.max), localMin));
     setLocalMax(clamped);
     setMaxInput(String(clamped));

--- a/app/(storefront)/search/price-filter.tsx
+++ b/app/(storefront)/search/price-filter.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Slider } from "@/components/ui/slider";
 import { Input } from "@/components/ui/input";
 import { formatPrice } from "@/lib/utils/format";
@@ -26,12 +26,16 @@ export function PriceFilter({ priceRange, activeMin, activeMax, onUpdate }: Pric
   // Separate string state allows free typing in inputs without clamping mid-entry.
   const [minInput, setMinInput] = useState(String(initMin));
   const [maxInput, setMaxInput] = useState(String(initMax));
-  // Track last URL values to detect external resets (e.g. "Réinitialiser les filtres").
+  // Track last URL values to detect any external change to price params — full resets
+  // ("Réinitialiser les filtres", "Tout effacer") or individual chip removals.
   const [prevActive, setPrevActive] = useState({ min: activeMin, max: activeMax });
+  // ReturnType<typeof setTimeout> avoids the number vs NodeJS.Timeout environment split.
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   // Sync when URL changes externally without user interaction.
   // Called during render (not useEffect) to avoid a one-frame flash of stale values.
+  // React's getDerivedStateFromProps replacement pattern: calling setState during render
+  // is safe only because the condition prevents re-triggering on the resulting re-render.
   if (prevActive.min !== activeMin || prevActive.max !== activeMax) {
     const newMin = parsePrice(activeMin, priceRange.min);
     const newMax = parsePrice(activeMax, priceRange.max);
@@ -42,6 +46,9 @@ export function PriceFilter({ priceRange, activeMin, activeMax, onUpdate }: Pric
     setMaxInput(String(newMax));
   }
 
+  // Debounces the URL update by 500 ms to avoid pushing a history entry on every
+  // slider tick. Passes null for params at the range boundary so the URL stays clean
+  // (e.g., no ?min_price=0 when the range starts at 0).
   function scheduleUpdate(min: number, max: number) {
     clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => {
@@ -52,7 +59,9 @@ export function PriceFilter({ priceRange, activeMin, activeMax, onUpdate }: Pric
     }, 500);
   }
 
-  function handleSliderChange([min, max]: number[]) {
+  useEffect(() => () => clearTimeout(timerRef.current), []);
+
+  function handleSliderChange([min, max]: [number, number]) {
     setLocalMin(min);
     setLocalMax(max);
     setMinInput(String(min));

--- a/app/(storefront)/search/search-filters.tsx
+++ b/app/(storefront)/search/search-filters.tsx
@@ -1,12 +1,11 @@
 "use client";
 
+import { useCallback } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useRef, useState } from "react";
-import { Input } from "@/components/ui/input";
-import { formatPrice } from "@/lib/utils/format";
 import { CategorySidebar } from "@/components/storefront/category-sidebar";
 import { useFilterData } from "./filter-context";
 import { BrandFilter } from "./brand-filter";
+import { PriceFilter } from "./price-filter";
 
 export function SearchFilters() {
   const { categoryTree, activeCategorySlug, brands, priceRange, basePath } = useFilterData();
@@ -16,17 +15,6 @@ export function SearchFilters() {
   const activeBrands = searchParams.get("brand")?.split(",").filter(Boolean) ?? [];
   const activeMinPrice = searchParams.get("min_price") ?? "";
   const activeMaxPrice = searchParams.get("max_price") ?? "";
-
-  const [priceState, setPriceState] = useState({ min: activeMinPrice, max: activeMaxPrice, urlMin: activeMinPrice, urlMax: activeMaxPrice });
-  const priceTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-
-  // Sync local price state when URL changes externally (e.g. "Tout effacer")
-  let { min: minPrice, max: maxPrice } = priceState;
-  if (priceState.urlMin !== activeMinPrice || priceState.urlMax !== activeMaxPrice) {
-    minPrice = activeMinPrice;
-    maxPrice = activeMaxPrice;
-    setPriceState({ min: activeMinPrice, max: activeMaxPrice, urlMin: activeMinPrice, urlMax: activeMaxPrice });
-  }
 
   const updateParams = useCallback(
     (updates: Record<string, string | null>) => {
@@ -49,18 +37,6 @@ export function SearchFilters() {
       ? activeBrands.filter((b) => b !== brand)
       : [...activeBrands, brand];
     updateParams({ brand: next.length > 0 ? next.join(",") : null });
-  };
-
-  const handlePriceChange = (field: "min_price" | "max_price", value: string) => {
-    setPriceState((prev) => ({
-      ...prev,
-      [field === "min_price" ? "min" : "max"]: value,
-    }));
-
-    clearTimeout(priceTimerRef.current);
-    priceTimerRef.current = setTimeout(() => {
-      updateParams({ [field]: value || null });
-    }, 500);
   };
 
   const handleReset = () => {
@@ -88,37 +64,17 @@ export function SearchFilters() {
       />
 
       {/* Price range */}
-      <fieldset>
-        <legend className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-          Prix
-        </legend>
-        <p className="mb-2 text-[10px] text-muted-foreground">
-          {formatPrice(priceRange.min)} — {formatPrice(priceRange.max)}
-        </p>
-        <div className="flex items-center gap-2">
-          <Input
-            type="number"
-            placeholder="Min…"
-            aria-label="Prix minimum"
-            value={minPrice}
-            onChange={(e) => handlePriceChange("min_price", e.target.value)}
-            className="h-8 text-xs"
-          />
-          <span className="text-muted-foreground" aria-hidden="true">—</span>
-          <Input
-            type="number"
-            placeholder="Max…"
-            aria-label="Prix maximum"
-            value={maxPrice}
-            onChange={(e) => handlePriceChange("max_price", e.target.value)}
-            className="h-8 text-xs"
-          />
-        </div>
-      </fieldset>
+      <PriceFilter
+        priceRange={priceRange}
+        activeMin={activeMinPrice}
+        activeMax={activeMaxPrice}
+        onUpdate={(min, max) => updateParams({ min_price: min, max_price: max })}
+      />
 
       {/* Reset */}
       {hasFilters && (
         <button
+          type="button"
           onClick={handleReset}
           className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none"
         >

--- a/components/ui/slider.tsx
+++ b/components/ui/slider.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import * as React from "react"
+import { Slider as SliderPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Slider({
+  className,
+  defaultValue,
+  value,
+  min = 0,
+  max = 100,
+  ...props
+}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+  const _values = React.useMemo(
+    () =>
+      Array.isArray(value)
+        ? value
+        : Array.isArray(defaultValue)
+          ? defaultValue
+          : [min, max],
+    [value, defaultValue, min, max]
+  )
+
+  return (
+    <SliderPrimitive.Root
+      data-slot="slider"
+      defaultValue={defaultValue}
+      value={value}
+      min={min}
+      max={max}
+      className={cn(
+        "data-vertical:min-h-40 relative flex w-full touch-none items-center select-none data-disabled:opacity-50 data-vertical:h-full data-vertical:w-auto data-vertical:flex-col",
+        className
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        data-slot="slider-track"
+        className="bg-muted rounded-md data-horizontal:h-3 data-vertical:w-3 relative grow overflow-hidden data-horizontal:w-full data-vertical:h-full"
+      >
+        <SliderPrimitive.Range
+          data-slot="slider-range"
+          className="bg-primary absolute select-none data-horizontal:h-full data-vertical:w-full"
+        />
+      </SliderPrimitive.Track>
+      {Array.from({ length: _values.length }, (_, index) => (
+        <SliderPrimitive.Thumb
+          data-slot="slider-thumb"
+          key={index}
+          className="border-primary ring-ring/30 size-4 rounded-md border bg-white shadow-sm transition-colors hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden block shrink-0 select-none disabled:pointer-events-none disabled:opacity-50"
+        />
+      ))}
+    </SliderPrimitive.Root>
+  )
+}
+
+export { Slider }

--- a/docs/plans/2026-02-26-price-filter-design.md
+++ b/docs/plans/2026-02-26-price-filter-design.md
@@ -1,0 +1,77 @@
+# Design — Filtre prix combiné (slider + inputs)
+
+**Date :** 2026-02-26
+**Contexte :** Pages catégorie et recherche — sidebar desktop + bottom sheet mobile
+
+## Problème
+
+Le filtre prix actuel utilise deux `<Input type="number">` sans retour visuel. Sur de grandes plages (ex. 5 000 — 850 000 FCFA), l'utilisateur doit deviner les valeurs à saisir.
+
+## Solution
+
+Remplacer les inputs seuls par un slider double poignée (shadcn Slider) accompagné de deux inputs numériques. Le slider donne le ressenti visuel, les inputs permettent la précision.
+
+## UX
+
+```
+Prix
+────
+[━━━●━━━━━━━━━━━●━━]  ← slider double poignée
+[ 15 000 ] — [ 200 000 ]  FCFA
+```
+
+- **Slider → inputs** : déplacer une poignée met à jour l'input correspondant immédiatement, puis déclenche un debounce 500ms pour la mise à jour URL.
+- **Input → slider** : saisir une valeur clamp la valeur à `[priceRange.min, localMax]` ou `[localMin, priceRange.max]`, met à jour le slider, puis debounce URL.
+- Pas de bouton "Appliquer" — tout est live avec debounce (comportement existant conservé).
+- Sync externe : si l'URL change sans interaction utilisateur (ex. "Réinitialiser les filtres"), les valeurs locales se réinitialisent.
+
+## Architecture
+
+### Dépendance à installer
+
+```bash
+npx shadcn@latest add slider
+```
+
+Installe `components/ui/slider.tsx` (Radix `@radix-ui/react-slider`, déjà utilisé par le projet).
+
+### Nouveau composant
+
+`app/(storefront)/search/price-filter.tsx` — composant client extrait
+
+**Props :**
+```ts
+interface PriceFilterProps {
+  priceRange: { min: number; max: number };
+  activeMin: string;  // valeur URL actuelle (ou "")
+  activeMax: string;  // valeur URL actuelle (ou "")
+  onUpdate: (min: string | null, max: string | null) => void;
+}
+```
+
+**State local :**
+- `localMin: number` — valeur courante du min (initialisée depuis activeMin ou priceRange.min)
+- `localMax: number` — valeur courante du max (initialisée depuis activeMax ou priceRange.max)
+
+**Logique de sync externe :**
+Comparer les valeurs locales aux valeurs URL à chaque render. Si différentes (changement externe), réinitialiser le state local. Même pattern que le filtre prix actuel dans `SearchFilters`.
+
+### Modification de `SearchFilters`
+
+- Supprimer le state `priceState` et `priceTimerRef` actuels
+- Supprimer `handlePriceChange`
+- Remplacer le bloc `<fieldset>` prix par `<PriceFilter priceRange={priceRange} activeMin={activeMinPrice} activeMax={activeMaxPrice} onUpdate={(min, max) => updateParams({ min_price: min, max_price: max })} />`
+
+## Périmètre
+
+### Inclus
+- Installation shadcn Slider
+- Composant `PriceFilter`
+- Modification de `SearchFilters` (suppression ancien prix, ajout PriceFilter)
+
+### Exclus (non touchés)
+- `filter-context.tsx`
+- `active-filters.tsx`
+- `mobile-filter-sheet.tsx`
+- `brand-filter.tsx`
+- Pages catégorie et recherche


### PR DESCRIPTION
## Summary
- Installe le composant shadcn Slider (Radix-based, accessible)
- Nouveau composant `PriceFilter` : slider double poignée + deux inputs numériques synchronisés
- Slider → met à jour les inputs immédiatement + debounce URL 500ms
- Inputs → saisie libre sans clamping mid-entry, clamp + sync slider sur blur + debounce URL
- Réinitialisation externe ("Réinitialiser les filtres") correctement synchronisée via render-time state update
- `SearchFilters` nettoyé : suppression du state prix inline, imports inutilisés retirés

## Test plan
- [ ] Déplacer le slider min → l'input min se met à jour immédiatement
- [ ] Déplacer le slider max → l'input max se met à jour immédiatement
- [ ] Saisir une valeur dans l'input min, tabber → le slider se repositionne
- [ ] Saisir une valeur min > max, tabber → clamp à localMax
- [ ] Saisir une valeur max < min, tabber → clamp à localMin
- [ ] Cliquer "Réinitialiser les filtres" → slider et inputs reviennent à priceRange.min/max
- [ ] URL mise à jour après 500ms de debounce (pas immédiatement)
- [ ] Vérifier sur mobile (bottom sheet) : comportement identique
- [ ] Vérifier que les chips de filtre actifs s'affichent correctement

🤖 Generated with [Claude Code](https://claude.com/claude-code)