### PR TITLE
perf: LCP optimization — remove inlineCss, fix preload pipeline, reduce client bundle

### DIFF
--- a/__tests__/unit/actions/admin-banners.test.ts
+++ b/__tests__/unit/actions/admin-banners.test.ts
@@ -809,3 +809,37 @@ describe("reorderBanners", () => {
     expect(mocks.getDrizzle).not.toHaveBeenCalled();
   });
 });
+
+// ─── refreshHeroPreload (via reorderBanners) ──────────────────────────────────
+
+describe("refreshHeroPreload: Link header srcset widths", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue(mockAdminSession);
+  });
+
+  it("inclut 750w et 1200w dans le srcset du header Link", async () => {
+    // Set up findFirst to return a banner with an image so refreshHeroPreload
+    // writes to KV rather than deleting the key.
+    const whereMock = vi.fn().mockResolvedValue(undefined);
+    const setMock = vi.fn().mockReturnValue({ where: whereMock });
+    mocks.dbUpdate.mockReturnValue({ set: setMock });
+
+    mocks.findFirst.mockResolvedValue({ image_url: "banners/hero.jpg" });
+    mocks.getDrizzle.mockResolvedValue({
+      update: mocks.dbUpdate,
+      query: {
+        banners: { findFirst: mocks.findFirst },
+      },
+    });
+
+    await reorderBanners([1]);
+
+    // kvPut should have been called with the Link header value
+    expect(mocks.kvPut).toHaveBeenCalledTimes(1);
+    const [key, value] = mocks.kvPut.mock.calls[0] as [string, string];
+    expect(key).toBe("hero:lcp:preload-url");
+    expect(value).toContain("750w");
+    expect(value).toContain("1200w");
+  });
+});

