### PR TITLE
feat(wishlist): align wishlist button style with cart button

### DIFF
--- a/components/storefront/wishlist-button-dynamic.tsx
+++ b/components/storefront/wishlist-button-dynamic.tsx
@@ -5,6 +5,7 @@ import dynamic from "next/dynamic";
 import { authClient } from "@/lib/auth/client";
 import { WishlistButton } from "@/components/storefront/wishlist-button";
 import { checkWishlist } from "@/actions/wishlist";
+import { Button } from "@/components/ui/button";
 
 const AuthDialog = dynamic(
   () =>
@@ -54,8 +55,11 @@ export function WishlistButtonDynamic({ productId }: { productId: string }) {
   if (!isAuthenticated) {
     return (
       <>
-        <button
+        <Button
           type="button"
+          size="icon-touch"
+          variant="outline"
+          className="hover:text-destructive hover:border-destructive/50"
           onMouseEnter={prefetchAuthDialog}
           onFocus={prefetchAuthDialog}
           onClick={(e) => {
@@ -63,20 +67,18 @@ export function WishlistButtonDynamic({ productId }: { productId: string }) {
             e.stopPropagation();
             setDialogOpen(true);
           }}
-          className="flex size-8 items-center justify-center rounded-full bg-background/80 text-muted-foreground backdrop-blur-sm transition-colors hover:text-destructive"
           aria-label="Ajouter aux favoris"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 24 24"
-            className="size-[45%]"
             fill="none"
             stroke="currentColor"
             strokeWidth={2}
           >
             <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
           </svg>
-        </button>
+        </Button>
 
         {dialogOpen && (
           <AuthDialog

--- a/components/storefront/wishlist-button.tsx
+++ b/components/storefront/wishlist-button.tsx
@@ -4,6 +4,7 @@ import { useTransition, useOptimistic } from "react";
 import { toast } from "sonner";
 import { toggleWishlist } from "@/actions/wishlist";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 
 interface Props {
   productId: string;
@@ -32,26 +33,23 @@ export function WishlistButton({ productId, isWishlisted, onToggled, className }
   }
 
   return (
-    <button
+    <Button
       onClick={handleClick}
       disabled={pending}
-      className={cn(
-        "flex size-8 items-center justify-center rounded-full bg-background/80 text-muted-foreground backdrop-blur-sm transition-colors hover:text-destructive",
-        optimistic && "text-destructive",
-        className
-      )}
+      size="icon-touch"
+      variant={optimistic ? "destructive" : "outline"}
+      className={cn(!optimistic && "hover:text-destructive hover:border-destructive/50", className)}
       aria-label={optimistic ? "Retirer des favoris" : "Ajouter aux favoris"}
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"
-        className="size-[45%]"
         fill={optimistic ? "currentColor" : "none"}
         stroke="currentColor"
         strokeWidth={2}
       >
         <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
       </svg>
-    </button>
+    </Button>
   );
 }


### PR DESCRIPTION
## Summary
- Replace hand-rolled circular button (`size-8 rounded-full`) with `Button size="icon-touch"` (44px square)
- Authenticated state: `variant="outline"` → `variant="destructive"` when wishlisted
- Unauthenticated state: `variant="outline"` with red hover
- Both buttons now match the height and shape of the add-to-cart button

🤖 Generated with [Claude Code](https://claude.com/claude-code)