### PR TITLE
feat(category): show subcategories as filter on category pages

### DIFF
--- a/app/(storefront)/c/[slug]/page.tsx
+++ b/app/(storefront)/c/[slug]/page.tsx
@@ -6,6 +6,7 @@ import {
   getCategoryBySlug,
   getCategoryAncestors,
   getCategoryDescendantIds,
+  getCategoryChildren,
 } from "@/lib/db/categories";
 import {
   searchProducts,
@@ -79,9 +80,10 @@ export default async function CategoryPage({ params, searchParams }: Props) {
   const currentPage = Math.max(1, parseInt(sp.page ?? "1", 10) || 1);
   const limit = 20;
 
-  const [ancestors, descendantIds] = await Promise.all([
+  const [ancestors, descendantIds, children] = await Promise.all([
     getCategoryAncestors(category.id),
     getCategoryDescendantIds(category.id),
+    getCategoryChildren(category.id),
   ]);
 
   // Aggregate category IDs: current + all descendants
@@ -115,7 +117,7 @@ export default async function CategoryPage({ params, searchParams }: Props) {
 
   return (
     <FilterProvider
-      categoryTree={[]}
+      categoryTree={children.map((c) => ({ id: c.id, slug: c.slug, name: c.name, children: [] }))}
       activeCategorySlug={slug}
       brands={brands}
       priceRange={priceRange}

--- a/app/(storefront)/search/search-filters.tsx
+++ b/app/(storefront)/search/search-filters.tsx
@@ -52,13 +52,12 @@ export function SearchFilters() {
 
   return (
     <div className="space-y-6">
-      {/* Category tree sidebar — search page only */}
-      {!isCategoryPage && (
-        <CategorySidebar
-          categoryTree={categoryTree}
-          activeCategorySlug={activeCategorySlug}
-        />
-      )}
+      {/* Category/subcategory sidebar */}
+      <CategorySidebar
+        categoryTree={categoryTree}
+        activeCategorySlug={activeCategorySlug}
+        label={isCategoryPage ? "Sous-catégories" : "Catégories"}
+      />
 
       {/* Brands */}
       <BrandFilter

--- a/components/storefront/category-sidebar.tsx
+++ b/components/storefront/category-sidebar.tsx
@@ -9,6 +9,7 @@ import type { SidebarCategoryNode } from "@/lib/db/types";
 interface CategorySidebarProps {
   categoryTree: SidebarCategoryNode[];
   activeCategorySlug?: string;
+  label?: string;
 }
 
 function isActiveOrAncestor(node: SidebarCategoryNode, activeSlug: string): boolean {
@@ -78,13 +79,14 @@ function CategoryTreeNode({
 export function CategorySidebar({
   categoryTree,
   activeCategorySlug,
+  label = "Catégories",
 }: CategorySidebarProps) {
   if (categoryTree.length === 0) return null;
 
   return (
-    <nav aria-label="Catégories">
+    <nav aria-label={label}>
       <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-        Catégories
+        {label}
       </p>
       <div className="space-y-0.5">
         {categoryTree.map((node) => (


### PR DESCRIPTION
## Summary

- Sur une page de catégorie parente, le filtre sidebar affiche les **sous-catégories** sous le label "Sous-catégories"
- Si la catégorie n'a pas de sous-catégories (feuille), aucun filtre catégorie n'est affiché
- La page de recherche `/search` affiche toujours l'arbre complet "Catégories"

## Changements

- `CategorySidebar` — prop `label` optionnelle (défaut : "Catégories")
- `SearchFilters` — passe `label="Sous-catégories"` sur les pages `/c/...`
- `c/[slug]/page.tsx` — fetch `getCategoryChildren`, mappés en `SidebarCategoryNode[]` pour le `FilterProvider`

## Test plan

- [ ] Catégorie parente (ex: `/c/informatique`) → filtre "Sous-catégories" visible avec ses enfants
- [ ] Catégorie feuille (sans enfants) → aucun filtre catégorie affiché
- [ ] Page `/search` → "Catégories" (arbre complet) inchangé

🤖 Generated with [Claude Code](https://claude.com/claude-code)