### PR TITLE
fix(category): remove subcategory filter from category pages

### DIFF
--- a/app/(storefront)/c/[slug]/page.tsx
+++ b/app/(storefront)/c/[slug]/page.tsx
@@ -6,7 +6,6 @@ import {
   getCategoryBySlug,
   getCategoryAncestors,
   getCategoryDescendantIds,
-  getCategoryChildren,
 } from "@/lib/db/categories";
 import {
   searchProducts,
@@ -80,10 +79,9 @@ export default async function CategoryPage({ params, searchParams }: Props) {
   const currentPage = Math.max(1, parseInt(sp.page ?? "1", 10) || 1);
   const limit = 20;
 
-  const [ancestors, descendantIds, children] = await Promise.all([
+  const [ancestors, descendantIds] = await Promise.all([
     getCategoryAncestors(category.id),
     getCategoryDescendantIds(category.id),
-    getCategoryChildren(category.id),
   ]);
 
   // Aggregate category IDs: current + all descendants
@@ -117,7 +115,7 @@ export default async function CategoryPage({ params, searchParams }: Props) {
 
   return (
     <FilterProvider
-      categoryTree={children.map((c) => ({ id: c.id, slug: c.slug, name: c.name, children: [] }))}
+      categoryTree={[]}
       activeCategorySlug={slug}
       brands={brands}
       priceRange={priceRange}

--- a/app/(storefront)/search/search-filters.tsx
+++ b/app/(storefront)/search/search-filters.tsx
@@ -52,12 +52,14 @@ export function SearchFilters() {
 
   return (
     <div className="space-y-6">
-      {/* Category/subcategory sidebar */}
-      <CategorySidebar
-        categoryTree={categoryTree}
-        activeCategorySlug={activeCategorySlug}
-        label={isCategoryPage ? "Sous-catégories" : "Catégories"}
-      />
+      {/* Category sidebar — search page only */}
+      {!isCategoryPage && (
+        <CategorySidebar
+          categoryTree={categoryTree}
+          activeCategorySlug={activeCategorySlug}
+          label="Catégories"
+        />
+      )}
 
       {/* Brands */}
       <BrandFilter


### PR DESCRIPTION
## Summary
- Hides the `CategorySidebar` on category pages (`/c/[slug]`) — the subcategory filter is no longer shown in the sidebar or mobile filter sheet
- Removes the `getCategoryChildren` DB call on category pages since the data is no longer needed
- The category filter on the global search page (`/search`) is unaffected

## Test plan
- [ ] Visit a category page (e.g. `/c/smartphones`) — sidebar should show only brand and price filters, no subcategory list
- [ ] Visit `/search` — sidebar should still show the category tree filter
- [ ] Open mobile filter sheet on a category page — no subcategory section

🤖 Generated with [Claude Code](https://claude.com/claude-code)