### PR TITLE
feat(admin): auto-generate slug and SKU on product save

### DIFF
--- a/__tests__/unit/actions/admin-products.test.ts
+++ b/__tests__/unit/actions/admin-products.test.ts
@@ -166,7 +166,7 @@ describe("updateProduct", () => {
       mocks.nanoid.mockReturnValue("xxxxxxxx");
       mocks.execute.mockRejectedValue(new Error("UNIQUE constraint failed: products.sku"));
       const result = await updateProduct("prod-1", baseFormData());
-      expect(result).toEqual({ success: false, error: "Impossible de générer un SKU unique, veuillez réessayer" });
+      expect(result).toEqual({ success: false, error: "Impossible de générer un SKU unique. Veuillez contacter le support." });
       expect(mocks.execute).toHaveBeenCalledTimes(3);
     });
 
@@ -188,7 +188,7 @@ describe("updateProduct", () => {
       mocks.nanoid.mockReturnValue("abcd1234");
       mocks.execute.mockRejectedValue(new Error("UNIQUE constraint failed: products.slug"));
       const result = await updateProduct("prod-1", baseFormData());
-      expect(result).toEqual({ success: false, error: "Conflit de slug, veuillez réessayer" });
+      expect(result).toEqual({ success: false, error: "Un conflit de slug s'est produit. Modifiez légèrement le nom et réessayez." });
     });
 
     it("appelle revalidatePath sur /p/{slug} lors de la première publication", async () => {
@@ -215,6 +215,50 @@ describe("updateProduct", () => {
         expect.arrayContaining(["NET-EXISTING1"])
       );
       expect(mocks.nanoid).not.toHaveBeenCalled();
+    });
+
+    it("retourne une erreur si toutes les variantes de slug sont prises (épuisement)", async () => {
+      // First queryFirst is for the existing product, subsequent ones all return "taken"
+      mocks.queryFirst.mockResolvedValueOnce({ slug: "draft-abc", sku: null, is_draft: 1 });
+      // All slug candidates are taken (simulate by always returning a row)
+      mocks.queryFirst.mockResolvedValue({ id: "other-prod" });
+      mocks.slugify.mockReturnValue("samsung-galaxy");
+      const result = await updateProduct("prod-1", baseFormData());
+      expect(result).toEqual({ success: false, error: "Impossible de générer un slug unique pour ce nom" });
+      expect(mocks.execute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("produit publié sans SKU (données migrées)", () => {
+    it("génère un SKU pour un produit publié sans SKU (données migrées)", async () => {
+      mocks.queryFirst.mockResolvedValueOnce({ slug: "old-product", sku: null, is_draft: 0 });
+      mocks.nanoid.mockReturnValue("migrated1");
+      mocks.execute.mockResolvedValueOnce(undefined);
+      const result = await updateProduct("prod-1", baseFormData());
+      expect(result.success).toBe(true);
+      expect(mocks.execute).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE products"),
+        expect.arrayContaining(["NET-MIGRATED1"])
+      );
+      // slug preserved, no revalidatePath on /p/ since is_draft was already 0
+      expect(mocks.execute).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE products"),
+        expect.arrayContaining(["old-product"])
+      );
+      expect(mocks.revalidatePath).not.toHaveBeenCalledWith(expect.stringContaining("/p/"));
+      expect(mocks.slugify).not.toHaveBeenCalled();
+    });
+
+    it("ignore tout slug soumis manuellement dans le FormData", async () => {
+      mocks.queryFirst.mockResolvedValueOnce({ slug: "existing-slug", sku: "NET-ABCD1234", is_draft: 0 });
+      mocks.execute.mockResolvedValueOnce(undefined);
+      const result = await updateProduct("prod-1", baseFormData({ slug: "my-manual-slug" }));
+      expect(result.success).toBe(true);
+      // The manually submitted slug must NOT appear in the UPDATE params
+      const executeCall = mocks.execute.mock.calls[0];
+      expect(executeCall[1]).not.toContain("my-manual-slug");
+      // The existing slug IS preserved
+      expect(executeCall[1]).toContain("existing-slug");
     });
   });
 });

--- a/__tests__/unit/actions/admin-products.test.ts
+++ b/__tests__/unit/actions/admin-products.test.ts
@@ -42,6 +42,16 @@ describe("updateProduct", () => {
     mocks.requireAdmin.mockResolvedValue(undefined);
   });
 
+  describe("validation du formulaire", () => {
+    it("retourne une erreur si le nom est vide", async () => {
+      const result = await updateProduct("prod-1", baseFormData({ name: "" }));
+      expect(result.success).toBe(false);
+      expect(result.error).toBeTruthy();
+      expect(mocks.queryFirst).not.toHaveBeenCalled();
+      expect(mocks.execute).not.toHaveBeenCalled();
+    });
+  });
+
   describe("product introuvable", () => {
     it("retourne une erreur si le produit n'existe pas en base", async () => {
       mocks.queryFirst.mockResolvedValueOnce(null);
@@ -80,6 +90,19 @@ describe("updateProduct", () => {
       mocks.execute.mockResolvedValueOnce(undefined);
       await updateProduct("prod-1", baseFormData());
       expect(mocks.revalidatePath).not.toHaveBeenCalledWith("/p/iphone-15-pro");
+    });
+
+    it("retourne une erreur de conflit slug si execute lève une contrainte slug (produit publié)", async () => {
+      mocks.queryFirst.mockResolvedValueOnce({ slug: "iphone-15-pro", sku: "NET-ABCD1234", is_draft: 0 });
+      mocks.execute.mockRejectedValueOnce(new Error("UNIQUE constraint failed: products.slug"));
+      const result = await updateProduct("prod-1", baseFormData());
+      expect(result).toEqual({ success: false, error: "Un conflit de slug s'est produit (collision concurrente). Enregistrez à nouveau pour résoudre le conflit." });
+    });
+
+    it("propage une erreur DB inattendue pour un produit publié avec SKU existant", async () => {
+      mocks.queryFirst.mockResolvedValueOnce({ slug: "iphone-15-pro", sku: "NET-ABCD1234", is_draft: 0 });
+      mocks.execute.mockRejectedValueOnce(new Error("D1 unavailable"));
+      await expect(updateProduct("prod-1", baseFormData())).rejects.toThrow("D1 unavailable");
     });
   });
 
@@ -188,7 +211,7 @@ describe("updateProduct", () => {
       mocks.nanoid.mockReturnValue("abcd1234");
       mocks.execute.mockRejectedValue(new Error("UNIQUE constraint failed: products.slug"));
       const result = await updateProduct("prod-1", baseFormData());
-      expect(result).toEqual({ success: false, error: "Un conflit de slug s'est produit. Modifiez légèrement le nom et réessayez." });
+      expect(result).toEqual({ success: false, error: "Un conflit de slug s'est produit (collision concurrente). Enregistrez à nouveau pour résoudre le conflit." });
     });
 
     it("appelle revalidatePath sur /p/{slug} lors de la première publication", async () => {
@@ -226,6 +249,8 @@ describe("updateProduct", () => {
       const result = await updateProduct("prod-1", baseFormData());
       expect(result).toEqual({ success: false, error: "Impossible de générer un slug unique pour ce nom" });
       expect(mocks.execute).not.toHaveBeenCalled();
+      // 1 fetch for existing product + 100 slug uniqueness checks = 101 total
+      expect(mocks.queryFirst).toHaveBeenCalledTimes(101);
     });
   });
 

--- a/__tests__/unit/actions/admin-products.test.ts
+++ b/__tests__/unit/actions/admin-products.test.ts
@@ -201,5 +201,20 @@ describe("updateProduct", () => {
       await updateProduct("prod-1", baseFormData());
       expect(mocks.revalidatePath).toHaveBeenCalledWith("/p/iphone-15-pro");
     });
+
+    it("préserve le SKU existant si is_draft = 1 mais sku déjà défini (re-draft)", async () => {
+      mocks.queryFirst
+        .mockResolvedValueOnce({ slug: "draft-abc", sku: "NET-EXISTING1", is_draft: 1 })
+        .mockResolvedValueOnce(null); // slug libre
+      mocks.slugify.mockReturnValue("iphone-15-pro");
+      mocks.execute.mockResolvedValueOnce(undefined);
+      const result = await updateProduct("prod-1", baseFormData());
+      expect(result.success).toBe(true);
+      expect(mocks.execute).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE products"),
+        expect.arrayContaining(["NET-EXISTING1"])
+      );
+      expect(mocks.nanoid).not.toHaveBeenCalled();
+    });
   });
 });

--- a/__tests__/unit/actions/admin-products.test.ts
+++ b/__tests__/unit/actions/admin-products.test.ts
@@ -240,6 +240,29 @@ describe("updateProduct", () => {
       expect(mocks.nanoid).not.toHaveBeenCalled();
     });
 
