### PR TITLE
feat(banners): auto-assign display_order on creation

### DIFF
--- a/__tests__/unit/actions/admin-banners.test.ts
+++ b/__tests__/unit/actions/admin-banners.test.ts
@@ -33,6 +33,7 @@ vi.mock("nanoid", () => ({ nanoid: vi.fn().mockReturnValue("mockuid8") }));
 vi.mock("@/lib/db/drizzle", () => ({ getDrizzle: mocks.getDrizzle }));
 
 import {
+  createBanner,
   uploadBannerImage,
   setBannerImageUrl,
   createBannerGradient,
@@ -71,6 +72,146 @@ function makeDrizzleMock(findFirstResult: unknown) {
 
   return { whereMock, setMock };
 }
+
+// ─── createBanner ────────────────────────────────────────────────────────────
+
+describe("createBanner", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue(mockAdminSession);
+  });
+
+  /** Stub select().from() for max() and insert().values().returning() */
+  function makeCreateBannerMock(
+    maxOrder: number | null,
+    insertResult: object[] = [{ id: 42 }]
+  ) {
+    const fromMock = vi.fn().mockResolvedValue([{ maxOrder }]);
+    const selectMock = vi.fn().mockReturnValue({ from: fromMock });
+
+    const returningMock = vi.fn().mockResolvedValue(insertResult);
+    const valuesMock = vi.fn().mockReturnValue({ returning: returningMock });
+    mocks.dbInsert.mockReturnValue({ values: valuesMock });
+
+    mocks.getDrizzle.mockResolvedValue({
+      select: selectMock,
+      insert: mocks.dbInsert,
+    });
+
+    return { selectMock, fromMock, valuesMock, returningMock };
+  }
+
+  function makeCreateBannerFormData(overrides: Record<string, string> = {}): FormData {
+    const fd = new FormData();
+    fd.append("title", overrides.title ?? "Bannière Test");
+    fd.append("link_url", overrides.link_url ?? "/p/test-produit");
+    for (const [key, value] of Object.entries(overrides)) {
+      if (!fd.has(key)) fd.append(key, value);
+    }
+    return fd;
+  }
+
+  // ── Auth ─────────────────────────────────────────────────────────────────
+
+  it("redirige si non admin (customer session)", async () => {
+    mocks.getSession.mockResolvedValue(mockCustomerSession);
+    await expect(createBanner(makeCreateBannerFormData())).rejects.toThrow("NEXT_REDIRECT");
+  });
+
+  // ── Validation ───────────────────────────────────────────────────────────
+
+  it("rejette si le titre est manquant", async () => {
+    const fd = new FormData();
+    fd.append("link_url", "/p/test");
+    const result = await createBanner(fd);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejette si link_url ne commence pas par /", async () => {
+    const result = await createBanner(makeCreateBannerFormData({ link_url: "http://example.com" }));
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("chemin relatif");
+  });
+
+  // ── Calcul automatique de display_order ──────────────────────────────────
+
+  it("table vide : max() retourne null → display_order = 0", async () => {
+    const { valuesMock } = makeCreateBannerMock(null);
+
+    const result = await createBanner(makeCreateBannerFormData());
+
+    expect(result.success).toBe(true);
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ display_order: 0 })
+    );
+  });
+
+  it("table non-vide : max() = 5 → display_order = 6", async () => {
+    const { valuesMock } = makeCreateBannerMock(5);
+
+    const result = await createBanner(makeCreateBannerFormData());
+
+    expect(result.success).toBe(true);
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ display_order: 6 })
+    );
+  });
+
+  it("la valeur display_order du formulaire est ignorée même si fournie", async () => {
+    const { valuesMock } = makeCreateBannerMock(3);
+
+    // Simule un submit manuel avec display_order=99 dans le formulaire
+    const result = await createBanner(makeCreateBannerFormData({ display_order: "99" }));
+
+    expect(result.success).toBe(true);
+    // Doit utiliser max+1=4, pas 99
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ display_order: 4 })
+    );
+  });
+
+  // ── Erreurs DB ───────────────────────────────────────────────────────────
+
+  it("retourne une erreur distincte si la requête max() échoue (avant l'insert)", async () => {
+    const fromMock = vi.fn().mockRejectedValue(new Error("D1 select failed"));
+    const selectMock = vi.fn().mockReturnValue({ from: fromMock });
+    mocks.getDrizzle.mockResolvedValue({ select: selectMock, insert: mocks.dbInsert });
+
+    const result = await createBanner(makeCreateBannerFormData());
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("ordre d'affichage");
+    // L'insert ne doit pas être tenté après l'échec du max()
+    expect(mocks.dbInsert).not.toHaveBeenCalled();
+  });
+
+  it("retourne une erreur si l'insertion échoue (le max() a réussi)", async () => {
+    const fromMock = vi.fn().mockResolvedValue([{ maxOrder: 2 }]);
+    const selectMock = vi.fn().mockReturnValue({ from: fromMock });
+    mocks.getDrizzle.mockResolvedValue({
+      select: selectMock,
+      insert: vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockRejectedValue(new Error("D1 insert failed")),
+        }),
+      }),
+    });
+
+    const result = await createBanner(makeCreateBannerFormData());
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("création de la bannière");
+  });
+
+  it("retourne une erreur si l'insert retourne un tableau vide", async () => {
+    makeCreateBannerMock(0, []);
+
+    const result = await createBanner(makeCreateBannerFormData());
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Échec");
+  });
+});
 
 // ─── uploadBannerImage ───────────────────────────────────────────────────────
 

