### PR TITLE
feat(category): show subcategories in sidebar filter on category pages

### DIFF
--- a/components/storefront/category-sidebar.tsx
+++ b/components/storefront/category-sidebar.tsx
@@ -16,6 +16,18 @@ function isActiveOrAncestor(node: SidebarCategoryNode, activeSlug: string): bool
   return node.children.some((child) => isActiveOrAncestor(child, activeSlug));
 }
 
+function findNode(
+  nodes: readonly SidebarCategoryNode[],
+  slug: string
+): SidebarCategoryNode | null {
+  for (const node of nodes) {
+    if (node.slug === slug) return node;
+    const found = findNode(node.children, slug);
+    if (found) return found;
+  }
+  return null;
+}
+
 function CategoryTreeNode({
   node,
   activeCategorySlug,
@@ -79,15 +91,23 @@ export function CategorySidebar({
   categoryTree,
   activeCategorySlug,
 }: CategorySidebarProps) {
-  if (categoryTree.length === 0) return null;
+  const activeNode = activeCategorySlug
+    ? findNode(categoryTree, activeCategorySlug)
+    : null;
+  const subcategories = activeNode?.children ?? [];
+
+  const nodesToRender = subcategories.length > 0 ? subcategories : categoryTree;
+  const label = subcategories.length > 0 ? "Sous-catégories" : "Catégories";
+
+  if (nodesToRender.length === 0) return null;
 
   return (
-    <nav aria-label="Catégories">
+    <nav aria-label={label}>
       <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-        Catégories
+        {label}
       </p>
       <div className="space-y-0.5">
-        {categoryTree.map((node) => (
+        {nodesToRender.map((node) => (
           <CategoryTreeNode
             key={node.id}
             node={node}


### PR DESCRIPTION
## Summary

- Sur une page de catégorie parente, le filtre sidebar affiche maintenant les **sous-catégories** (label "Sous-catégories") au lieu de l'arbre complet
- Repli automatique sur l'arbre complet pour les catégories feuilles (sans enfants) et sur la page de recherche sans catégorie active
- Aucune modification des pages ni du contexte — logique entièrement dans `CategorySidebar`

## Comportement

| Contexte | Avant | Après |
|---|---|---|
| Page catégorie parente (ex: `/c/smartphones`) | Arbre complet "Catégories" | Sous-catégories de Smartphones "Sous-catégories" |
| Page catégorie feuille (sans enfants) | Arbre complet | Arbre complet (inchangé) |
| Page de recherche sans filtre | Arbre complet | Arbre complet (inchangé) |

## Test plan

- [ ] Naviguer vers une catégorie parente → le filtre affiche "Sous-catégories" avec ses enfants
- [ ] Naviguer vers une catégorie feuille → le filtre affiche "Catégories" (arbre complet)
- [ ] Page de recherche `/search` → "Catégories" (arbre complet) inchangé

🤖 Generated with [Claude Code](https://claude.com/claude-code)