### PR TITLE
fix(admin): resolve RichTextEditor hydration mismatch

### DIFF
--- a/components/admin/rich-text-editor.tsx
+++ b/components/admin/rich-text-editor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
 import { ContentEditable } from "@lexical/react/LexicalContentEditable";
@@ -47,8 +47,13 @@ export function RichTextEditor({
   defaultValue,
   placeholder = "Rédigez la description du produit…",
 }: RichTextEditorProps) {
+  const [mounted, setMounted] = useState(false);
   const [jsonValue, setJsonValue] = useState(defaultValue ?? "");
   const lastGoodRef = useRef(defaultValue ?? "");
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   const isLexicalJson = defaultValue?.trim().startsWith("{") ?? false;
 
@@ -112,6 +117,15 @@ export function RichTextEditor({
       toast.error("Erreur de sérialisation. L'état précédent est conservé — ne sauvegardez pas encore.", { duration: Infinity });
     }
   }, []);
+
+  if (!mounted) {
+    return (
+      <div className="rounded-md border">
+        <div className="min-h-[200px] p-3" />
+        <input type="hidden" name={name} value={jsonValue} />
+      </div>
+    );
+  }
 
   return (
     <div className="rounded-md border focus-within:ring-2 focus-within:ring-ring">


### PR DESCRIPTION
## Summary

- Lexical's placeholder visibility is driven by client-side editor state, causing a server/client HTML mismatch: the placeholder is rendered in the server HTML but hidden on the client once Lexical initialises with `defaultValue`
- Fix: defer the full Lexical editor render until after mount using a `mounted` state; a minimal skeleton (same border + height) is shown during SSR
- The hidden `<input>` carries the serialized value in both states, so form submission is unaffected

## Test plan

- [ ] Open `/admin/products/[id]/edit` — no hydration warning in the console
- [ ] Editor loads and displays existing description correctly
- [ ] Saving the form still persists the description as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)