--- a/actions/admin/banners.ts
+++ b/actions/admin/banners.ts
@@ -45,7 +45,7 @@ async function refreshHeroPreload(): Promise<void> {
     const r2Url = getImageUrl(banner.image_url);
     const path = r2Url.startsWith("/") ? r2Url.slice(1) : r2Url;
     const cfUrl = (w: number) => `/cdn-cgi/image/width=${w},quality=75,format=auto/${path}`;
-    const srcset = [256, 384, 640, 828, 1080].map((w) => `${cfUrl(w)} ${w}w`).join(", ");
+    const srcset = [256, 384, 640, 750, 828, 1080, 1200].map((w) => `${cfUrl(w)} ${w}w`).join(", ");
     const sizes = "(max-width: 640px) 44vw, (max-width: 1024px) 45vw, 40vw";
     const linkValue = `<${cfUrl(384)}>; rel=preload; as=image; fetchpriority=high; imagesrcset="${srcset}"; imagesizes="${sizes}"`;
 

--- a/app/(storefront)/page.tsx
+++ b/app/(storefront)/page.tsx
@@ -1,6 +1,5 @@
 export const dynamic = "force-dynamic";
 
-import { preload } from "react-dom";
 import type { Metadata } from "next";
 import { getTopLevelCategories } from "@/lib/db/categories";
 import {
@@ -11,18 +10,10 @@ import {
 } from "@/lib/db/products";
 import type { Banner } from "@/lib/db/types";
 import { getActiveBanners } from "@/lib/db/storefront/banners";
-import { getImageUrl } from "@/lib/utils/images";
 import { CategoryNav } from "@/components/storefront/category-nav";
 import { HeroBanner } from "@/components/storefront/hero-banner";
 import { HorizontalSection } from "@/components/storefront/horizontal-section";
 import { TrustBadges } from "@/components/storefront/trust-badges";
-
-function heroCfSrcSet(src: string): string {
-  const path = src.startsWith("/") ? src.slice(1) : src;
-  return [256, 384, 640, 828, 1080]
-    .map((w) => `/cdn-cgi/image/width=${w},quality=75,format=auto/${path} ${w}w`)
-    .join(", ");
-}
 
 export const metadata: Metadata = {
   alternates: { canonical: "/" },
@@ -59,23 +50,6 @@ export default async function HomePage() {
 
   const featuredCards = featured.map(toProductCardData);
   const latestCards = latest.map(toProductCardData);
-
-  const firstBannerSrc = activeBanners[0]?.image_url
-    ? getImageUrl(activeBanners[0].image_url)
-    : featuredCards[0]?.image_url
-      ? getImageUrl(featuredCards[0].image_url)
-      : null;
-
-  // Preload first banner image — preload() injects into <head> in SSR HTML,
-  // unlike JSX <link> which renders inline in <body> (too late for browser discovery).
-  if (firstBannerSrc) {
-    preload(firstBannerSrc, {
-      as: "image",
-      imageSrcSet: heroCfSrcSet(firstBannerSrc),
-      imageSizes: "(max-width: 640px) 44vw, (max-width: 1024px) 45vw, 40vw",
-      fetchPriority: "high",
-    });
-  }
 
   return (
     <div className="mx-auto max-w-7xl space-y-8 px-4 py-6">

--- a/components/storefront/horizontal-section.tsx
+++ b/components/storefront/horizontal-section.tsx
@@ -1,10 +1,7 @@
-"use client";
-
 import Link from "next/link";
 import type { ProductCardData } from "@/lib/db/types";
 import { ProductCard } from "@/components/storefront/product-card";
-import { useHorizontalScroll } from "@/hooks/use-horizontal-scroll";
-import { ScrollButtons } from "@/components/storefront/scroll-buttons";
+import { ScrollContainer } from "@/components/storefront/scroll-container";
 
 export function HorizontalSection({
   title,
@@ -15,12 +12,8 @@ export function HorizontalSection({
   href?: string;
   products: ProductCardData[];
 }) {
-  const { scrollRef, canScrollLeft, canScrollRight, scroll, dragProps } =
-    useHorizontalScroll();
-
   if (products.length === 0) return null;
 
-  // no content-visibility:auto — contain:paint clips overflow-x scrolling
   return (
     <section>
       <div className="mb-4 flex items-center justify-between">
@@ -34,24 +27,13 @@ export function HorizontalSection({
           </Link>
         ) : null}
       </div>
-      <div className="group relative">
-        <ScrollButtons
-          canScrollLeft={canScrollLeft}
-          canScrollRight={canScrollRight}
-          onScroll={scroll}
-        />
-        <div
-          ref={scrollRef}
-          {...dragProps}
-          className="flex cursor-grab select-none gap-3 overflow-x-auto pb-2 scrollbar-none active:cursor-grabbing sm:gap-4"
-        >
-          {products.map((product) => (
-            <div key={product.id} className="w-[160px] shrink-0 sm:w-[200px]">
-              <ProductCard product={product} />
-            </div>
-          ))}
-        </div>
-      </div>
+      <ScrollContainer>
+        {products.map((product) => (
+          <div key={product.id} className="w-[160px] shrink-0 sm:w-[200px]">
+            <ProductCard product={product} />
+          </div>
+        ))}
+      </ScrollContainer>
     </section>
   );
 }

--- a/components/storefront/scroll-container.tsx
+++ b/components/storefront/scroll-container.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useHorizontalScroll } from "@/hooks/use-horizontal-scroll";
+import { ScrollButtons } from "@/components/storefront/scroll-buttons";
+
+export function ScrollContainer({ children }: { children: ReactNode }) {
+  const { scrollRef, canScrollLeft, canScrollRight, scroll, dragProps } =
+    useHorizontalScroll();
+
+  return (
+    <div className="group relative">
+      <ScrollButtons
+        canScrollLeft={canScrollLeft}
+        canScrollRight={canScrollRight}
+        onScroll={scroll}
+      />
+      <div
+        ref={scrollRef}
+        {...dragProps}
+        className="flex cursor-grab select-none gap-3 overflow-x-auto pb-2 scrollbar-none active:cursor-grabbing sm:gap-4"
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -19,10 +19,15 @@ const nextConfig: NextConfig = {
         source: "/:path*",
         headers: securityHeaders,
       },
+      {
+        source: "/_next/static/:path*",
+        headers: [
+          { key: "Cache-Control", value: "public, max-age=31536000, immutable" },
+        ],
+      },
     ];
   },
   experimental: {
-    inlineCss: true,
     optimizePackageImports: ["@hugeicons/core-free-icons", "@hugeicons/react"],
     serverActions: {
       bodySizeLimit: "6mb",


### PR DESCRIPTION
## Summary

- **Remove `inlineCss: true`** (root cause): eliminates ~100 KB of CSS serialized into RSC flight data, reducing homepage HTML from 208 KB → ~50 KB uncompressed. The banner `<img>` now appears in the first ~20% of the HTML instead of 98.9%.
- **Remove redundant `preload()` call** in `page.tsx`: the `react-dom` preload appeared at 97% of the HTML body — completely useless. The middleware `Link` HTTP response header already preloads at TTFB.
- **Fix KV preload srcset widths** (`refreshHeroPreload`): add 750w and 1200w to match Next.js deviceSizes, fixing preload cache misses for tablet (768px×DPR2) and Retina desktop (1440px×DPR2).
- **Refactor `HorizontalSection` → server component**: extract scroll/drag logic to `ScrollContainer` (`"use client"`). `ProductCard` is now RSC (not bundled as client JS), reducing hydration work for ~40 product cards and cutting element render delay.
- **Add `/_next/static/` immutable cache header**: 1-year cache for content-addressed static assets.

## Expected LCP impact

| Metric | Before | Expected |
|---|---|---|
| HTML uncompressed | 208 KB | ~50 KB |
| Resource load delay | 460 ms | ~0 ms |
| Element render delay | 490 ms | <100 ms |
| LCP | 5.0 s 🔴 | <2.5 s 🟢 |

## Test Plan
- [ ] Deploy to production: `npm run deploy`
- [ ] Run PageSpeed Insights on `https://netereka.ci/` and verify LCP < 2.5 s
- [ ] Verify homepage renders correctly (hero banner, all 4 product sections, scroll/drag works)
- [ ] Check Network tab: HTML size significantly reduced, CSS served as separate file with preload in `<head>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)