+    it("ne génère pas de suffixe -2 si le slug de base est disponible (exclusion du produit courant via AND id != ?)", async () => {
+      // Simulates re-saving a draft: slug check returns null (current product's own slug excluded)
+      mocks.queryFirst
+        .mockResolvedValueOnce({ slug: "draft-abc", sku: null, is_draft: 1 })
+        .mockResolvedValueOnce(null); // slug "iphone-15-pro" is free (own draft excluded)
+      mocks.slugify.mockReturnValue("iphone-15-pro");
+      mocks.nanoid.mockReturnValue("abcd1234");
+      mocks.execute.mockResolvedValueOnce(undefined);
+      const result = await updateProduct("prod-1", baseFormData());
+      expect(result.success).toBe(true);
+      // Must use bare slug, not "iphone-15-pro-2"
+      expect(mocks.execute).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE products"),
+        expect.arrayContaining(["iphone-15-pro"])
+      );
+      expect(mocks.execute).not.toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE products"),
+        expect.arrayContaining(["iphone-15-pro-2"])
+      );
+      // Only 2 queryFirst calls: 1 for existing product + 1 for slug check
+      expect(mocks.queryFirst).toHaveBeenCalledTimes(2);
+    });
+
     it("retourne une erreur si toutes les variantes de slug sont prises (épuisement)", async () => {
       // First queryFirst is for the existing product, subsequent ones all return "taken"
       mocks.queryFirst.mockResolvedValueOnce({ slug: "draft-abc", sku: null, is_draft: 1 });

--- a/__tests__/unit/actions/admin-products.test.ts
+++ b/__tests__/unit/actions/admin-products.test.ts
@@ -1,0 +1,205 @@
+// __tests__/unit/actions/admin-products.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  requireAdmin: vi.fn(),
+  queryFirst: vi.fn(),
+  execute: vi.fn(),
+  revalidatePath: vi.fn(),
+  nanoid: vi.fn(),
+  slugify: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/guards", () => ({ requireAdmin: mocks.requireAdmin }));
+vi.mock("@/lib/db", () => ({
+  queryFirst: mocks.queryFirst,
+  execute: mocks.execute,
+  query: vi.fn(),
+}));
+vi.mock("next/cache", () => ({ revalidatePath: mocks.revalidatePath }));
+vi.mock("nanoid", () => ({ nanoid: mocks.nanoid }));
+vi.mock("@/lib/utils", () => ({ slugify: mocks.slugify }));
+
+import { updateProduct } from "@/actions/admin/products";
+
+const baseFormData = (overrides: Record<string, string> = {}) => {
+  const fd = new FormData();
+  fd.append("name", "iPhone 15 Pro");
+  fd.append("category_id", "cat-1");
+  fd.append("brand", "Apple");
+  fd.append("base_price", "850000");
+  fd.append("stock_quantity", "10");
+  fd.append("low_stock_threshold", "5");
+  fd.append("is_active", "1");
+  fd.append("is_featured", "0");
+  for (const [k, v] of Object.entries(overrides)) fd.set(k, v);
+  return fd;
+};
+
+describe("updateProduct", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireAdmin.mockResolvedValue(undefined);
+  });
+
+  describe("product introuvable", () => {
+    it("retourne une erreur si le produit n'existe pas en base", async () => {
+      mocks.queryFirst.mockResolvedValueOnce(null);
+      const result = await updateProduct("prod-1", baseFormData());
+      expect(result).toEqual({ success: false, error: "Produit introuvable" });
+      expect(mocks.execute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("produit déjà publié (is_draft = 0)", () => {
+    it("préserve le slug existant sans le régénérer", async () => {
+      mocks.queryFirst.mockResolvedValueOnce({ slug: "iphone-15-pro", sku: "NET-ABCD1234", is_draft: 0 });
+      mocks.execute.mockResolvedValueOnce(undefined);
+      const result = await updateProduct("prod-1", baseFormData());
+      expect(result.success).toBe(true);
+      expect(mocks.execute).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE products"),
+        expect.arrayContaining(["iphone-15-pro"])
+      );
+      expect(mocks.slugify).not.toHaveBeenCalled();
+    });
+
+    it("préserve le SKU existant sans le régénérer", async () => {
+      mocks.queryFirst.mockResolvedValueOnce({ slug: "iphone-15-pro", sku: "NET-ABCD1234", is_draft: 0 });
+      mocks.execute.mockResolvedValueOnce(undefined);
+      await updateProduct("prod-1", baseFormData());
+      expect(mocks.execute).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE products"),
+        expect.arrayContaining(["NET-ABCD1234"])
+      );
+      expect(mocks.nanoid).not.toHaveBeenCalled();
+    });
+
+    it("n'appelle pas revalidatePath sur /p/ si produit déjà publié", async () => {
+      mocks.queryFirst.mockResolvedValueOnce({ slug: "iphone-15-pro", sku: "NET-ABCD1234", is_draft: 0 });
+      mocks.execute.mockResolvedValueOnce(undefined);
+      await updateProduct("prod-1", baseFormData());
+      expect(mocks.revalidatePath).not.toHaveBeenCalledWith("/p/iphone-15-pro");
+    });
+  });
+
+  describe("nouveau produit draft (is_draft = 1)", () => {
+    it("génère un slug depuis le nom si is_draft = 1", async () => {
+      mocks.queryFirst
+        .mockResolvedValueOnce({ slug: "draft-abc", sku: null, is_draft: 1 })
+        .mockResolvedValueOnce(null); // slug "iphone-15-pro" libre
+      mocks.slugify.mockReturnValue("iphone-15-pro");
+      mocks.nanoid.mockReturnValue("ABCD1234");
+      mocks.execute.mockResolvedValueOnce(undefined);
+      const result = await updateProduct("prod-1", baseFormData());
+      expect(result.success).toBe(true);
+      expect(mocks.execute).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE products"),
+        expect.arrayContaining(["iphone-15-pro"])
+      );
+    });
+
+    it("génère slug avec suffixe -2 si base déjà pris", async () => {
+      mocks.queryFirst
+        .mockResolvedValueOnce({ slug: "draft-abc", sku: null, is_draft: 1 })
+        .mockResolvedValueOnce({ id: "other-prod" }) // "iphone-15-pro" pris
+        .mockResolvedValueOnce(null); // "iphone-15-pro-2" libre
+      mocks.slugify.mockReturnValue("iphone-15-pro");
+      mocks.nanoid.mockReturnValue("ABCD1234");
+      mocks.execute.mockResolvedValueOnce(undefined);
+      const result = await updateProduct("prod-1", baseFormData());
+      expect(result.success).toBe(true);
+      expect(mocks.execute).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE products"),
+        expect.arrayContaining(["iphone-15-pro-2"])
+      );
+    });
+
+    it("retourne une erreur si slugify produit une chaîne vide", async () => {
+      mocks.queryFirst.mockResolvedValueOnce({ slug: "draft-abc", sku: null, is_draft: 1 });
+      mocks.slugify.mockReturnValue("");
+      const result = await updateProduct("prod-1", baseFormData());
+      expect(result).toEqual({ success: false, error: "Le nom ne permet pas de générer un slug valide" });
+      expect(mocks.execute).not.toHaveBeenCalled();
+    });
+
+    it("génère un SKU au format NET-XXXXXXXX si sku = null", async () => {
+      mocks.queryFirst
+        .mockResolvedValueOnce({ slug: "draft-abc", sku: null, is_draft: 1 })
+        .mockResolvedValueOnce(null);
+      mocks.slugify.mockReturnValue("iphone-15-pro");
+      mocks.nanoid.mockReturnValue("abcd1234");
+      mocks.execute.mockResolvedValueOnce(undefined);
+      const result = await updateProduct("prod-1", baseFormData());
+      expect(result.success).toBe(true);
+      expect(mocks.execute).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE products"),
+        expect.arrayContaining(["NET-ABCD1234"])
+      );
+    });
+
+    it("réessaie la génération SKU en cas de collision UNIQUE constraint", async () => {
+      mocks.queryFirst
+        .mockResolvedValueOnce({ slug: "draft-abc", sku: null, is_draft: 1 })
+        .mockResolvedValueOnce(null);
+      mocks.slugify.mockReturnValue("iphone-15-pro");
+      mocks.nanoid
+        .mockReturnValueOnce("aaaaaaaa") // 1er SKU — collision
+        .mockReturnValueOnce("bbbbbbbb"); // 2e SKU — succès
+      mocks.execute
+        .mockRejectedValueOnce(new Error("UNIQUE constraint failed: products.sku"))
+        .mockResolvedValueOnce(undefined);
+      const result = await updateProduct("prod-1", baseFormData());
+      expect(result.success).toBe(true);
+      expect(mocks.execute).toHaveBeenCalledTimes(2);
+      expect(mocks.execute).toHaveBeenLastCalledWith(
+        expect.stringContaining("UPDATE products"),
+        expect.arrayContaining(["NET-BBBBBBBB"])
+      );
+    });
+
+    it("retourne une erreur après 3 collisions SKU consécutives", async () => {
+      mocks.queryFirst
+        .mockResolvedValueOnce({ slug: "draft-abc", sku: null, is_draft: 1 })
+        .mockResolvedValueOnce(null);
+      mocks.slugify.mockReturnValue("iphone-15-pro");
+      mocks.nanoid.mockReturnValue("xxxxxxxx");
+      mocks.execute.mockRejectedValue(new Error("UNIQUE constraint failed: products.sku"));
+      const result = await updateProduct("prod-1", baseFormData());
+      expect(result).toEqual({ success: false, error: "Impossible de générer un SKU unique, veuillez réessayer" });
+      expect(mocks.execute).toHaveBeenCalledTimes(3);
+    });
+
+    it("propage les erreurs execute non liées à une contrainte unique", async () => {
+      mocks.queryFirst
+        .mockResolvedValueOnce({ slug: "draft-abc", sku: null, is_draft: 1 })
+        .mockResolvedValueOnce(null);
+      mocks.slugify.mockReturnValue("iphone-15-pro");
+      mocks.nanoid.mockReturnValue("abcd1234");
+      mocks.execute.mockRejectedValue(new Error("D1 unavailable"));
+      await expect(updateProduct("prod-1", baseFormData())).rejects.toThrow("D1 unavailable");
+    });
+
+    it("retourne une erreur de conflit slug lors d'une collision slug pendant la génération de SKU", async () => {
+      mocks.queryFirst
+        .mockResolvedValueOnce({ slug: "draft-abc", sku: null, is_draft: 1 })
+        .mockResolvedValueOnce(null);
+      mocks.slugify.mockReturnValue("iphone-15-pro");
+      mocks.nanoid.mockReturnValue("abcd1234");
+      mocks.execute.mockRejectedValue(new Error("UNIQUE constraint failed: products.slug"));
+      const result = await updateProduct("prod-1", baseFormData());
+      expect(result).toEqual({ success: false, error: "Conflit de slug, veuillez réessayer" });
+    });
+
+    it("appelle revalidatePath sur /p/{slug} lors de la première publication", async () => {
+      mocks.queryFirst
+        .mockResolvedValueOnce({ slug: "draft-abc", sku: null, is_draft: 1 })
+        .mockResolvedValueOnce(null);
+      mocks.slugify.mockReturnValue("iphone-15-pro");
+      mocks.nanoid.mockReturnValue("abcd1234");
+      mocks.execute.mockResolvedValueOnce(undefined);
+      await updateProduct("prod-1", baseFormData());
+      expect(mocks.revalidatePath).toHaveBeenCalledWith("/p/iphone-15-pro");
+    });
+  });
+});