--- a/actions/admin/banners.ts
+++ b/actions/admin/banners.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { eq, and, or, isNull, isNotNull, lte, gt, asc } from "drizzle-orm";
+import { eq, and, or, isNull, isNotNull, lte, gt, asc, max } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { z } from "zod";
 import { requireAdmin } from "@/lib/auth/guards";
@@ -96,6 +96,9 @@ export async function createBanner(formData: FormData): Promise<ActionResult> {
     const data = parsed.data;
     const db = await getDrizzle();
 
+    const [maxRow] = await db.select({ maxOrder: max(banners.display_order) }).from(banners);
+    const nextOrder = (maxRow?.maxOrder ?? -1) + 1;
+
     const rows = await db.insert(banners).values({
       title: data.title,
       subtitle: data.subtitle || null,
@@ -106,7 +109,7 @@ export async function createBanner(formData: FormData): Promise<ActionResult> {
       price: data.price ?? null,
       bg_gradient_from: data.bg_gradient_from,
       bg_gradient_to: data.bg_gradient_to,
-      display_order: data.display_order,
+      display_order: nextOrder,
       is_active: data.is_active,
       starts_at: data.starts_at || null,
       ends_at: data.ends_at || null,

--- a/actions/admin/banners.ts
+++ b/actions/admin/banners.ts
@@ -68,6 +68,7 @@ const bannerSchema = z.object({
   price: z.coerce.number().int().min(0).optional(),
   bg_gradient_from: z.string().regex(/^#[0-9a-fA-F]{6}$/, "Couleur invalide").default("#183C78"),
   bg_gradient_to: z.string().regex(/^#[0-9a-fA-F]{6}$/, "Couleur invalide").default("#1E4A8F"),
+  // Only consumed by updateBanner — createBanner ignores this and computes display_order from max().
   display_order: z.coerce.number().int().min(0).default(0),
   is_active: z.coerce.number().min(0).max(1).default(1),
   starts_at: z.string().optional().default(""),
@@ -96,8 +97,16 @@ export async function createBanner(formData: FormData): Promise<ActionResult> {
     const data = parsed.data;
     const db = await getDrizzle();
 
-    const [maxRow] = await db.select({ maxOrder: max(banners.display_order) }).from(banners);
-    const nextOrder = (maxRow?.maxOrder ?? -1) + 1;
+    // SQL MAX() on an empty table returns one row with NULL — not an empty array.
+    // maxRow is always defined; maxRow.maxOrder is null when the table is empty.
+    let nextOrder: number;
+    try {
+      const [maxRow] = await db.select({ maxOrder: max(banners.display_order) }).from(banners);
+      nextOrder = (maxRow.maxOrder ?? -1) + 1; // null when table is empty → start at 0
+    } catch (orderError) {
+      console.error("[admin/banners] createBanner: failed to compute max display_order:", orderError);
+      return { success: false, error: "Impossible de calculer l'ordre d'affichage. Veuillez réessayer." };
+    }
 
     const rows = await db.insert(banners).values({
       title: data.title,

--- a/components/admin/banner-form.tsx
+++ b/components/admin/banner-form.tsx
@@ -336,16 +336,18 @@ export function BannerForm({ banner, savedGradients: initialGradients = [] }: Ba
                   }}
                 />
               </div>
-              <div className="space-y-2">
-                <Label htmlFor="display_order">Ordre d&apos;affichage</Label>
-                <Input
-                  id="display_order"
-                  name="display_order"
-                  type="number"
-                  min={0}
-                  defaultValue={banner?.display_order ?? 0}
-                />
-              </div>
+              {isEdit && (
+                <div className="space-y-2">
+                  <Label htmlFor="display_order">Ordre d&apos;affichage</Label>
+                  <Input
+                    id="display_order"
+                    name="display_order"
+                    type="number"
+                    min={0}
+                    defaultValue={banner?.display_order ?? 0}
+                  />
+                </div>
+              )}
             </CardContent>
           </Card>
 


### PR DESCRIPTION
## Summary

- À la création d'une bannière, `display_order` est automatiquement calculé comme `max(display_order) + 1`, plaçant la nouvelle bannière en dernière position dans le carousel
- Le champ **Ordre d'affichage** est masqué dans le formulaire de création (inutile puisqu'auto-assigné)
- Le champ reste visible et modifiable dans le formulaire d'édition pour que l'admin puisse réordonner manuellement les bannières

## Test plan

- [ ] Créer une première bannière → `display_order = 0`
- [ ] Créer une deuxième bannière → `display_order = 1`
- [ ] Vérifier que le champ "Ordre d'affichage" n'apparaît pas sur la page `/banners/new`
- [ ] Vérifier que le champ apparaît bien sur la page `/banners/[id]/edit`
- [ ] Modifier l'ordre via édition et vérifier l'ordre du carousel en storefront

🤖 Generated with [Claude Code](https://claude.com/claude-code)