### PR TITLE
feat(banners): drag-and-drop reordering

### DIFF
--- a/__tests__/unit/actions/admin-banners.test.ts
+++ b/__tests__/unit/actions/admin-banners.test.ts
@@ -718,9 +718,17 @@ describe("reorderBanners", () => {
     expect(mocks.getDrizzle).not.toHaveBeenCalled();
   });
 
+  it("valeur non-tableau (null) → succès sans appel DB", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await reorderBanners(null as any);
+    expect(result.success).toBe(true);
+    expect(mocks.getDrizzle).not.toHaveBeenCalled();
+  });
+
   it("met à jour display_order pour chaque ID dans le bon ordre", async () => {
     const { setMock } = makeReorderMock();
     const { revalidatePath } = await import("next/cache");
+    const { getKV } = await import("@/lib/cloudflare/context");
 
     const result = await reorderBanners([3, 1, 2]);
 
@@ -731,6 +739,7 @@ describe("reorderBanners", () => {
     expect(setMock).toHaveBeenNthCalledWith(3, expect.objectContaining({ display_order: 2 }));
     expect(revalidatePath).toHaveBeenCalledWith("/banners");
     expect(revalidatePath).toHaveBeenCalledWith("/");
+    expect(getKV).toHaveBeenCalled();
   });
 
   it("passe l'updated_at avec chaque mise à jour", async () => {

--- a/__tests__/unit/actions/admin-banners.test.ts
+++ b/__tests__/unit/actions/admin-banners.test.ts
@@ -748,4 +748,18 @@ describe("reorderBanners", () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain("ordre");
   });
+
+  it("rejette si un ID n'est pas un entier positif", async () => {
+    const result = await reorderBanners([1, -1, 3]);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("invalide");
+    expect(mocks.getDrizzle).not.toHaveBeenCalled();
+  });
+
+  it("rejette si des IDs sont en double", async () => {
+    const result = await reorderBanners([1, 2, 1]);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("doublons");
+    expect(mocks.getDrizzle).not.toHaveBeenCalled();
+  });
 });

--- a/__tests__/unit/actions/admin-banners.test.ts
+++ b/__tests__/unit/actions/admin-banners.test.ts
@@ -15,6 +15,8 @@ const mocks = vi.hoisted(() => ({
   dbInsert: vi.fn(),
   dbDelete: vi.fn(),
   getDrizzle: vi.fn(),
+  kvPut: vi.fn(),
+  kvDelete: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({ redirect: mocks.redirect }));
@@ -31,6 +33,11 @@ vi.mock("@/lib/storage/images", () => ({
 }));
 vi.mock("nanoid", () => ({ nanoid: vi.fn().mockReturnValue("mockuid8") }));
 vi.mock("@/lib/db/drizzle", () => ({ getDrizzle: mocks.getDrizzle }));
+vi.mock("@/lib/cloudflare/context", () => ({
+  getKV: vi.fn().mockImplementation(() =>
+    Promise.resolve({ put: mocks.kvPut, delete: mocks.kvDelete })
+  ),
+}));
 
 import {
   createBanner,
@@ -693,7 +700,10 @@ describe("reorderBanners", () => {
     const whereMock = vi.fn().mockResolvedValue(undefined);
     const setMock = vi.fn().mockReturnValue({ where: whereMock });
     mocks.dbUpdate.mockReturnValue({ set: setMock });
-    mocks.getDrizzle.mockResolvedValue({ update: mocks.dbUpdate });
+    mocks.getDrizzle.mockResolvedValue({
+      update: mocks.dbUpdate,
+      query: { banners: { findFirst: vi.fn().mockResolvedValue(null) } },
+    });
     return { whereMock, setMock };
   }
 
@@ -710,6 +720,7 @@ describe("reorderBanners", () => {
 
   it("met à jour display_order pour chaque ID dans le bon ordre", async () => {
     const { setMock } = makeReorderMock();
+    const { revalidatePath } = await import("next/cache");
 
     const result = await reorderBanners([3, 1, 2]);
 
@@ -718,6 +729,8 @@ describe("reorderBanners", () => {
     expect(setMock).toHaveBeenNthCalledWith(1, expect.objectContaining({ display_order: 0 }));
     expect(setMock).toHaveBeenNthCalledWith(2, expect.objectContaining({ display_order: 1 }));
     expect(setMock).toHaveBeenNthCalledWith(3, expect.objectContaining({ display_order: 2 }));
+    expect(revalidatePath).toHaveBeenCalledWith("/banners");
+    expect(revalidatePath).toHaveBeenCalledWith("/");
   });
 
   it("passe l'updated_at avec chaque mise à jour", async () => {
@@ -730,7 +743,7 @@ describe("reorderBanners", () => {
     );
   });
 
-  it("appelle where() avec l'ID correct pour chaque bannière", async () => {
+  it("appelle where() pour chaque bannière de la liste", async () => {
     const { whereMock } = makeReorderMock();
 
     await reorderBanners([10, 20]);
@@ -742,11 +755,13 @@ describe("reorderBanners", () => {
     const whereMock = vi.fn().mockRejectedValue(new Error("D1 error"));
     mocks.dbUpdate.mockReturnValue({ set: vi.fn().mockReturnValue({ where: whereMock }) });
     mocks.getDrizzle.mockResolvedValue({ update: mocks.dbUpdate });
+    const { revalidatePath } = await import("next/cache");
 
     const result = await reorderBanners([1, 2]);
 
     expect(result.success).toBe(false);
     expect(result.error).toContain("ordre");
+    expect(revalidatePath).not.toHaveBeenCalled();
   });
 
   it("rejette si un ID n'est pas un entier positif", async () => {
@@ -756,10 +771,32 @@ describe("reorderBanners", () => {
     expect(mocks.getDrizzle).not.toHaveBeenCalled();
   });
 
+  it("rejette si un ID est zéro", async () => {
+    const result = await reorderBanners([0, 1, 2]);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("invalide");
+    expect(mocks.getDrizzle).not.toHaveBeenCalled();
+  });
+
+  it("rejette si un ID est un flottant", async () => {
+    const result = await reorderBanners([1, 1.5, 2]);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("invalide");
+    expect(mocks.getDrizzle).not.toHaveBeenCalled();
+  });
+
   it("rejette si des IDs sont en double", async () => {
     const result = await reorderBanners([1, 2, 1]);
     expect(result.success).toBe(false);
     expect(result.error).toContain("doublons");
+    expect(mocks.getDrizzle).not.toHaveBeenCalled();
+  });
+
+  it("rejette si le tableau dépasse 100 éléments", async () => {
+    const ids = Array.from({ length: 101 }, (_, i) => i + 1);
+    const result = await reorderBanners(ids);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Trop");
     expect(mocks.getDrizzle).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/unit/actions/admin-banners.test.ts
+++ b/__tests__/unit/actions/admin-banners.test.ts
@@ -38,6 +38,7 @@ import {
   setBannerImageUrl,
   createBannerGradient,
   deleteBannerGradient,
+  reorderBanners,
 } from "@/actions/admin/banners";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -677,5 +678,74 @@ describe("deleteBannerGradient", () => {
     const result = await deleteBannerGradient(5);
     expect(result.success).toBe(false);
     expect(result.error).toBeTruthy();
+  });
+});
+
+// ─── reorderBanners ───────────────────────────────────────────────────────────
+
+describe("reorderBanners", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue(mockAdminSession);
+  });
+
+  function makeReorderMock() {
+    const whereMock = vi.fn().mockResolvedValue(undefined);
+    const setMock = vi.fn().mockReturnValue({ where: whereMock });
+    mocks.dbUpdate.mockReturnValue({ set: setMock });
+    mocks.getDrizzle.mockResolvedValue({ update: mocks.dbUpdate });
+    return { whereMock, setMock };
+  }
+
+  it("redirige si non admin (customer session)", async () => {
+    mocks.getSession.mockResolvedValue(mockCustomerSession);
+    await expect(reorderBanners([1, 2])).rejects.toThrow("NEXT_REDIRECT");
+  });
+
+  it("tableau vide → succès sans appel DB", async () => {
+    const result = await reorderBanners([]);
+    expect(result.success).toBe(true);
+    expect(mocks.getDrizzle).not.toHaveBeenCalled();
+  });
+
+  it("met à jour display_order pour chaque ID dans le bon ordre", async () => {
+    const { setMock } = makeReorderMock();
+
+    const result = await reorderBanners([3, 1, 2]);
+
+    expect(result.success).toBe(true);
+    expect(mocks.dbUpdate).toHaveBeenCalledTimes(3);
+    expect(setMock).toHaveBeenNthCalledWith(1, expect.objectContaining({ display_order: 0 }));
+    expect(setMock).toHaveBeenNthCalledWith(2, expect.objectContaining({ display_order: 1 }));
+    expect(setMock).toHaveBeenNthCalledWith(3, expect.objectContaining({ display_order: 2 }));
+  });
+
+  it("passe l'updated_at avec chaque mise à jour", async () => {
+    const { setMock } = makeReorderMock();
+
+    await reorderBanners([5]);
+
+    expect(setMock).toHaveBeenCalledWith(
+      expect.objectContaining({ updated_at: expect.stringMatching(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/) })
+    );
+  });
+
+  it("appelle where() avec l'ID correct pour chaque bannière", async () => {
+    const { whereMock } = makeReorderMock();
+
+    await reorderBanners([10, 20]);
+
+    expect(whereMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retourne une erreur si une mise à jour DB échoue", async () => {
+    const whereMock = vi.fn().mockRejectedValue(new Error("D1 error"));
+    mocks.dbUpdate.mockReturnValue({ set: vi.fn().mockReturnValue({ where: whereMock }) });
+    mocks.getDrizzle.mockResolvedValue({ update: mocks.dbUpdate });
+
+    const result = await reorderBanners([1, 2]);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("ordre");
   });
 });

--- a/actions/admin/banners.ts
+++ b/actions/admin/banners.ts
@@ -454,15 +454,32 @@ export async function reorderBanners(orderedIds: number[]): Promise<ActionResult
     return { success: true };
   }
 
+  if (orderedIds.some((id) => !Number.isInteger(id) || id <= 0)) {
+    return { success: false, error: "Données de réorganisation invalides" };
+  }
+
+  if (new Set(orderedIds).size !== orderedIds.length) {
+    return { success: false, error: "Données de réorganisation invalides (doublons)" };
+  }
+
   try {
     const db = await getDrizzle();
     const now = new Date().toISOString().replace("T", " ").slice(0, 19);
 
-    await Promise.all(
+    const results = await Promise.allSettled(
       orderedIds.map((id, index) =>
         db.update(banners).set({ display_order: index, updated_at: now }).where(eq(banners.id, id))
       )
     );
+
+    const failures = results.filter((r) => r.status === "rejected");
+    if (failures.length > 0) {
+      console.error(
+        `[admin/banners] reorderBanners: ${failures.length}/${results.length} updates failed:`,
+        failures.map((f) => (f as PromiseRejectedResult).reason)
+      );
+      return { success: false, error: "Erreur lors de la mise à jour de l'ordre" };
+    }
 
     revalidatePath("/banners");
     revalidatePath("/");

--- a/actions/admin/banners.ts
+++ b/actions/admin/banners.ts
@@ -446,3 +446,30 @@ export async function deleteBannerGradient(id: number): Promise<ActionResult> {
     return { success: false, error: "Erreur lors de la suppression du dégradé" };
   }
 }
+
+export async function reorderBanners(orderedIds: number[]): Promise<ActionResult> {
+  await requireAdmin();
+
+  if (!Array.isArray(orderedIds) || orderedIds.length === 0) {
+    return { success: true };
+  }
+
+  try {
+    const db = await getDrizzle();
+    const now = new Date().toISOString().replace("T", " ").slice(0, 19);
+
+    await Promise.all(
+      orderedIds.map((id, index) =>
+        db.update(banners).set({ display_order: index, updated_at: now }).where(eq(banners.id, id))
+      )
+    );
+
+    revalidatePath("/banners");
+    revalidatePath("/");
+    await refreshHeroPreload();
+    return { success: true };
+  } catch (error) {
+    console.error("[admin/banners] reorderBanners error:", error);
+    return { success: false, error: "Erreur lors de la mise à jour de l'ordre" };
+  }
+}

--- a/actions/admin/banners.ts
+++ b/actions/admin/banners.ts
@@ -454,6 +454,10 @@ export async function reorderBanners(orderedIds: number[]): Promise<ActionResult
     return { success: true };
   }
 
+  if (orderedIds.length > 100) {
+    return { success: false, error: "Trop de bannières" };
+  }
+
   if (orderedIds.some((id) => !Number.isInteger(id) || id <= 0)) {
     return { success: false, error: "Données de réorganisation invalides" };
   }
@@ -466,19 +470,11 @@ export async function reorderBanners(orderedIds: number[]): Promise<ActionResult
     const db = await getDrizzle();
     const now = new Date().toISOString().replace("T", " ").slice(0, 19);
 
-    const results = await Promise.allSettled(
-      orderedIds.map((id, index) =>
-        db.update(banners).set({ display_order: index, updated_at: now }).where(eq(banners.id, id))
-      )
-    );
-
-    const failures = results.filter((r) => r.status === "rejected");
-    if (failures.length > 0) {
-      console.error(
-        `[admin/banners] reorderBanners: ${failures.length}/${results.length} updates failed:`,
-        failures.map((f) => (f as PromiseRejectedResult).reason)
-      );
-      return { success: false, error: "Erreur lors de la mise à jour de l'ordre" };
+    for (let i = 0; i < orderedIds.length; i++) {
+      await db
+        .update(banners)
+        .set({ display_order: i, updated_at: now })
+        .where(eq(banners.id, orderedIds[i]));
     }
 
     revalidatePath("/banners");

--- a/components/admin/banner-table.tsx
+++ b/components/admin/banner-table.tsx
@@ -275,6 +275,7 @@ export function BannerTable({ banners: initialBanners }: { banners: BannerRowDat
     setActiveId(null);
     if (!over || active.id === over.id) return;
 
+    const previousItems = items;
     const oldIndex = items.findIndex((b) => b.id === active.id);
     const newIndex = items.findIndex((b) => b.id === over.id);
     const newItems = arrayMove(items, oldIndex, newIndex).map((item, idx) => ({
@@ -289,11 +290,14 @@ export function BannerTable({ banners: initialBanners }: { banners: BannerRowDat
       try {
         const result = await reorderBanners(newOrder);
         if (!result.success) {
+          setItems(previousItems);
           toast.error(result.error || "Erreur lors de la sauvegarde de l'ordre");
         } else {
           toast.success("Ordre sauvegardé");
         }
-      } catch {
+      } catch (error) {
+        console.error("[BannerTable] reorderBanners failed:", error);
+        setItems(previousItems);
         toast.error("Erreur de connexion au serveur");
       }
     });
@@ -303,8 +307,15 @@ export function BannerTable({ banners: initialBanners }: { banners: BannerRowDat
     startTransition(async () => {
       try {
         const result = await toggleBannerActive(id);
-        if (!result.success) toast.error(result.error || "Une erreur est survenue");
-      } catch {
+        if (result.success) {
+          setItems((prev) =>
+            prev.map((b) => (b.id === id ? { ...b, is_active: b.is_active === 1 ? 0 : 1 } : b))
+          );
+        } else {
+          toast.error(result.error || "Une erreur est survenue");
+        }
+      } catch (error) {
+        console.error("[BannerTable] toggleBannerActive failed:", error);
         toast.error("Erreur de connexion au serveur");
       }
     });
@@ -315,11 +326,13 @@ export function BannerTable({ banners: initialBanners }: { banners: BannerRowDat
       try {
         const result = await deleteBanner(id);
         if (result.success) {
+          setItems((prev) => prev.filter((b) => b.id !== id));
           toast.success("Bannière supprimée");
         } else {
           toast.error(result.error || "Une erreur est survenue");
         }
-      } catch {
+      } catch (error) {
+        console.error("[BannerTable] deleteBanner failed:", error);
         toast.error("Erreur de connexion au serveur");
       }
     });

--- a/components/admin/banner-table.tsx
+++ b/components/admin/banner-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useTransition, memo } from "react";
+import { useState, useCallback, useTransition, useRef, memo } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import {
@@ -101,7 +101,8 @@ function formatDate(dateStr: string | null): string {
       month: "short",
       year: "numeric",
     }).format(new Date(dateStr));
-  } catch {
+  } catch (error) {
+    console.error("[BannerTable] formatDate: invalid date string:", dateStr, error);
     return "Date invalide";
   }
 }
@@ -260,6 +261,8 @@ export function BannerTable({ banners: initialBanners }: { banners: BannerRowDat
   const [items, setItems] = useState(initialBanners);
   const [activeId, setActiveId] = useState<number | null>(null);
   const [isPending, startTransition] = useTransition();
+  // Tracks the last server-confirmed state so rollbacks don't undo unrelated confirmed mutations
+  const confirmedItemsRef = useRef(initialBanners);
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -275,7 +278,6 @@ export function BannerTable({ banners: initialBanners }: { banners: BannerRowDat
     setActiveId(null);
     if (!over || active.id === over.id) return;
 
-    const previousItems = items;
     const oldIndex = items.findIndex((b) => b.id === active.id);
     const newIndex = items.findIndex((b) => b.id === over.id);
     const newItems = arrayMove(items, oldIndex, newIndex).map((item, idx) => ({
@@ -290,14 +292,15 @@ export function BannerTable({ banners: initialBanners }: { banners: BannerRowDat
       try {
         const result = await reorderBanners(newOrder);
         if (!result.success) {
-          setItems(previousItems);
+          setItems(confirmedItemsRef.current);
           toast.error(result.error || "Erreur lors de la sauvegarde de l'ordre");
         } else {
+          confirmedItemsRef.current = newItems;
           toast.success("Ordre sauvegardé");
         }
       } catch (error) {
         console.error("[BannerTable] reorderBanners failed:", error);
-        setItems(previousItems);
+        setItems(confirmedItemsRef.current);
         toast.error("Erreur de connexion au serveur");
       }
     });
@@ -308,9 +311,13 @@ export function BannerTable({ banners: initialBanners }: { banners: BannerRowDat
       try {
         const result = await toggleBannerActive(id);
         if (result.success) {
-          setItems((prev) =>
-            prev.map((b) => (b.id === id ? { ...b, is_active: b.is_active === 1 ? 0 : 1 } : b))
-          );
+          setItems((prev) => {
+            const next = prev.map((b) =>
+              b.id === id ? { ...b, is_active: b.is_active === 1 ? 0 : 1 } : b
+            );
+            confirmedItemsRef.current = next;
+            return next;
+          });
         } else {
           toast.error(result.error || "Une erreur est survenue");
         }
@@ -326,7 +333,11 @@ export function BannerTable({ banners: initialBanners }: { banners: BannerRowDat
       try {
         const result = await deleteBanner(id);
         if (result.success) {
-          setItems((prev) => prev.filter((b) => b.id !== id));
+          setItems((prev) => {
+            const next = prev.filter((b) => b.id !== id);
+            confirmedItemsRef.current = next;
+            return next;
+          });
           toast.success("Bannière supprimée");
         } else {
           toast.error(result.error || "Une erreur est survenue");

--- a/components/admin/banner-table.tsx
+++ b/components/admin/banner-table.tsx
@@ -1,8 +1,27 @@
 "use client";
 
-import { memo, useCallback, useTransition } from "react";
+import { useState, useCallback, useTransition, memo } from "react";
 import Link from "next/link";
 import Image from "next/image";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragOverlay,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { getImageUrl } from "@/lib/utils/images";
 import { toast } from "sonner";
 import {
@@ -34,10 +53,11 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { MoreVerticalIcon } from "@hugeicons/core-free-icons";
+import { MoreVerticalIcon, DragDropVerticalIcon } from "@hugeicons/core-free-icons";
 import {
   toggleBannerActive,
   deleteBanner,
+  reorderBanners,
 } from "@/actions/admin/banners";
 import type { Banner } from "@/lib/db/types";
 
@@ -86,12 +106,13 @@ function formatDate(dateStr: string | null): string {
   }
 }
 
-// Hoisted static elements (rendering-hoist-jsx)
+// Hoisted static elements
 const imagePlaceholder = <div className="h-10 w-10 rounded bg-muted" />;
 const moreIcon = <HugeiconsIcon icon={MoreVerticalIcon} size={18} />;
+const dragIcon = <HugeiconsIcon icon={DragDropVerticalIcon} size={18} />;
 
-// Memoized row component for better performance (rerender-memo)
-const BannerRow = memo(function BannerRow({
+// Sortable row with drag handle
+const SortableBannerRow = memo(function SortableBannerRow({
   banner,
   onToggleActive,
   onDelete,
@@ -100,13 +121,37 @@ const BannerRow = memo(function BannerRow({
   onToggleActive: (id: number) => void;
   onDelete: (id: number) => void;
 }) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: banner.id });
+
   const status = getBannerStatus(banner);
 
   return (
     <TableRow
-      style={{ contentVisibility: "auto", containIntrinsicSize: "0 56px" }}
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.4 : 1,
+      }}
       className="transition-colors hover:bg-muted/50"
     >
+      <TableCell className="w-10 px-2">
+        <button
+          {...attributes}
+          {...listeners}
+          className="flex cursor-grab items-center justify-center rounded p-1 text-muted-foreground hover:text-foreground active:cursor-grabbing touch-none"
+          aria-label="Réorganiser"
+        >
+          {dragIcon}
+        </button>
+      </TableCell>
       <TableCell>
         {banner.image_url ? (
           <Image
@@ -155,9 +200,7 @@ const BannerRow = memo(function BannerRow({
               <DropdownMenuItem asChild>
                 <Link href={`/banners/${banner.id}/edit`}>Modifier</Link>
               </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => onToggleActive(banner.id)}
-              >
+              <DropdownMenuItem onClick={() => onToggleActive(banner.id)}>
                 {banner.is_active === 1 ? "Désactiver" : "Activer"}
               </DropdownMenuItem>
               <DropdownMenuSeparator />
@@ -192,8 +235,70 @@ const BannerRow = memo(function BannerRow({
   );
 });
 
-export function BannerTable({ banners }: { banners: BannerRowData[] }) {
+// Lightweight overlay shown while dragging (renders outside the table in a portal)
+function DragOverlayRow({ banner }: { banner: BannerRowData }) {
+  return (
+    <div className="flex items-center gap-3 rounded-lg border bg-background px-4 py-3 shadow-xl">
+      <HugeiconsIcon icon={DragDropVerticalIcon} size={18} className="shrink-0 text-muted-foreground" />
+      {banner.image_url ? (
+        <Image
+          src={getImageUrl(banner.image_url)}
+          alt={banner.title}
+          width={32}
+          height={32}
+          className="rounded object-cover"
+        />
+      ) : (
+        <div className="h-8 w-8 rounded bg-muted" />
+      )}
+      <span className="font-medium">{banner.title}</span>
+    </div>
+  );
+}
+
+export function BannerTable({ banners: initialBanners }: { banners: BannerRowData[] }) {
+  const [items, setItems] = useState(initialBanners);
+  const [activeId, setActiveId] = useState<number | null>(null);
   const [isPending, startTransition] = useTransition();
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setActiveId(event.active.id as number);
+  }, []);
+
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    const { active, over } = event;
+    setActiveId(null);
+    if (!over || active.id === over.id) return;
+
+    setItems((current) => {
+      const oldIndex = current.findIndex((b) => b.id === active.id);
+      const newIndex = current.findIndex((b) => b.id === over.id);
+      return arrayMove(current, oldIndex, newIndex);
+    });
+
+    // Capture new order after state update via functional update
+    setItems((current) => {
+      const newOrder = current.map((b) => b.id);
+      startTransition(async () => {
+        try {
+          const result = await reorderBanners(newOrder);
+          if (!result.success) {
+            toast.error(result.error || "Erreur lors de la sauvegarde de l'ordre");
+          } else {
+            toast.success("Ordre sauvegardé");
+          }
+        } catch {
+          toast.error("Erreur de connexion au serveur");
+        }
+      });
+      return current; // no additional state change
+    });
+  }, []);
 
   const handleToggleActive = useCallback((id: number) => {
     startTransition(async () => {
@@ -221,7 +326,9 @@ export function BannerTable({ banners }: { banners: BannerRowData[] }) {
     });
   }, []);
 
-  if (banners.length === 0) {
+  const activeItem = activeId !== null ? items.find((b) => b.id === activeId) ?? null : null;
+
+  if (items.length === 0) {
     return (
       <div className="rounded-lg border p-8 text-center text-muted-foreground">
         Aucune bannière créée
@@ -230,30 +337,46 @@ export function BannerTable({ banners }: { banners: BannerRowData[] }) {
   }
 
   return (
-    <div className="rounded-lg border touch-manipulation" data-pending={isPending || undefined}>
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead className="w-16">Image</TableHead>
-            <TableHead>Titre</TableHead>
-            <TableHead>Statut</TableHead>
-            <TableHead className="hidden sm:table-cell">Ordre</TableHead>
-            <TableHead className="hidden md:table-cell">Début</TableHead>
-            <TableHead className="hidden md:table-cell">Fin</TableHead>
-            <TableHead className="w-14"></TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {banners.map((banner) => (
-            <BannerRow
-              key={banner.id}
-              banner={banner}
-              onToggleActive={handleToggleActive}
-              onDelete={handleDelete}
-            />
-          ))}
-        </TableBody>
-      </Table>
-    </div>
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+    >
+      <div className="rounded-lg border touch-manipulation" data-pending={isPending || undefined}>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-10"></TableHead>
+              <TableHead className="w-16">Image</TableHead>
+              <TableHead>Titre</TableHead>
+              <TableHead>Statut</TableHead>
+              <TableHead className="hidden sm:table-cell">Ordre</TableHead>
+              <TableHead className="hidden md:table-cell">Début</TableHead>
+              <TableHead className="hidden md:table-cell">Fin</TableHead>
+              <TableHead className="w-14"></TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <SortableContext
+              items={items.map((b) => b.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              {items.map((banner) => (
+                <SortableBannerRow
+                  key={banner.id}
+                  banner={banner}
+                  onToggleActive={handleToggleActive}
+                  onDelete={handleDelete}
+                />
+              ))}
+            </SortableContext>
+          </TableBody>
+        </Table>
+      </div>
+      <DragOverlay>
+        {activeItem ? <DragOverlayRow banner={activeItem} /> : null}
+      </DragOverlay>
+    </DndContext>
   );
 }

--- a/components/admin/banner-table.tsx
+++ b/components/admin/banner-table.tsx
@@ -273,6 +273,10 @@ export function BannerTable({ banners: initialBanners }: { banners: BannerRowDat
     setActiveId(event.active.id as number);
   }, []);
 
+  const handleDragCancel = useCallback(() => {
+    setActiveId(null);
+  }, []);
+
   const handleDragEnd = useCallback((event: DragEndEvent) => {
     const { active, over } = event;
     setActiveId(null);
@@ -365,6 +369,7 @@ export function BannerTable({ banners: initialBanners }: { banners: BannerRowDat
       collisionDetection={closestCenter}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
     >
       <div className="rounded-lg border touch-manipulation" data-pending={isPending || undefined}>
         <Table>

--- a/components/admin/banner-table.tsx
+++ b/components/admin/banner-table.tsx
@@ -275,30 +275,26 @@ export function BannerTable({ banners: initialBanners }: { banners: BannerRowDat
     setActiveId(null);
     if (!over || active.id === over.id) return;
 
-    setItems((current) => {
-      const oldIndex = current.findIndex((b) => b.id === active.id);
-      const newIndex = current.findIndex((b) => b.id === over.id);
-      return arrayMove(current, oldIndex, newIndex);
-    });
+    const oldIndex = items.findIndex((b) => b.id === active.id);
+    const newIndex = items.findIndex((b) => b.id === over.id);
+    const newItems = arrayMove(items, oldIndex, newIndex);
 
-    // Capture new order after state update via functional update
-    setItems((current) => {
-      const newOrder = current.map((b) => b.id);
-      startTransition(async () => {
-        try {
-          const result = await reorderBanners(newOrder);
-          if (!result.success) {
-            toast.error(result.error || "Erreur lors de la sauvegarde de l'ordre");
-          } else {
-            toast.success("Ordre sauvegardé");
-          }
-        } catch {
-          toast.error("Erreur de connexion au serveur");
+    setItems(newItems);
+
+    const newOrder = newItems.map((b) => b.id);
+    startTransition(async () => {
+      try {
+        const result = await reorderBanners(newOrder);
+        if (!result.success) {
+          toast.error(result.error || "Erreur lors de la sauvegarde de l'ordre");
+        } else {
+          toast.success("Ordre sauvegardé");
         }
-      });
-      return current; // no additional state change
+      } catch {
+        toast.error("Erreur de connexion au serveur");
+      }
     });
-  }, []);
+  }, [items]);
 
   const handleToggleActive = useCallback((id: number) => {
     startTransition(async () => {

--- a/components/admin/banner-table.tsx
+++ b/components/admin/banner-table.tsx
@@ -277,7 +277,10 @@ export function BannerTable({ banners: initialBanners }: { banners: BannerRowDat
 
     const oldIndex = items.findIndex((b) => b.id === active.id);
     const newIndex = items.findIndex((b) => b.id === over.id);
-    const newItems = arrayMove(items, oldIndex, newIndex);
+    const newItems = arrayMove(items, oldIndex, newIndex).map((item, idx) => ({
+      ...item,
+      display_order: idx,
+    }));
 
     setItems(newItems);
 

--- a/docs/plans/2026-03-02-banner-dnd-design.md
+++ b/docs/plans/2026-03-02-banner-dnd-design.md
@@ -1,0 +1,68 @@
+# Banner Drag-and-Drop Reordering — Design
+
+**Date:** 2026-03-02
+**Status:** Approved
+
+## Problem
+
+The banner list in the admin shows a `display_order` column but order can only be changed by editing each banner individually. There is no way to quickly reorder banners visually.
+
+## Goal
+
+Allow admins to reorder banners via drag-and-drop directly in the banner list table. Order is saved instantly on drop.
+
+## Approach
+
+`@dnd-kit/sortable` — lightweight (~12 KB), accessible (keyboard + touch), actively maintained, works well with React table rows.
+
+## Architecture
+
+### New Server Action
+
+`reorderBanners(orderedIds: number[]): Promise<ActionResult>` in `actions/admin/banners.ts`.
+
+- Receives the banner IDs in their new order
+- Batch-updates `display_order` as 0, 1, 2… (compact reassignment)
+- Calls `revalidatePath("/banners")`, `revalidatePath("/")`, and `refreshHeroPreload()`
+
+### BannerTable
+
+- Maintains local `items` state (optimistic copy of the list)
+- On drop: updates local state immediately, fires `reorderBanners` in a `startTransition`
+- On error: shows an error toast (no rollback — rare case, acceptable)
+- The `Ordre` column remains visible and reflects the saved index
+
+## Components
+
+| Component | Role |
+|---|---|
+| `BannerTable` | Wraps table with `DndContext` + `SortableContext` |
+| `SortableBannerRow` | `useSortable` wrapper around existing `BannerRow` |
+| `DragOverlay` | Floating clone of the row shown during drag |
+
+### Column changes
+
+- New leftmost column: drag handle (`DragDropVerticalIcon` from HugeIcons), `cursor-grab`
+- `SortableBannerRow` applies `transform`, `transition`, and `opacity: 0.5` when `isDragging`
+
+## Interaction Flow
+
+1. User grabs the handle → row lifts (shadow + 80% opacity)
+2. User drags → other rows animate to new positions in real time
+3. User drops → local order updates instantly; server action fires in background
+4. Success: subtle toast "Ordre sauvegardé"
+5. Error: error toast; UI keeps the new order (optimistic, no rollback)
+
+## Dependencies to Install
+
+```
+@dnd-kit/core @dnd-kit/sortable @dnd-kit/utilities
+```
+
+## Files to Change
+
+| File | Change |
+|---|---|
+| `package.json` | Add `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities` |
+| `actions/admin/banners.ts` | Add `reorderBanners` server action |
+| `components/admin/banner-table.tsx` | Add DnD logic, drag handle column, `SortableBannerRow` |

--- a/docs/plans/2026-03-02-banner-dnd.md
+++ b/docs/plans/2026-03-02-banner-dnd.md
@@ -1,0 +1,683 @@
+# Banner Drag-and-Drop Reordering — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Allow admins to reorder banners via drag-and-drop in the banner list table, with instant server-side save on drop.
+
+**Architecture:** Add a `reorderBanners(orderedIds[])` Server Action (Promise.all of individual Drizzle `UPDATE`s), then transform `BannerTable` with `@dnd-kit/core` + `@dnd-kit/sortable`. The table gains a drag-handle column; local state updates optimistically on drop, and the server action fires in the background.
+
+**Tech Stack:** Next.js 15 App Router, Drizzle ORM + D1 SQLite, @dnd-kit/core + @dnd-kit/sortable + @dnd-kit/utilities, HugeIcons, Sonner toasts, Vitest.
+
+---
+
+### Task 1: Create feature branch
+
+**Step 1: Create and switch to branch**
+
+```bash
+git checkout -b feat/banner-dnd-reorder
+```
+
+**Step 2: Verify**
+
+```bash
+git branch --show-current
+```
+Expected: `feat/banner-dnd-reorder`
+
+---
+
+### Task 2: Install @dnd-kit packages
+
+**Files:**
+- Modify: `package.json` (npm handles this)
+
+**Step 1: Install the three packages**
+
+```bash
+npm install @dnd-kit/core @dnd-kit/sortable @dnd-kit/utilities
+```
+
+**Step 2: Verify installation**
+
+```bash
+node -e "require('@dnd-kit/core'); require('@dnd-kit/sortable'); require('@dnd-kit/utilities'); console.log('ok')"
+```
+Expected: `ok`
+
+**Step 3: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: install @dnd-kit packages for banner drag-and-drop"
+```
+
+---
+
+### Task 3: Add `reorderBanners` server action (TDD)
+
+**Files:**
+- Modify: `actions/admin/banners.ts`
+- Modify: `__tests__/unit/actions/admin-banners.test.ts`
+
+**Step 1: Write the failing tests**
+
+Add this describe block at the **end** of `__tests__/unit/actions/admin-banners.test.ts`, just before the final closing brace. Also add `reorderBanners` to the existing import on line 41:
+
+```typescript
+// Change:
+import {
+  createBanner,
+  uploadBannerImage,
+  setBannerImageUrl,
+  createBannerGradient,
+  deleteBannerGradient,
+} from "@/actions/admin/banners";
+
+// To:
+import {
+  createBanner,
+  uploadBannerImage,
+  setBannerImageUrl,
+  createBannerGradient,
+  deleteBannerGradient,
+  reorderBanners,
+} from "@/actions/admin/banners";
+```
+
+Then append this describe block at the end of the file:
+
+```typescript
+// ─── reorderBanners ───────────────────────────────────────────────────────────
+
+describe("reorderBanners", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue(mockAdminSession);
+  });
+
+  function makeReorderMock() {
+    const whereMock = vi.fn().mockResolvedValue(undefined);
+    const setMock = vi.fn().mockReturnValue({ where: whereMock });
+    mocks.dbUpdate.mockReturnValue({ set: setMock });
+    mocks.getDrizzle.mockResolvedValue({ update: mocks.dbUpdate });
+    return { whereMock, setMock };
+  }
+
+  it("redirige si non admin (customer session)", async () => {
+    mocks.getSession.mockResolvedValue(mockCustomerSession);
+    await expect(reorderBanners([1, 2])).rejects.toThrow("NEXT_REDIRECT");
+  });
+
+  it("tableau vide → succès sans appel DB", async () => {
+    const result = await reorderBanners([]);
+    expect(result.success).toBe(true);
+    expect(mocks.getDrizzle).not.toHaveBeenCalled();
+  });
+
+  it("met à jour display_order pour chaque ID dans le bon ordre", async () => {
+    const { setMock } = makeReorderMock();
+
+    const result = await reorderBanners([3, 1, 2]);
+
+    expect(result.success).toBe(true);
+    expect(mocks.dbUpdate).toHaveBeenCalledTimes(3);
+    expect(setMock).toHaveBeenNthCalledWith(1, expect.objectContaining({ display_order: 0 }));
+    expect(setMock).toHaveBeenNthCalledWith(2, expect.objectContaining({ display_order: 1 }));
+    expect(setMock).toHaveBeenNthCalledWith(3, expect.objectContaining({ display_order: 2 }));
+  });
+
+  it("passe l'updated_at avec chaque mise à jour", async () => {
+    const { setMock } = makeReorderMock();
+
+    await reorderBanners([5]);
+
+    expect(setMock).toHaveBeenCalledWith(
+      expect.objectContaining({ updated_at: expect.stringMatching(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/) })
+    );
+  });
+
+  it("appelle where() avec l'ID correct pour chaque bannière", async () => {
+    const { whereMock } = makeReorderMock();
+
+    await reorderBanners([10, 20]);
+
+    expect(whereMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retourne une erreur si une mise à jour DB échoue", async () => {
+    const whereMock = vi.fn().mockRejectedValue(new Error("D1 error"));
+    mocks.dbUpdate.mockReturnValue({ set: vi.fn().mockReturnValue({ where: whereMock }) });
+    mocks.getDrizzle.mockResolvedValue({ update: mocks.dbUpdate });
+
+    const result = await reorderBanners([1, 2]);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("ordre");
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+```bash
+npm run test -- --reporter=verbose __tests__/unit/actions/admin-banners.test.ts
+```
+Expected: the 6 new `reorderBanners` tests fail with "reorderBanners is not a function" or similar.
+
+**Step 3: Implement `reorderBanners` in `actions/admin/banners.ts`**
+
+Add this export at the **end** of `actions/admin/banners.ts`, after `deleteBannerGradient`:
+
+```typescript
+export async function reorderBanners(orderedIds: number[]): Promise<ActionResult> {
+  await requireAdmin();
+
+  if (!Array.isArray(orderedIds) || orderedIds.length === 0) {
+    return { success: true };
+  }
+
+  try {
+    const db = await getDrizzle();
+    const now = new Date().toISOString().replace("T", " ").slice(0, 19);
+
+    await Promise.all(
+      orderedIds.map((id, index) =>
+        db.update(banners).set({ display_order: index, updated_at: now }).where(eq(banners.id, id))
+      )
+    );
+
+    revalidatePath("/banners");
+    revalidatePath("/");
+    await refreshHeroPreload();
+    return { success: true };
+  } catch (error) {
+    console.error("[admin/banners] reorderBanners error:", error);
+    return { success: false, error: "Erreur lors de la mise à jour de l'ordre" };
+  }
+}
+```
+
+Note: `eq` and `revalidatePath` are already imported at the top of the file. No new imports needed.
+
+**Step 4: Run tests to verify they pass**
+
+```bash
+npm run test -- --reporter=verbose __tests__/unit/actions/admin-banners.test.ts
+```
+Expected: all tests pass, including the 6 new ones.
+
+**Step 5: Run full test suite**
+
+```bash
+npm run test
+```
+Expected: all tests pass.
+
+**Step 6: Commit**
+
+```bash
+git add "actions/admin/banners.ts" "__tests__/unit/actions/admin-banners.test.ts"
+git commit -m "feat(banners): add reorderBanners server action"
+```
+
+---
+
+### Task 4: Implement drag-and-drop in BannerTable
+
+**Files:**
+- Modify: `components/admin/banner-table.tsx`
+
+**Step 1: Rewrite `banner-table.tsx` with DnD**
+
+Replace the entire contents of `components/admin/banner-table.tsx` with:
+
+```tsx
+"use client";
+
+import { useState, useCallback, useTransition, memo } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragOverlay,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { getImageUrl } from "@/lib/utils/images";
+import { toast } from "sonner";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { MoreVerticalIcon, DragDropVerticalIcon } from "@hugeicons/core-free-icons";
+import {
+  toggleBannerActive,
+  deleteBanner,
+  reorderBanners,
+} from "@/actions/admin/banners";
+import type { Banner } from "@/lib/db/types";
+
+type BannerRowData = Pick<Banner, "id" | "title" | "image_url" | "display_order" | "is_active" | "starts_at" | "ends_at">;
+
+function getBannerStatus(banner: BannerRowData): {
+  label: string;
+  variant: "default" | "secondary" | "destructive" | "outline";
+  className?: string;
+} {
+  if (banner.is_active === 0) {
+    return { label: "Inactive", variant: "secondary" };
+  }
+
+  const now = new Date().toISOString().replace("T", " ").slice(0, 19);
+
+  if (banner.starts_at && banner.starts_at > now) {
+    return {
+      label: "Programmée",
+      variant: "outline",
+      className: "border-yellow-500/50 bg-yellow-500/10 text-yellow-700 dark:text-yellow-400",
+    };
+  }
+
+  if (banner.ends_at && banner.ends_at <= now) {
+    return { label: "Expirée", variant: "destructive" };
+  }
+
+  return {
+    label: "Active",
+    variant: "outline",
+    className: "border-green-500/50 bg-green-500/10 text-green-700 dark:text-green-400",
+  };
+}
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return "—";
+  try {
+    return new Intl.DateTimeFormat("fr-FR", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    }).format(new Date(dateStr));
+  } catch {
+    return "Date invalide";
+  }
+}
+
+// Hoisted static elements
+const imagePlaceholder = <div className="h-10 w-10 rounded bg-muted" />;
+const moreIcon = <HugeiconsIcon icon={MoreVerticalIcon} size={18} />;
+const dragIcon = <HugeiconsIcon icon={DragDropVerticalIcon} size={18} />;
+
+// Sortable row with drag handle
+const SortableBannerRow = memo(function SortableBannerRow({
+  banner,
+  onToggleActive,
+  onDelete,
+}: {
+  banner: BannerRowData;
+  onToggleActive: (id: number) => void;
+  onDelete: (id: number) => void;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: banner.id });
+
+  const status = getBannerStatus(banner);
+
+  return (
+    <TableRow
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.4 : 1,
+      }}
+      className="transition-colors hover:bg-muted/50"
+    >
+      <TableCell className="w-10 px-2">
+        <button
+          {...attributes}
+          {...listeners}
+          className="flex cursor-grab items-center justify-center rounded p-1 text-muted-foreground hover:text-foreground active:cursor-grabbing touch-none"
+          aria-label="Réorganiser"
+        >
+          {dragIcon}
+        </button>
+      </TableCell>
+      <TableCell>
+        {banner.image_url ? (
+          <Image
+            src={getImageUrl(banner.image_url)}
+            alt={banner.title}
+            width={40}
+            height={40}
+            className="rounded object-cover"
+          />
+        ) : (
+          imagePlaceholder
+        )}
+      </TableCell>
+      <TableCell>
+        <Link
+          href={`/banners/${banner.id}/edit`}
+          className="font-medium hover:underline"
+        >
+          {banner.title}
+        </Link>
+      </TableCell>
+      <TableCell>
+        <Badge variant={status.variant} className={status.className}>
+          {status.label}
+        </Badge>
+      </TableCell>
+      <TableCell className="hidden sm:table-cell text-muted-foreground text-sm font-mono">
+        {banner.display_order}
+      </TableCell>
+      <TableCell className="hidden md:table-cell text-muted-foreground text-sm">
+        {formatDate(banner.starts_at)}
+      </TableCell>
+      <TableCell className="hidden md:table-cell text-muted-foreground text-sm">
+        {formatDate(banner.ends_at)}
+      </TableCell>
+      <TableCell>
+        <AlertDialog>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="icon" className="h-11 w-11">
+                {moreIcon}
+                <span className="sr-only">Actions</span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem asChild>
+                <Link href={`/banners/${banner.id}/edit`}>Modifier</Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => onToggleActive(banner.id)}>
+                {banner.is_active === 1 ? "Désactiver" : "Activer"}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <AlertDialogTrigger asChild>
+                <DropdownMenuItem className="text-destructive">
+                  Supprimer
+                </DropdownMenuItem>
+              </AlertDialogTrigger>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Supprimer cette bannière ?</AlertDialogTitle>
+              <AlertDialogDescription>
+                Cette action supprimera définitivement &quot;{banner.title}&quot;
+                ainsi que son image associée.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Annuler</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={() => onDelete(banner.id)}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                Supprimer
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </TableCell>
+    </TableRow>
+  );
+});
+
+// Lightweight overlay shown while dragging (renders outside the table in a portal)
+function DragOverlayRow({ banner }: { banner: BannerRowData }) {
+  return (
+    <div className="flex items-center gap-3 rounded-lg border bg-background px-4 py-3 shadow-xl">
+      <HugeiconsIcon icon={DragDropVerticalIcon} size={18} className="shrink-0 text-muted-foreground" />
+      {banner.image_url ? (
+        <Image
+          src={getImageUrl(banner.image_url)}
+          alt={banner.title}
+          width={32}
+          height={32}
+          className="rounded object-cover"
+        />
+      ) : (
+        <div className="h-8 w-8 rounded bg-muted" />
+      )}
+      <span className="font-medium">{banner.title}</span>
+    </div>
+  );
+}
+
+export function BannerTable({ banners: initialBanners }: { banners: BannerRowData[] }) {
+  const [items, setItems] = useState(initialBanners);
+  const [activeId, setActiveId] = useState<number | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setActiveId(event.active.id as number);
+  }, []);
+
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    const { active, over } = event;
+    setActiveId(null);
+    if (!over || active.id === over.id) return;
+
+    setItems((current) => {
+      const oldIndex = current.findIndex((b) => b.id === active.id);
+      const newIndex = current.findIndex((b) => b.id === over.id);
+      return arrayMove(current, oldIndex, newIndex);
+    });
+
+    // Capture new order after state update via functional update
+    setItems((current) => {
+      const newOrder = current.map((b) => b.id);
+      startTransition(async () => {
+        try {
+          const result = await reorderBanners(newOrder);
+          if (!result.success) {
+            toast.error(result.error || "Erreur lors de la sauvegarde de l'ordre");
+          } else {
+            toast.success("Ordre sauvegardé");
+          }
+        } catch {
+          toast.error("Erreur de connexion au serveur");
+        }
+      });
+      return current; // no additional state change
+    });
+  }, []);
+
+  const handleToggleActive = useCallback((id: number) => {
+    startTransition(async () => {
+      try {
+        const result = await toggleBannerActive(id);
+        if (!result.success) toast.error(result.error || "Une erreur est survenue");
+      } catch {
+        toast.error("Erreur de connexion au serveur");
+      }
+    });
+  }, []);
+
+  const handleDelete = useCallback((id: number) => {
+    startTransition(async () => {
+      try {
+        const result = await deleteBanner(id);
+        if (result.success) {
+          toast.success("Bannière supprimée");
+        } else {
+          toast.error(result.error || "Une erreur est survenue");
+        }
+      } catch {
+        toast.error("Erreur de connexion au serveur");
+      }
+    });
+  }, []);
+
+  const activeItem = activeId !== null ? items.find((b) => b.id === activeId) ?? null : null;
+
+  if (items.length === 0) {
+    return (
+      <div className="rounded-lg border p-8 text-center text-muted-foreground">
+        Aucune bannière créée
+      </div>
+    );
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+    >
+      <div className="rounded-lg border touch-manipulation" data-pending={isPending || undefined}>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-10"></TableHead>
+              <TableHead className="w-16">Image</TableHead>
+              <TableHead>Titre</TableHead>
+              <TableHead>Statut</TableHead>
+              <TableHead className="hidden sm:table-cell">Ordre</TableHead>
+              <TableHead className="hidden md:table-cell">Début</TableHead>
+              <TableHead className="hidden md:table-cell">Fin</TableHead>
+              <TableHead className="w-14"></TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <SortableContext
+              items={items.map((b) => b.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              {items.map((banner) => (
+                <SortableBannerRow
+                  key={banner.id}
+                  banner={banner}
+                  onToggleActive={handleToggleActive}
+                  onDelete={handleDelete}
+                />
+              ))}
+            </SortableContext>
+          </TableBody>
+        </Table>
+      </div>
+      <DragOverlay>
+        {activeItem ? <DragOverlayRow banner={activeItem} /> : null}
+      </DragOverlay>
+    </DndContext>
+  );
+}
+```
+
+**Step 2: Run TypeScript check**
+
+```bash
+npx tsc --noEmit
+```
+Expected: no errors.
+
+**Step 3: Run lint**
+
+```bash
+npm run lint
+```
+Expected: no errors.
+
+**Step 4: Run full test suite**
+
+```bash
+npm run test
+```
+Expected: all tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add "components/admin/banner-table.tsx"
+git commit -m "feat(banners): drag-and-drop reordering in banner list"
+```
+
+---
+
+### Task 5: Push and open PR
+
+**Step 1: Push branch**
+
+```bash
+git push -u origin feat/banner-dnd-reorder
+```
+
+**Step 2: Open PR**
+
+```bash
+gh pr create \
+  --title "feat(banners): drag-and-drop reordering" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds `reorderBanners(orderedIds[])` Server Action that batch-updates `display_order` (0, 1, 2…) for all banners
+- Transforms `BannerTable` into a `@dnd-kit/sortable` sortable list with a drag-handle column
+- Order saves instantly on drop with optimistic UI update; success/error feedback via Sonner toast
+- Refreshes KV hero preload and revalidates `/` + `/banners` after every reorder
+
+## Test plan
+
+- [ ] Open `/banners` in admin
+- [ ] Drag a banner row by its handle icon and drop it at a different position
+- [ ] Verify the `Ordre` column reflects the new index immediately
+- [ ] Verify a "Ordre sauvegardé" toast appears
+- [ ] Refresh the page and confirm the order persisted
+- [ ] Verify other actions (toggle active, delete) still work
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "hasInstallScript": true,
       "dependencies": {
         "@base-ui/react": "^1.1.0",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^5.2.2",
         "@hugeicons/core-free-icons": "^3.1.1",
         "@hugeicons/react": "^1.1.4",
@@ -2151,6 +2154,60 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dotenvx/dotenvx": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.1.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.2.2",
     "@hugeicons/core-free-icons": "^3.1.1",
     "@hugeicons/react": "^1.1.4",


### PR DESCRIPTION
## Summary

- Adds `reorderBanners(orderedIds[])` Server Action that batch-updates `display_order` (0, 1, 2…) for all banners
- Transforms `BannerTable` into a `@dnd-kit/sortable` sortable list with a drag-handle column
- Order saves instantly on drop with optimistic UI update; success/error feedback via Sonner toast
- Refreshes KV hero preload and revalidates `/` + `/banners` after every reorder

## Test plan

- [ ] Open `/banners` in admin
- [ ] Drag a banner row by its handle icon and drop it at a different position
- [ ] Verify the `Ordre` column reflects the new index immediately
- [ ] Verify a "Ordre sauvegardé" toast appears
- [ ] Refresh the page and confirm the order persisted
- [ ] Verify other actions (toggle active, delete) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)