### PR TITLE
perf(lcp): inject responsive hero preload in storefront layout

### DIFF
--- a/app/(storefront)/layout.tsx
+++ b/app/(storefront)/layout.tsx
@@ -1,12 +1,37 @@
+import { headers } from "next/headers";
+import { preload } from "react-dom";
 import { Header } from "@/components/storefront/header";
 import { Footer } from "@/components/storefront/footer";
 import { CartDrawer } from "@/components/storefront/cart-drawer";
 
-export default function StorefrontLayout({
+const R2_URL = process.env.NEXT_PUBLIC_R2_URL;
+const HERO_WIDTHS = [256, 384, 640, 750, 828, 1080, 1200];
+const HERO_SIZES = "(max-width: 640px) 44vw, (max-width: 1024px) 45vw, 40vw";
+
+// Inject a responsive image preload for the hero banner into the initial HTML bytes.
+// The preload fires as soon as the layout streams (before the page Suspense resolves),
+// so the browser fetches the correct DPR variant while D1 queries are still in flight.
+async function maybePreloadHero() {
+  if (!R2_URL) return;
+  const imageKey = (await headers()).get("x-hero-image-key");
+  if (!imageKey) return;
+  const r2Url = `${R2_URL}/${imageKey}`;
+  const cfUrl = (w: number) => `/cdn-cgi/image/width=${w},quality=75,format=auto/${r2Url}`;
+  preload(cfUrl(384), {
+    as: "image",
+    fetchPriority: "high",
+    imageSrcSet: HERO_WIDTHS.map((w) => `${cfUrl(w)} ${w}w`).join(", "),
+    imageSizes: HERO_SIZES,
+  });
+}
+
+export default async function StorefrontLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  await maybePreloadHero();
+
   return (
     <>
       <Header />

--- a/middleware.ts
+++ b/middleware.ts
@@ -17,13 +17,26 @@ export async function middleware(request: NextRequest) {
     return NextResponse.redirect(url, 301);
   }
 
-  // Add Link preload header for homepage LCP — browser starts hero image fetch at TTFB
+  // Add Link preload header for homepage LCP — browser starts hero image fetch at TTFB.
+  // Also forward the image key as a request header so the storefront layout can inject a
+  // responsive <link rel="preload" imagesrcset="..."> in the initial HTML head bytes,
+  // allowing the browser to pick the correct DPR variant before the Suspense resolves.
   if (pathname === "/") {
     try {
       const { env } = await getCloudflareContext();
       const linkValue = await env.KV.get(KV_HERO_PRELOAD_KEY);
       if (linkValue) {
-        const response = NextResponse.next();
+        // Extract image key from the stored Link header value, e.g.:
+        //   </cdn-cgi/image/width=640,...https://r2.netereka.ci/banners/foo.png>; rel=preload...
+        const urlMatch = linkValue.match(/<([^>]+)>/);
+        const imageUrl = urlMatch?.[1] ?? "";
+        const keyMatch = imageUrl.match(/format=auto\/https?:\/\/r2\.netereka\.ci\/(.+)/);
+        const imageKey = keyMatch?.[1];
+
+        const requestHeaders = new Headers(request.headers);
+        if (imageKey) requestHeaders.set("x-hero-image-key", imageKey);
+
+        const response = NextResponse.next({ request: { headers: requestHeaders } });
         response.headers.set("Link", linkValue);
         return response;
       }


### PR DESCRIPTION
## Summary

- **Middleware** extracts the banner image key from the stored KV link value and forwards it as `x-hero-image-key` on the request headers (homepage only, no overhead on other pages)
- **Storefront layout** reads `x-hero-image-key` and calls `ReactDOM.preload()` with the full `imageSrcSet` + `imageSizes` before rendering its children

## Why this matters

The `<link rel="preload" imagesrcset="...">` that Next.js auto-generates for `<Image priority>` only appears **late in the HTML stream** — after the `loading.tsx` Suspense boundary resolves (i.e. after all D1 queries finish). Because the banner is inside that boundary, the browser can't start fetching the LCP image until `~4s` into the page load.

By injecting the preload in the **layout** (which renders before any Suspense boundary), the preload fires in the **very first HTML bytes** the browser receives. The browser downloads the correct DPR variant while D1 queries are still in flight, so the image is already cached when the banner finally appears in the DOM.

| Subpart | Before | Expected after |
|---|---|---|
| Resource load delay | 1,300 ms 🔴 | ~0 ms ✅ |
| Resource load duration | 500 ms | 500 ms |
| Element render delay | 90 ms | 90 ms |
| **LCP** | **4.5 s** 🔴 | **~2 s** 🟡 |

## Test plan

- [ ] Deploy and run PageSpeed Insights on `https://netereka.ci/`
- [ ] Verify LCP breakdown: resource load delay drops to ~0 ms
- [ ] Verify LCP drops from 4.5 s toward 2 s target
- [ ] Verify no CLS regression (CLS should remain 0)
- [ ] Verify no Speed Index regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)