--- a/actions/admin/products.ts
+++ b/actions/admin/products.ts
@@ -8,6 +8,9 @@ import { execute, query, queryFirst } from "@/lib/db";
 import { slugify, type ActionResult } from "@/lib/utils";
 import { deleteFromR2 } from "@/lib/storage/images";
 
+const DB_CONSTRAINT_SKU = "UNIQUE constraint failed: products.sku";
+const DB_CONSTRAINT_SLUG = "UNIQUE constraint failed: products.slug";
+
 const idSchema = z.string().min(1, "ID requis");
 
 const productSchema = z.object({
@@ -29,8 +32,9 @@ const productSchema = z.object({
   is_featured: z.coerce.number().int().min(0).max(1).default(0),
 });
 
-/** @deprecated The product form uses createDraftProduct + updateProduct. This function is kept as a reference until the draft flow is confirmed stable. */
+/** @deprecated Never called from the UI — product creation now goes through createDraftProduct() + updateProduct(). Scheduled for removal once the draft flow is confirmed stable in production. */
 export async function createProduct(formData: FormData): Promise<ActionResult> {
+  console.warn("[admin/products] createProduct is deprecated and not called from the UI. Use createDraftProduct + updateProduct.");
   await requireAdmin();
 
   const raw = Object.fromEntries(formData);
@@ -109,16 +113,22 @@ export async function updateProduct(
     "SELECT slug, sku, is_draft FROM products WHERE id = ?",
     [id]
   );
-  if (!existing) return { success: false, error: "Produit introuvable" };
+  if (!existing) {
+    console.error("[admin/products] updateProduct: product not found", { id });
+    return { success: false, error: "Produit introuvable" };
+  }
 
   // Slug: generate on first save (draft), preserve thereafter
   let finalSlug: string;
   if (existing.is_draft === 1) {
     const base = slugify(data.name);
-    if (!base) return { success: false, error: "Le nom ne permet pas de générer un slug valide" };
+    if (!base) {
+      console.warn("[admin/products] updateProduct: slugify returned empty string", { id, name: data.name });
+      return { success: false, error: "Le nom ne permet pas de générer un slug valide" };
+    }
 
     let candidate = base;
-    let suffix = 1; // sequence: base, base-2, base-3, … (no -1 by convention)
+    let suffix = 1; // suffix=1 means "try bare slug first"; appended only after first collision → sequence: base, base-2, base-3, … (skips base-1 by convention)
     while (suffix <= 100) {
       const taken = await queryFirst<{ id: string }>(
         "SELECT id FROM products WHERE slug = ? AND id != ? LIMIT 1",
@@ -129,6 +139,7 @@ export async function updateProduct(
       candidate = `${base}-${suffix}`;
     }
     if (suffix > 100) {
+      console.error("[admin/products] updateProduct: slug exhaustion after 100 attempts", { id, base });
       return { success: false, error: "Impossible de générer un slug unique pour ce nom" };
     }
     finalSlug = candidate;
@@ -141,7 +152,7 @@ export async function updateProduct(
      base_price = ?, compare_price = ?, sku = ?, brand = ?,
      is_active = ?, is_featured = ?, stock_quantity = ?,
      low_stock_threshold = ?, weight_grams = ?, meta_title = ?, meta_description = ?,
-     is_draft = 0, -- Clear draft flag: saving "publishes" the product
+     is_draft = 0, -- Clear draft flag (product becomes live if is_active = 1)
      updated_at = datetime('now')
    WHERE id = ?`;
 
@@ -165,7 +176,7 @@ export async function updateProduct(
     id,
   ];
 
-  // SKU: generate if null (new or migrated product), preserve otherwise
+  // SKU: auto-generate when null (covers both draft-flow products and pre-existing rows that predate SKU auto-assignment)
   const existingSku = existing.sku;
   if (existingSku === null) {
     let skuWritten = false;
@@ -176,24 +187,32 @@ export async function updateProduct(
         skuWritten = true;
         break;
       } catch (err) {
-        const msg = (err as Error).message;
-        if (msg.includes("UNIQUE constraint failed: products.slug")) {
-          return { success: false, error: "Conflit de slug, veuillez réessayer" };
+        const msg = (err as Error).message ?? "";
+        if (msg.includes(DB_CONSTRAINT_SLUG)) {
+          console.error("[admin/products] updateProduct: slug race condition on UPDATE", { id, finalSlug });
+          return { success: false, error: "Un conflit de slug s'est produit. Modifiez légèrement le nom et réessayez." };
         }
-        if (!msg.includes("UNIQUE constraint failed: products.sku")) throw err;
+        if (!msg.includes(DB_CONSTRAINT_SKU)) {
+          console.error("[admin/products] updateProduct: unexpected DB error during SKU generation", { id, attempt }, err);
+          throw err;
+        }
         // SKU collision — retry
       }
     }
     if (!skuWritten) {
-      return { success: false, error: "Impossible de générer un SKU unique, veuillez réessayer" };
+      console.error("[admin/products] updateProduct: SKU generation exhausted after 3 attempts", { id });
+      return { success: false, error: "Impossible de générer un SKU unique. Veuillez contacter le support." };
     }
   } else {
     try {
       await execute(updateSql, buildParams(existingSku));
     } catch (err) {
-      if ((err as Error).message.includes("UNIQUE constraint failed: products.slug")) {
-        return { success: false, error: "Conflit de slug, veuillez réessayer" };
+      const msg = (err as Error).message ?? "";
+      if (msg.includes(DB_CONSTRAINT_SLUG)) {
+        console.error("[admin/products] updateProduct: slug race condition on UPDATE", { id, finalSlug });
+        return { success: false, error: "Un conflit de slug s'est produit. Modifiez légèrement le nom et réessayez." };
       }
+      console.error("[admin/products] updateProduct: unexpected DB error on UPDATE", { id }, err);
       throw err;
     }
   }

--- a/actions/admin/products.ts
+++ b/actions/admin/products.ts
@@ -120,8 +120,8 @@ export async function updateProduct(
     let suffix = 1;
     while (suffix <= 100) {
       const taken = await queryFirst<{ id: string }>(
-        "SELECT id FROM products WHERE slug = ? LIMIT 1",
-        [candidate]
+        "SELECT id FROM products WHERE slug = ? AND id != ? LIMIT 1",
+        [candidate, id]
       );
       if (!taken) break;
       suffix++;
@@ -135,6 +135,35 @@ export async function updateProduct(
     finalSlug = existing.slug;
   }
 
+  const updateSql = `UPDATE products SET
+     category_id = ?, name = ?, slug = ?, description = ?, short_description = ?,
+     base_price = ?, compare_price = ?, sku = ?, brand = ?,
+     is_active = ?, is_featured = ?, stock_quantity = ?,
+     low_stock_threshold = ?, weight_grams = ?, meta_title = ?, meta_description = ?,
+     is_draft = 0, -- Clear draft flag: saving "publishes" the product
+     updated_at = datetime('now')
+   WHERE id = ?`;
+
+  const buildParams = (sku: string) => [
+    data.category_id,
+    data.name,
+    finalSlug,
+    data.description || null,
+    data.short_description || null,
+    data.base_price,
+    data.compare_price ?? null,
+    sku,
+    data.brand || null,
+    data.is_active,
+    data.is_featured,
+    data.stock_quantity,
+    data.low_stock_threshold,
+    data.weight_grams ?? null,
+    data.meta_title || null,
+    data.meta_description || null,
+    id,
+  ];
+
   // SKU: generate if null (new or migrated product), preserve otherwise
   const existingSku = existing.sku;
   if (existingSku === null) {
@@ -142,34 +171,7 @@ export async function updateProduct(
     for (let attempt = 0; attempt < 3; attempt++) {
       const generatedSku = `NET-${nanoid(8).toUpperCase()}`;
       try {
-        await execute(
-          `UPDATE products SET
-             category_id = ?, name = ?, slug = ?, description = ?, short_description = ?,
-             base_price = ?, compare_price = ?, sku = ?, brand = ?,
-             is_active = ?, is_featured = ?, stock_quantity = ?,
-             low_stock_threshold = ?, weight_grams = ?, meta_title = ?, meta_description = ?,
-             is_draft = 0, updated_at = datetime('now')
-           WHERE id = ?`,
-          [
-            data.category_id,
-            data.name,
-            finalSlug,
-            data.description || null,
-            data.short_description || null,
-            data.base_price,
-            data.compare_price ?? null,
-            generatedSku,
-            data.brand || null,
-            data.is_active,
-            data.is_featured,
-            data.stock_quantity,
-            data.low_stock_threshold,
-            data.weight_grams ?? null,
-            data.meta_title || null,
-            data.meta_description || null,
-            id,
-          ]
-        );
+        await execute(updateSql, buildParams(generatedSku));
         skuWritten = true;
         break;
       } catch (err) {
@@ -186,34 +188,7 @@ export async function updateProduct(
     }
   } else {
     try {
-      await execute(
-        `UPDATE products SET
-           category_id = ?, name = ?, slug = ?, description = ?, short_description = ?,
-           base_price = ?, compare_price = ?, sku = ?, brand = ?,
-           is_active = ?, is_featured = ?, stock_quantity = ?,
-           low_stock_threshold = ?, weight_grams = ?, meta_title = ?, meta_description = ?,
-           is_draft = 0, updated_at = datetime('now')
-         WHERE id = ?`,
-        [
-          data.category_id,
-          data.name,
-          finalSlug,
-          data.description || null,
-          data.short_description || null,
-          data.base_price,
-          data.compare_price ?? null,
-          existingSku,
-          data.brand || null,
-          data.is_active,
-          data.is_featured,
-          data.stock_quantity,
-          data.low_stock_threshold,
-          data.weight_grams ?? null,
-          data.meta_title || null,
-          data.meta_description || null,
-          id,
-        ]
-      );
+      await execute(updateSql, buildParams(existingSku));
     } catch (err) {
       if ((err as Error).message.includes("UNIQUE constraint failed: products.slug")) {
         return { success: false, error: "Conflit de slug, veuillez réessayer" };

--- a/actions/admin/products.ts
+++ b/actions/admin/products.ts
@@ -29,6 +29,7 @@ const productSchema = z.object({
   is_featured: z.coerce.number().int().min(0).max(1).default(0),
 });
 
+/** @deprecated The product form uses createDraftProduct + updateProduct. This function is kept as a reference until the draft flow is confirmed stable. */
 export async function createProduct(formData: FormData): Promise<ActionResult> {
   await requireAdmin();
 
@@ -117,7 +118,7 @@ export async function updateProduct(
     if (!base) return { success: false, error: "Le nom ne permet pas de générer un slug valide" };
 
     let candidate = base;
-    let suffix = 1;
+    let suffix = 1; // sequence: base, base-2, base-3, … (no -1 by convention)
     while (suffix <= 100) {
       const taken = await queryFirst<{ id: string }>(
         "SELECT id FROM products WHERE slug = ? AND id != ? LIMIT 1",

--- a/actions/admin/products.ts
+++ b/actions/admin/products.ts
@@ -15,10 +15,8 @@ const idSchema = z.string().min(1, "ID requis");
 
 const productSchema = z.object({
   name: z.string().min(1, "Le nom est requis"),
-  slug: z.string().optional().default(""),
   category_id: z.string().min(1, "La catégorie est requise"),
   brand: z.string().optional().default(""),
-  sku: z.string().optional().default(""),
   description: z.string().optional().default(""),
   short_description: z.string().optional().default(""),
   base_price: z.coerce.number().int().min(0, "Le prix doit être positif"),
@@ -50,39 +48,47 @@ export async function createProduct(formData: FormData): Promise<ActionResult> {
 
   const data = parsed.data;
   const id = nanoid();
+  // slug and sku are not in productSchema (server-managed) — read them directly from raw
+  const slug = (raw.slug as string | undefined) ?? "";
+  const sku = (raw.sku as string | undefined) ?? "";
 
   // Ensure unique slug — return error like categories for consistency
   const existing = await queryFirst<{ id: string }>(
     "SELECT id FROM products WHERE slug = ?",
-    [data.slug]
+    [slug]
   );
   if (existing) {
-    return { success: false, error: `Un produit avec le slug "${data.slug}" existe déjà` };
+    return { success: false, error: `Un produit avec le slug "${slug}" existe déjà` };
   }
 
-  await execute(
-    `INSERT INTO products (id, category_id, name, slug, description, short_description, base_price, compare_price, sku, brand, is_active, is_featured, stock_quantity, low_stock_threshold, weight_grams, meta_title, meta_description, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))`,
-    [
-      id,
-      data.category_id,
-      data.name,
-      data.slug,
-      data.description || null,
-      data.short_description || null,
-      data.base_price,
-      data.compare_price ?? null,
-      data.sku || null,
-      data.brand || null,
-      data.is_active,
-      data.is_featured,
-      data.stock_quantity,
-      data.low_stock_threshold,
-      data.weight_grams ?? null,
-      data.meta_title || null,
-      data.meta_description || null,
-    ]
-  );
+  try {
+    await execute(
+      `INSERT INTO products (id, category_id, name, slug, description, short_description, base_price, compare_price, sku, brand, is_active, is_featured, stock_quantity, low_stock_threshold, weight_grams, meta_title, meta_description, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))`,
+      [
+        id,
+        data.category_id,
+        data.name,
+        slug,
+        data.description || null,
+        data.short_description || null,
+        data.base_price,
+        data.compare_price ?? null,
+        sku || null,
+        data.brand || null,
+        data.is_active,
+        data.is_featured,
+        data.stock_quantity,
+        data.low_stock_threshold,
+        data.weight_grams ?? null,
+        data.meta_title || null,
+        data.meta_description || null,
+      ]
+    );
+  } catch (error) {
+    console.error("[admin/products] createProduct error:", error);
+    return { success: false, error: "Erreur lors de la création du produit" };
+  }
 
   revalidatePath("/products");
   revalidatePath("/dashboard");
@@ -187,10 +193,10 @@ export async function updateProduct(
         skuWritten = true;
         break;
       } catch (err) {
-        const msg = (err as Error).message ?? "";
+        const msg = err instanceof Error ? err.message : String(err);
         if (msg.includes(DB_CONSTRAINT_SLUG)) {
           console.error("[admin/products] updateProduct: slug race condition on UPDATE", { id, finalSlug });
-          return { success: false, error: "Un conflit de slug s'est produit. Modifiez légèrement le nom et réessayez." };
+          return { success: false, error: "Un conflit de slug s'est produit (collision concurrente). Enregistrez à nouveau pour résoudre le conflit." };
         }
         if (!msg.includes(DB_CONSTRAINT_SKU)) {
           console.error("[admin/products] updateProduct: unexpected DB error during SKU generation", { id, attempt }, err);
@@ -207,10 +213,10 @@ export async function updateProduct(
     try {
       await execute(updateSql, buildParams(existingSku));
     } catch (err) {
-      const msg = (err as Error).message ?? "";
+      const msg = err instanceof Error ? err.message : String(err);
       if (msg.includes(DB_CONSTRAINT_SLUG)) {
         console.error("[admin/products] updateProduct: slug race condition on UPDATE", { id, finalSlug });
-        return { success: false, error: "Un conflit de slug s'est produit. Modifiez légèrement le nom et réessayez." };
+        return { success: false, error: "Un conflit de slug s'est produit (collision concurrente). Enregistrez à nouveau pour résoudre le conflit." };
       }
       console.error("[admin/products] updateProduct: unexpected DB error on UPDATE", { id }, err);
       throw err;

--- a/actions/admin/products.ts
+++ b/actions/admin/products.ts
@@ -12,7 +12,7 @@ const idSchema = z.string().min(1, "ID requis");
 
 const productSchema = z.object({
   name: z.string().min(1, "Le nom est requis"),
-  slug: z.string().min(1),
+  slug: z.string().optional().default(""),
   category_id: z.string().min(1, "La catégorie est requise"),
   brand: z.string().optional().default(""),
   sku: z.string().optional().default(""),
@@ -94,9 +94,6 @@ export async function updateProduct(
   if (!idResult.success) return { success: false, error: "ID produit invalide" };
 
   const raw = Object.fromEntries(formData);
-  if (!raw.slug || (raw.slug as string).trim() === "") {
-    raw.slug = slugify(raw.name as string);
-  }
 
   const parsed = productSchema.safeParse(raw);
   if (!parsed.success) {
@@ -106,47 +103,131 @@ export async function updateProduct(
 
   const data = parsed.data;
 
-  // Ensure unique slug (excluding self) — return error for consistency
-  const existing = await queryFirst<{ id: string }>(
-    "SELECT id FROM products WHERE slug = ? AND id != ?",
-    [data.slug, id]
+  // Fetch existing product to preserve slug and SKU
+  const existing = await queryFirst<{ slug: string; sku: string | null; is_draft: number }>(
+    "SELECT slug, sku, is_draft FROM products WHERE id = ?",
+    [id]
   );
-  if (existing) {
-    return { success: false, error: `Un produit avec le slug "${data.slug}" existe déjà` };
+  if (!existing) return { success: false, error: "Produit introuvable" };
+
+  // Slug: generate on first save (draft), preserve thereafter
+  let finalSlug: string;
+  if (existing.is_draft === 1) {
+    const base = slugify(data.name);
+    if (!base) return { success: false, error: "Le nom ne permet pas de générer un slug valide" };
+
+    let candidate = base;
+    let suffix = 1;
+    while (suffix <= 100) {
+      const taken = await queryFirst<{ id: string }>(
+        "SELECT id FROM products WHERE slug = ? LIMIT 1",
+        [candidate]
+      );
+      if (!taken) break;
+      suffix++;
+      candidate = `${base}-${suffix}`;
+    }
+    if (suffix > 100) {
+      return { success: false, error: "Impossible de générer un slug unique pour ce nom" };
+    }
+    finalSlug = candidate;
+  } else {
+    finalSlug = existing.slug;
   }
 
-  await execute(
-    `UPDATE products SET
-       category_id = ?, name = ?, slug = ?, description = ?, short_description = ?,
-       base_price = ?, compare_price = ?, sku = ?, brand = ?,
-       is_active = ?, is_featured = ?, stock_quantity = ?,
-       low_stock_threshold = ?, weight_grams = ?, meta_title = ?, meta_description = ?,
-       is_draft = 0, updated_at = datetime('now') -- Clear draft flag: saving "publishes" the product
-     WHERE id = ?`,
-    [
-      data.category_id,
-      data.name,
-      data.slug,
-      data.description || null,
-      data.short_description || null,
-      data.base_price,
-      data.compare_price ?? null,
-      data.sku || null,
-      data.brand || null,
-      data.is_active,
-      data.is_featured,
-      data.stock_quantity,
-      data.low_stock_threshold,
-      data.weight_grams ?? null,
-      data.meta_title || null,
-      data.meta_description || null,
-      id,
-    ]
-  );
+  // SKU: generate if null (new or migrated product), preserve otherwise
+  const existingSku = existing.sku;
+  if (existingSku === null) {
+    let skuWritten = false;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const generatedSku = `NET-${nanoid(8).toUpperCase()}`;
+      try {
+        await execute(
+          `UPDATE products SET
+             category_id = ?, name = ?, slug = ?, description = ?, short_description = ?,
+             base_price = ?, compare_price = ?, sku = ?, brand = ?,
+             is_active = ?, is_featured = ?, stock_quantity = ?,
+             low_stock_threshold = ?, weight_grams = ?, meta_title = ?, meta_description = ?,
+             is_draft = 0, updated_at = datetime('now')
+           WHERE id = ?`,
+          [
+            data.category_id,
+            data.name,
+            finalSlug,
+            data.description || null,
+            data.short_description || null,
+            data.base_price,
+            data.compare_price ?? null,
+            generatedSku,
+            data.brand || null,
+            data.is_active,
+            data.is_featured,
+            data.stock_quantity,
+            data.low_stock_threshold,
+            data.weight_grams ?? null,
+            data.meta_title || null,
+            data.meta_description || null,
+            id,
+          ]
+        );
+        skuWritten = true;
+        break;
+      } catch (err) {
+        const msg = (err as Error).message;
+        if (msg.includes("UNIQUE constraint failed: products.slug")) {
+          return { success: false, error: "Conflit de slug, veuillez réessayer" };
+        }
+        if (!msg.includes("UNIQUE constraint failed: products.sku")) throw err;
+        // SKU collision — retry
+      }
+    }
+    if (!skuWritten) {
+      return { success: false, error: "Impossible de générer un SKU unique, veuillez réessayer" };
+    }
+  } else {
+    try {
+      await execute(
+        `UPDATE products SET
+           category_id = ?, name = ?, slug = ?, description = ?, short_description = ?,
+           base_price = ?, compare_price = ?, sku = ?, brand = ?,
+           is_active = ?, is_featured = ?, stock_quantity = ?,
+           low_stock_threshold = ?, weight_grams = ?, meta_title = ?, meta_description = ?,
+           is_draft = 0, updated_at = datetime('now')
+         WHERE id = ?`,
+        [
+          data.category_id,
+          data.name,
+          finalSlug,
+          data.description || null,
+          data.short_description || null,
+          data.base_price,
+          data.compare_price ?? null,
+          existingSku,
+          data.brand || null,
+          data.is_active,
+          data.is_featured,
+          data.stock_quantity,
+          data.low_stock_threshold,
+          data.weight_grams ?? null,
+          data.meta_title || null,
+          data.meta_description || null,
+          id,
+        ]
+      );
+    } catch (err) {
+      if ((err as Error).message.includes("UNIQUE constraint failed: products.slug")) {
+        return { success: false, error: "Conflit de slug, veuillez réessayer" };
+      }
+      throw err;
+    }
+  }
 
   revalidatePath("/products");
   revalidatePath(`/products/${id}/edit`);
   revalidatePath("/dashboard");
+  if (existing.is_draft === 1) {
+    revalidatePath("/p/" + finalSlug);
+  }
   return { success: true, id };
 }
 

--- a/components/admin/product-form-sections.tsx
+++ b/components/admin/product-form-sections.tsx
@@ -83,15 +83,6 @@ export function ProductFormSections({
                   placeholder="Ex: iPhone 15 Pro Max"
                 />
               </div>
-              <div className="space-y-2">
-                <Label htmlFor="slug">Slug</Label>
-                <Input
-                  id="slug"
-                  name="slug"
-                  defaultValue={isNew ? "" : product.slug}
-                  placeholder="Auto-généré si vide"
-                />
-              </div>
               <div className="grid gap-4 sm:grid-cols-2">
                 <div className="space-y-2">
                   <Label htmlFor="brand">Marque</Label>
@@ -102,15 +93,12 @@ export function ProductFormSections({
                     placeholder="Ex: Apple"
                   />
                 </div>
-                <div className="space-y-2">
-                  <Label htmlFor="sku">SKU</Label>
-                  <Input
-                    id="sku"
-                    name="sku"
-                    defaultValue={product.sku ?? ""}
-                    placeholder="Ex: IP15PM-256"
-                  />
-                </div>
+                {!isNew && product.sku && (
+                  <div className="space-y-2">
+                    <Label>SKU</Label>
+                    <p className="text-sm text-muted-foreground font-mono">{product.sku}</p>
+                  </div>
+                )}
               </div>
               <div className="space-y-2">
                 <Label htmlFor="short_description">Description courte</Label>

--- a/components/admin/product-form-sections.tsx
+++ b/components/admin/product-form-sections.tsx
@@ -56,7 +56,8 @@ export function ProductFormSections({
         } else {
           toast.error(result.error || "Une erreur est survenue");
         }
-      } catch {
+      } catch (err) {
+        console.error("[ProductFormSections] handleSubmit unexpected error:", err);
         toast.error("Une erreur inattendue est survenue. Veuillez réessayer.");
       }
     });

--- a/docs/superpowers/plans/2026-03-15-auto-slug-sku.md
+++ b/docs/superpowers/plans/2026-03-15-auto-slug-sku.md
@@ -1,0 +1,548 @@
+# Auto-génération Slug & SKU — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Masquer les champs slug et SKU du formulaire admin produit et les générer automatiquement côté serveur.
+
+**Architecture:** Modifier `updateProduct` pour lire le state existant en DB et générer automatiquement slug (sur premier enregistrement) et SKU (si null). Mettre à jour le formulaire pour supprimer le champ slug et afficher le SKU en lecture seule.
+
+**Tech Stack:** Next.js 16 App Router, TypeScript, Zod, Cloudflare D1, nanoid, Vitest
+
+---
+
+## Chunk 1: Server action
+
+### Task 1: Tests pour la nouvelle logique `updateProduct`
+
+**Files:**
+- Create: `__tests__/unit/actions/admin-products.test.ts`
+
+- [ ] **Step 1: Créer le fichier de test avec les mocks**
+
+```typescript
+// __tests__/unit/actions/admin-products.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  requireAdmin: vi.fn(),
+  queryFirst: vi.fn(),
+  execute: vi.fn(),
+  revalidatePath: vi.fn(),
+  nanoid: vi.fn(),
+  slugify: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/guards", () => ({ requireAdmin: mocks.requireAdmin }));
+vi.mock("@/lib/db", () => ({
+  queryFirst: mocks.queryFirst,
+  execute: mocks.execute,
+  query: vi.fn(),
+}));
+vi.mock("next/cache", () => ({ revalidatePath: mocks.revalidatePath }));
+vi.mock("nanoid", () => ({ nanoid: mocks.nanoid }));
+vi.mock("@/lib/utils", () => ({ slugify: mocks.slugify }));
+
+import { updateProduct } from "@/actions/admin/products";
+
+const baseFormData = (overrides: Record<string, string> = {}) => {
+  const fd = new FormData();
+  fd.append("name", "iPhone 15 Pro");
+  fd.append("category_id", "cat-1");
+  fd.append("brand", "Apple");
+  fd.append("base_price", "850000");
+  fd.append("stock_quantity", "10");
+  fd.append("low_stock_threshold", "5");
+  fd.append("is_active", "1");
+  fd.append("is_featured", "0");
+  for (const [k, v] of Object.entries(overrides)) fd.set(k, v);
+  return fd;
+};
+
+describe("updateProduct", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireAdmin.mockResolvedValue(undefined);
+  });
+
+  describe("product introuvable", () => {
+    it("retourne une erreur si le produit n'existe pas en base", async () => {
+      mocks.queryFirst.mockResolvedValueOnce(null);
+      const result = await updateProduct("prod-1", baseFormData());
+      expect(result).toEqual({ success: false, error: "Produit introuvable" });
+      expect(mocks.execute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("produit déjà publié (is_draft = 0)", () => {
+    it("préserve le slug existant sans le régénérer", async () => {
+      mocks.queryFirst.mockResolvedValueOnce({ slug: "iphone-15-pro", sku: "NET-ABCD1234", is_draft: 0 });
+      mocks.execute.mockResolvedValueOnce(undefined);
+      const result = await updateProduct("prod-1", baseFormData());
+      expect(result.success).toBe(true);
+      expect(mocks.execute).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE products"),
+        expect.arrayContaining(["iphone-15-pro"])
+      );
+      expect(mocks.slugify).not.toHaveBeenCalled();
+    });
+
+    it("préserve le SKU existant sans le régénérer", async () => {
+      mocks.queryFirst.mockResolvedValueOnce({ slug: "iphone-15-pro", sku: "NET-ABCD1234", is_draft: 0 });
+      mocks.execute.mockResolvedValueOnce(undefined);
+      await updateProduct("prod-1", baseFormData());
+      expect(mocks.execute).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE products"),
+        expect.arrayContaining(["NET-ABCD1234"])
+      );
+      expect(mocks.nanoid).not.toHaveBeenCalled();
+    });
+
+    it("n'appelle pas revalidatePath sur /p/ si produit déjà publié", async () => {
+      mocks.queryFirst.mockResolvedValueOnce({ slug: "iphone-15-pro", sku: "NET-ABCD1234", is_draft: 0 });
+      mocks.execute.mockResolvedValueOnce(undefined);
+      await updateProduct("prod-1", baseFormData());
+      expect(mocks.revalidatePath).not.toHaveBeenCalledWith("/p/iphone-15-pro");
+    });
+  });
+
+  describe("nouveau produit draft (is_draft = 1)", () => {
+    it("génère un slug depuis le nom si is_draft = 1", async () => {
+      mocks.queryFirst
+        .mockResolvedValueOnce({ slug: "draft-abc", sku: null, is_draft: 1 })
+        .mockResolvedValueOnce(null); // slug "iphone-15-pro" libre
+      mocks.slugify.mockReturnValue("iphone-15-pro");
+      mocks.nanoid.mockReturnValue("ABCD1234");
+      mocks.execute.mockResolvedValueOnce(undefined);
+      const result = await updateProduct("prod-1", baseFormData());
+      expect(result.success).toBe(true);
+      expect(mocks.execute).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE products"),
+        expect.arrayContaining(["iphone-15-pro"])
+      );
+    });
+
+    it("génère slug avec suffixe -2 si base déjà pris", async () => {
+      mocks.queryFirst
+        .mockResolvedValueOnce({ slug: "draft-abc", sku: null, is_draft: 1 })
+        .mockResolvedValueOnce({ id: "other-prod" }) // "iphone-15-pro" pris
+        .mockResolvedValueOnce(null); // "iphone-15-pro-2" libre
+      mocks.slugify.mockReturnValue("iphone-15-pro");
+      mocks.nanoid.mockReturnValue("ABCD1234");
+      mocks.execute.mockResolvedValueOnce(undefined);
+      const result = await updateProduct("prod-1", baseFormData());
+      expect(result.success).toBe(true);
+      expect(mocks.execute).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE products"),
+        expect.arrayContaining(["iphone-15-pro-2"])
+      );
+    });
+
+    it("retourne une erreur si slugify produit une chaîne vide", async () => {
+      mocks.queryFirst.mockResolvedValueOnce({ slug: "draft-abc", sku: null, is_draft: 1 });
+      mocks.slugify.mockReturnValue("");
+      const result = await updateProduct("prod-1", baseFormData());
+      expect(result).toEqual({ success: false, error: "Le nom ne permet pas de générer un slug valide" });
+      expect(mocks.execute).not.toHaveBeenCalled();
+    });
+
+    it("génère un SKU au format NET-XXXXXXXX si sku = null", async () => {
+      mocks.queryFirst
+        .mockResolvedValueOnce({ slug: "draft-abc", sku: null, is_draft: 1 })
+        .mockResolvedValueOnce(null);
+      mocks.slugify.mockReturnValue("iphone-15-pro");
+      mocks.nanoid.mockReturnValue("abcd1234");
+      mocks.execute.mockResolvedValueOnce(undefined);
+      const result = await updateProduct("prod-1", baseFormData());
+      expect(result.success).toBe(true);
+      expect(mocks.execute).toHaveBeenCalledWith(
+        expect.stringContaining("UPDATE products"),
+        expect.arrayContaining(["NET-ABCD1234"])
+      );
+    });
+
+    it("réessaie la génération SKU en cas de collision UNIQUE constraint", async () => {
+      mocks.queryFirst
+        .mockResolvedValueOnce({ slug: "draft-abc", sku: null, is_draft: 1 })
+        .mockResolvedValueOnce(null);
+      mocks.slugify.mockReturnValue("iphone-15-pro");
+      mocks.nanoid
+        .mockReturnValueOnce("aaaaaaaa") // 1er SKU — collision
+        .mockReturnValueOnce("bbbbbbbb"); // 2e SKU — succès
+      mocks.execute
+        .mockRejectedValueOnce(new Error("UNIQUE constraint failed: products.sku"))
+        .mockResolvedValueOnce(undefined);
+      const result = await updateProduct("prod-1", baseFormData());
+      expect(result.success).toBe(true);
+      expect(mocks.execute).toHaveBeenCalledTimes(2);
+      expect(mocks.execute).toHaveBeenLastCalledWith(
+        expect.stringContaining("UPDATE products"),
+        expect.arrayContaining(["NET-BBBBBBBB"])
+      );
+    });
+
+    it("retourne une erreur après 3 collisions SKU consécutives", async () => {
+      mocks.queryFirst
+        .mockResolvedValueOnce({ slug: "draft-abc", sku: null, is_draft: 1 })
+        .mockResolvedValueOnce(null);
+      mocks.slugify.mockReturnValue("iphone-15-pro");
+      mocks.nanoid.mockReturnValue("xxxxxxxx");
+      mocks.execute.mockRejectedValue(new Error("UNIQUE constraint failed: products.sku"));
+      const result = await updateProduct("prod-1", baseFormData());
+      expect(result).toEqual({ success: false, error: "Impossible de générer un SKU unique, veuillez réessayer" });
+      expect(mocks.execute).toHaveBeenCalledTimes(3);
+    });
+
+    it("propage les erreurs execute non liées à une contrainte unique", async () => {
+      mocks.queryFirst
+        .mockResolvedValueOnce({ slug: "draft-abc", sku: null, is_draft: 1 })
+        .mockResolvedValueOnce(null);
+      mocks.slugify.mockReturnValue("iphone-15-pro");
+      mocks.nanoid.mockReturnValue("abcd1234");
+      mocks.execute.mockRejectedValue(new Error("D1 unavailable"));
+      await expect(updateProduct("prod-1", baseFormData())).rejects.toThrow("D1 unavailable");
+    });
+
+    it("retourne une erreur de conflit slug lors d'une collision slug pendant la génération de SKU", async () => {
+      mocks.queryFirst
+        .mockResolvedValueOnce({ slug: "draft-abc", sku: null, is_draft: 1 })
+        .mockResolvedValueOnce(null);
+      mocks.slugify.mockReturnValue("iphone-15-pro");
+      mocks.nanoid.mockReturnValue("abcd1234");
+      mocks.execute.mockRejectedValue(new Error("UNIQUE constraint failed: products.slug"));
+      const result = await updateProduct("prod-1", baseFormData());
+      expect(result).toEqual({ success: false, error: "Conflit de slug, veuillez réessayer" });
+    });
+
+    it("appelle revalidatePath sur /p/{slug} lors de la première publication", async () => {
+      mocks.queryFirst
+        .mockResolvedValueOnce({ slug: "draft-abc", sku: null, is_draft: 1 })
+        .mockResolvedValueOnce(null);
+      mocks.slugify.mockReturnValue("iphone-15-pro");
+      mocks.nanoid.mockReturnValue("abcd1234");
+      mocks.execute.mockResolvedValueOnce(undefined);
+      await updateProduct("prod-1", baseFormData());
+      expect(mocks.revalidatePath).toHaveBeenCalledWith("/p/iphone-15-pro");
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Vérifier que les tests échouent**
+
+```bash
+npm run test -- __tests__/unit/actions/admin-products.test.ts
+```
+
+Résultat attendu : plusieurs tests FAIL (logique absente)
+
+---
+
+### Task 2: Implémenter les changements dans `updateProduct`
+
+**Files:**
+- Modify: `actions/admin/products.ts`
+
+- [ ] **Step 3: Modifier `productSchema` — remplacer la ligne slug**
+
+Dans `actions/admin/products.ts`, remplacer :
+```typescript
+slug: z.string().min(1),
+```
+par :
+```typescript
+slug: z.string().optional().default(""),
+```
+
+- [ ] **Step 4: Réécrire `updateProduct`**
+
+Remplacer entièrement la fonction `updateProduct` (lignes 87–151) par :
+
+```typescript
+export async function updateProduct(
+  id: string,
+  formData: FormData
+): Promise<ActionResult> {
+  await requireAdmin();
+
+  const idResult = idSchema.safeParse(id);
+  if (!idResult.success) return { success: false, error: "ID produit invalide" };
+
+  const raw = Object.fromEntries(formData);
+
+  const parsed = productSchema.safeParse(raw);
+  if (!parsed.success) {
+    const msg = parsed.error.issues.map((e: { message: string }) => e.message).join(", ");
+    return { success: false, error: msg };
+  }
+
+  const data = parsed.data;
+
+  // Fetch existing product to preserve slug and SKU
+  const existing = await queryFirst<{ slug: string; sku: string | null; is_draft: number }>(
+    "SELECT slug, sku, is_draft FROM products WHERE id = ?",
+    [id]
+  );
+  if (!existing) return { success: false, error: "Produit introuvable" };
+
+  // Slug: generate on first save (draft), preserve thereafter
+  let finalSlug: string;
+  if (existing.is_draft === 1) {
+    const base = slugify(data.name);
+    if (!base) return { success: false, error: "Le nom ne permet pas de générer un slug valide" };
+
+    let candidate = base;
+    let suffix = 1;
+    while (suffix <= 100) {
+      const taken = await queryFirst<{ id: string }>(
+        "SELECT id FROM products WHERE slug = ? LIMIT 1",
+        [candidate]
+      );
+      if (!taken) break;
+      suffix++;
+      candidate = `${base}-${suffix}`;
+    }
+    if (suffix > 100) {
+      return { success: false, error: "Impossible de générer un slug unique pour ce nom" };
+    }
+    finalSlug = candidate;
+  } else {
+    finalSlug = existing.slug;
+  }
+
+  // SKU: generate if null (new or migrated product), preserve otherwise
+  const finalSku = existing.sku;
+  if (finalSku === null) {
+    let skuWritten = false;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const generatedSku = `NET-${nanoid(8).toUpperCase()}`;
+      try {
+        await execute(
+          `UPDATE products SET
+             category_id = ?, name = ?, slug = ?, description = ?, short_description = ?,
+             base_price = ?, compare_price = ?, sku = ?, brand = ?,
+             is_active = ?, is_featured = ?, stock_quantity = ?,
+             low_stock_threshold = ?, weight_grams = ?, meta_title = ?, meta_description = ?,
+             is_draft = 0, updated_at = datetime('now')
+           WHERE id = ?`,
+          [
+            data.category_id,
+            data.name,
+            finalSlug,
+            data.description || null,
+            data.short_description || null,
+            data.base_price,
+            data.compare_price ?? null,
+            generatedSku,
+            data.brand || null,
+            data.is_active,
+            data.is_featured,
+            data.stock_quantity,
+            data.low_stock_threshold,
+            data.weight_grams ?? null,
+            data.meta_title || null,
+            data.meta_description || null,
+            id,
+          ]
+        );
+        skuWritten = true;
+        break;
+      } catch (err) {
+        const msg = (err as Error).message;
+        if (msg.includes("UNIQUE constraint failed: products.slug")) {
+          return { success: false, error: "Conflit de slug, veuillez réessayer" };
+        }
+        if (!msg.includes("UNIQUE constraint failed: products.sku")) throw err;
+        // SKU collision — retry
+      }
+    }
+    if (!skuWritten) {
+      return { success: false, error: "Impossible de générer un SKU unique, veuillez réessayer" };
+    }
+  } else {
+    try {
+      await execute(
+        `UPDATE products SET
+           category_id = ?, name = ?, slug = ?, description = ?, short_description = ?,
+           base_price = ?, compare_price = ?, sku = ?, brand = ?,
+           is_active = ?, is_featured = ?, stock_quantity = ?,
+           low_stock_threshold = ?, weight_grams = ?, meta_title = ?, meta_description = ?,
+           is_draft = 0, updated_at = datetime('now')
+         WHERE id = ?`,
+        [
+          data.category_id,
+          data.name,
+          finalSlug,
+          data.description || null,
+          data.short_description || null,
+          data.base_price,
+          data.compare_price ?? null,
+          finalSku,
+          data.brand || null,
+          data.is_active,
+          data.is_featured,
+          data.stock_quantity,
+          data.low_stock_threshold,
+          data.weight_grams ?? null,
+          data.meta_title || null,
+          data.meta_description || null,
+          id,
+        ]
+      );
+    } catch (err) {
+      if ((err as Error).message.includes("UNIQUE constraint failed: products.slug")) {
+        return { success: false, error: "Conflit de slug, veuillez réessayer" };
+      }
+      throw err;
+    }
+  }
+
+  revalidatePath("/products");
+  revalidatePath(`/products/${id}/edit`);
+  revalidatePath("/dashboard");
+  if (existing.is_draft === 1) {
+    revalidatePath("/p/" + finalSlug);
+  }
+  return { success: true, id };
+}
+```
+
+- [ ] **Step 5: Lancer les tests**
+
+```bash
+npm run test -- __tests__/unit/actions/admin-products.test.ts
+```
+
+Résultat attendu : tous les tests PASS
+
+- [ ] **Step 6: Lancer tous les tests pour vérifier l'absence de régression**
+
+```bash
+npm run test
+```
+
+Résultat attendu : suite complète verte (les `stderr` D1 unavailable existants sont normaux)
+
+- [ ] **Step 7: Vérifier les types TypeScript**
+
+```bash
+npx tsc --noEmit
+```
+
+Résultat attendu : aucune erreur
+
+- [ ] **Step 8: Commit**
+
+```bash
+git checkout -b feat/auto-slug-sku
+git add actions/admin/products.ts "__tests__/unit/actions/admin-products.test.ts"
+git commit -m "feat(admin): auto-generate slug and SKU in updateProduct"
+```
+
+---
+
+## Chunk 2: UI
+
+### Task 3: Mettre à jour le formulaire produit
+
+**Files:**
+- Modify: `components/admin/product-form-sections.tsx`
+
+- [ ] **Step 1: Supprimer le bloc slug (lignes 86–94)**
+
+Dans la section "Informations générales", supprimer entièrement :
+```tsx
+<div className="space-y-2">
+  <Label htmlFor="slug">Slug</Label>
+  <Input
+    id="slug"
+    name="slug"
+    defaultValue={isNew ? "" : product.slug}
+    placeholder="Auto-généré si vide"
+  />
+</div>
+```
+
+- [ ] **Step 2: Refactorer le bloc brand + SKU**
+
+La grille 2-colonnes actuelle (lignes 95–114) deviendrait cassée avec une seule cellule. Remplacer entièrement le bloc `<div className="grid gap-4 sm:grid-cols-2">` par :
+
+```tsx
+<div className="grid gap-4 sm:grid-cols-2">
+  <div className="space-y-2">
+    <Label htmlFor="brand">Marque</Label>
+    <Input
+      id="brand"
+      name="brand"
+      defaultValue={product.brand ?? ""}
+      placeholder="Ex: Apple"
+    />
+  </div>
+  {!isNew && product.sku && (
+    <div className="space-y-2">
+      <Label>SKU</Label>
+      <p className="text-sm text-muted-foreground font-mono">{product.sku}</p>
+    </div>
+  )}
+</div>
+```
+
+Quand `!isNew && product.sku` est faux (draft ou pas encore de SKU), la grille n'a qu'un enfant : brand prend la colonne de gauche, la droite reste vide — comportement CSS grid normal et visuellement propre.
+
+- [ ] **Step 3: Supprimer l'import `Input` si plus utilisé ailleurs dans le fichier**
+
+Vérifier si `Input` est encore utilisé dans le fichier. Si non, retirer l'import :
+```typescript
+import { Input } from "@/components/ui/input";
+```
+
+Note : `Input` est utilisé pour les champs `name`, `brand`, `short_description` — le laisser.
+
+- [ ] **Step 4: Vérifier les types TypeScript**
+
+```bash
+npx tsc --noEmit
+```
+
+Résultat attendu : aucune erreur
+
+- [ ] **Step 5: Vérifier le lint**
+
+```bash
+npm run lint
+```
+
+Résultat attendu : aucune erreur
+
+- [ ] **Step 6: Lancer tous les tests**
+
+```bash
+npm run test
+```
+
+Résultat attendu : suite complète verte
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add "components/admin/product-form-sections.tsx"
+git commit -m "feat(admin): remove slug/SKU inputs from product form"
+```
+
+- [ ] **Step 8: Créer la PR**
+
+```bash
+gh pr create --title "feat(admin): auto-generate slug and SKU on product save" --body "$(cat <<'EOF'
+## Summary
+- Slug auto-generated from product name on first save (with deduplication suffix -2, -3…), preserved on subsequent edits
+- SKU auto-generated as NET-XXXXXXXX on first save, preserved thereafter
+- Both fields hidden from the product form; SKU displayed as read-only text in edit mode
+
+## Test plan
+- [ ] Create a new product → verify slug matches the name (slugified) and SKU starts with NET-
+- [ ] Edit the product name → verify slug is unchanged
+- [ ] Verify the storefront page /p/{slug} loads correctly after first save
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-03-15-auto-slug-sku-design.md
+++ b/docs/superpowers/specs/2026-03-15-auto-slug-sku-design.md
@@ -7,32 +7,114 @@
 
 Masquer les champs `slug` et `sku` du formulaire admin. Ces valeurs sont générées automatiquement côté serveur, sans intervention de l'utilisateur.
 
+## Flux réel du formulaire
+
+Le formulaire utilise exclusivement :
+1. `createDraftProduct` — déclenché à l'ouverture de `/products/new`, crée une ligne draft avec `slug = draft-{id}`, `sku = null`, `is_draft = 1`
+2. `updateProduct` — utilisé pour **tous** les enregistrements (création depuis draft et édition)
+
+`createProduct` n'est jamais appelé depuis l'UI. Les changements se concentrent donc sur `updateProduct`.
+
 ## Comportement attendu
 
+### Requête de récupération en début de `updateProduct`
+
+```typescript
+const existing = await queryFirst<{ slug: string; sku: string | null; is_draft: number }>(
+  "SELECT slug, sku, is_draft FROM products WHERE id = ?",
+  [id]
+);
+if (!existing) return { success: false, error: "Produit introuvable" };
+```
+
 ### Slug
-- Généré automatiquement depuis le `name` du produit via `slugify()` (logique existante dans `lib/utils.ts`)
-- La logique serveur existe déjà dans `createProduct` et `updateProduct` — elle génère le slug si le champ est vide
-- Le champ `slug` est retiré du formulaire UI et rendu optionnel dans le schéma Zod
+
+**Sentinelle :** `existing.is_draft === 1` indique un premier enregistrement.
+
+**Si `existing.is_draft === 1` :**
+1. `base = slugify(data.name)` (le bloc pré-parse lignes 97–99 doit être supprimé en prérequis)
+2. Si `base` est vide : `{ success: false, error: "Le nom ne permet pas de générer un slug valide" }`
+3. Boucle de déduplication :
+   ```sql
+   SELECT id FROM products WHERE slug = ? LIMIT 1
+   ```
+   Tester `base`, puis `base-2`, …, `base-100`. Ne pas ajouter `AND id != ?` — le slug draft actuel ne conflictera jamais avec `base`.
+4. Si aucun slug libre après 100 tentatives : `{ success: false, error: "Impossible de générer un slug unique pour ce nom" }`
+5. `finalSlug = slug trouvé`
+
+**Si `existing.is_draft === 0` :** `finalSlug = existing.slug`. Note : un row avec `is_draft = 0` ne peut pas avoir un slug `draft-{id}` dans le flux normal — `is_draft` ne passe à `0` qu'au moment où un `finalSlug` définitif est écrit.
 
 ### SKU
-- Généré automatiquement dans `createProduct` au format `NET-{nanoid(8).toUpperCase()}` — ex: `NET-A3X7K2PQ`
-- Garanti unique grâce à nanoid (déjà utilisé dans le projet pour les IDs)
-- `updateProduct` préserve le SKU existant sans le régénérer
-- `createDraftProduct` : pas de changement (utilise déjà un slug temporaire `draft-{id}`)
+
+**Condition :** `existing.sku === null`. Intentionnel pour les produits migrés sans SKU : la génération s'applique à tout produit `sku = null`, quel que soit `is_draft`. La coercion `data.sku || null` existante garantit qu'aucune ligne ne contient `sku = ""`.
+
+**Si `existing.sku === null` :**
+```typescript
+let finalSku = "";
+let skuWritten = false;
+for (let attempt = 0; attempt < 3; attempt++) {
+  finalSku = `NET-${nanoid(8).toUpperCase()}`;
+  try {
+    await execute("UPDATE products SET ..., sku = ?, ... WHERE id = ?", [..., finalSku, id]);
+    skuWritten = true;
+    break; // succès
+  } catch (err) {
+    if (!(err as Error).message.includes("UNIQUE constraint failed")) throw err;
+    // collision SKU : régénérer et réessayer
+  }
+}
+if (!skuWritten) return { success: false, error: "Impossible de générer un SKU unique, veuillez réessayer" };
+```
+
+**Si `existing.sku !== null` :** `finalSku = existing.sku`. L'UPDATE est exécuté normalement (sans try/catch pour SKU).
+
+### Race condition sur le slug
+
+Si l'UPDATE lève une exception dont le `.message` contient `"UNIQUE constraint failed: products.slug"`, retourner `{ success: false, error: "Conflit de slug, veuillez réessayer" }`. Re-lancer toute autre exception.
+
+### Revalidation sur première publication
+
+Après le succès de l'UPDATE, si `existing.is_draft === 1` (transition draft→publié) :
+- Conserver les `revalidatePath` existants (`/products`, `/products/${id}/edit`, etc.)
+- Ajouter `revalidatePath("/p/" + finalSlug)` pour exposer la page produit fraîche
+
+### Règle absolue sur le UPDATE
+
+`finalSlug` et `finalSku` **remplacent entièrement** `data.slug` et `data.sku || null` dans les paramètres SQL. `data.slug` (`""` après Zod) ne doit jamais apparaître dans l'UPDATE.
+
+## Affichage du SKU en mode édition
+
+Remplacer le `<Input name="sku">` par un affichage en lecture seule : badge ou texte grisé montrant `product.sku`. Les produits en draft affichent rien.
 
 ## Fichiers modifiés
 
 ### `components/admin/product-form-sections.tsx`
-- Retirer le champ `slug` de la section "Informations générales"
-- Retirer le champ `sku` de la section "Informations générales"
+- Retirer le champ `slug` (input + label)
+- Remplacer le champ `sku` (input) par un affichage en lecture seule
 
 ### `actions/admin/products.ts`
-- **`productSchema`** : passer `slug` de `z.string().min(1)` à `z.string().optional().default("")`
-- **`createProduct`** : ajouter la génération du SKU `NET-${nanoid(8).toUpperCase()}` avant l'insertion
-- **`updateProduct`** : aucun changement sur la logique SKU (préservation de l'existant)
+
+**`productSchema` — remplacer la ligne `slug` par :**
+```typescript
+slug: z.string().optional().default(""),
+```
+(supprimer le `min(1)` existant — prérequis de la nouvelle logique)
+
+**`updateProduct` — blocs à supprimer :**
+- Lignes 97–99 : bloc pré-parse de génération de slug (**supprimer en premier**)
+- Lignes 110–116 : bloc de vérification de slug dupliqué (rendu obsolète)
+
+**`updateProduct` — logique à ajouter :**
+1. Requête `queryFirst` en début de fonction (`slug`, `sku`, `is_draft`)
+2. Construction de `finalSlug` avec boucle de déduplication si `is_draft === 1`
+3. Construction de `finalSku` : si `existing.sku === null`, boucle try/catch autour de l'UPDATE complet (max 3) ; sinon réutiliser directement
+4. `revalidatePath("/p/" + finalSlug)` si `existing.is_draft === 1` (en plus des revalidations existantes)
+5. `finalSlug` et `finalSku` dans le UPDATE (jamais `data.slug` ni `data.sku`)
+
+**`createProduct` :** aucun changement
+**`createDraftProduct` :** aucun changement
 
 ## Non-changements
 
-- Schéma DB inchangé : `slug` reste `unique().notNull()` (toujours fourni par le serveur), `sku` reste `unique()` nullable
+- Schéma DB inchangé : `slug` reste `unique().notNull()`, `sku` reste `unique()` nullable
 - Aucune migration DB requise
-- `createDraftProduct` inchangé

--- a/docs/superpowers/specs/2026-03-15-auto-slug-sku-design.md
+++ b/docs/superpowers/specs/2026-03-15-auto-slug-sku-design.md
@@ -1,0 +1,38 @@
+# Auto-génération Slug & SKU — Design Spec
+
+**Date:** 2026-03-15
+**Scope:** Formulaire de création/édition de produit (admin)
+
+## Objectif
+
+Masquer les champs `slug` et `sku` du formulaire admin. Ces valeurs sont générées automatiquement côté serveur, sans intervention de l'utilisateur.
+
+## Comportement attendu
+
+### Slug
+- Généré automatiquement depuis le `name` du produit via `slugify()` (logique existante dans `lib/utils.ts`)
+- La logique serveur existe déjà dans `createProduct` et `updateProduct` — elle génère le slug si le champ est vide
+- Le champ `slug` est retiré du formulaire UI et rendu optionnel dans le schéma Zod
+
+### SKU
+- Généré automatiquement dans `createProduct` au format `NET-{nanoid(8).toUpperCase()}` — ex: `NET-A3X7K2PQ`
+- Garanti unique grâce à nanoid (déjà utilisé dans le projet pour les IDs)
+- `updateProduct` préserve le SKU existant sans le régénérer
+- `createDraftProduct` : pas de changement (utilise déjà un slug temporaire `draft-{id}`)
+
+## Fichiers modifiés
+
+### `components/admin/product-form-sections.tsx`
+- Retirer le champ `slug` de la section "Informations générales"
+- Retirer le champ `sku` de la section "Informations générales"
+
+### `actions/admin/products.ts`
+- **`productSchema`** : passer `slug` de `z.string().min(1)` à `z.string().optional().default("")`
+- **`createProduct`** : ajouter la génération du SKU `NET-${nanoid(8).toUpperCase()}` avant l'insertion
+- **`updateProduct`** : aucun changement sur la logique SKU (préservation de l'existant)
+
+## Non-changements
+
+- Schéma DB inchangé : `slug` reste `unique().notNull()` (toujours fourni par le serveur), `sku` reste `unique()` nullable
+- Aucune migration DB requise
+- `createDraftProduct` inchangé


### PR DESCRIPTION
## Summary
- Slug auto-généré depuis le nom du produit au premier enregistrement (avec déduplication suffixe `-2`, `-3`…), préservé sur les sauvegardes suivantes pour ne pas casser les URLs SEO
- SKU auto-généré au format `NET-XXXXXXXX` (nanoid 8 chars) quand null, avec retry sur contrainte unique, préservé ensuite
- Champs slug et SKU retirés du formulaire admin ; SKU affiché en lecture seule en mode édition

## Test Plan
- [ ] Créer un nouveau produit → vérifier que le slug correspond au nom (slugifié) et que le SKU commence par `NET-`
- [ ] Éditer le nom du produit → vérifier que le slug est inchangé
- [ ] Vérifier que la page vitrine `/p/{slug}` se charge correctement après la première sauvegarde
- [ ] 569 tests unitaires passent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-side auto-generation of product slugs and SKUs; slug input removed from the admin form and SKU shown read-only when present.
  * Revalidation runs for generated slug paths when a draft is published.

* **Bug Fixes**
  * Preserves existing slug/SKU for published products; robust retry handling for slug/SKU collisions with localized errors.

* **Documentation**
  * Added implementation plan and design spec for auto-generation behavior.

* **Tests**
  * Added comprehensive unit tests for the product update workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->