### PR TITLE
refactor(admin): post-merge cleanup from PR #124

### DIFF
--- a/__tests__/unit/actions/admin-customers.test.ts
+++ b/__tests__/unit/actions/admin-customers.test.ts
@@ -117,7 +117,7 @@ describe("banCustomer", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.getSession.mockResolvedValue(mockAdminSession);
-    mocks.queryFirst.mockResolvedValue({ id: "user-target" });
+    mocks.queryFirst.mockResolvedValue({ id: "user-target", role: "customer" });
     mocks.batch.mockResolvedValue([]);
     mocks.banUser.mockResolvedValue({ user: { id: "user-target" } });
   });
@@ -171,6 +171,30 @@ describe("banCustomer", () => {
   it("rejette si agent (droits insuffisants)", async () => {
     mocks.getSession.mockResolvedValue(mockAgentSession);
     await expect(banCustomer("user-target")).rejects.toThrow("NEXT_REDIRECT");
+  });
+
+  it("refuse de bannir un utilisateur avec le rôle admin", async () => {
+    mocks.queryFirst.mockResolvedValue({ id: "admin-target", role: "admin" });
+    const result = await banCustomer("admin-target");
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("administrateur");
+    expect(mocks.banUser).not.toHaveBeenCalled();
+  });
+
+  it("refuse de bannir un utilisateur avec le rôle super_admin", async () => {
+    mocks.queryFirst.mockResolvedValue({ id: "super-target", role: "super_admin" });
+    const result = await banCustomer("super-target");
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("administrateur");
+    expect(mocks.banUser).not.toHaveBeenCalled();
+  });
+
+  it("retourne une erreur si la requête DB échoue", async () => {
+    mocks.queryFirst.mockRejectedValue(new Error("D1 error"));
+    const result = await banCustomer("user-target");
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(mocks.banUser).not.toHaveBeenCalled();
   });
 });
 

--- a/actions/admin/customers.ts
+++ b/actions/admin/customers.ts
@@ -8,7 +8,7 @@ import { initAuth } from "@/lib/auth";
 import { queryFirst, batch } from "@/lib/db";
 import { prepareAuditLog } from "@/lib/db/admin/audit-log";
 import type { ActionResult } from "@/lib/utils";
-import type { UserRole } from "@/lib/db/types";
+import type { UserRole, StaffRole } from "@/lib/db/types";
 import { ROLE_LABELS } from "@/lib/constants/customers";
 
 const idSchema = z.string().min(1, "ID requis");
