### PR TITLE
feat(storefront): wishlist button for unauthenticated users with auth dialog

### DIFF
--- a/actions/wishlist.ts
+++ b/actions/wishlist.ts
@@ -30,7 +30,8 @@ export async function toggleWishlist(productId: string): Promise<{ success: bool
     const added = await atomicToggleWishlist(userId, parsed.data);
     revalidatePath("/account/wishlist");
     return { success: true, added };
-  } catch {
+  } catch (err) {
+    console.error("[wishlist] atomicToggleWishlist failed for userId:", userId, "productId:", parsed.data, err);
     return { success: false, added: false };
   }
 }

--- a/actions/wishlist.ts
+++ b/actions/wishlist.ts
@@ -14,6 +14,7 @@ export async function toggleWishlist(productId: string): Promise<{ success: bool
 
   const parsed = productIdSchema.safeParse(productId);
   if (!parsed.success) {
+    console.error("[wishlist] toggleWishlist received invalid productId:", productId);
     return { success: false, added: false };
   }
 
@@ -23,6 +24,7 @@ export async function toggleWishlist(productId: string): Promise<{ success: bool
     [parsed.data]
   );
   if (!product) {
+    console.error("[wishlist] toggleWishlist product not found:", parsed.data);
     return { success: false, added: false };
   }
 

--- a/app/(auth)/auth/sign-in/sign-in-form.tsx
+++ b/app/(auth)/auth/sign-in/sign-in-form.tsx
@@ -37,7 +37,7 @@ const errorTextMessages: Record<string, string> = {
 };
 
 interface SignInFormProps {
-  onSuccess?: () => void;
+  onSuccess?: () => Promise<void>;
 }
 
 export function SignInForm({ onSuccess }: SignInFormProps = {}) {
@@ -86,7 +86,7 @@ export function SignInForm({ onSuccess }: SignInFormProps = {}) {
         );
       } else {
         if (onSuccess) {
-          onSuccess();
+          await onSuccess();
         } else {
           router.push("/");
           router.refresh();

--- a/app/(auth)/auth/sign-in/sign-in-form.tsx
+++ b/app/(auth)/auth/sign-in/sign-in-form.tsx
@@ -36,7 +36,11 @@ const errorTextMessages: Record<string, string> = {
   "Something went wrong": "Une erreur est survenue. Veuillez réessayer.",
 };
 
-export function SignInForm() {
+interface SignInFormProps {
+  onSuccess?: () => void;
+}
+
+export function SignInForm({ onSuccess }: SignInFormProps = {}) {
   const router = useRouter();
   const [captchaKey, setCaptchaKey] = useState(0);
   const [captchaToken, setCaptchaToken] = useState("");
@@ -81,8 +85,12 @@ export function SignInForm() {
             "Une erreur est survenue. Veuillez réessayer."
         );
       } else {
-        router.push("/");
-        router.refresh();
+        if (onSuccess) {
+          onSuccess();
+        } else {
+          router.push("/");
+          router.refresh();
+        }
       }
     } catch (err) {
       console.error("[sign-in] unexpected error during authClient.signIn.email:", err);

--- a/app/(auth)/auth/sign-in/sign-in-form.tsx
+++ b/app/(auth)/auth/sign-in/sign-in-form.tsx
@@ -40,7 +40,7 @@ interface SignInFormProps {
   onSuccess?: () => Promise<void>;
 }
 
-export function SignInForm({ onSuccess }: SignInFormProps = {}) {
+export function SignInForm({ onSuccess }: SignInFormProps) {
   const router = useRouter();
   const [captchaKey, setCaptchaKey] = useState(0);
   const [captchaToken, setCaptchaToken] = useState("");
@@ -84,13 +84,11 @@ export function SignInForm({ onSuccess }: SignInFormProps = {}) {
             errorTextMessages[error.message ?? ""] ??
             "Une erreur est survenue. Veuillez réessayer."
         );
+      } else if (onSuccess) {
+        await onSuccess();
       } else {
-        if (onSuccess) {
-          await onSuccess();
-        } else {
-          router.push("/");
-          router.refresh();
-        }
+        router.push("/");
+        router.refresh();
       }
     } catch (err) {
       console.error("[sign-in] unexpected error during authClient.signIn.email:", err);

--- a/app/(auth)/auth/sign-up/sign-up-form.tsx
+++ b/app/(auth)/auth/sign-up/sign-up-form.tsx
@@ -39,7 +39,7 @@ const errorTextMessages: Record<string, string> = {
 };
 
 interface SignUpFormProps {
-  onSuccess?: () => void;
+  onSuccess?: () => Promise<void>;
 }
 
 export function SignUpForm({ onSuccess }: SignUpFormProps = {}) {
@@ -89,8 +89,11 @@ export function SignUpForm({ onSuccess }: SignUpFormProps = {}) {
             "Une erreur est survenue. Veuillez réessayer."
         );
       } else {
-        onSuccess?.();
-        router.push(`/auth/verify-email?email=${encodeURIComponent(data.email)}`);
+        if (onSuccess) {
+          await onSuccess();
+        } else {
+          router.push(`/auth/verify-email?email=${encodeURIComponent(data.email)}`);
+        }
       }
     } catch (err) {
       console.error("[sign-up] unexpected error during authClient.signUp.email:", err);

--- a/app/(auth)/auth/sign-up/sign-up-form.tsx
+++ b/app/(auth)/auth/sign-up/sign-up-form.tsx
@@ -42,7 +42,7 @@ interface SignUpFormProps {
   onSuccess?: () => Promise<void>;
 }
 
-export function SignUpForm({ onSuccess }: SignUpFormProps = {}) {
+export function SignUpForm({ onSuccess }: SignUpFormProps) {
   const router = useRouter();
   const [captchaKey, setCaptchaKey] = useState(0);
   const [captchaToken, setCaptchaToken] = useState("");
@@ -88,12 +88,10 @@ export function SignUpForm({ onSuccess }: SignUpFormProps = {}) {
             errorTextMessages[error.message ?? ""] ??
             "Une erreur est survenue. Veuillez réessayer."
         );
+      } else if (onSuccess) {
+        await onSuccess();
       } else {
-        if (onSuccess) {
-          await onSuccess();
-        } else {
-          router.push(`/auth/verify-email?email=${encodeURIComponent(data.email)}`);
-        }
+        router.push(`/auth/verify-email?email=${encodeURIComponent(data.email)}`);
       }
     } catch (err) {
       console.error("[sign-up] unexpected error during authClient.signUp.email:", err);

--- a/app/(auth)/auth/sign-up/sign-up-form.tsx
+++ b/app/(auth)/auth/sign-up/sign-up-form.tsx
@@ -38,7 +38,11 @@ const errorTextMessages: Record<string, string> = {
   "Something went wrong": "Une erreur est survenue. Veuillez réessayer.",
 };
 
-export function SignUpForm() {
+interface SignUpFormProps {
+  onSuccess?: () => void;
+}
+
+export function SignUpForm({ onSuccess }: SignUpFormProps = {}) {
   const router = useRouter();
   const [captchaKey, setCaptchaKey] = useState(0);
   const [captchaToken, setCaptchaToken] = useState("");
@@ -85,6 +89,7 @@ export function SignUpForm() {
             "Une erreur est survenue. Veuillez réessayer."
         );
       } else {
+        onSuccess?.();
         router.push(`/auth/verify-email?email=${encodeURIComponent(data.email)}`);
       }
     } catch (err) {

--- a/components/storefront/auth-dialog.tsx
+++ b/components/storefront/auth-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { toast } from "sonner";
+import { isRedirectError } from "next/dist/client/components/redirect-error";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { SignInForm } from "@/app/(auth)/auth/sign-in/sign-in-form";
 import { SignUpForm } from "@/app/(auth)/auth/sign-up/sign-up-form";
@@ -30,18 +31,13 @@ export function AuthDialog({ open, onOpenChange, productId }: Props) {
       if (result.success) {
         toast.success(result.added ? "Ajouté aux favoris" : "Retiré des favoris");
       } else {
-        toast.error("Impossible de mettre à jour les favoris.");
+        console.error("[auth-dialog] toggleWishlist returned success:false for productId:", productId);
+        toast.error("Impossible de mettre à jour les favoris. Réessayez en cliquant à nouveau.");
       }
     } catch (err) {
-      // Re-throw Next.js redirect errors — these must propagate
-      if (
-        err instanceof Error &&
-        typeof (err as { digest?: string }).digest === "string" &&
-        (err as { digest?: string }).digest!.startsWith("NEXT_REDIRECT")
-      ) {
-        throw err;
-      }
-      toast.error("Impossible de mettre à jour les favoris.");
+      if (isRedirectError(err)) throw err;
+      console.error("[auth-dialog] toggleWishlist failed for productId:", productId, err);
+      toast.error("Impossible de mettre à jour les favoris. Réessayez en cliquant à nouveau.");
     }
   }
 

--- a/components/storefront/auth-dialog.tsx
+++ b/components/storefront/auth-dialog.tsx
@@ -18,6 +18,11 @@ type View = "sign-in" | "sign-up";
 export function AuthDialog({ open, onOpenChange, productId }: Props) {
   const [view, setView] = useState<View>("sign-in");
 
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) setView("sign-in");
+    onOpenChange(nextOpen);
+  }
+
   async function handleAuthSuccess() {
     onOpenChange(false);
     try {
@@ -27,13 +32,21 @@ export function AuthDialog({ open, onOpenChange, productId }: Props) {
       } else {
         toast.error("Impossible de mettre à jour les favoris.");
       }
-    } catch {
+    } catch (err) {
+      // Re-throw Next.js redirect errors — these must propagate
+      if (
+        err instanceof Error &&
+        typeof (err as { digest?: string }).digest === "string" &&
+        (err as { digest?: string }).digest!.startsWith("NEXT_REDIRECT")
+      ) {
+        throw err;
+      }
       toast.error("Impossible de mettre à jour les favoris.");
     }
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-sm overflow-y-auto max-h-[90svh]">
         <DialogHeader>
           <DialogTitle className="text-sm font-semibold">

--- a/components/storefront/auth-dialog.tsx
+++ b/components/storefront/auth-dialog.tsx
@@ -8,7 +8,7 @@ import { SignInForm } from "@/app/(auth)/auth/sign-in/sign-in-form";
 import { SignUpForm } from "@/app/(auth)/auth/sign-up/sign-up-form";
 import { toggleWishlist } from "@/actions/wishlist";
 
-interface Props {
+interface AuthDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   productId: string;
@@ -16,7 +16,9 @@ interface Props {
 
 type View = "sign-in" | "sign-up";
 
-export function AuthDialog({ open, onOpenChange, productId }: Props) {
+const WISHLIST_ERROR_MSG = "Impossible de mettre à jour les favoris. Réessayez en cliquant à nouveau.";
+
+export function AuthDialog({ open, onOpenChange, productId }: AuthDialogProps) {
   const [view, setView] = useState<View>("sign-in");
 
   function handleOpenChange(nextOpen: boolean) {
@@ -24,7 +26,7 @@ export function AuthDialog({ open, onOpenChange, productId }: Props) {
     onOpenChange(nextOpen);
   }
 
-  async function handleAuthSuccess() {
+  async function handleAuthSuccess(): Promise<void> {
     onOpenChange(false);
     try {
       const result = await toggleWishlist(productId);
@@ -32,12 +34,12 @@ export function AuthDialog({ open, onOpenChange, productId }: Props) {
         toast.success(result.added ? "Ajouté aux favoris" : "Retiré des favoris");
       } else {
         console.error("[auth-dialog] toggleWishlist returned success:false for productId:", productId);
-        toast.error("Impossible de mettre à jour les favoris. Réessayez en cliquant à nouveau.");
+        toast.error(WISHLIST_ERROR_MSG);
       }
     } catch (err) {
       if (isRedirectError(err)) throw err;
       console.error("[auth-dialog] toggleWishlist failed for productId:", productId, err);
-      toast.error("Impossible de mettre à jour les favoris. Réessayez en cliquant à nouveau.");
+      toast.error(WISHLIST_ERROR_MSG);
     }
   }
 
@@ -53,33 +55,44 @@ export function AuthDialog({ open, onOpenChange, productId }: Props) {
         {view === "sign-in" ? (
           <>
             <SignInForm onSuccess={handleAuthSuccess} />
-            <p className="text-center text-sm text-muted-foreground mt-2">
-              Pas encore de compte ?{" "}
-              <button
-                type="button"
-                className="text-primary hover:underline"
-                onClick={() => setView("sign-up")}
-              >
-                S&apos;inscrire
-              </button>
-            </p>
+            <ViewToggle
+              label="Pas encore de compte ?"
+              actionLabel="S'inscrire"
+              onClick={() => setView("sign-up")}
+            />
           </>
         ) : (
           <>
             <SignUpForm onSuccess={handleAuthSuccess} />
-            <p className="text-center text-sm text-muted-foreground mt-2">
-              Déjà un compte ?{" "}
-              <button
-                type="button"
-                className="text-primary hover:underline"
-                onClick={() => setView("sign-in")}
-              >
-                Se connecter
-              </button>
-            </p>
+            <ViewToggle
+              label="Déjà un compte ?"
+              actionLabel="Se connecter"
+              onClick={() => setView("sign-in")}
+            />
           </>
         )}
       </DialogContent>
     </Dialog>
+  );
+}
+
+interface ViewToggleProps {
+  label: string;
+  actionLabel: string;
+  onClick: () => void;
+}
+
+function ViewToggle({ label, actionLabel, onClick }: ViewToggleProps) {
+  return (
+    <p className="text-center text-sm text-muted-foreground mt-2">
+      {label}{" "}
+      <button
+        type="button"
+        className="text-primary hover:underline"
+        onClick={onClick}
+      >
+        {actionLabel}
+      </button>
+    </p>
   );
 }

--- a/components/storefront/auth-dialog.tsx
+++ b/components/storefront/auth-dialog.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { SignInForm } from "@/app/(auth)/auth/sign-in/sign-in-form";
+import { SignUpForm } from "@/app/(auth)/auth/sign-up/sign-up-form";
+import { toggleWishlist } from "@/actions/wishlist";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  productId: string;
+}
+
+type View = "sign-in" | "sign-up";
+
+export function AuthDialog({ open, onOpenChange, productId }: Props) {
+  const [view, setView] = useState<View>("sign-in");
+
+  async function handleAuthSuccess() {
+    onOpenChange(false);
+    try {
+      const result = await toggleWishlist(productId);
+      if (result.success) {
+        toast.success(result.added ? "Ajouté aux favoris" : "Retiré des favoris");
+      } else {
+        toast.error("Impossible de mettre à jour les favoris.");
+      }
+    } catch {
+      toast.error("Impossible de mettre à jour les favoris.");
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm overflow-y-auto max-h-[90svh]">
+        <DialogHeader>
+          <DialogTitle className="text-sm font-semibold">
+            {view === "sign-in" ? "Connectez-vous pour sauvegarder" : "Créer un compte"}
+          </DialogTitle>
+        </DialogHeader>
+
+        {view === "sign-in" ? (
+          <>
+            <SignInForm onSuccess={handleAuthSuccess} />
+            <p className="text-center text-sm text-muted-foreground mt-2">
+              Pas encore de compte ?{" "}
+              <button
+                type="button"
+                className="text-primary hover:underline"
+                onClick={() => setView("sign-up")}
+              >
+                S&apos;inscrire
+              </button>
+            </p>
+          </>
+        ) : (
+          <>
+            <SignUpForm onSuccess={handleAuthSuccess} />
+            <p className="text-center text-sm text-muted-foreground mt-2">
+              Déjà un compte ?{" "}
+              <button
+                type="button"
+                className="text-primary hover:underline"
+                onClick={() => setView("sign-in")}
+              >
+                Se connecter
+              </button>
+            </p>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/storefront/wishlist-button-dynamic.tsx
+++ b/components/storefront/wishlist-button-dynamic.tsx
@@ -1,13 +1,27 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import dynamic from "next/dynamic";
 import { authClient } from "@/lib/auth/client";
 import { WishlistButton } from "@/components/storefront/wishlist-button";
 import { checkWishlist } from "@/actions/wishlist";
+import { cn } from "@/lib/utils";
+
+const AuthDialog = dynamic(
+  () =>
+    import("@/components/storefront/auth-dialog")
+      .then((m) => m.AuthDialog)
+      .catch((err) => {
+        console.error("[wishlist-button-dynamic] Failed to load AuthDialog chunk", err);
+        throw err;
+      }),
+  { ssr: false }
+);
 
 export function WishlistButtonDynamic({ productId }: { productId: string }) {
   const session = authClient.useSession();
   const [isWishlisted, setIsWishlisted] = useState<boolean | undefined>(undefined);
+  const [dialogOpen, setDialogOpen] = useState(false);
 
   useEffect(() => {
     if (session.data?.user) {
@@ -15,13 +29,54 @@ export function WishlistButtonDynamic({ productId }: { productId: string }) {
     }
   }, [session.data?.user, productId]);
 
-  if (!session.data?.user || isWishlisted === undefined) return null;
+  // Authenticated and wishlist status known
+  if (session.data?.user && isWishlisted !== undefined) {
+    return (
+      <WishlistButton
+        productId={productId}
+        isWishlisted={isWishlisted}
+        onToggled={setIsWishlisted}
+      />
+    );
+  }
 
-  return (
-    <WishlistButton
-      productId={productId}
-      isWishlisted={isWishlisted}
-      onToggled={setIsWishlisted}
-    />
-  );
+  // Not authenticated — show ghost button that opens auth dialog
+  if (!session.data?.user) {
+    return (
+      <>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setDialogOpen(true);
+          }}
+          className={cn(
+            "flex size-8 items-center justify-center rounded-full bg-background/80 text-muted-foreground backdrop-blur-sm transition-colors hover:text-destructive"
+          )}
+          aria-label="Ajouter aux favoris"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            className="size-[45%]"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+          </svg>
+        </button>
+
+        <AuthDialog
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+          productId={productId}
+        />
+      </>
+    );
+  }
+
+  // Authenticated but wishlist status still loading — brief, avoid ghost flash
+  return null;
 }

--- a/components/storefront/wishlist-button-dynamic.tsx
+++ b/components/storefront/wishlist-button-dynamic.tsx
@@ -46,6 +46,8 @@ export function WishlistButtonDynamic({ productId }: { productId: string }) {
       <>
         <button
           type="button"
+          onMouseEnter={() => { void import("@/components/storefront/auth-dialog"); }}
+          onFocus={() => { void import("@/components/storefront/auth-dialog"); }}
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();

--- a/components/storefront/wishlist-button-dynamic.tsx
+++ b/components/storefront/wishlist-button-dynamic.tsx
@@ -5,7 +5,6 @@ import dynamic from "next/dynamic";
 import { authClient } from "@/lib/auth/client";
 import { WishlistButton } from "@/components/storefront/wishlist-button";
 import { checkWishlist } from "@/actions/wishlist";
-import { cn } from "@/lib/utils";
 
 const AuthDialog = dynamic(
   () =>
@@ -18,24 +17,29 @@ const AuthDialog = dynamic(
   { ssr: false }
 );
 
+function prefetchAuthDialog(): void {
+  void import("@/components/storefront/auth-dialog");
+}
+
 export function WishlistButtonDynamic({ productId }: { productId: string }) {
   const session = authClient.useSession();
   const [isWishlisted, setIsWishlisted] = useState<boolean | undefined>(undefined);
   const [dialogOpen, setDialogOpen] = useState(false);
 
+  const isAuthenticated = !!session.data?.user;
+
   useEffect(() => {
-    if (session.data?.user) {
-      checkWishlist(productId)
-        .then(setIsWishlisted)
-        .catch((err) => {
-          console.error("[wishlist-button-dynamic] checkWishlist failed for productId:", productId, err);
-          setIsWishlisted(false);
-        });
-    }
-  }, [session.data?.user, productId]);
+    if (!isAuthenticated) return;
+    checkWishlist(productId)
+      .then(setIsWishlisted)
+      .catch((err) => {
+        console.error("[wishlist-button-dynamic] checkWishlist failed for productId:", productId, err);
+        setIsWishlisted(false);
+      });
+  }, [isAuthenticated, productId]);
 
   // Authenticated and wishlist status known
-  if (session.data?.user && isWishlisted !== undefined) {
+  if (isAuthenticated && isWishlisted !== undefined) {
     return (
       <WishlistButton
         productId={productId}
@@ -45,22 +49,20 @@ export function WishlistButtonDynamic({ productId }: { productId: string }) {
     );
   }
 
-  // Not authenticated — show ghost button that opens auth dialog
-  if (!session.data?.user) {
+  // Not authenticated -- show ghost button that opens auth dialog
+  if (!isAuthenticated) {
     return (
       <>
         <button
           type="button"
-          onMouseEnter={() => { void import("@/components/storefront/auth-dialog"); }}
-          onFocus={() => { void import("@/components/storefront/auth-dialog"); }}
+          onMouseEnter={prefetchAuthDialog}
+          onFocus={prefetchAuthDialog}
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();
             setDialogOpen(true);
           }}
-          className={cn(
-            "flex size-8 items-center justify-center rounded-full bg-background/80 text-muted-foreground backdrop-blur-sm transition-colors hover:text-destructive"
-          )}
+          className="flex size-8 items-center justify-center rounded-full bg-background/80 text-muted-foreground backdrop-blur-sm transition-colors hover:text-destructive"
           aria-label="Ajouter aux favoris"
         >
           <svg
@@ -86,6 +88,6 @@ export function WishlistButtonDynamic({ productId }: { productId: string }) {
     );
   }
 
-  // Authenticated but wishlist status still loading — brief, avoid ghost flash
+  // Authenticated but wishlist status still loading
   return null;
 }

--- a/components/storefront/wishlist-button-dynamic.tsx
+++ b/components/storefront/wishlist-button-dynamic.tsx
@@ -18,7 +18,8 @@ const AuthDialog = dynamic(
 );
 
 function prefetchAuthDialog(): void {
-  void import("@/components/storefront/auth-dialog");
+  // Prefetch failure is non-critical; click will retry via dynamic()
+  void import("@/components/storefront/auth-dialog").catch(() => {});
 }
 
 export function WishlistButtonDynamic({ productId }: { productId: string }) {

--- a/components/storefront/wishlist-button-dynamic.tsx
+++ b/components/storefront/wishlist-button-dynamic.tsx
@@ -25,7 +25,12 @@ export function WishlistButtonDynamic({ productId }: { productId: string }) {
 
   useEffect(() => {
     if (session.data?.user) {
-      checkWishlist(productId).then(setIsWishlisted).catch(console.error);
+      checkWishlist(productId)
+        .then(setIsWishlisted)
+        .catch((err) => {
+          console.error("[wishlist-button-dynamic] checkWishlist failed for productId:", productId, err);
+          setIsWishlisted(false);
+        });
     }
   }, [session.data?.user, productId]);
 
@@ -70,11 +75,13 @@ export function WishlistButtonDynamic({ productId }: { productId: string }) {
           </svg>
         </button>
 
-        <AuthDialog
-          open={dialogOpen}
-          onOpenChange={setDialogOpen}
-          productId={productId}
-        />
+        {dialogOpen && (
+          <AuthDialog
+            open={dialogOpen}
+            onOpenChange={setDialogOpen}
+            productId={productId}
+          />
+        )}
       </>
     );
   }

--- a/components/storefront/wishlist-button.tsx
+++ b/components/storefront/wishlist-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTransition, useOptimistic } from "react";
+import { toast } from "sonner";
 import { toggleWishlist } from "@/actions/wishlist";
 import { cn } from "@/lib/utils";
 
@@ -21,6 +22,11 @@ export function WishlistButton({ productId, isWishlisted, onToggled, className }
     startTransition(async () => {
       setOptimistic(!optimistic);
       const result = await toggleWishlist(productId);
+      if (!result.success) {
+        setOptimistic(optimistic);
+        toast.error("Impossible de mettre à jour les favoris. Réessayez.");
+        return;
+      }
       onToggled?.(result.added);
     });
   }

--- a/docs/plans/2026-02-27-wishlist-auth-dialog-design.md
+++ b/docs/plans/2026-02-27-wishlist-auth-dialog-design.md
@@ -1,0 +1,67 @@
+# Wishlist Auth Dialog — Design
+
+**Goal:** Afficher le bouton favori sur toutes les product cards, même pour les utilisateurs non connectés ; un clic ouvre un dialogue d'authentification in-page, et après connexion/inscription, le produit est automatiquement ajouté aux favoris.
+
+**Architecture:** Le composant `WishlistButtonDynamic` affiche toujours le bouton. Quand la session est absente, un clic ouvre un nouveau composant `AuthDialog` (chargé dynamiquement). `SignInForm` et `SignUpForm` reçoivent un prop optionnel `onSuccess` : quand fourni, il remplace le `router.push("/")` existant. Le callback ferme le dialogue et appelle `toggleWishlist`.
+
+**Tech Stack:** better-auth (`authClient.useSession()`), Cloudflare Turnstile (requis sur tous les formulaires auth), shadcn/ui Dialog, Zustand (cart store pattern), Sonner (toasts), next/dynamic (lazy load du dialogue).
+
+---
+
+## Composants
+
+### Modifié : `components/storefront/wishlist-button-dynamic.tsx`
+
+- Supprimer le `return null` quand non connecté
+- Quand `!session.data?.user` : rendre un bouton cœur (style identique à `WishlistButton` mais sans état actif) qui ouvre `AuthDialog`
+- `AuthDialog` chargé via `next/dynamic` avec `ssr: false`
+
+### Modifié : `app/(auth)/auth/sign-in/sign-in-form.tsx`
+
+- Ajouter `onSuccess?: () => void` aux props
+- Si fourni : appeler `onSuccess()` au lieu de `router.push("/")` + `router.refresh()`
+- Comportement existant inchangé quand absent
+
+### Modifié : `app/(auth)/auth/sign-up/sign-up-form.tsx`
+
+- Même ajout `onSuccess?: () => void`
+- Même logique conditionnelle
+
+### Nouveau : `components/storefront/auth-dialog.tsx`
+
+- Props : `open`, `onOpenChange`, `onSuccess: () => void`, `productId: string`
+- State local : `view: "sign-in" | "sign-up"`
+- `DialogContent` avec `DialogTitle` ("Connectez-vous pour sauvegarder")
+- Embed `SignInForm` / `SignUpForm` avec `onSuccess`
+- Lien de switch "Pas encore de compte ? S'inscrire" / "Déjà un compte ? Se connecter"
+
+---
+
+## Flux de données
+
+```
+clic wishlist (non connecté)
+  → AuthDialog s'ouvre
+  → utilisateur remplit SignInForm ou SignUpForm
+  → auth réussie → onSuccess()
+    → AuthDialog fermé
+    → toggleWishlist(productId) appelé
+    → toast de confirmation
+```
+
+---
+
+## Gestion des erreurs
+
+- Erreurs de formulaire (champ invalide, mauvais mot de passe) : gérées inline par les formulaires existants
+- Échec de `toggleWishlist` après auth : toast d'erreur Sonner
+- Dialogue fermé avant la fin de l'auth : aucune action wishlist, état propre
+
+---
+
+## Tests
+
+- `WishlistButtonDynamic` non connecté : rend un bouton (pas `null`), clic déclenche l'ouverture du dialogue
+- `AuthDialog` : rend sign-in par défaut, switch vers sign-up au clic du lien
+- `SignInForm` avec `onSuccess` : appelle `onSuccess()` à la connexion réussie (pas de redirect)
+- `SignUpForm` avec `onSuccess` : idem

--- a/docs/plans/2026-02-27-wishlist-auth-dialog.md
+++ b/docs/plans/2026-02-27-wishlist-auth-dialog.md
@@ -1,0 +1,394 @@
+# Wishlist Auth Dialog — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Afficher le bouton favori sur toutes les product cards, même pour les utilisateurs non connectés ; un clic ouvre un dialogue d'authentification in-page qui, après connexion/inscription, ajoute automatiquement le produit aux favoris.
+
+**Architecture:** `WishlistButtonDynamic` affiche toujours le bouton cœur. Quand la session est absente, un clic ouvre `AuthDialog` (nouveau composant, chargé dynamiquement). `SignInForm` et `SignUpForm` reçoivent `onSuccess?: () => void` — si fourni, ce callback remplace (ou précède) le `router.push`. Dans `AuthDialog`, `onSuccess` appelle `toggleWishlist(productId)` puis ferme le dialogue via Sonner toast.
+
+**Tech Stack:** better-auth (`authClient.useSession()`), Cloudflare Turnstile (obligatoire), shadcn/ui Dialog, Zustand-free (server action directe), Sonner toasts, `next/dynamic` (ssr: false).
+
+**Note sur les tests:** Le projet utilise Vitest en `environment: "node"` sans React Testing Library. Les composants client ne sont pas testables dans cette configuration. Seule la logique pure est testée. Les vérifications de composants se font via TypeScript (`tsc --noEmit`) et le pre-commit hook.
+
+---
+
+### Task 1: Créer la branche de travail
+
+**Step 1: Créer et basculer sur la branche**
+
+```bash
+git checkout -b feat/wishlist-auth-dialog
+```
+
+**Step 2: Vérifier**
+
+```bash
+git branch --show-current
+```
+Expected: `feat/wishlist-auth-dialog`
+
+---
+
+### Task 2: Modifier `SignInForm` — ajouter le prop `onSuccess`
+
+**Files:**
+- Modify: `app/(auth)/auth/sign-in/sign-in-form.tsx:39`
+
+**Context:** `SignInForm` est utilisé sur la page `/auth/sign-in`. Il redirige vers `/` après succès. On ajoute `onSuccess?: () => void`. Quand fourni (contexte dialogue), on appelle `onSuccess()` au lieu de rediriger.
+
+**Step 1: Modifier la signature de la fonction et le bloc succès**
+
+Remplacer la ligne 39 :
+```tsx
+export function SignInForm() {
+```
+Par :
+```tsx
+interface SignInFormProps {
+  onSuccess?: () => void;
+}
+
+export function SignInForm({ onSuccess }: SignInFormProps = {}) {
+```
+
+Puis remplacer le bloc succès (lignes 83-86) :
+```tsx
+      } else {
+        router.push("/");
+        router.refresh();
+      }
+```
+Par :
+```tsx
+      } else {
+        if (onSuccess) {
+          onSuccess();
+        } else {
+          router.push("/");
+          router.refresh();
+        }
+      }
+```
+
+**Step 2: Vérifier TypeScript**
+
+```bash
+npx tsc --noEmit 2>&1 | grep "sign-in-form"
+```
+Expected: aucune sortie (pas d'erreur)
+
+**Step 3: Commit**
+
+```bash
+git add "app/(auth)/auth/sign-in/sign-in-form.tsx"
+git commit -m "feat(auth): add optional onSuccess prop to SignInForm"
+```
+
+---
+
+### Task 3: Modifier `SignUpForm` — ajouter le prop `onSuccess`
+
+**Files:**
+- Modify: `app/(auth)/auth/sign-up/sign-up-form.tsx:41`
+
+**Context:** `SignUpForm` redirige vers `/auth/verify-email?email=...` après succès (obligatoire — better-auth crée une session immédiatement mais l'email doit être vérifié). Quand `onSuccess` est fourni, on l'appelle EN PLUS de la redirection vers verify-email (pour fermer le dialogue et déclencher l'action wishlist pendant que l'utilisateur vérifie son email).
+
+**Step 1: Modifier la signature de la fonction et le bloc succès**
+
+Remplacer la ligne 41 :
+```tsx
+export function SignUpForm() {
+```
+Par :
+```tsx
+interface SignUpFormProps {
+  onSuccess?: () => void;
+}
+
+export function SignUpForm({ onSuccess }: SignUpFormProps = {}) {
+```
+
+Puis remplacer le bloc succès (lignes 87-89) :
+```tsx
+      } else {
+        router.push(`/auth/verify-email?email=${encodeURIComponent(data.email)}`);
+      }
+```
+Par :
+```tsx
+      } else {
+        onSuccess?.();
+        router.push(`/auth/verify-email?email=${encodeURIComponent(data.email)}`);
+      }
+```
+
+**Step 2: Vérifier TypeScript**
+
+```bash
+npx tsc --noEmit 2>&1 | grep "sign-up-form"
+```
+Expected: aucune sortie
+
+**Step 3: Commit**
+
+```bash
+git add "app/(auth)/auth/sign-up/sign-up-form.tsx"
+git commit -m "feat(auth): add optional onSuccess prop to SignUpForm"
+```
+
+---
+
+### Task 4: Créer `AuthDialog`
+
+**Files:**
+- Create: `components/storefront/auth-dialog.tsx`
+
+**Context:** Ce composant est un `Dialog` shadcn/ui qui embarque `SignInForm` ou `SignUpForm`. Il gère le switch entre les deux vues. Il reçoit `productId` et appelle `toggleWishlist` lors du succès de l'auth. Utiliser Sonner `toast` pour le feedback.
+
+**Step 1: Créer le fichier**
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { SignInForm } from "@/app/(auth)/auth/sign-in/sign-in-form";
+import { SignUpForm } from "@/app/(auth)/auth/sign-up/sign-up-form";
+import { toggleWishlist } from "@/actions/wishlist";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  productId: string;
+}
+
+type View = "sign-in" | "sign-up";
+
+export function AuthDialog({ open, onOpenChange, productId }: Props) {
+  const [view, setView] = useState<View>("sign-in");
+
+  async function handleAuthSuccess() {
+    onOpenChange(false);
+    try {
+      const result = await toggleWishlist(productId);
+      if (result.success) {
+        toast.success(result.added ? "Ajouté aux favoris" : "Retiré des favoris");
+      } else {
+        toast.error("Impossible de mettre à jour les favoris.");
+      }
+    } catch {
+      toast.error("Impossible de mettre à jour les favoris.");
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="text-sm font-semibold">
+            {view === "sign-in" ? "Connectez-vous pour sauvegarder" : "Créer un compte"}
+          </DialogTitle>
+        </DialogHeader>
+
+        {view === "sign-in" ? (
+          <>
+            <SignInForm onSuccess={handleAuthSuccess} />
+            <p className="text-center text-sm text-muted-foreground mt-2">
+              Pas encore de compte ?{" "}
+              <button
+                type="button"
+                className="text-primary hover:underline"
+                onClick={() => setView("sign-up")}
+              >
+                S&apos;inscrire
+              </button>
+            </p>
+          </>
+        ) : (
+          <>
+            <SignUpForm onSuccess={handleAuthSuccess} />
+            <p className="text-center text-sm text-muted-foreground mt-2">
+              Déjà un compte ?{" "}
+              <button
+                type="button"
+                className="text-primary hover:underline"
+                onClick={() => setView("sign-in")}
+              >
+                Se connecter
+              </button>
+            </p>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+**Step 2: Vérifier TypeScript**
+
+```bash
+npx tsc --noEmit 2>&1 | grep "auth-dialog"
+```
+Expected: aucune sortie
+
+**Step 3: Commit**
+
+```bash
+git add components/storefront/auth-dialog.tsx
+git commit -m "feat(storefront): add AuthDialog component for wishlist auth flow"
+```
+
+---
+
+### Task 5: Modifier `WishlistButtonDynamic` — toujours visible
+
+**Files:**
+- Modify: `components/storefront/wishlist-button-dynamic.tsx`
+
+**Context:** Actuellement la ligne 18 retourne `null` quand `!session.data?.user || isWishlisted === undefined`. On doit :
+1. Toujours afficher un bouton cœur, même sans session
+2. Charger `AuthDialog` via `next/dynamic` avec `ssr: false`
+3. Quand non connecté et clic → ouvrir l'`AuthDialog`
+4. Quand connecté → comportement inchangé via `WishlistButton`
+
+**Step 1: Réécrire le fichier**
+
+```tsx
+"use client";
+
+import { useEffect, useState } from "react";
+import dynamic from "next/dynamic";
+import { authClient } from "@/lib/auth/client";
+import { WishlistButton } from "@/components/storefront/wishlist-button";
+import { checkWishlist } from "@/actions/wishlist";
+import { cn } from "@/lib/utils";
+
+const AuthDialog = dynamic(
+  () =>
+    import("@/components/storefront/auth-dialog")
+      .then((m) => m.AuthDialog)
+      .catch((err) => {
+        console.error("[wishlist-button-dynamic] Failed to load AuthDialog chunk", err);
+        throw err;
+      }),
+  { ssr: false }
+);
+
+export function WishlistButtonDynamic({ productId }: { productId: string }) {
+  const session = authClient.useSession();
+  const [isWishlisted, setIsWishlisted] = useState<boolean | undefined>(undefined);
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  useEffect(() => {
+    if (session.data?.user) {
+      checkWishlist(productId).then(setIsWishlisted).catch(console.error);
+    }
+  }, [session.data?.user, productId]);
+
+  // Authenticated and wishlist status known
+  if (session.data?.user && isWishlisted !== undefined) {
+    return (
+      <WishlistButton
+        productId={productId}
+        isWishlisted={isWishlisted}
+        onToggled={setIsWishlisted}
+      />
+    );
+  }
+
+  // Not authenticated (or session loading) — show ghost button
+  if (!session.data?.user) {
+    return (
+      <>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setDialogOpen(true);
+          }}
+          className={cn(
+            "flex size-8 items-center justify-center rounded-full bg-background/80 text-muted-foreground backdrop-blur-sm transition-colors hover:text-destructive"
+          )}
+          aria-label="Ajouter aux favoris"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            className="size-[45%]"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+          </svg>
+        </button>
+
+        <AuthDialog
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+          productId={productId}
+        />
+      </>
+    );
+  }
+
+  // Authenticated but wishlist status still loading — render nothing (brief flash avoided)
+  return null;
+}
+```
+
+**Pourquoi `return null` à la fin ?** Quand l'utilisateur est connecté mais que `isWishlisted` est encore `undefined` (appel en cours), on retourne `null` pour éviter d'afficher le bouton ghost (qui ouvrirait le dialogue auth inutilement). Ce cas est bref (< 1 requête réseau).
+
+**Step 2: Vérifier TypeScript**
+
+```bash
+npx tsc --noEmit 2>&1 | grep "wishlist"
+```
+Expected: aucune sortie
+
+**Step 3: Vérifier le lint**
+
+```bash
+npm run lint 2>&1 | grep -A2 "wishlist-button-dynamic\|auth-dialog\|sign-in-form\|sign-up-form" | head -40
+```
+Expected: aucune erreur sur ces fichiers
+
+**Step 4: Lancer tous les tests**
+
+```bash
+npm run test
+```
+Expected: all tests passing (les tests existants ne sont pas affectés par ces changements)
+
+**Step 5: Commit final**
+
+```bash
+git add components/storefront/wishlist-button-dynamic.tsx
+git commit -m "feat(storefront): show wishlist button for unauthenticated users with auth dialog"
+```
+
+---
+
+## Vérification manuelle post-implémentation
+
+1. Démarrer le serveur : `npm run dev`
+2. Ouvrir une page catalogue en navigation privée (non connecté)
+3. Vérifier : le bouton cœur est visible sur chaque product card
+4. Cliquer le cœur → un dialogue "Connectez-vous pour sauvegarder" s'ouvre avec le formulaire sign-in
+5. Cliquer "S'inscrire" → bascule vers le formulaire sign-up
+6. Se connecter avec un compte existant → le dialogue se ferme + toast "Ajouté aux favoris"
+7. Le cœur est maintenant rempli (rouge)
+
+---
+
+## Résumé des fichiers touchés
+
+| Fichier | Action |
+|---------|--------|
+| `app/(auth)/auth/sign-in/sign-in-form.tsx` | Modify — ajouter `onSuccess` prop |
+| `app/(auth)/auth/sign-up/sign-up-form.tsx` | Modify — ajouter `onSuccess` prop |
+| `components/storefront/auth-dialog.tsx` | Create — nouveau composant dialogue |
+| `components/storefront/wishlist-button-dynamic.tsx` | Modify — toujours visible + ouvre AuthDialog |


### PR DESCRIPTION
## Summary

- Bouton favori toujours visible sur les product cards, même pour les utilisateurs non connectés
- Clic quand non connecté → dialogue d'authentification in-page (sign-in / sign-up switchable, Turnstile inclus)
- Après connexion ou inscription → produit automatiquement ajouté aux favoris via `toggleWishlist`
- `AuthDialog` chargé via `next/dynamic` (ssr: false) avec preload sur hover/focus

## Fichiers changés

- `components/storefront/auth-dialog.tsx` — nouveau composant dialogue (sign-in + sign-up + switch)
- `components/storefront/wishlist-button-dynamic.tsx` — bouton ghost pour non-connectés, ouvre AuthDialog
- `components/storefront/wishlist-button.tsx` — revert optimistic state + toast sur échec
- `app/(auth)/auth/sign-in/sign-in-form.tsx` — prop `onSuccess?: () => Promise<void>` (remplace redirect)
- `app/(auth)/auth/sign-up/sign-up-form.tsx` — même prop (remplace redirect verify-email)
- `actions/wishlist.ts` — logs sur early returns + catch block

## Test Plan

- [ ] Ouvrir une page catalogue en navigation privée (non connecté) — vérifier que le bouton cœur est visible
- [ ] Cliquer le cœur → dialogue "Connectez-vous pour sauvegarder" s'ouvre
- [ ] Switcher entre sign-in et sign-up
- [ ] Se connecter → dialogue se ferme + toast "Ajouté aux favoris" + icône devient rouge
- [ ] S'inscrire → dialogue se ferme + toast + icône rouge (email de vérification reçu séparément)
- [ ] Fermer et rouvrir le dialogue → revient en mode sign-in
- [ ] Survol du bouton → chunk AuthDialog préchargé (Network tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)