### PR TITLE
fix(category): hide category filter on category pages

### DIFF
--- a/app/(storefront)/c/[slug]/page.tsx
+++ b/app/(storefront)/c/[slug]/page.tsx
@@ -6,8 +6,6 @@ import {
   getCategoryBySlug,
   getCategoryAncestors,
   getCategoryDescendantIds,
-  getCategoryTree,
-  minifyCategoryTree,
 } from "@/lib/db/categories";
 import {
   searchProducts,
@@ -75,20 +73,15 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
 export default async function CategoryPage({ params, searchParams }: Props) {
   const { slug } = await params;
   const sp = await searchParams;
-  // Start category tree fetch early (doesn't depend on category.id)
-  const categoryTreePromise = getCategoryTree();
-
   const category = await getCategoryCached(slug);
   if (!category) notFound();
 
   const currentPage = Math.max(1, parseInt(sp.page ?? "1", 10) || 1);
   const limit = 20;
 
-  // Fetch ancestors, descendant IDs in parallel (+ await tree started above)
-  const [ancestors, descendantIds, categoryTree] = await Promise.all([
+  const [ancestors, descendantIds] = await Promise.all([
     getCategoryAncestors(category.id),
     getCategoryDescendantIds(category.id),
-    categoryTreePromise,
   ]);
 
   // Aggregate category IDs: current + all descendants
@@ -122,7 +115,7 @@ export default async function CategoryPage({ params, searchParams }: Props) {
 
   return (
     <FilterProvider
-      categoryTree={minifyCategoryTree(categoryTree)}
+      categoryTree={[]}
       activeCategorySlug={slug}
       brands={brands}
       priceRange={priceRange}

--- a/app/(storefront)/search/search-filters.tsx
+++ b/app/(storefront)/search/search-filters.tsx
@@ -48,13 +48,17 @@ export function SearchFilters() {
 
   const hasFilters = activeBrands.length > 0 || activeMinPrice || activeMaxPrice;
 
+  const isCategoryPage = basePath.startsWith("/c/");
+
   return (
     <div className="space-y-6">
-      {/* Category tree sidebar */}
-      <CategorySidebar
-        categoryTree={categoryTree}
-        activeCategorySlug={activeCategorySlug}
-      />
+      {/* Category tree sidebar — search page only */}
+      {!isCategoryPage && (
+        <CategorySidebar
+          categoryTree={categoryTree}
+          activeCategorySlug={activeCategorySlug}
+        />
+      )}
 
       {/* Brands */}
       <BrandFilter


### PR DESCRIPTION
## Summary

- Le filtre "Catégories" est masqué sur les pages de catégorie (`/c/...`) — il n'y a pas sa place puisque l'utilisateur est déjà dans un contexte de catégorie
- Il reste visible uniquement sur la page de recherche `/search` où il sert à naviguer dans les catégories
- Implémenté via `basePath` déjà disponible dans le `FilterContext`

## Test plan

- [ ] Page de catégorie → le filtre "Catégories" ne s'affiche plus, seuls "Marques" et "Prix" restent
- [ ] Page `/search` → le filtre "Catégories" s'affiche toujours

🤖 Generated with [Claude Code](https://claude.com/claude-code)