@@ -19,7 +19,7 @@ const staffRoleSchema = z.enum(["agent", "admin", "super_admin"], {
 
 export async function updateUserRole(
   userId: string,
-  newRole: "agent" | "admin" | "super_admin"
+  newRole: StaffRole
 ): Promise<ActionResult> {
   const session = await requireSuperAdmin();
 
@@ -92,11 +92,16 @@ export async function banCustomer(userId: string, reason?: string): Promise<Acti
   const idResult = idSchema.safeParse(userId);
   if (!idResult.success) return { success: false, error: "ID utilisateur invalide" };
 
-  const user = await queryFirst<{ id: string }>(
-    "SELECT id FROM user WHERE id = ?",
+  const user = await queryFirst<{ id: string; role: string }>(
+    "SELECT id, role FROM user WHERE id = ?",
     [userId]
   );
   if (!user) return { success: false, error: "Utilisateur introuvable" };
+
+  // Prevent banning admin or super_admin (privilege escalation)
+  if (user.role === "admin" || user.role === "super_admin") {
+    return { success: false, error: "Impossible de bannir un administrateur" };
+  }
 
   const auth = await initAuth();
   try {

--- a/actions/admin/customers.ts
+++ b/actions/admin/customers.ts
@@ -92,10 +92,16 @@ export async function banCustomer(userId: string, reason?: string): Promise<Acti
   const idResult = idSchema.safeParse(userId);
   if (!idResult.success) return { success: false, error: "ID utilisateur invalide" };
 
-  const user = await queryFirst<{ id: string; role: string }>(
-    "SELECT id, role FROM user WHERE id = ?",
-    [userId]
-  );
+  let user: { id: string; role: string } | null;
+  try {
+    user = await queryFirst<{ id: string; role: string }>(
+      "SELECT id, role FROM user WHERE id = ?",
+      [userId]
+    );
+  } catch (dbError) {
+    console.error("[admin/customers] queryFirst failed in banCustomer for userId:", userId, dbError);
+    return { success: false, error: "Erreur lors de la récupération de l'utilisateur" };
+  }
   if (!user) return { success: false, error: "Utilisateur introuvable" };
 
   // Prevent banning admin or super_admin (privilege escalation)

--- a/app/(admin)/layout.tsx
+++ b/app/(admin)/layout.tsx
@@ -1,7 +1,7 @@
 import { requireAnyAdmin } from "@/lib/auth/guards";
 import { Sidebar } from "@/components/admin/sidebar";
 import { ViewProvider } from "@/components/admin/view-context";
-import { AdminUserProvider, type AdminUser } from "@/components/admin/admin-user-context";
+import { AdminSessionUserProvider, type AdminSessionUser } from "@/components/admin/admin-user-context";
 import { Toaster } from "@/components/ui/sonner";
 
 export const dynamic = "force-dynamic";
@@ -14,7 +14,7 @@ export default async function AdminLayout({
   const session = await requireAnyAdmin();
 
   return (
-    <AdminUserProvider user={session.user as AdminUser}>
+    <AdminSessionUserProvider user={session.user as AdminSessionUser}>
     <ViewProvider>
       <div className="flex h-dvh">
         <aside className="sticky top-0 hidden h-dvh w-64 shrink-0 overflow-y-auto border-r bg-sidebar lg:block">
@@ -24,6 +24,6 @@ export default async function AdminLayout({
         <Toaster richColors position="top-right" />
       </div>
     </ViewProvider>
-    </AdminUserProvider>
+    </AdminSessionUserProvider>
   );
 }

--- a/app/(admin)/users/[id]/_components/user-sidebar.tsx
+++ b/app/(admin)/users/[id]/_components/user-sidebar.tsx
@@ -16,7 +16,7 @@ import { formatDateLong } from "@/lib/utils";
 import { STAFF_ROLE_OPTIONS } from "@/lib/constants/customers";
 import { updateUserRole, banCustomer, unbanCustomer } from "@/actions/admin/customers";
 import type { AdminUser } from "@/lib/db/admin/users";
-import type { UserRole } from "@/lib/db/types";
+import type { UserRole, StaffRole } from "@/lib/db/types";
 
 interface UserSidebarProps {
   user: AdminUser;
@@ -32,7 +32,7 @@ export function UserSidebar({ user, isSuperAdmin }: UserSidebarProps) {
     setRoleError(null);
     startTransition(async () => {
       try {
-        const result = await updateUserRole(user.id, newRole as "agent" | "admin" | "super_admin");
+        const result = await updateUserRole(user.id, newRole as StaffRole);
         if (!result.success) {
           setRoleError(result.error || "Erreur lors du changement de rôle");
         } else {

--- a/app/(admin)/users/[id]/_components/user-sidebar.tsx
+++ b/app/(admin)/users/[id]/_components/user-sidebar.tsx
@@ -16,7 +16,7 @@ import { formatDateLong } from "@/lib/utils";
 import { STAFF_ROLE_OPTIONS } from "@/lib/constants/customers";
 import { updateUserRole, banCustomer, unbanCustomer } from "@/actions/admin/customers";
 import type { AdminUser } from "@/lib/db/admin/users";
-import type { UserRole, StaffRole } from "@/lib/db/types";
+import type { StaffRole } from "@/lib/db/types";
 
 interface UserSidebarProps {
   user: AdminUser;
@@ -28,11 +28,11 @@ export function UserSidebar({ user, isSuperAdmin }: UserSidebarProps) {
   const [isPending, startTransition] = useTransition();
   const [roleError, setRoleError] = useState<string | null>(null);
 
-  async function handleRoleChange(newRole: UserRole) {
+  async function handleRoleChange(newRole: StaffRole) {
     setRoleError(null);
     startTransition(async () => {
       try {
-        const result = await updateUserRole(user.id, newRole as StaffRole);
+        const result = await updateUserRole(user.id, newRole);
         if (!result.success) {
           setRoleError(result.error || "Erreur lors du changement de rôle");
         } else {
@@ -110,7 +110,7 @@ export function UserSidebar({ user, isSuperAdmin }: UserSidebarProps) {
               </label>
               <Select
                 value={user.role}
-                onValueChange={(value) => handleRoleChange(value as UserRole)}
+                onValueChange={(value) => handleRoleChange(value as StaffRole)}
                 disabled={isPending}
               >
                 <SelectTrigger>

--- a/app/(admin)/users/_components/create-admin-user-dialog.tsx
+++ b/app/(admin)/users/_components/create-admin-user-dialog.tsx
@@ -22,8 +22,9 @@ import {
 } from "@/components/ui/select";
 import { createAdminUser } from "@/actions/admin/users";
 import { STAFF_ROLE_OPTIONS } from "@/lib/constants/customers";
+import type { StaffRole } from "@/lib/db/types";
 
-type Role = "agent" | "admin" | "super_admin";
+type Role = StaffRole;
 
 interface FormValues {
   name: string;

--- a/app/(admin)/users/page.tsx
+++ b/app/(admin)/users/page.tsx
@@ -9,6 +9,7 @@ import {
   getAdminUsers,
   getAdminUserCount,
 } from "@/lib/db/admin/users";
+import type { StaffRole } from "@/lib/db/types";
 
 interface Props {
   searchParams: Promise<{
@@ -28,7 +29,7 @@ export default async function UsersPage({ searchParams }: Props) {
   const params = await searchParams;
   const requestedPage = Math.max(1, Number(params.page) || 1);
 
-  const role: "agent" | "admin" | "super_admin" | undefined =
+  const role: StaffRole | undefined =
     params.role === "agent" || params.role === "admin" || params.role === "super_admin"
       ? params.role
       : undefined;

--- a/components/admin/admin-user-context.tsx
+++ b/components/admin/admin-user-context.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { createContext, useContext, type ReactNode } from "react";
+import type { StaffRole } from "@/lib/db/types";
 
 export type AdminSessionUser = {
   id: string;
   name: string;
   email: string;
   image?: string | null;
-  role: "agent" | "admin" | "super_admin";
+  role: StaffRole;
 };
 
 const AdminSessionUserContext = createContext<AdminSessionUser | null>(null);

--- a/components/admin/admin-user-context.tsx
+++ b/components/admin/admin-user-context.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext, type ReactNode } from "react";
 
-export type AdminUser = {
+export type AdminSessionUser = {
   id: string;
   name: string;
   email: string;
@@ -10,26 +10,26 @@ export type AdminUser = {
   role: "agent" | "admin" | "super_admin";
 };
 
-const AdminUserContext = createContext<AdminUser | null>(null);
+const AdminSessionUserContext = createContext<AdminSessionUser | null>(null);
 
-export function AdminUserProvider({
+export function AdminSessionUserProvider({
   user,
   children,
 }: {
-  user: AdminUser;
+  user: AdminSessionUser;
   children: ReactNode;
 }) {
   return (
-    <AdminUserContext.Provider value={user}>
+    <AdminSessionUserContext.Provider value={user}>
       {children}
-    </AdminUserContext.Provider>
+    </AdminSessionUserContext.Provider>
   );
 }
 
-export function useAdminUser(): AdminUser {
-  const ctx = useContext(AdminUserContext);
+export function useAdminSessionUser(): AdminSessionUser {
+  const ctx = useContext(AdminSessionUserContext);
   if (!ctx) {
-    throw new Error("useAdminUser must be used within an AdminUserProvider");
+    throw new Error("useAdminSessionUser must be used within an AdminSessionUserProvider");
   }
   return ctx;
 }

--- a/components/admin/sidebar-user-menu.tsx
+++ b/components/admin/sidebar-user-menu.tsx
@@ -13,11 +13,11 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { useAdminUser } from "./admin-user-context";
+import { useAdminSessionUser } from "./admin-user-context";
 import { authClient } from "@/lib/auth/client";
 
 export function SidebarUserMenu() {
-  const user = useAdminUser();
+  const user = useAdminSessionUser();
   const router = useRouter();
 
   const initials = (user.name || "?")

--- a/components/admin/sidebar.tsx
+++ b/components/admin/sidebar.tsx
@@ -16,7 +16,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { cn } from "@/lib/utils";
 import { SidebarUserMenu } from "./sidebar-user-menu";
-import { useAdminUser } from "./admin-user-context";
+import { useAdminSessionUser } from "./admin-user-context";
 
 const navItems = [
   { href: "/dashboard", label: "Dashboard", icon: DashboardSquare01Icon, minRole: "agent" as const },
@@ -33,7 +33,7 @@ const ROLE_RANK = { agent: 0, admin: 1, super_admin: 2 } as const;
 
 export function Sidebar() {
   const pathname = usePathname();
-  const { role } = useAdminUser();
+  const { role } = useAdminSessionUser();
 
   return (
     <div className="flex h-full flex-col">

--- a/lib/auth/guards.ts
+++ b/lib/auth/guards.ts
@@ -1,13 +1,14 @@
 import { redirect } from "next/navigation";
 import { headers } from "next/headers";
 import { initAuth, type Session } from "@/lib/auth";
+import type { StaffRole } from "@/lib/db/types";
 
 export type AdminSession = Omit<Session, "user"> & {
   user: Omit<Session["user"], "role"> & { role: "admin" | "super_admin" };
 };
 
 export type AnyAdminSession = Omit<Session, "user"> & {
-  user: Omit<Session["user"], "role"> & { role: "agent" | "admin" | "super_admin" };
+  user: Omit<Session["user"], "role"> & { role: StaffRole };
 };
 
 export type SuperAdminSession = Omit<Session, "user"> & {

--- a/lib/constants/customers.ts
+++ b/lib/constants/customers.ts
@@ -1,4 +1,4 @@
-import type { UserRole } from "@/lib/db/types";
+import type { UserRole, StaffRole } from "@/lib/db/types";
 
 export const ROLE_LABELS: Record<UserRole, string> = {
   customer: "Client",
@@ -25,7 +25,7 @@ export const ROLE_OPTIONS: { value: UserRole; label: string }[] = [
 ];
 
 // Options for staff management only (no customer)
-export const STAFF_ROLE_OPTIONS: { value: "agent" | "admin" | "super_admin"; label: string }[] = [
+export const STAFF_ROLE_OPTIONS: { value: StaffRole; label: string }[] = [
   { value: "agent", label: "Agent" },
   { value: "admin", label: "Administrateur" },
   { value: "super_admin", label: "Super Administrateur" },

--- a/lib/db/admin/users.ts
+++ b/lib/db/admin/users.ts
@@ -1,11 +1,11 @@
 import { query, queryFirst } from "@/lib/db";
-import type { AdminCustomer } from "@/lib/db/types";
+import type { AdminCustomer, StaffRole } from "@/lib/db/types";
 
 export type AdminUser = Omit<AdminCustomer, "order_count" | "total_spent">;
 
 export interface AdminUserFilters {
   search?: string;
-  role?: "agent" | "admin" | "super_admin";
+  role?: StaffRole;
   dateFrom?: string;
   dateTo?: string;
   sort?: "newest" | "oldest" | "name_asc" | "name_desc";

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -285,6 +285,7 @@ export interface AdminOrderDetail extends Order {
 
 // Customer Management Types
 export type UserRole = "customer" | "agent" | "admin" | "super_admin";
+export type StaffRole = Exclude<UserRole, "customer">;
 
 export interface AdminCustomer {
   id: string;


### PR DESCRIPTION
## Summary

Three small cleanups identified during the PR #124 review cycle:

- **Rename `AdminUser` → `AdminSessionUser`** — the context type/provider/hook were ambiguously named `AdminUser`, colliding with the `AdminUser` DB query type exported from `lib/db/admin/users.ts`; all consumers updated (layout, sidebar, sidebar-user-menu)
- **Extract `StaffRole` type** — `Exclude<UserRole, "customer">` replaces the repeated inline union `"agent" | "admin" | "super_admin"` across guards, constants, actions and components
- **Anti-admin-ban guard** — `banCustomer` now fetches the target user's role and returns an error if they are `admin` or `super_admin`, preventing privilege-escalation via the ban endpoint

## Test plan

- [ ] All 488 unit tests pass (`npm run test`)
- [ ] TypeScript compiles without errors (`tsc --noEmit`)
- [ ] No ESLint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)