### PR TITLE
feat(admin): guided product creation wizard

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -16,7 +16,8 @@
       "Bash(git -C /media/zakkoff/CODES/netereka log --oneline -3)",
       "Bash(git -C /media/zakkoff/CODES/netereka diff NETEREKA_Plan_Developpement.md)",
       "Bash(gh pr view:*)",
-      "Bash(git fetch:*)"
+      "Bash(git fetch:*)",
+      "Bash(GIT_EDITOR=true git rebase --continue)"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/.gitignore
+++ b/.gitignore
@@ -59,4 +59,5 @@ next-env.d.ts
 .playwright-report
 
 # downloaded product images (uploaded to R2)
-scripts/images/.superpowers/
+scripts/images/
+.superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,14 @@ next-env.d.ts
 .playwright-test-results
 .playwright-report
 
+# downloaded/uploaded images
+*.jpg
+*.jpeg
+*.png
+*.gif
+*.webp
+*.avif
+
 # downloaded product images (uploaded to R2)
 scripts/images/
 .superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -59,4 +59,4 @@ next-env.d.ts
 .playwright-report
 
 # downloaded product images (uploaded to R2)
-scripts/images/
+scripts/images/.superpowers/

--- a/__tests__/unit/actions/admin-products-draft.test.ts
+++ b/__tests__/unit/actions/admin-products-draft.test.ts
@@ -103,7 +103,7 @@ describe("saveDraftStep", () => {
       makeFormData({ _step: "1", name: "", category_id: "cat-1" }),
     );
     expect(result.success).toBe(false);
-    expect(result.error).toContain("nom");
+    expect(result.fieldErrors?.name).toBeDefined();
     expect(mocks.execute).not.toHaveBeenCalled();
   });
 
@@ -166,52 +166,53 @@ describe("saveDraftStep", () => {
     expect(sql).not.toContain("slug = ?");
   });
 
-  // ── Étape 2 : Prix & Stock ────────────────────────────────────────────────
+  // ── Étape 3 : Prix & Stock ────────────────────────────────────────────────
 
-  it("étape 2 : réussit avec un prix valide", async () => {
+  it("étape 3 : réussit avec un prix valide", async () => {
     const result = await saveDraftStep(
       "prod-1",
-      makeFormData({ _step: "2", base_price: "125000" }),
+      makeFormData({ _step: "3", base_price: "125000" }),
     );
     expect(result).toEqual({ success: true });
     expect(mocks.execute).toHaveBeenCalledOnce();
   });
 
-  it("étape 2 : rejette un prix négatif", async () => {
+  it("étape 3 : rejette un prix négatif", async () => {
     const result = await saveDraftStep(
       "prod-1",
-      makeFormData({ _step: "2", base_price: "-1" }),
+      makeFormData({ _step: "3", base_price: "-1" }),
     );
     expect(result.success).toBe(false);
     expect(mocks.execute).not.toHaveBeenCalled();
   });
 
-  it("étape 2 : rejette un prix non-entier", async () => {
+  it("étape 3 : rejette un prix non-entier", async () => {
     const result = await saveDraftStep(
       "prod-1",
-      makeFormData({ _step: "2", base_price: "125.50" }),
+      makeFormData({ _step: "3", base_price: "125.50" }),
     );
     expect(result.success).toBe(false);
+    expect(mocks.execute).not.toHaveBeenCalled();
   });
 
-  // ── Étape 3 : Médias (no-op) ──────────────────────────────────────────────
+  // ── Étape 4 : Médias (no-op) ──────────────────────────────────────────────
 
-  it("étape 3 : réussit sans appel DB (aucun champ à sauvegarder)", async () => {
+  it("étape 4 : réussit sans appel DB (aucun champ à sauvegarder)", async () => {
     const result = await saveDraftStep(
       "prod-1",
-      makeFormData({ _step: "3" }),
+      makeFormData({ _step: "4" }),
     );
     expect(result).toEqual({ success: true });
     expect(mocks.execute).not.toHaveBeenCalled();
   });
 
-  // ── Étape 4 : Finalisation ────────────────────────────────────────────────
+  // ── Étape 5 : Finalisation ────────────────────────────────────────────────
 
-  it("étape 4 : réussit avec des champs valides", async () => {
+  it("étape 5 : réussit avec des champs valides", async () => {
     const result = await saveDraftStep(
       "prod-1",
       makeFormData({
-        _step: "4",
+        _step: "5",
         short_description: "Un super téléphone",
         meta_title: "Samsung Galaxy A55 | Netereka",
         meta_description: "Achetez le Samsung Galaxy A55",
@@ -223,30 +224,30 @@ describe("saveDraftStep", () => {
     expect(mocks.execute).toHaveBeenCalledOnce();
   });
 
-  it("étape 4 : rejette meta_title > 60 caractères", async () => {
+  it("étape 5 : rejette meta_title > 60 caractères", async () => {
     const result = await saveDraftStep(
       "prod-1",
-      makeFormData({ _step: "4", meta_title: "a".repeat(61) }),
+      makeFormData({ _step: "5", meta_title: "a".repeat(61) }),
     );
     expect(result.success).toBe(false);
-    expect(result.error).toContain("60");
+    expect(result.fieldErrors?.meta_title).toBeDefined();
     expect(mocks.execute).not.toHaveBeenCalled();
   });
 
-  it("étape 4 : rejette meta_description > 160 caractères", async () => {
+  it("étape 5 : rejette meta_description > 160 caractères", async () => {
     const result = await saveDraftStep(
       "prod-1",
-      makeFormData({ _step: "4", meta_description: "a".repeat(161) }),
+      makeFormData({ _step: "5", meta_description: "a".repeat(161) }),
     );
     expect(result.success).toBe(false);
-    expect(result.error).toContain("160");
+    expect(result.fieldErrors?.meta_description).toBeDefined();
     expect(mocks.execute).not.toHaveBeenCalled();
   });
 
-  it("étape 4 : ne touche pas is_draft dans le SQL SET et garde le WHERE guard", async () => {
+  it("étape 5 : ne touche pas is_draft dans le SQL SET et garde le WHERE guard", async () => {
     await saveDraftStep(
       "prod-1",
-      makeFormData({ _step: "4", is_active: "1", is_featured: "0" }),
+      makeFormData({ _step: "5", is_active: "1", is_featured: "0" }),
     );
     const sql: string = mocks.execute.mock.calls[0][0];
     // SET clause must not modify is_draft
@@ -275,18 +276,16 @@ describe("saveDraftStep", () => {
     expect(mocks.execute).not.toHaveBeenCalled();
   });
 
-  it("étape 1 : brand vide est sauvegardé comme null dans les paramètres SQL", async () => {
+  it("étape 1 : les champs hors schéma (brand) sont ignorés par safeParse", async () => {
     mocks.queryFirst
       .mockResolvedValueOnce(DRAFT_PRODUCT)
       .mockResolvedValueOnce(null); // no slug collision
     await saveDraftStep(
       "prod-1",
-      makeFormData({ _step: "1", name: "Samsung Galaxy A55", category_id: "cat-1", brand: "" }),
+      makeFormData({ _step: "1", name: "Samsung Galaxy A55", category_id: "cat-1", brand: "Samsung" }),
     );
-    const values: unknown[] = mocks.execute.mock.calls[0][1];
-    // brand should be null, not ""
-    expect(values).toContain(null);
-    // Verify "" is not stored — brand is a NULLABLE_FIELD
-    expect(values).not.toContain("");
+    const sql: string = mocks.execute.mock.calls[0][0];
+    // brand is not in step 1 schema, so it should not appear in the SQL
+    expect(sql).not.toContain("brand");
   });
 });

--- a/__tests__/unit/actions/admin-products-draft.test.ts
+++ b/__tests__/unit/actions/admin-products-draft.test.ts
@@ -243,12 +243,16 @@ describe("saveDraftStep", () => {
     expect(mocks.execute).not.toHaveBeenCalled();
   });
 
-  it("étape 4 : ne touche pas is_draft dans le SQL", async () => {
+  it("étape 4 : ne touche pas is_draft dans le SQL SET et garde le WHERE guard", async () => {
     await saveDraftStep(
       "prod-1",
       makeFormData({ _step: "4", is_active: "1", is_featured: "0" }),
     );
     const sql: string = mocks.execute.mock.calls[0][0];
-    expect(sql).not.toContain("is_draft");
+    // SET clause must not modify is_draft
+    const setClause = sql.split("WHERE")[0];
+    expect(setClause).not.toContain("is_draft");
+    // WHERE clause must still guard against non-drafts
+    expect(sql).toContain("AND is_draft = 1");
   });
 });

--- a/__tests__/unit/actions/admin-products-draft.test.ts
+++ b/__tests__/unit/actions/admin-products-draft.test.ts
@@ -1,0 +1,254 @@
+// __tests__/unit/actions/admin-products-draft.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockAdminSession } from "../../helpers/mocks";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  redirect: vi.fn((url: string): never => {
+    const error = new Error(`NEXT_REDIRECT: ${url}`) as Error & {
+      digest: string;
+    };
+    error.digest = `NEXT_REDIRECT;${url}`;
+    throw error;
+  }),
+  queryFirst: vi.fn(),
+  execute: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({ redirect: mocks.redirect }));
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/auth", () => ({
+  initAuth: vi
+    .fn()
+    .mockResolvedValue({ api: { getSession: mocks.getSession } }),
+}));
+vi.mock("@/lib/db", () => ({
+  queryFirst: mocks.queryFirst,
+  execute: mocks.execute,
+}));
+
+import { saveDraftStep } from "@/actions/admin/products";
+
+const DRAFT_PRODUCT = { slug: "draft-abc123" };
+
+function makeFormData(fields: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(fields)) fd.append(k, v);
+  return fd;
+}
+
+describe("saveDraftStep", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue(mockAdminSession);
+    mocks.queryFirst.mockResolvedValue(DRAFT_PRODUCT);
+    mocks.execute.mockResolvedValue(undefined);
+  });
+
+  // ── Auth & ID guards ──────────────────────────────────────────────────────
+
+  it("rejette un id vide", async () => {
+    const result = await saveDraftStep("", makeFormData({ _step: "1" }));
+    expect(result).toEqual({ success: false, error: expect.any(String) });
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
+  it("retourne une erreur si le produit est introuvable ou non-brouillon", async () => {
+    mocks.queryFirst.mockResolvedValue(null);
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({ _step: "1", name: "Test", category_id: "cat-1" }),
+    );
+    expect(result).toEqual({ success: false, error: "Produit introuvable" });
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
+  // ── Étape invalide ────────────────────────────────────────────────────────
+
+  it("retourne une erreur pour une étape invalide", async () => {
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({ _step: "99" }),
+    );
+    expect(result).toEqual({ success: false, error: "Étape invalide" });
+  });
+
+  // ── Étape 1 : Identité ────────────────────────────────────────────────────
+
+  it("étape 1 : réussit avec nom et catégorie valides", async () => {
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({
+        _step: "1",
+        name: "Samsung Galaxy A55",
+        category_id: "cat-1",
+        brand: "Samsung",
+        sku: "SGX-A55",
+      }),
+    );
+    expect(result).toEqual({ success: true });
+    expect(mocks.execute).toHaveBeenCalledOnce();
+    const sql: string = mocks.execute.mock.calls[0][0];
+    expect(sql).toContain("UPDATE products SET");
+    expect(sql).toContain("WHERE id = ? AND is_draft = 1");
+    expect(sql).not.toContain("is_draft = 0");
+  });
+
+  it("étape 1 : rejette si nom vide", async () => {
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({ _step: "1", name: "", category_id: "cat-1" }),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("nom");
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
+  it("étape 1 : rejette si category_id vide", async () => {
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({ _step: "1", name: "Test", category_id: "" }),
+    );
+    expect(result.success).toBe(false);
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
+  it("étape 1 : auto-dérive le slug depuis name si slug actuel commence par draft-", async () => {
+    mocks.queryFirst
+      .mockResolvedValueOnce(DRAFT_PRODUCT)
+      .mockResolvedValueOnce(null);
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({
+        _step: "1",
+        name: "Samsung Galaxy A55",
+        category_id: "cat-1",
+      }),
+    );
+    expect(result).toEqual({ success: true });
+    const sql: string = mocks.execute.mock.calls[0][0];
+    expect(sql).toContain("slug = ?");
+  });
+
+  it("étape 1 : retourne erreur si slug collide avec un autre produit", async () => {
+    mocks.queryFirst
+      .mockResolvedValueOnce(DRAFT_PRODUCT)
+      .mockResolvedValueOnce({ id: "other-product" });
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({
+        _step: "1",
+        name: "Samsung Galaxy A55",
+        category_id: "cat-1",
+      }),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("slug");
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
+  it("étape 1 : ne dérive pas le slug si le slug actuel n'est pas un draft-slug", async () => {
+    mocks.queryFirst.mockResolvedValueOnce({ slug: "samsung-galaxy-a55" });
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({
+        _step: "1",
+        name: "Samsung Galaxy A55 modifié",
+        category_id: "cat-1",
+      }),
+    );
+    expect(result).toEqual({ success: true });
+    expect(mocks.queryFirst).toHaveBeenCalledOnce();
+    const sql: string = mocks.execute.mock.calls[0][0];
+    expect(sql).not.toContain("slug = ?");
+  });
+
+  // ── Étape 2 : Prix & Stock ────────────────────────────────────────────────
+
+  it("étape 2 : réussit avec un prix valide", async () => {
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({ _step: "2", base_price: "125000" }),
+    );
+    expect(result).toEqual({ success: true });
+    expect(mocks.execute).toHaveBeenCalledOnce();
+  });
+
+  it("étape 2 : rejette un prix négatif", async () => {
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({ _step: "2", base_price: "-1" }),
+    );
+    expect(result.success).toBe(false);
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
+  it("étape 2 : rejette un prix non-entier", async () => {
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({ _step: "2", base_price: "125.50" }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  // ── Étape 3 : Médias (no-op) ──────────────────────────────────────────────
+
+  it("étape 3 : réussit sans appel DB (aucun champ à sauvegarder)", async () => {
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({ _step: "3" }),
+    );
+    expect(result).toEqual({ success: true });
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
+  // ── Étape 4 : Finalisation ────────────────────────────────────────────────
+
+  it("étape 4 : réussit avec des champs valides", async () => {
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({
+        _step: "4",
+        short_description: "Un super téléphone",
+        meta_title: "Samsung Galaxy A55 | Netereka",
+        meta_description: "Achetez le Samsung Galaxy A55",
+        is_active: "0",
+        is_featured: "0",
+      }),
+    );
+    expect(result).toEqual({ success: true });
+    expect(mocks.execute).toHaveBeenCalledOnce();
+  });
+
+  it("étape 4 : rejette meta_title > 60 caractères", async () => {
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({ _step: "4", meta_title: "a".repeat(61) }),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("60");
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
+  it("étape 4 : rejette meta_description > 160 caractères", async () => {
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({ _step: "4", meta_description: "a".repeat(161) }),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("160");
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
+  it("étape 4 : ne touche pas is_draft dans le SQL", async () => {
+    await saveDraftStep(
+      "prod-1",
+      makeFormData({ _step: "4", is_active: "1", is_featured: "0" }),
+    );
+    const sql: string = mocks.execute.mock.calls[0][0];
+    expect(sql).not.toContain("is_draft");
+  });
+});

--- a/__tests__/unit/actions/admin-products-draft.test.ts
+++ b/__tests__/unit/actions/admin-products-draft.test.ts
@@ -1,6 +1,6 @@
 // __tests__/unit/actions/admin-products-draft.test.ts
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { mockAdminSession } from "../../helpers/mocks";
+import { mockAdminSession, mockCustomerSession } from "../../helpers/mocks";
 
 const mocks = vi.hoisted(() => ({
   getSession: vi.fn(),
@@ -254,5 +254,39 @@ describe("saveDraftStep", () => {
     expect(setClause).not.toContain("is_draft");
     // WHERE clause must still guard against non-drafts
     expect(sql).toContain("AND is_draft = 1");
+  });
+
+  it("redirige si l'utilisateur n'est pas admin", async () => {
+    mocks.getSession.mockResolvedValue(mockCustomerSession);
+    await expect(
+      saveDraftStep(
+        "prod-1",
+        makeFormData({ _step: "1", name: "Test", category_id: "cat-1" }),
+      ),
+    ).rejects.toThrow("NEXT_REDIRECT");
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
+  it("retourne une erreur si l'étape est absente (_step manquant)", async () => {
+    const fd = new FormData();
+    // No _step field at all
+    const result = await saveDraftStep("prod-1", fd);
+    expect(result).toEqual({ success: false, error: "Étape invalide" });
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
+  it("étape 1 : brand vide est sauvegardé comme null dans les paramètres SQL", async () => {
+    mocks.queryFirst
+      .mockResolvedValueOnce(DRAFT_PRODUCT)
+      .mockResolvedValueOnce(null); // no slug collision
+    await saveDraftStep(
+      "prod-1",
+      makeFormData({ _step: "1", name: "Samsung Galaxy A55", category_id: "cat-1", brand: "" }),
+    );
+    const values: unknown[] = mocks.execute.mock.calls[0][1];
+    // brand should be null, not ""
+    expect(values).toContain(null);
+    // Verify "" is not stored — brand is a NULLABLE_FIELD
+    expect(values).not.toContain("");
   });
 });

--- a/__tests__/unit/components/product-wizard-initial-step.test.ts
+++ b/__tests__/unit/components/product-wizard-initial-step.test.ts
@@ -1,0 +1,105 @@
+// __tests__/unit/components/product-wizard-initial-step.test.ts
+import { describe, it, expect, vi } from "vitest";
+
+// Mock client-side dependencies so the module can be imported in node environment
+vi.mock("next/navigation", () => ({ useRouter: vi.fn() }));
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return {
+    ...actual,
+    useRef: vi.fn(() => ({ current: null })),
+    useState: vi.fn((init: unknown) => [init, vi.fn()]),
+    useTransition: vi.fn(() => [false, vi.fn()]),
+  };
+});
+vi.mock("@/components/ui/button", () => ({ Button: vi.fn() }));
+vi.mock("@/actions/admin/products", () => ({
+  saveDraftStep: vi.fn(),
+  updateProduct: vi.fn(),
+}));
+vi.mock("@/components/admin/product-wizard/wizard-stepper", () => ({ WizardStepper: vi.fn() }));
+vi.mock("@/components/admin/product-wizard/step-identity", () => ({ StepIdentity: vi.fn() }));
+vi.mock("@/components/admin/product-wizard/step-pricing", () => ({ StepPricing: vi.fn() }));
+vi.mock("@/components/admin/product-wizard/step-media", () => ({ StepMedia: vi.fn() }));
+vi.mock("@/components/admin/product-wizard/step-finalization", () => ({ StepFinalization: vi.fn() }));
+
+import { getInitialStep } from "@/components/admin/product-wizard";
+import type { ProductDetail } from "@/lib/db/types";
+
+function makeProduct(overrides: Partial<ProductDetail> = {}): ProductDetail {
+  return {
+    id: "prod-1",
+    name: "",
+    slug: "draft-prod-1",
+    category_id: null,
+    brand: null,
+    sku: null,
+    description: null,
+    short_description: null,
+    base_price: 0,
+    compare_price: null,
+    stock_quantity: 0,
+    low_stock_threshold: 5,
+    weight_grams: null,
+    meta_title: null,
+    meta_description: null,
+    is_active: 0,
+    is_featured: 0,
+    is_draft: 1,
+    created_at: "2026-01-01",
+    updated_at: "2026-01-01",
+    images: [],
+    variants: [],
+    attributes: [],
+    ...overrides,
+  } as ProductDetail;
+}
+
+describe("getInitialStep", () => {
+  it("retourne 0 si le produit n'a pas de nom", () => {
+    expect(getInitialStep(makeProduct({ name: "" }))).toBe(0);
+  });
+
+  it("retourne 1 si le nom est défini mais pas la catégorie", () => {
+    expect(getInitialStep(makeProduct({ name: "Test", category_id: null, base_price: 0 }))).toBe(1);
+  });
+
+  it("retourne 1 si le nom est défini mais le prix est 0", () => {
+    expect(getInitialStep(makeProduct({ name: "Test", category_id: "cat-1", base_price: 0 }))).toBe(1);
+  });
+
+  it("retourne 2 si nom et catégorie sont définis mais pas d'image principale", () => {
+    expect(
+      getInitialStep(
+        makeProduct({
+          name: "Test",
+          category_id: "cat-1",
+          base_price: 125000,
+          images: [{ id: "img-1", product_id: "prod-1", url: "/img.jpg", alt: null, sort_order: 0, is_primary: 0 }],
+        }),
+      ),
+    ).toBe(2);
+  });
+
+  it("retourne 2 si aucune image", () => {
+    expect(
+      getInitialStep(
+        makeProduct({ name: "Test", category_id: "cat-1", base_price: 125000, images: [] }),
+      ),
+    ).toBe(2);
+  });
+
+  it("retourne 3 si tout est rempli avec une image principale", () => {
+    expect(
+      getInitialStep(
+        makeProduct({
+          name: "Test",
+          category_id: "cat-1",
+          base_price: 125000,
+          images: [{ id: "img-1", product_id: "prod-1", url: "/img.jpg", alt: null, sort_order: 0, is_primary: 1 }],
+        }),
+      ),
+    ).toBe(3);
+  });
+});

--- a/__tests__/unit/components/product-wizard-initial-step.test.ts
+++ b/__tests__/unit/components/product-wizard-initial-step.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from "vitest";
 
 // Mock client-side dependencies so the module can be imported in node environment
 vi.mock("next/navigation", () => ({ useRouter: vi.fn() }));
-vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() } }));
 vi.mock("react", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react")>();
   return {
@@ -26,6 +26,8 @@ vi.mock("@/components/admin/product-wizard/step-finalization", () => ({ StepFina
 
 import { getInitialStep } from "@/components/admin/product-wizard";
 import type { ProductDetail } from "@/lib/db/types";
+
+const ATTR = { id: "a1", product_id: "prod-1", name: "Couleur", value: "Noir|#1a1a1a" };
 
 function makeProduct(overrides: Partial<ProductDetail> = {}): ProductDetail {
   return {
@@ -61,45 +63,53 @@ describe("getInitialStep", () => {
     expect(getInitialStep(makeProduct({ name: "" }))).toBe(0);
   });
 
-  it("retourne 1 si le nom est défini mais pas la catégorie", () => {
-    expect(getInitialStep(makeProduct({ name: "Test", category_id: null, base_price: 0 }))).toBe(1);
+  it("retourne 0 si le nom est défini mais pas la catégorie", () => {
+    expect(getInitialStep(makeProduct({ name: "Test", category_id: null }))).toBe(0);
   });
 
-  it("retourne 1 si le nom est défini mais le prix est 0", () => {
-    expect(getInitialStep(makeProduct({ name: "Test", category_id: "cat-1", base_price: 0 }))).toBe(1);
+  it("retourne 1 si nom et catégorie définis mais pas d'attributs", () => {
+    expect(getInitialStep(makeProduct({ name: "Test", category_id: "cat-1", attributes: [] }))).toBe(1);
   });
 
-  it("retourne 2 si nom et catégorie sont définis mais pas d'image principale", () => {
+  it("retourne 2 si des attributs existent mais le prix est 0", () => {
+    expect(
+      getInitialStep(makeProduct({ name: "Test", category_id: "cat-1", attributes: [ATTR], base_price: 0 })),
+    ).toBe(2);
+  });
+
+  it("retourne 3 si nom, catégorie, attributs et prix définis mais pas d'image principale", () => {
     expect(
       getInitialStep(
         makeProduct({
           name: "Test",
           category_id: "cat-1",
+          attributes: [ATTR],
           base_price: 125000,
-          images: [{ id: "img-1", product_id: "prod-1", url: "/img.jpg", alt: null, sort_order: 0, is_primary: 0 }],
-        }),
-      ),
-    ).toBe(2);
-  });
-
-  it("retourne 2 si aucune image", () => {
-    expect(
-      getInitialStep(
-        makeProduct({ name: "Test", category_id: "cat-1", base_price: 125000, images: [] }),
-      ),
-    ).toBe(2);
-  });
-
-  it("retourne 3 si tout est rempli avec une image principale", () => {
-    expect(
-      getInitialStep(
-        makeProduct({
-          name: "Test",
-          category_id: "cat-1",
-          base_price: 125000,
-          images: [{ id: "img-1", product_id: "prod-1", url: "/img.jpg", alt: null, sort_order: 0, is_primary: 1 }],
+          images: [{ id: "img-1", product_id: "prod-1", variant_id: null, url: "/img.jpg", alt: null, sort_order: 0, is_primary: 0 }],
         }),
       ),
     ).toBe(3);
+  });
+
+  it("retourne 3 si aucune image", () => {
+    expect(
+      getInitialStep(
+        makeProduct({ name: "Test", category_id: "cat-1", attributes: [ATTR], base_price: 125000, images: [] }),
+      ),
+    ).toBe(3);
+  });
+
+  it("retourne 4 si tout est rempli avec une image principale", () => {
+    expect(
+      getInitialStep(
+        makeProduct({
+          name: "Test",
+          category_id: "cat-1",
+          attributes: [ATTR],
+          base_price: 125000,
+          images: [{ id: "img-1", product_id: "prod-1", variant_id: null, url: "/img.jpg", alt: null, sort_order: 0, is_primary: 1 }],
+        }),
+      ),
+    ).toBe(4);
   });
 });

--- a/actions/admin/images.ts
+++ b/actions/admin/images.ts
@@ -46,11 +46,20 @@ export async function uploadProductImage(
   const isPrimary = existing.length === 0 ? 1 : 0;
 
   const url = key;
-  await execute(
-    `INSERT INTO product_images (id, product_id, url, alt, sort_order, is_primary)
-     VALUES (?, ?, ?, ?, ?, ?)`,
-    [id, productId, url, null, existing.length, isPrimary]
-  );
+  const variantIdRaw = (formData.get("variant_id") as string) || null;
+  const variantId = variantIdRaw && idSchema.safeParse(variantIdRaw).success ? variantIdRaw : null;
+
+  try {
+    await execute(
+      `INSERT INTO product_images (id, product_id, variant_id, url, alt, sort_order, is_primary)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [id, productId, variantId, url, null, existing.length, isPrimary]
+    );
+  } catch (error) {
+    console.error(`[admin/images] DB insert failed for image="${id}":`, error);
+    try { await deleteFromR2(key); } catch { /* cleanup best-effort */ }
+    return { success: false, error: "Erreur lors de l'enregistrement de l'image" };
+  }
 
   revalidatePath(`/products/${productId}/edit`);
   return { success: true, id, url };
@@ -135,6 +144,49 @@ export async function setPrimaryImage(
     imageId,
     productId,
   ]);
+
+  revalidatePath(`/products/${productId}/edit`);
+  return { success: true };
+}
+
+export async function setImageVariant(
+  imageId: string,
+  productId: string,
+  variantId: string | null,
+): Promise<ActionResult> {
+  await requireAdmin();
+
+  const iidResult = idSchema.safeParse(imageId);
+  const pidResult = idSchema.safeParse(productId);
+  if (!iidResult.success || !pidResult.success) {
+    return { success: false, error: "ID invalide" };
+  }
+
+  if (variantId !== null) {
+    const vidResult = idSchema.safeParse(variantId);
+    if (!vidResult.success) {
+      return { success: false, error: "ID de variante invalide" };
+    }
+  }
+
+  // Verify ownership
+  const image = await queryFirst<{ id: string }>(
+    "SELECT id FROM product_images WHERE id = ? AND product_id = ?",
+    [imageId, productId],
+  );
+  if (!image) {
+    return { success: false, error: "Image introuvable pour ce produit" };
+  }
+
+  try {
+    await execute(
+      "UPDATE product_images SET variant_id = ? WHERE id = ? AND product_id = ?",
+      [variantId, imageId, productId],
+    );
+  } catch (error) {
+    console.error(`[admin/images] setImageVariant failed for image="${imageId}":`, error);
+    return { success: false, error: "Erreur lors de l'association image-variante" };
+  }
 
   revalidatePath(`/products/${productId}/edit`);
   return { success: true };

--- a/actions/admin/products.ts
+++ b/actions/admin/products.ts
@@ -340,19 +340,49 @@ export async function saveDraftStep(
       .object({
         name: z.string().min(1, "Le nom est requis"),
         category_id: z.string().min(1, "La catégorie est requise"),
-        brand: z.string().optional().default(""),
-        sku: z.string().optional().default(""),
       })
       .safeParse(raw);
     if (!parsed.success)
       return {
         success: false,
-        error: parsed.error.issues.map((e) => e.message).join(", "),
+        fieldErrors: parsed.error.flatten().fieldErrors,
       };
     return applyDraftUpdate(id, parsed.data, product.slug);
   }
 
   if (step === "2") {
+    const raw2 = formData.get("attributes");
+    let attrs: { name: string; value: string }[] = [];
+    if (raw2 && typeof raw2 === "string") {
+      try {
+        const parsed = JSON.parse(raw2);
+        if (!Array.isArray(parsed)) {
+          return { success: false, error: "Format des caractéristiques invalide" };
+        }
+        attrs = parsed;
+      } catch {
+        return { success: false, error: "Format des caractéristiques invalide" };
+      }
+    }
+    const valid = attrs.filter(
+      (a) => typeof a.name === "string" && a.name.trim() && typeof a.value === "string",
+    );
+    try {
+      await execute("DELETE FROM product_attributes WHERE product_id = ?", [id]);
+      for (const attr of valid) {
+        await execute(
+          "INSERT INTO product_attributes (id, product_id, name, value) VALUES (?, ?, ?, ?)",
+          [nanoid(), id, attr.name.trim(), attr.value.trim()],
+        );
+      }
+    } catch (error) {
+      console.error(`[admin/products] saveDraftStep attributes failed for id="${id}":`, error);
+      return { success: false, error: "Erreur lors de la sauvegarde des caractéristiques" };
+    }
+    return { success: true };
+  }
+
+  if (step === "3") {
     const parsed = z
       .object({
         base_price: z.coerce
@@ -368,16 +398,123 @@ export async function saveDraftStep(
     if (!parsed.success)
       return {
         success: false,
-        error: parsed.error.issues.map((e) => e.message).join(", "),
+        fieldErrors: parsed.error.flatten().fieldErrors,
       };
+
+    // Handle per-color variants
+    const variantsRaw = formData.get("variants") as string | null;
+    const uniformPrice = formData.get("uniform_price") === "1";
+
+    const variantEntrySchema = z.array(
+      z.object({
+        color: z.string().min(1),
+        colorName: z.string().min(1),
+        stock: z.number().int().min(0),
+        price: z.number().int().min(0).nullable(),
+      }),
+    );
+
+    if (variantsRaw) {
+      let variantEntries: z.infer<typeof variantEntrySchema>;
+      try {
+        const rawParsed = JSON.parse(variantsRaw);
+        const validated = variantEntrySchema.safeParse(rawParsed);
+        if (!validated.success) {
+          return { success: false, error: "Données de variantes invalides" };
+        }
+        variantEntries = validated.data;
+      } catch {
+        return { success: false, error: "Format des variantes invalide" };
+      }
+
+      // Compute total stock from variants
+      const totalStock = variantEntries.reduce((sum, v) => sum + (v.stock ?? 0), 0);
+      parsed.data.stock_quantity = totalStock;
+
+      try {
+        // Get existing color variants for this product
+        const existingVariants = await query<{ id: string; attributes: string }>(
+          "SELECT id, attributes FROM product_variants WHERE product_id = ?",
+          [id],
+        );
+        const existingColorMap = new Map<string, string>();
+        for (const v of existingVariants) {
+          try {
+            const attrs = JSON.parse(v.attributes);
+            if (attrs.color) {
+              existingColorMap.set(attrs.color, v.id);
+            }
+          } catch (error) {
+            console.error(`[admin/products] Malformed attributes JSON for variant id="${v.id}":`, v.attributes, error);
+          }
+        }
+
+        const processedColorKeys = new Set<string>();
+
+        // Build all statements for atomic batch execution
+        const { getDB } = await import("@/lib/cloudflare/context");
+        const db = await getDB();
+        const statements: ReturnType<typeof db.prepare>[] = [];
+
+        for (const entry of variantEntries) {
+          const variantPrice = uniformPrice || entry.price == null
+            ? parsed.data.base_price
+            : entry.price;
+          const variantComparePrice = uniformPrice
+            ? (parsed.data.compare_price ?? null)
+            : null;
+          const attrs = JSON.stringify({ color: entry.color });
+
+          processedColorKeys.add(entry.color);
+
+          const existingId = existingColorMap.get(entry.color);
+          if (existingId) {
+            statements.push(
+              db.prepare(
+                `UPDATE product_variants
+                 SET name = ?, price = ?, compare_price = ?, stock_quantity = ?, attributes = ?
+                 WHERE id = ?`,
+              ).bind(entry.colorName, variantPrice, variantComparePrice, entry.stock ?? 0, attrs, existingId),
+            );
+          } else {
+            statements.push(
+              db.prepare(
+                `INSERT INTO product_variants (id, product_id, name, price, compare_price, stock_quantity, attributes, is_active, sort_order)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?)`,
+              ).bind(nanoid(), id, entry.colorName, variantPrice, variantComparePrice, entry.stock ?? 0, attrs, variantEntries.indexOf(entry)),
+            );
+          }
+        }
+
+        // Remove color variants that no longer exist + clear image associations
+        for (const [colorKey, variantId] of existingColorMap) {
+          if (!processedColorKeys.has(colorKey)) {
+            statements.push(
+              db.prepare("UPDATE product_images SET variant_id = NULL WHERE variant_id = ?").bind(variantId),
+            );
+            statements.push(
+              db.prepare("DELETE FROM product_variants WHERE id = ?").bind(variantId),
+            );
+          }
+        }
+
+        if (statements.length > 0) {
+          await db.batch(statements);
+        }
+      } catch (error) {
+        console.error(`[admin/products] saveDraftStep variants failed for id="${id}":`, error);
+        return { success: false, error: "Erreur lors de la sauvegarde des variantes" };
+      }
+    }
+
     return applyDraftUpdate(id, parsed.data, product.slug);
   }
 
-  if (step === "3") {
+  if (step === "4") {
     return { success: true };
   }
 
-  if (step === "4") {
+  if (step === "5") {
     const parsed = z
       .object({
         short_description: z.string().optional().default(""),
@@ -399,7 +536,7 @@ export async function saveDraftStep(
     if (!parsed.success)
       return {
         success: false,
-        error: parsed.error.issues.map((e) => e.message).join(", "),
+        fieldErrors: parsed.error.flatten().fieldErrors,
       };
     return applyDraftUpdate(id, parsed.data, product.slug);
   }
@@ -418,6 +555,9 @@ async function applyDraftUpdate(
   // Slug auto-derivation: only when name is set and current slug is a draft placeholder
   if ("name" in data && data.name && currentSlug.startsWith("draft-")) {
     const candidateSlug = slugify(data.name as string);
+    if (!candidateSlug) {
+      return { success: false, error: "Le nom ne peut pas produire un slug valide" };
+    }
     const collision = await queryFirst<{ id: string }>(
       "SELECT id FROM products WHERE slug = ? AND id != ?",
       [candidateSlug, id],
@@ -471,10 +611,18 @@ async function applyDraftUpdate(
 
   values.push(id);
 
-  await execute(
-    `UPDATE products SET ${sets.join(", ")} WHERE id = ? AND is_draft = 1`,
-    values,
-  );
+  try {
+    const result = await execute(
+      `UPDATE products SET ${sets.join(", ")} WHERE id = ? AND is_draft = 1`,
+      values,
+    );
+    if (result?.meta?.changes === 0) {
+      return { success: false, error: "Ce brouillon n'existe plus ou a déjà été publié" };
+    }
+  } catch (error) {
+    console.error(`[admin/products] applyDraftUpdate failed for id="${id}":`, error);
+    return { success: false, error: "Erreur lors de l'enregistrement du brouillon" };
+  }
 
   return { success: true };
 }

--- a/actions/admin/products.ts
+++ b/actions/admin/products.ts
@@ -401,8 +401,7 @@ export async function saveDraftStep(
         success: false,
         error: parsed.error.issues.map((e) => e.message).join(", "),
       };
-    // Step 4: draft already verified above; don't include is_draft in the SQL
-    return applyDraftUpdate(id, parsed.data, product.slug, false);
+    return applyDraftUpdate(id, parsed.data, product.slug);
   }
 
   return { success: false, error: "Étape invalide" };
@@ -412,7 +411,6 @@ async function applyDraftUpdate(
   id: string,
   data: Record<string, unknown>,
   currentSlug: string,
-  guardDraft = true,
 ): Promise<ActionResult> {
   const sets: string[] = ["updated_at = datetime('now')"];
   const values: unknown[] = [];
@@ -473,9 +471,8 @@ async function applyDraftUpdate(
 
   values.push(id);
 
-  const whereClause = guardDraft ? "WHERE id = ? AND is_draft = 1" : "WHERE id = ?";
   await execute(
-    `UPDATE products SET ${sets.join(", ")} ${whereClause}`,
+    `UPDATE products SET ${sets.join(", ")} WHERE id = ? AND is_draft = 1`,
     values,
   );
 

--- a/actions/admin/products.ts
+++ b/actions/admin/products.ts
@@ -316,6 +316,172 @@ export async function createDraftProduct(): Promise<ActionResult> {
   return { success: true, id };
 }
 
+export async function saveDraftStep(
+  id: string,
+  formData: FormData,
+): Promise<ActionResult> {
+  await requireAdmin();
+
+  const idResult = idSchema.safeParse(id);
+  if (!idResult.success) return { success: false, error: "ID produit invalide" };
+
+  const product = await queryFirst<{ slug: string }>(
+    "SELECT slug FROM products WHERE id = ? AND is_draft = 1",
+    [id],
+  );
+  if (!product) return { success: false, error: "Produit introuvable" };
+
+  const step = (formData.get("_step") as string) ?? "";
+  const raw = Object.fromEntries(formData);
+  delete raw._step;
+
+  if (step === "1") {
+    const parsed = z
+      .object({
+        name: z.string().min(1, "Le nom est requis"),
+        category_id: z.string().min(1, "La catégorie est requise"),
+        brand: z.string().optional().default(""),
+        sku: z.string().optional().default(""),
+      })
+      .safeParse(raw);
+    if (!parsed.success)
+      return {
+        success: false,
+        error: parsed.error.issues.map((e) => e.message).join(", "),
+      };
+    return applyDraftUpdate(id, parsed.data, product.slug);
+  }
+
+  if (step === "2") {
+    const parsed = z
+      .object({
+        base_price: z.coerce
+          .number()
+          .int("Le prix doit être un entier")
+          .min(0, "Le prix doit être positif"),
+        compare_price: z.coerce.number().int().min(0).optional(),
+        stock_quantity: z.coerce.number().int().min(0).default(0),
+        low_stock_threshold: z.coerce.number().int().min(0).default(5),
+        weight_grams: z.coerce.number().int().min(0).optional(),
+      })
+      .safeParse(raw);
+    if (!parsed.success)
+      return {
+        success: false,
+        error: parsed.error.issues.map((e) => e.message).join(", "),
+      };
+    return applyDraftUpdate(id, parsed.data, product.slug);
+  }
+
+  if (step === "3") {
+    return { success: true };
+  }
+
+  if (step === "4") {
+    const parsed = z
+      .object({
+        short_description: z.string().optional().default(""),
+        description: z.string().optional().default(""),
+        meta_title: z
+          .string()
+          .max(60, "Le titre SEO ne peut pas dépasser 60 caractères")
+          .optional()
+          .default(""),
+        meta_description: z
+          .string()
+          .max(160, "La méta-description ne peut pas dépasser 160 caractères")
+          .optional()
+          .default(""),
+        is_active: z.coerce.number().int().min(0).max(1).default(0),
+        is_featured: z.coerce.number().int().min(0).max(1).default(0),
+      })
+      .safeParse(raw);
+    if (!parsed.success)
+      return {
+        success: false,
+        error: parsed.error.issues.map((e) => e.message).join(", "),
+      };
+    // Step 4: draft already verified above; don't include is_draft in the SQL
+    return applyDraftUpdate(id, parsed.data, product.slug, false);
+  }
+
+  return { success: false, error: "Étape invalide" };
+}
+
+async function applyDraftUpdate(
+  id: string,
+  data: Record<string, unknown>,
+  currentSlug: string,
+  guardDraft = true,
+): Promise<ActionResult> {
+  const sets: string[] = ["updated_at = datetime('now')"];
+  const values: unknown[] = [];
+
+  // Slug auto-derivation: only when name is set and current slug is a draft placeholder
+  if ("name" in data && data.name && currentSlug.startsWith("draft-")) {
+    const candidateSlug = slugify(data.name as string);
+    const collision = await queryFirst<{ id: string }>(
+      "SELECT id FROM products WHERE slug = ? AND id != ?",
+      [candidateSlug, id],
+    );
+    if (collision?.id) {
+      return {
+        success: false,
+        error: `Un produit avec le slug "${candidateSlug}" existe déjà`,
+      };
+    }
+    sets.push("slug = ?");
+    values.push(candidateSlug);
+  }
+
+  const NULLABLE_FIELDS = new Set([
+    "brand",
+    "sku",
+    "compare_price",
+    "weight_grams",
+    "short_description",
+    "description",
+    "meta_title",
+    "meta_description",
+  ]);
+
+  const ALLOWED_COLUMNS = new Set([
+    "name",
+    "brand",
+    "sku",
+    "category_id",
+    "base_price",
+    "compare_price",
+    "stock_quantity",
+    "low_stock_threshold",
+    "weight_grams",
+    "short_description",
+    "description",
+    "meta_title",
+    "meta_description",
+    "is_active",
+    "is_featured",
+  ]);
+
+  for (const [key, val] of Object.entries(data)) {
+    if (!ALLOWED_COLUMNS.has(key)) continue;
+    sets.push(`${key} = ?`);
+    values.push(
+      NULLABLE_FIELDS.has(key) && (val === "" || val == null) ? null : val,
+    );
+  }
+
+  values.push(id);
+
+  const whereClause = guardDraft ? "WHERE id = ? AND is_draft = 1" : "WHERE id = ?";
+  await execute(
+    `UPDATE products SET ${sets.join(", ")} ${whereClause}`,
+    values,
+  );
+
+  return { success: true };
+}
+
 /** Delete draft products abandoned for 24+ hours (name still empty).
  *  Also removes associated product_images, product_variants rows and R2 files. */
 export async function cleanupDraftProducts(): Promise<void> {

--- a/app/(admin)/products/[id]/edit/page.tsx
+++ b/app/(admin)/products/[id]/edit/page.tsx
@@ -1,3 +1,4 @@
+// app/(admin)/products/[id]/edit/page.tsx
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -5,6 +6,7 @@ import { ArrowLeft02Icon } from "@hugeicons/core-free-icons";
 import { Button } from "@/components/ui/button";
 import { AdminPageHeader } from "@/components/admin/admin-page-header";
 import { ProductFormSections } from "@/components/admin/product-form-sections";
+import { ProductWizard } from "@/components/admin/product-wizard";
 import { getAdminProductById } from "@/lib/db/admin/products";
 import { getAllCategories } from "@/lib/db/admin/categories";
 import type { CategoryOption } from "@/components/admin/category-cascading-select";
@@ -24,6 +26,15 @@ export default async function EditProductPage({ params }: Props) {
   if (!product) notFound();
 
   const isNew = product.is_draft === 1;
+
+  const categoryOptions = categories.map(
+    (c): CategoryOption => ({
+      id: c.id,
+      name: c.name,
+      depth: c.depth,
+      parent_id: c.parent_id,
+    }),
+  );
 
   return (
     <div>
@@ -50,15 +61,11 @@ export default async function EditProductPage({ params }: Props) {
           </div>
         </header>
       </AdminPageHeader>
-      <ProductFormSections
-        product={product}
-        categories={categories.map((c): CategoryOption => ({
-          id: c.id,
-          name: c.name,
-          depth: c.depth,
-          parent_id: c.parent_id,
-        }))}
-      />
+      {isNew ? (
+        <ProductWizard product={product} categories={categoryOptions} />
+      ) : (
+        <ProductFormSections product={product} categories={categoryOptions} />
+      )}
     </div>
   );
 }

--- a/app/(admin)/products/[id]/edit/page.tsx
+++ b/app/(admin)/products/[id]/edit/page.tsx
@@ -36,6 +36,14 @@ export default async function EditProductPage({ params }: Props) {
     }),
   );
 
+  if (isNew) {
+    return (
+      <div className="flex h-full flex-col overflow-hidden">
+        <ProductWizard product={product} categories={categoryOptions} />
+      </div>
+    );
+  }
+
   return (
     <div>
       <AdminPageHeader>
@@ -52,20 +60,12 @@ export default async function EditProductPage({ params }: Props) {
             </Link>
           </Button>
           <div className="min-w-0">
-            <h1 className="truncate text-lg font-bold sm:text-2xl">
-              {isNew ? "Nouveau produit" : product.name}
-            </h1>
-            <p className="text-sm text-muted-foreground">
-              {isNew ? "Créer un produit" : "Modifier le produit"}
-            </p>
+            <h1 className="truncate text-lg font-bold sm:text-2xl">{product.name}</h1>
+            <p className="text-sm text-muted-foreground">Modifier le produit</p>
           </div>
         </header>
       </AdminPageHeader>
-      {isNew ? (
-        <ProductWizard product={product} categories={categoryOptions} />
-      ) : (
-        <ProductFormSections product={product} categories={categoryOptions} />
-      )}
+      <ProductFormSections product={product} categories={categoryOptions} />
     </div>
   );
 }

--- a/app/(storefront)/p/[slug]/page.tsx
+++ b/app/(storefront)/p/[slug]/page.tsx
@@ -6,7 +6,7 @@ import Image from "next/image";
 import { getProductBySlug, getRelatedProducts, toProductCardData } from "@/lib/db/products";
 import { ImageGallery } from "@/components/storefront/image-gallery";
 import { getImageUrl } from "@/lib/utils/images";
-import { VariantSelector } from "@/components/storefront/variant-selector";
+import { ProductGalleryWithVariants } from "@/components/storefront/product-gallery-with-variants";
 import { AddToCartButton } from "@/components/storefront/add-to-cart-button";
 import { HorizontalSection } from "@/components/storefront/horizontal-section";
 import { WishlistButtonDynamic } from "@/components/storefront/wishlist-button-dynamic";
@@ -242,22 +242,18 @@ export default async function ProductPage({ params }: Props) {
         <span className="text-foreground">{product.name}</span>
       </nav>
 
-      <div className="grid gap-8 md:grid-cols-2">
-        {/* Images */}
-        <ImageGallery images={product.images}>
-          <Image
-            src={getImageUrl(product.images[0]?.url)}
-            alt={product.images[0]?.alt || product.name}
-            fill
-            priority
-            fetchPriority="high"
-            sizes="(max-width: 768px) 100vw, 50vw"
-            className="object-contain p-6"
-          />
-        </ImageGallery>
-
-        {/* Product info */}
-        <div className="space-y-4">
+      {product.variants.length > 0 ? (
+        <ProductGalleryWithVariants
+          images={product.images}
+          variants={product.variants}
+          basePrice={product.base_price}
+          product={{
+            id: product.id,
+            name: product.name,
+            slug: product.slug,
+            imageUrl: product.image_url ?? product.images[0]?.url ?? null,
+          }}
+        >
           <div className="flex items-start justify-between gap-2">
             <div>
               {product.brand ? (
@@ -269,57 +265,71 @@ export default async function ProductPage({ params }: Props) {
             </div>
             <WishlistButtonDynamic productId={product.id} />
           </div>
-
-          {product.variants.length > 0 ? (
-            <VariantSelector
-              variants={product.variants}
-              basePrice={product.base_price}
-              product={{
-                id: product.id,
-                name: product.name,
-                slug: product.slug,
-                imageUrl: product.image_url ?? product.images[0]?.url ?? null,
-              }}
+        </ProductGalleryWithVariants>
+      ) : (
+        <div className="grid gap-8 md:grid-cols-2">
+          <ImageGallery images={product.images}>
+            <Image
+              src={getImageUrl(product.images[0]?.url)}
+              alt={product.images[0]?.alt || product.name}
+              fill
+              priority
+              fetchPriority="high"
+              sizes="(max-width: 768px) 100vw, 50vw"
+              className="object-contain p-6"
             />
-          ) : (
-            <div className="space-y-4">
-                  <div>
-                    <div className="flex items-center gap-3">
-                      <p className="text-2xl font-bold">
-                        {formatPrice(product.base_price)}
-                      </p>
-                      {hasDiscount && (
-                        <span className="rounded-md bg-destructive px-2 py-0.5 text-xs font-bold text-white">
-                          -{discountPercent}%
-                        </span>
-                      )}
-                    </div>
-                    {hasDiscount && (
-                      <p className="text-sm text-muted-foreground line-through">
-                        {formatPrice(comparePrice)}
-                      </p>
-                    )}
-                  </div>
-                  {isOutOfStock && (
-                    <p className="text-sm font-medium text-destructive">Rupture de stock</p>
-                  )}
-                  <AddToCartButton
-                    disabled={isOutOfStock}
-                    item={{
-                      productId: product.id,
-                      variantId: null,
-                      name: product.name,
-                      variantName: null,
-                      price: product.base_price,
-                      imageUrl: product.image_url ?? product.images[0]?.url ?? null,
-                      slug: product.slug,
-                    }}
-                  />
-                </div>
-          )}
+          </ImageGallery>
 
+          <div className="space-y-4">
+            <div className="flex items-start justify-between gap-2">
+              <div>
+                {product.brand ? (
+                  <span className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+                    {product.brand}
+                  </span>
+                ) : null}
+                <h1 className="text-2xl font-bold sm:text-3xl">{product.name}</h1>
+              </div>
+              <WishlistButtonDynamic productId={product.id} />
+            </div>
+
+            <div className="space-y-4">
+              <div>
+                <div className="flex items-center gap-3">
+                  <p className="text-2xl font-bold">
+                    {formatPrice(product.base_price)}
+                  </p>
+                  {hasDiscount && (
+                    <span className="rounded-md bg-destructive px-2 py-0.5 text-xs font-bold text-white">
+                      -{discountPercent}%
+                    </span>
+                  )}
+                </div>
+                {hasDiscount && (
+                  <p className="text-sm text-muted-foreground line-through">
+                    {formatPrice(comparePrice)}
+                  </p>
+                )}
+              </div>
+              {isOutOfStock && (
+                <p className="text-sm font-medium text-destructive">Rupture de stock</p>
+              )}
+              <AddToCartButton
+                disabled={isOutOfStock}
+                item={{
+                  productId: product.id,
+                  variantId: null,
+                  name: product.name,
+                  variantName: null,
+                  price: product.base_price,
+                  imageUrl: product.image_url ?? product.images[0]?.url ?? null,
+                  slug: product.slug,
+                }}
+              />
+            </div>
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Description & Characteristics */}
       <ProductDetails

--- a/components/admin/category-cascading-select.tsx
+++ b/components/admin/category-cascading-select.tsx
@@ -1,17 +1,104 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useRef, useMemo, useState } from "react";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
 import type { CategoryWithCount } from "@/lib/db/admin/categories";
 
 export type CategoryOption = Pick<CategoryWithCount, "id" | "name" | "depth" | "parent_id">;
+
+interface ComboSelectProps {
+  items: CategoryOption[];
+  value: string;
+  onValueChange: (id: string) => void;
+  placeholder: string;
+  id?: string;
+}
+
+function ComboSelect({ items, value, onValueChange, placeholder, id }: ComboSelectProps) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const selectedName = items.find((c) => c.id === value)?.name ?? "";
+  const displayValue = open ? search : selectedName;
+
+  const filtered = useMemo(
+    () =>
+      search
+        ? items.filter((c) => c.name.toLowerCase().includes(search.toLowerCase()))
+        : items,
+    [items, search],
+  );
+
+  function handleFocus() {
+    setSearch("");
+    setOpen(true);
+  }
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setSearch(e.target.value);
+    setOpen(true);
+  }
+
+  function handleSelect(id: string) {
+    onValueChange(id);
+    setSearch("");
+    setOpen(false);
+  }
+
+  function handleBlur(e: React.FocusEvent) {
+    if (!containerRef.current?.contains(e.relatedTarget as Node)) {
+      setSearch("");
+      setOpen(false);
+    }
+  }
+
+  return (
+    <div ref={containerRef} className="relative" onBlur={handleBlur}>
+      <Input
+        id={id}
+        value={displayValue}
+        onChange={handleChange}
+        onFocus={handleFocus}
+        placeholder={placeholder}
+        autoComplete="off"
+        role="combobox"
+        aria-expanded={open}
+        aria-autocomplete="list"
+      />
+      {open && (
+        <div className="absolute z-50 mt-1 w-full overflow-hidden rounded-lg border bg-popover shadow-md">
+          <div className="max-h-56 overflow-y-auto p-1">
+            {filtered.length === 0 ? (
+              <p className="px-2 py-4 text-center text-xs text-muted-foreground">
+                Aucun résultat
+              </p>
+            ) : (
+              filtered.map((cat) => (
+                <button
+                  key={cat.id}
+                  type="button"
+                  role="option"
+                  aria-selected={value === cat.id}
+                  className={cn(
+                    "flex w-full cursor-default items-center rounded-md px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground",
+                    value === cat.id && "bg-accent/50 font-medium",
+                  )}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => handleSelect(cat.id)}
+                >
+                  {cat.name}
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
 
 interface CategoryCascadingSelectProps {
   categories: CategoryOption[];
@@ -35,7 +122,6 @@ export function CategoryCascadingSelect({
     return { roots: r, childrenByParent: map };
   }, [categories]);
 
-  // Determine initial state from defaultCategoryId
   let initialParentId = "";
   let initialSubcategoryId = "";
   if (defaultCategoryId) {
@@ -56,52 +142,40 @@ export function CategoryCascadingSelect({
   const subcategories = parentId ? (childrenByParent.get(parentId) ?? []) : [];
   const hasSubcategories = subcategories.length > 0;
 
-  // Submit subcategory if selected, otherwise fall back to parent
   const effectiveCategoryId = subcategoryId || parentId;
 
-  function handleParentChange(value: string) {
-    setParentId(value);
-    setSubcategoryId(""); // Reset subcategory when parent changes
+  function handleParentChange(id: string) {
+    setParentId(id);
+    setSubcategoryId("");
   }
 
   return (
-    <div className="space-y-4">
+    <div className={`grid gap-3 ${hasSubcategories ? "sm:grid-cols-2" : "grid-cols-1"}`}>
       <input type="hidden" name="category_id" value={effectiveCategoryId} />
 
-      <div className="space-y-2">
-        <Label htmlFor="parent-category">Catégorie</Label>
-        <Select value={parentId} onValueChange={handleParentChange}>
-          <SelectTrigger id="parent-category">
-            <SelectValue placeholder="Choisir une catégorie…" />
-          </SelectTrigger>
-          <SelectContent>
-            {roots.map((cat) => (
-              <SelectItem key={cat.id} value={cat.id}>
-                {cat.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="cat-parent">
+          Catégorie <span className="text-destructive">*</span>
+        </Label>
+        <ComboSelect
+          id="cat-parent"
+          items={roots}
+          value={parentId}
+          onValueChange={handleParentChange}
+          placeholder="Rechercher une catégorie…"
+        />
       </div>
 
       {hasSubcategories && (
-        <div className="space-y-2">
-          <Label htmlFor="subcategory">Sous-catégorie</Label>
-          <Select
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="cat-sub">Sous-catégorie</Label>
+          <ComboSelect
+            id="cat-sub"
+            items={subcategories}
             value={subcategoryId}
             onValueChange={setSubcategoryId}
-          >
-            <SelectTrigger id="subcategory">
-              <SelectValue placeholder="Choisir une sous-catégorie…" />
-            </SelectTrigger>
-            <SelectContent>
-              {subcategories.map((cat) => (
-                <SelectItem key={cat.id} value={cat.id}>
-                  {cat.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+            placeholder="Rechercher…"
+          />
         </div>
       )}
     </div>

--- a/components/admin/product-wizard.tsx
+++ b/components/admin/product-wizard.tsx
@@ -1,0 +1,184 @@
+// components/admin/product-wizard.tsx
+"use client";
+
+import { useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { saveDraftStep, updateProduct } from "@/actions/admin/products";
+import { WizardStepper } from "./product-wizard/wizard-stepper";
+import { StepIdentity } from "./product-wizard/step-identity";
+import { StepPricing } from "./product-wizard/step-pricing";
+import { StepMedia } from "./product-wizard/step-media";
+import { StepFinalization } from "./product-wizard/step-finalization";
+import type { ProductDetail } from "@/lib/db/types";
+import type { CategoryOption } from "./category-cascading-select";
+
+const STEPS = [
+  { label: "Identité", subtitle: "Nom · Marque · Catégorie" },
+  { label: "Prix & Stock", subtitle: "Prix · Quantité" },
+  { label: "Médias", subtitle: "Images · Variantes" },
+  { label: "Finalisation", subtitle: "Description · SEO" },
+];
+
+function getInitialStep(product: ProductDetail): number {
+  if (!product.name) return 0;
+  if (!product.category_id || product.base_price === 0) return 1;
+  if (!product.images.some((img) => img.is_primary === 1)) return 2;
+  return 3;
+}
+
+interface ProductWizardProps {
+  product: ProductDetail;
+  // CategoryOption from components/admin/category-cascading-select (4 fields: id, name, depth, parent_id)
+  categories: CategoryOption[];
+}
+
+export function ProductWizard({ product, categories }: ProductWizardProps) {
+  const [currentStep, setCurrentStep] = useState(getInitialStep(product));
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+  const formRef = useRef<HTMLFormElement | null>(null);
+
+  function handleNext() {
+    if (!formRef.current) return;
+    const formData = new FormData(formRef.current);
+    startTransition(async () => {
+      try {
+        const result = await saveDraftStep(product.id, formData);
+        if (result.success) {
+          setCurrentStep((prev) => prev + 1);
+        } else {
+          toast.error(result.error ?? "Une erreur est survenue");
+        }
+      } catch {
+        toast.error("Une erreur inattendue est survenue. Veuillez réessayer.");
+      }
+    });
+  }
+
+  function handlePublish() {
+    if (!formRef.current) return;
+    const formData = new FormData(formRef.current);
+    formData.set("is_active", "1");
+    startTransition(async () => {
+      try {
+        const result = await updateProduct(product.id, formData);
+        if (result.success) {
+          toast.success("Produit publié");
+          router.push("/products");
+        } else {
+          toast.error(result.error ?? "Une erreur est survenue");
+        }
+      } catch {
+        toast.error("Une erreur inattendue est survenue. Veuillez réessayer.");
+      }
+    });
+  }
+
+  function handleSaveDraft() {
+    if (!formRef.current) return;
+    const formData = new FormData(formRef.current);
+    startTransition(async () => {
+      try {
+        const result = await saveDraftStep(product.id, formData);
+        if (result.success) {
+          toast.success("Brouillon enregistré");
+          router.push("/products");
+        } else {
+          toast.error(result.error ?? "Une erreur est survenue");
+        }
+      } catch {
+        toast.error("Une erreur inattendue est survenue. Veuillez réessayer.");
+      }
+    });
+  }
+
+  const isLastStep = currentStep === STEPS.length - 1;
+
+  return (
+    <div className="flex flex-col">
+      {/* Stepper */}
+      <WizardStepper
+        steps={STEPS}
+        currentStep={currentStep}
+        onStepClick={setCurrentStep}
+      />
+
+      {/* Step content */}
+      <div className="mx-auto w-full max-w-2xl px-4 py-8">
+        {currentStep === 0 && (
+          <StepIdentity
+            product={product}
+            categories={categories}
+            formRef={formRef}
+            isPending={isPending}
+          />
+        )}
+        {currentStep === 1 && (
+          <StepPricing
+            product={product}
+            formRef={formRef}
+            isPending={isPending}
+          />
+        )}
+        {currentStep === 2 && (
+          <StepMedia product={product} formRef={formRef} />
+        )}
+        {currentStep === 3 && (
+          <StepFinalization
+            product={product}
+            formRef={formRef}
+            isPending={isPending}
+          />
+        )}
+
+        {/* Navigation footer */}
+        <div className="mt-8 flex items-center justify-between border-t pt-6">
+          <p className="text-xs text-muted-foreground">
+            {isPending ? "Enregistrement…" : "Brouillon sauvegardé automatiquement"}
+          </p>
+          <div className="flex gap-3">
+            {currentStep > 0 && (
+              <Button
+                type="button"
+                variant="outline"
+                disabled={isPending}
+                onClick={() => setCurrentStep((prev) => prev - 1)}
+              >
+                ← Précédent
+              </Button>
+            )}
+            {isLastStep ? (
+              <>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={isPending}
+                  onClick={handleSaveDraft}
+                >
+                  {isPending ? "…" : "Enregistrer comme brouillon"}
+                </Button>
+                <Button
+                  type="button"
+                  disabled={isPending}
+                  onClick={handlePublish}
+                >
+                  {isPending ? "…" : "Publier le produit"}
+                </Button>
+              </>
+            ) : (
+              <Button
+                type="button"
+                disabled={isPending}
+                onClick={handleNext}
+              >
+                {isPending ? "Enregistrement…" : "Suivant →"}
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/product-wizard.tsx
+++ b/components/admin/product-wizard.tsx
@@ -2,12 +2,16 @@
 "use client";
 
 import { useRef, useState, useTransition } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ArrowLeft02Icon } from "@hugeicons/core-free-icons";
 import { Button } from "@/components/ui/button";
 import { saveDraftStep, updateProduct } from "@/actions/admin/products";
 import { WizardStepper } from "./product-wizard/wizard-stepper";
 import { StepIdentity } from "./product-wizard/step-identity";
+import { StepAttributes } from "./product-wizard/step-attributes";
 import { StepPricing } from "./product-wizard/step-pricing";
 import { StepMedia } from "./product-wizard/step-media";
 import { StepFinalization } from "./product-wizard/step-finalization";
@@ -15,17 +19,20 @@ import type { ProductDetail } from "@/lib/db/types";
 import type { CategoryOption } from "./category-cascading-select";
 
 const STEPS = [
-  { label: "Identité", subtitle: "Nom · Marque · Catégorie" },
+  { label: "Identité", subtitle: "Nom · Catégorie" },
+  { label: "Caractéristiques", subtitle: "Écran · Processeur…" },
   { label: "Prix & Stock", subtitle: "Prix · Quantité" },
-  { label: "Médias", subtitle: "Images · Variantes" },
+  { label: "Médias", subtitle: "Images" },
   { label: "Finalisation", subtitle: "Description · SEO" },
 ];
 
 export function getInitialStep(product: ProductDetail): number {
   if (!product.name) return 0;
-  if (!product.category_id || product.base_price === 0) return 1;
-  if (!product.images.some((img) => img.is_primary === 1)) return 2;
-  return 3;
+  if (!product.category_id) return 0;
+  if (product.attributes.length === 0) return 1;
+  if (product.base_price === 0) return 2;
+  if (!product.images.some((img) => img.is_primary === 1)) return 3;
+  return 4;
 }
 
 interface ProductWizardProps {
@@ -120,9 +127,13 @@ export function ProductWizard({ product, categories }: ProductWizardProps) {
     const formData = new FormData(formRef.current);
     startTransition(async () => {
       try {
-        await saveDraftStep(product.id, formData);
-      } catch {
-        // best-effort — navigate regardless
+        const result = await saveDraftStep(product.id, formData);
+        if (!result.success) {
+          toast.warning("Vos modifications n'ont pas pu être enregistrées.");
+        }
+      } catch (error) {
+        console.error("[ProductWizard] handleNavigate save failed:", error);
+        toast.warning("Vos modifications n'ont pas pu être enregistrées.");
       }
       setCurrentStep(targetStep);
     });
@@ -131,15 +142,26 @@ export function ProductWizard({ product, categories }: ProductWizardProps) {
   const isLastStep = currentStep === STEPS.length - 1;
 
   return (
-    <div className="flex flex-col">
-      {/* Stepper */}
-      <WizardStepper
-        steps={STEPS}
-        currentStep={currentStep}
-        onStepClick={handleNavigate}
-      />
+    <div className="flex flex-1 flex-col min-h-0 overflow-hidden">
+      {/* Integrated header: back button + description + stepper */}
+      <div className="-mx-4 -mt-4 bg-background sm:-mx-6 sm:-mt-6">
+        <div className="flex items-center gap-2 px-4 pt-4 pb-2 sm:px-6 sm:pt-5">
+          <Button variant="ghost" size="icon" asChild className="shrink-0">
+            <Link href="/products" aria-label="Retour aux produits">
+              <HugeiconsIcon icon={ArrowLeft02Icon} size={20} />
+            </Link>
+          </Button>
+          <p className="text-sm text-muted-foreground">Créer un produit</p>
+        </div>
+        <WizardStepper
+          steps={STEPS}
+          currentStep={currentStep}
+          onStepClick={handleNavigate}
+        />
+      </div>
 
-      {/* Step content */}
+      {/* Step content — internal scroll */}
+      <div className="flex-1 min-h-0 overflow-y-auto">
       <div className="mx-auto w-full max-w-2xl px-4 py-8">
         {currentStep === 0 && (
           <StepIdentity
@@ -150,16 +172,23 @@ export function ProductWizard({ product, categories }: ProductWizardProps) {
           />
         )}
         {currentStep === 1 && (
-          <StepPricing
+          <StepAttributes
             product={product}
             formRef={formRef}
             isPending={isPending}
           />
         )}
         {currentStep === 2 && (
-          <StepMedia product={product} formRef={formRef} />
+          <StepPricing
+            product={product}
+            formRef={formRef}
+            isPending={isPending}
+          />
         )}
         {currentStep === 3 && (
+          <StepMedia product={product} formRef={formRef} />
+        )}
+        {currentStep === 4 && (
           <StepFinalization
             product={product}
             formRef={formRef}
@@ -170,7 +199,7 @@ export function ProductWizard({ product, categories }: ProductWizardProps) {
         {/* Navigation footer */}
         <div className="mt-8 flex items-center justify-between border-t pt-6">
           <p className="text-xs text-muted-foreground">
-            {isPending ? "Enregistrement…" : "Brouillon sauvegardé automatiquement"}
+            {isPending ? "Enregistrement…" : "Brouillon sauvegardé à chaque étape"}
           </p>
           <div className="flex gap-3">
             {currentStep > 0 && (
@@ -212,6 +241,7 @@ export function ProductWizard({ product, categories }: ProductWizardProps) {
             )}
           </div>
         </div>
+      </div>
       </div>
     </div>
   );

--- a/components/admin/product-wizard.tsx
+++ b/components/admin/product-wizard.tsx
@@ -21,7 +21,7 @@ const STEPS = [
   { label: "Finalisation", subtitle: "Description · SEO" },
 ];
 
-function getInitialStep(product: ProductDetail): number {
+export function getInitialStep(product: ProductDetail): number {
   if (!product.name) return 0;
   if (!product.category_id || product.base_price === 0) return 1;
   if (!product.images.some((img) => img.is_primary === 1)) return 2;
@@ -41,26 +41,36 @@ export function ProductWizard({ product, categories }: ProductWizardProps) {
   const formRef = useRef<HTMLFormElement | null>(null);
 
   function handleNext() {
-    if (!formRef.current) return;
+    if (!formRef.current) {
+      console.error("[ProductWizard] formRef is null — form component did not mount");
+      toast.error("Erreur inattendue. Veuillez actualiser la page.");
+      return;
+    }
     const formData = new FormData(formRef.current);
     startTransition(async () => {
       try {
         const result = await saveDraftStep(product.id, formData);
         if (result.success) {
           setCurrentStep((prev) => prev + 1);
+          router.refresh();
         } else {
           toast.error(result.error ?? "Une erreur est survenue");
         }
-      } catch {
+      } catch (error) {
+        if (error instanceof Error && error.message.startsWith("NEXT_REDIRECT")) throw error;
+        console.error("[ProductWizard] handleNext failed:", error);
         toast.error("Une erreur inattendue est survenue. Veuillez réessayer.");
       }
     });
   }
 
   function handlePublish() {
-    if (!formRef.current) return;
+    if (!formRef.current) {
+      console.error("[ProductWizard] formRef is null — form component did not mount");
+      toast.error("Erreur inattendue. Veuillez actualiser la page.");
+      return;
+    }
     const formData = new FormData(formRef.current);
-    formData.set("is_active", "1");
     startTransition(async () => {
       try {
         const result = await updateProduct(product.id, formData);
@@ -70,14 +80,20 @@ export function ProductWizard({ product, categories }: ProductWizardProps) {
         } else {
           toast.error(result.error ?? "Une erreur est survenue");
         }
-      } catch {
+      } catch (error) {
+        if (error instanceof Error && error.message.startsWith("NEXT_REDIRECT")) throw error;
+        console.error("[ProductWizard] handlePublish failed:", error);
         toast.error("Une erreur inattendue est survenue. Veuillez réessayer.");
       }
     });
   }
 
   function handleSaveDraft() {
-    if (!formRef.current) return;
+    if (!formRef.current) {
+      console.error("[ProductWizard] formRef is null — form component did not mount");
+      toast.error("Erreur inattendue. Veuillez actualiser la page.");
+      return;
+    }
     const formData = new FormData(formRef.current);
     startTransition(async () => {
       try {
@@ -88,9 +104,27 @@ export function ProductWizard({ product, categories }: ProductWizardProps) {
         } else {
           toast.error(result.error ?? "Une erreur est survenue");
         }
-      } catch {
+      } catch (error) {
+        if (error instanceof Error && error.message.startsWith("NEXT_REDIRECT")) throw error;
+        console.error("[ProductWizard] handleSaveDraft failed:", error);
         toast.error("Une erreur inattendue est survenue. Veuillez réessayer.");
       }
+    });
+  }
+
+  function handleNavigate(targetStep: number) {
+    if (!formRef.current) {
+      setCurrentStep(targetStep);
+      return;
+    }
+    const formData = new FormData(formRef.current);
+    startTransition(async () => {
+      try {
+        await saveDraftStep(product.id, formData);
+      } catch {
+        // best-effort — navigate regardless
+      }
+      setCurrentStep(targetStep);
     });
   }
 
@@ -102,7 +136,7 @@ export function ProductWizard({ product, categories }: ProductWizardProps) {
       <WizardStepper
         steps={STEPS}
         currentStep={currentStep}
-        onStepClick={setCurrentStep}
+        onStepClick={handleNavigate}
       />
 
       {/* Step content */}
@@ -144,7 +178,7 @@ export function ProductWizard({ product, categories }: ProductWizardProps) {
                 type="button"
                 variant="outline"
                 disabled={isPending}
-                onClick={() => setCurrentStep((prev) => prev - 1)}
+                onClick={() => handleNavigate(currentStep - 1)}
               >
                 ← Précédent
               </Button>

--- a/components/admin/product-wizard/step-attributes.tsx
+++ b/components/admin/product-wizard/step-attributes.tsx
@@ -1,0 +1,285 @@
+// components/admin/product-wizard/step-attributes.tsx
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ColorPicker } from "@/components/admin/color-picker";
+import type { ProductDetail } from "@/lib/db/types";
+
+interface StepAttributesProps {
+  product: ProductDetail;
+  formRef: React.RefObject<HTMLFormElement | null>;
+  isPending: boolean;
+}
+
+type ColorEntry = { uid: string; name: string; hex: string };
+type AttrRow = { uid: string; name: string; value: string };
+
+const FIXED_KEYS = new Set(["Longueur", "Hauteur", "Largeur", "Poids", "Couleur"]);
+
+const PRESET_COLORS = [
+  { name: "Noir",        hex: "#1a1a1a" },
+  { name: "Blanc",       hex: "#f5f5f5" },
+  { name: "Gris",        hex: "#9e9e9e" },
+  { name: "Argent",      hex: "#c0c0c0" },
+  { name: "Or",          hex: "#d4a847" },
+  { name: "Or rose",     hex: "#e8b4b8" },
+  { name: "Titane",      hex: "#878781" },
+  { name: "Bleu",        hex: "#1565c0" },
+  { name: "Bleu nuit",   hex: "#1a237e" },
+  { name: "Rouge",       hex: "#c62828" },
+  { name: "Vert",        hex: "#2e7d32" },
+  { name: "Violet",      hex: "#6a1b9a" },
+  { name: "Orange",      hex: "#e65100" },
+  { name: "Jaune",       hex: "#f9a825" },
+];
+
+const FIXED_DIMS = [
+  { key: "Longueur", unit: "mm" },
+  { key: "Hauteur", unit: "mm" },
+  { key: "Largeur", unit: "mm" },
+  { key: "Poids", unit: "g" },
+];
+
+/** Stored as "Nom|#hexcode". Falls back gracefully for legacy plain-name entries. */
+function parseColorValue(raw: string): { name: string; hex: string } {
+  const idx = raw.lastIndexOf("|");
+  if (idx !== -1 && raw[idx + 1] === "#") {
+    return { name: raw.slice(0, idx), hex: raw.slice(idx + 1) };
+  }
+  return { name: raw, hex: "#000000" };
+}
+
+export function StepAttributes({ product, formRef, isPending }: StepAttributesProps) {
+  const [colors, setColors] = useState<ColorEntry[]>(() =>
+    product.attributes
+      .filter((a) => a.name === "Couleur")
+      .map((a) => ({ uid: a.id, ...parseColorValue(a.value) })),
+  );
+  const [newName, setNewName] = useState("");
+  const [newHex, setNewHex] = useState("#000000");
+
+  const [fixed, setFixed] = useState<Record<string, string>>(() => {
+    const map: Record<string, string> = {};
+    for (const d of FIXED_DIMS) {
+      const existing = product.attributes.find((a) => a.name === d.key);
+      map[d.key] = existing?.value ?? "";
+    }
+    return map;
+  });
+
+  const [extras, setExtras] = useState<AttrRow[]>(() =>
+    product.attributes
+      .filter((a) => !FIXED_KEYS.has(a.name))
+      .map((a) => ({ uid: a.id, name: a.name, value: a.value })),
+  );
+
+  function addColor(name?: string, hex?: string) {
+    const n = (name ?? newName).trim();
+    const h = hex ?? newHex;
+    if (!n) return;
+    if (!colors.some((c) => c.name === n)) {
+      setColors((prev) => [...prev, { uid: crypto.randomUUID(), name: n, hex: h }]);
+    }
+    if (!name) {
+      setNewName("");
+      setNewHex("#000000");
+    }
+  }
+
+  function removeColor(uid: string) {
+    setColors((prev) => prev.filter((c) => c.uid !== uid));
+  }
+
+  function addExtra() {
+    setExtras((prev) => [...prev, { uid: crypto.randomUUID(), name: "", value: "" }]);
+  }
+
+  function removeExtra(uid: string) {
+    setExtras((prev) => prev.filter((a) => a.uid !== uid));
+  }
+
+  function updateExtra(uid: string, field: "name" | "value", val: string) {
+    setExtras((prev) => prev.map((a) => (a.uid === uid ? { ...a, [field]: val } : a)));
+  }
+
+  const serialized = JSON.stringify([
+    ...colors.map((c) => ({ name: "Couleur", value: `${c.name}|${c.hex}` })),
+    ...FIXED_DIMS.filter((d) => fixed[d.key]?.trim()).map((d) => ({
+      name: d.key,
+      value: fixed[d.key].trim(),
+    })),
+    ...extras
+      .filter((a) => a.name.trim())
+      .map((a) => ({ name: a.name.trim(), value: a.value.trim() })),
+  ]);
+
+  return (
+    <form ref={formRef} className="space-y-6">
+      <input type="hidden" name="_step" value="2" />
+      <input type="hidden" name="attributes" value={serialized} />
+
+      {/* Colors */}
+      <div className="space-y-3">
+        <h3 className="text-sm font-semibold">Couleurs disponibles</h3>
+        <p className="text-xs text-muted-foreground">
+          Sélectionnez toutes les couleurs dans lesquelles ce produit est disponible. Utilisez les
+          raccourcis ci-dessous ou définissez une couleur personnalisée avec le sélecteur.
+        </p>
+
+        {/* Preset swatches */}
+        <div className="flex flex-wrap gap-2">
+          {PRESET_COLORS.map((p) => {
+            const active = colors.some((c) => c.name === p.name);
+            return (
+              <button
+                key={p.name}
+                type="button"
+                disabled={isPending}
+                onClick={() => {
+                  if (active) {
+                    setColors((prev) => prev.filter((c) => c.name !== p.name));
+                  } else {
+                    addColor(p.name, p.hex);
+                  }
+                }}
+                title={p.name}
+                className={`flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-colors ${
+                  active
+                    ? "border-primary bg-primary/10 text-primary"
+                    : "border-border bg-background text-muted-foreground hover:border-foreground hover:text-foreground"
+                }`}
+              >
+                <span
+                  className="size-3 shrink-0 rounded-full border border-black/10"
+                  style={{ backgroundColor: p.hex }}
+                />
+                {p.name}
+              </button>
+            );
+          })}
+        </div>
+
+        {colors.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {colors.map((c) => (
+              <span
+                key={c.uid}
+                className="flex items-center gap-2 rounded-full border bg-muted pl-1.5 pr-3 py-1 text-sm"
+              >
+                <span
+                  className="size-4 shrink-0 rounded-full border border-black/10"
+                  style={{ backgroundColor: c.hex }}
+                />
+                {c.name}
+                <button
+                  type="button"
+                  disabled={isPending}
+                  onClick={() => removeColor(c.uid)}
+                  className="ml-0.5 text-muted-foreground hover:text-destructive"
+                  aria-label={`Retirer ${c.name}`}
+                >
+                  ×
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+
+        <div className="flex gap-2">
+          <ColorPicker
+            value={newHex}
+            onChange={setNewHex}
+            className="w-36 shrink-0"
+          />
+          <Input
+            value={newName}
+            disabled={isPending}
+            placeholder="Nom (ex: Noir, Bleu nuit…)"
+            onChange={(e) => setNewName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                addColor();
+              }
+            }}
+          />
+          <Button type="button" variant="outline" disabled={isPending} onClick={() => addColor()}>
+            Ajouter
+          </Button>
+        </div>
+      </div>
+
+      {/* Fixed dimensions & weight */}
+      <div className="space-y-3">
+        <h3 className="text-sm font-semibold">Dimensions &amp; Poids</h3>
+        <div className="grid grid-cols-2 gap-3">
+          {FIXED_DIMS.map((d) => (
+            <div key={d.key} className="space-y-1.5">
+              <Label htmlFor={`fixed-${d.key}`} className="text-xs">
+                {d.key}{" "}
+                <span className="text-muted-foreground">({d.unit})</span>
+              </Label>
+              <Input
+                id={`fixed-${d.key}`}
+                type="number"
+                min={0}
+                step="any"
+                value={fixed[d.key]}
+                onChange={(e) => setFixed((prev) => ({ ...prev, [d.key]: e.target.value }))}
+                disabled={isPending}
+                placeholder="—"
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Extra free-form attributes */}
+      {extras.length > 0 && (
+        <div className="space-y-3">
+          <h3 className="text-sm font-semibold">Autres caractéristiques</h3>
+          {extras.map((attr) => (
+            <div key={attr.uid} className="grid grid-cols-[1fr_1fr_2rem] items-center gap-2">
+              <Input
+                value={attr.name}
+                onChange={(e) => updateExtra(attr.uid, "name", e.target.value)}
+                disabled={isPending}
+                placeholder="ex: Écran"
+              />
+              <Input
+                value={attr.value}
+                onChange={(e) => updateExtra(attr.uid, "value", e.target.value)}
+                disabled={isPending}
+                placeholder='ex: 6.7" AMOLED'
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                disabled={isPending}
+                onClick={() => removeExtra(attr.uid)}
+                className="text-muted-foreground hover:text-destructive"
+                aria-label="Supprimer"
+              >
+                ×
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={isPending}
+        onClick={addExtra}
+      >
+        + Ajouter une caractéristique
+      </Button>
+    </form>
+  );
+}

--- a/components/admin/product-wizard/step-finalization.tsx
+++ b/components/admin/product-wizard/step-finalization.tsx
@@ -1,0 +1,180 @@
+// components/admin/product-wizard/step-finalization.tsx
+"use client";
+
+import { useRef, useState } from "react";
+import dynamic from "next/dynamic";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import type { ProductDetail } from "@/lib/db/types";
+
+const RichTextEditor = dynamic(() =>
+  import("@/components/admin/rich-text-editor").then((m) => m.RichTextEditor),
+);
+
+interface StepFinalizationProps {
+  product: ProductDetail;
+  formRef: React.RefObject<HTMLFormElement | null>;
+  isPending: boolean;
+}
+
+export function StepFinalization({
+  product,
+  formRef,
+  isPending,
+}: StepFinalizationProps) {
+  const [metaTitleLen, setMetaTitleLen] = useState(
+    (product.meta_title ?? "").length,
+  );
+  const [metaDescLen, setMetaDescLen] = useState(
+    (product.meta_description ?? "").length,
+  );
+  const isActiveRef = useRef<HTMLInputElement>(null);
+  const isFeaturedRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <form ref={formRef} className="space-y-6">
+      <input type="hidden" name="_step" value="4" />
+
+      {/* Hidden inputs: all fields required by updateProduct that aren't in this step */}
+      <input type="hidden" name="slug" value={product.slug} />
+      <input type="hidden" name="name" value={product.name} />
+      <input type="hidden" name="category_id" value={product.category_id ?? ""} />
+      <input type="hidden" name="base_price" value={product.base_price} />
+      <input type="hidden" name="stock_quantity" value={product.stock_quantity} />
+      <input
+        type="hidden"
+        name="low_stock_threshold"
+        value={product.low_stock_threshold}
+      />
+      {product.brand && (
+        <input type="hidden" name="brand" value={product.brand} />
+      )}
+      {product.sku && <input type="hidden" name="sku" value={product.sku} />}
+      {product.compare_price != null && (
+        <input
+          type="hidden"
+          name="compare_price"
+          value={product.compare_price}
+        />
+      )}
+      {product.weight_grams != null && (
+        <input
+          type="hidden"
+          name="weight_grams"
+          value={product.weight_grams}
+        />
+      )}
+
+      {/* Résumé court */}
+      <div className="space-y-1.5">
+        <Label htmlFor="wiz-short-desc">Résumé court</Label>
+        <Input
+          id="wiz-short-desc"
+          name="short_description"
+          disabled={isPending}
+          defaultValue={product.short_description ?? ""}
+          placeholder="ex: Smartphone 128Go avec triple caméra 50MP"
+        />
+      </div>
+
+      {/* Description riche */}
+      <div className="space-y-1.5">
+        <Label>Description</Label>
+        <RichTextEditor name="description" defaultValue={product.description} />
+      </div>
+
+      {/* SEO */}
+      <div className="space-y-4 rounded-lg border p-4">
+        <h3 className="text-sm font-semibold">SEO</h3>
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between">
+            <Label htmlFor="wiz-meta-title">Titre SEO</Label>
+            <span
+              className={`text-xs tabular-nums ${metaTitleLen > 55 ? "text-amber-600" : "text-muted-foreground"}`}
+            >
+              {metaTitleLen}/60
+            </span>
+          </div>
+          <Input
+            id="wiz-meta-title"
+            name="meta_title"
+            maxLength={60}
+            disabled={isPending}
+            defaultValue={product.meta_title ?? ""}
+            placeholder="Titre pour les moteurs de recherche"
+            onChange={(e) => setMetaTitleLen(e.target.value.length)}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between">
+            <Label htmlFor="wiz-meta-desc">Meta description</Label>
+            <span
+              className={`text-xs tabular-nums ${metaDescLen > 140 ? "text-amber-600" : "text-muted-foreground"}`}
+            >
+              {metaDescLen}/160
+            </span>
+          </div>
+          <Textarea
+            id="wiz-meta-desc"
+            name="meta_description"
+            rows={3}
+            maxLength={160}
+            disabled={isPending}
+            defaultValue={product.meta_description ?? ""}
+            placeholder="Description pour les moteurs de recherche"
+            onChange={(e) => setMetaDescLen(e.target.value.length)}
+          />
+        </div>
+      </div>
+
+      {/* Visibilité */}
+      <div className="space-y-4 rounded-lg border p-4">
+        <h3 className="text-sm font-semibold">Visibilité</h3>
+        <div className="flex items-center justify-between">
+          <div>
+            <Label>Publier immédiatement</Label>
+            <p className="text-xs text-muted-foreground">
+              Visible sur la boutique dès la publication
+            </p>
+          </div>
+          <input
+            type="hidden"
+            name="is_active"
+            ref={isActiveRef}
+            defaultValue={product.is_active}
+          />
+          <Switch
+            defaultChecked={product.is_active === 1}
+            onCheckedChange={(checked) => {
+              if (isActiveRef.current)
+                isActiveRef.current.value = checked ? "1" : "0";
+            }}
+          />
+        </div>
+        <div className="flex items-center justify-between">
+          <div>
+            <Label>Mettre en avant</Label>
+            <p className="text-xs text-muted-foreground">
+              Affiché dans la section vedette de la page d&apos;accueil
+            </p>
+          </div>
+          <input
+            type="hidden"
+            name="is_featured"
+            ref={isFeaturedRef}
+            defaultValue={product.is_featured}
+          />
+          <Switch
+            defaultChecked={product.is_featured === 1}
+            onCheckedChange={(checked) => {
+              if (isFeaturedRef.current)
+                isFeaturedRef.current.value = checked ? "1" : "0";
+            }}
+          />
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/components/admin/product-wizard/step-finalization.tsx
+++ b/components/admin/product-wizard/step-finalization.tsx
@@ -35,7 +35,7 @@ export function StepFinalization({
 
   return (
     <form ref={formRef} className="space-y-6">
-      <input type="hidden" name="_step" value="4" />
+      <input type="hidden" name="_step" value="5" />
 
       {/* Hidden inputs: all fields required by updateProduct that aren't in this step */}
       <input type="hidden" name="slug" value={product.slug} />

--- a/components/admin/product-wizard/step-identity.tsx
+++ b/components/admin/product-wizard/step-identity.tsx
@@ -1,0 +1,104 @@
+// components/admin/product-wizard/step-identity.tsx
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { CategoryCascadingSelect, type CategoryOption } from "@/components/admin/category-cascading-select";
+import type { ProductDetail } from "@/lib/db/types";
+
+interface StepIdentityProps {
+  product: ProductDetail;
+  categories: CategoryOption[];
+  formRef: React.RefObject<HTMLFormElement | null>;
+  isPending: boolean;
+}
+
+export function StepIdentity({
+  product,
+  categories,
+  formRef,
+  isPending,
+}: StepIdentityProps) {
+  return (
+    <form ref={formRef} className="space-y-6">
+      <input type="hidden" name="_step" value="1" />
+
+      {/* Nom du produit */}
+      <div className="space-y-1.5">
+        <div className="flex items-center gap-1.5">
+          <Label htmlFor="wiz-name">
+            Nom du produit <span className="text-destructive">*</span>
+          </Label>
+          <span
+            className="inline-flex h-4 w-4 cursor-help items-center justify-center rounded-full bg-muted text-[10px] font-bold text-muted-foreground"
+            title="Soyez précis : incluez la marque, le modèle, la capacité et la couleur si pertinent."
+          >
+            ?
+          </span>
+        </div>
+        <Input
+          id="wiz-name"
+          name="name"
+          required
+          disabled={isPending}
+          defaultValue={product.name}
+          placeholder="ex: Samsung Galaxy A55 128Go Noir"
+        />
+        <p className="text-xs text-muted-foreground">
+          Soyez précis : marque, modèle, capacité, couleur si pertinent.
+        </p>
+      </div>
+
+      {/* Marque + SKU */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label htmlFor="wiz-brand">Marque</Label>
+          <Input
+            id="wiz-brand"
+            name="brand"
+            disabled={isPending}
+            defaultValue={product.brand ?? ""}
+            placeholder="ex: Samsung"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-1.5">
+            <Label htmlFor="wiz-sku">SKU</Label>
+            <span
+              className="inline-flex h-4 w-4 cursor-help items-center justify-center rounded-full bg-muted text-[10px] font-bold text-muted-foreground"
+              title="Référence interne pour identifier ce produit dans vos stocks."
+            >
+              ?
+            </span>
+          </div>
+          <Input
+            id="wiz-sku"
+            name="sku"
+            disabled={isPending}
+            defaultValue={product.sku ?? ""}
+            placeholder="ex: SAM-A55-128-BLK"
+            className="bg-muted/40"
+          />
+          <p className="text-xs text-muted-foreground">
+            Laissez vide si vous n&apos;avez pas de référence interne.
+          </p>
+        </div>
+      </div>
+
+      {/* Catégorie */}
+      <div className="space-y-1.5">
+        <Label>
+          Catégorie <span className="text-destructive">*</span>
+        </Label>
+        <CategoryCascadingSelect
+          categories={categories}
+          defaultCategoryId={product.category_id || undefined}
+        />
+      </div>
+
+      {/* Step hint */}
+      <div className="rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800 dark:border-blue-900 dark:bg-blue-950 dark:text-blue-200">
+        💡 Le nom et la catégorie suffisent pour passer à l&apos;étape suivante.
+        Vous pourrez toujours revenir pour compléter.
+      </div>
+    </form>
+  );
+}

--- a/components/admin/product-wizard/step-identity.tsx
+++ b/components/admin/product-wizard/step-identity.tsx
@@ -47,47 +47,8 @@ export function StepIdentity({
         </p>
       </div>
 
-      {/* Marque + SKU */}
-      <div className="grid gap-4 sm:grid-cols-2">
-        <div className="space-y-1.5">
-          <Label htmlFor="wiz-brand">Marque</Label>
-          <Input
-            id="wiz-brand"
-            name="brand"
-            disabled={isPending}
-            defaultValue={product.brand ?? ""}
-            placeholder="ex: Samsung"
-          />
-        </div>
-        <div className="space-y-1.5">
-          <div className="flex items-center gap-1.5">
-            <Label htmlFor="wiz-sku">SKU</Label>
-            <span
-              className="inline-flex h-4 w-4 cursor-help items-center justify-center rounded-full bg-muted text-[10px] font-bold text-muted-foreground"
-              title="Référence interne pour identifier ce produit dans vos stocks."
-            >
-              ?
-            </span>
-          </div>
-          <Input
-            id="wiz-sku"
-            name="sku"
-            disabled={isPending}
-            defaultValue={product.sku ?? ""}
-            placeholder="ex: SAM-A55-128-BLK"
-            className="bg-muted/40"
-          />
-          <p className="text-xs text-muted-foreground">
-            Laissez vide si vous n&apos;avez pas de référence interne.
-          </p>
-        </div>
-      </div>
-
       {/* Catégorie */}
       <div className="space-y-1.5">
-        <Label>
-          Catégorie <span className="text-destructive">*</span>
-        </Label>
         <CategoryCascadingSelect
           categories={categories}
           defaultCategoryId={product.category_id || undefined}

--- a/components/admin/product-wizard/step-media.tsx
+++ b/components/admin/product-wizard/step-media.tsx
@@ -1,55 +1,356 @@
 // components/admin/product-wizard/step-media.tsx
-import dynamic from "next/dynamic";
-import type { ProductDetail } from "@/lib/db/types";
+"use client";
 
-const ImageManager = dynamic(() =>
-  import("@/components/admin/image-manager").then((m) => m.ImageManager),
-);
-const VariantList = dynamic(() =>
-  import("@/components/admin/variant-list").then((m) => m.VariantList),
-);
+import { useRef, useTransition } from "react";
+import Image from "next/image";
+import { toast } from "sonner";
+import { getImageUrl } from "@/lib/utils/images";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  uploadProductImage,
+  deleteProductImage,
+  setPrimaryImage,
+} from "@/actions/admin/images";
+import { ImageUpload } from "@/components/admin/image-upload";
+import type { ProductDetail } from "@/lib/db/types";
 
 interface StepMediaProps {
   product: ProductDetail;
   formRef: React.RefObject<HTMLFormElement | null>;
 }
 
-export function StepMedia({ product, formRef }: StepMediaProps) {
-  return (
-    <form ref={formRef} className="space-y-8">
-      <input type="hidden" name="_step" value="3" />
+type ColorInfo = { variantId: string | null; name: string; hex: string };
 
-      {/* Images */}
+/** Parse "Nom|#hex" format from product attributes */
+function parseColorValue(raw: string): { name: string; hex: string } {
+  const idx = raw.lastIndexOf("|");
+  if (idx !== -1 && raw[idx + 1] === "#") {
+    return { name: raw.slice(0, idx), hex: raw.slice(idx + 1) };
+  }
+  return { name: raw, hex: "#000000" };
+}
+
+/** Convert attribute color format "Nom|#hex" to variant format "Nom:#hex" */
+function toVariantColorValue(raw: string): string {
+  const { name, hex } = parseColorValue(raw);
+  return `${name}:${hex}`;
+}
+
+/** Parse variant color format "Nom:#hex" or "Nom" */
+function parseVariantColor(stored: string): { name: string; hex: string } {
+  const idx = stored.lastIndexOf(":#");
+  if (idx > 0 && stored.length - idx <= 8) {
+    return { name: stored.slice(0, idx), hex: stored.slice(idx + 1) };
+  }
+  const pipeIdx = stored.lastIndexOf("|");
+  if (pipeIdx !== -1 && stored[pipeIdx + 1] === "#") {
+    return { name: stored.slice(0, pipeIdx), hex: stored.slice(pipeIdx + 1) };
+  }
+  return { name: stored, hex: "#000000" };
+}
+
+export function StepMedia({ product, formRef }: StepMediaProps) {
+  const [isPending, startTransition] = useTransition();
+
+  // Build color→variant mapping from product variants
+  const colorVariants = product.variants
+    .map((v): ColorInfo | null => {
+      try {
+        const attrs = JSON.parse(v.attributes);
+        if (!attrs.color) return null;
+        const parsed = parseVariantColor(attrs.color);
+        return { variantId: v.id, name: parsed.name, hex: parsed.hex };
+      } catch {
+        return null;
+      }
+    })
+    .filter((c): c is ColorInfo => c !== null);
+
+  // Build colors from attributes — always shown, even without variants
+  const attrColors: ColorInfo[] = product.attributes
+    .filter((a) => a.name === "Couleur")
+    .map((a) => {
+      const parsed = parseColorValue(a.value);
+      const variantColor = toVariantColorValue(a.value);
+      const variant = product.variants.find((v) => {
+        try {
+          return JSON.parse(v.attributes).color === variantColor;
+        } catch {
+          return false;
+        }
+      });
+      return { variantId: variant?.id ?? null, name: parsed.name, hex: parsed.hex };
+    });
+
+  const colors = attrColors.length > 0 ? attrColors : colorVariants;
+  const hasColors = colors.length > 0;
+
+  // Images not assigned to any color variant
+  const generalImages = hasColors
+    ? product.images.filter(
+        (img) => !img.variant_id || !colors.some((c) => c.variantId === img.variant_id),
+      )
+    : product.images;
+
+  function handleUpload(file: File, variantId?: string) {
+    const formData = new FormData();
+    formData.set("file", file);
+    if (variantId) formData.set("variant_id", variantId);
+    startTransition(async () => {
+      const result = await uploadProductImage(product.id, formData);
+      if (result.success) {
+        toast.success("Image ajoutée");
+      } else {
+        toast.error(result.error);
+      }
+    });
+  }
+
+  function handleDelete(imageId: string) {
+    startTransition(async () => {
+      const result = await deleteProductImage(imageId, product.id);
+      if (result.success) {
+        toast.success("Image supprimée");
+      } else {
+        toast.error(result.error);
+      }
+    });
+  }
+
+  function handleSetPrimary(imageId: string) {
+    startTransition(async () => {
+      const result = await setPrimaryImage(imageId, product.id);
+      if (result.success) {
+        toast.success("Image principale définie");
+      } else {
+        toast.error(result.error);
+      }
+    });
+  }
+
+  return (
+    <form ref={formRef} className="space-y-6">
+      <input type="hidden" name="_step" value="4" />
+
+      <div>
+        <h3 className="text-sm font-semibold">Images</h3>
+        <p className="text-xs text-muted-foreground">
+          Ajoutez au moins une photo avant de publier.
+          {hasColors && " Téléchargez une image pour chaque couleur du produit."}
+        </p>
+      </div>
+
+      {product.images.length === 0 && !hasColors && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-200">
+          Aucune image pour l&apos;instant. Au moins une image est recommandée avant la
+          publication.
+        </div>
+      )}
+
+      {/* Per-color image table */}
+      {hasColors && (
+        <div className="space-y-3">
+          <h3 className="text-sm font-semibold">Image par couleur</h3>
+          <div className="rounded-lg border">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b bg-muted/50">
+                  <th className="px-3 py-2 text-left font-medium">Couleur</th>
+                  <th className="px-3 py-2 text-left font-medium">Image</th>
+                  <th className="px-3 py-2 text-right font-medium">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {colors.map((color, i) => {
+                  const img = color.variantId
+                    ? product.images.find((im) => im.variant_id === color.variantId)
+                    : undefined;
+                  return (
+                    <tr
+                      key={color.variantId ?? `color-${color.name}`}
+                      className={i < colors.length - 1 ? "border-b" : ""}
+                    >
+                      <td className="px-3 py-2.5">
+                        <div className="flex items-center gap-2">
+                          <span
+                            className="size-4 shrink-0 rounded-full border border-black/10"
+                            style={{ backgroundColor: color.hex }}
+                          />
+                          <span>{color.name}</span>
+                        </div>
+                      </td>
+                      <td className="px-3 py-2.5">
+                        {img ? (
+                          <div className="flex items-center gap-2">
+                            <Image
+                              src={getImageUrl(img.url)}
+                              alt={img.alt || color.name}
+                              width={40}
+                              height={40}
+                              className="size-10 shrink-0 rounded-md border object-cover"
+                            />
+                            {img.is_primary === 1 && (
+                              <Badge variant="outline" className="text-[10px] px-1 py-0">
+                                Principale
+                              </Badge>
+                            )}
+                          </div>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">—</span>
+                        )}
+                      </td>
+                      <td className="px-3 py-2.5 text-right">
+                        <div className="flex items-center justify-end gap-1.5">
+                          {img ? (
+                            <>
+                              {img.is_primary !== 1 && (
+                                <Button
+                                  type="button"
+                                  size="sm"
+                                  variant="ghost"
+                                  className="h-7 text-xs"
+                                  disabled={isPending}
+                                  onClick={() => handleSetPrimary(img.id)}
+                                >
+                                  Principale
+                                </Button>
+                              )}
+                              <Button
+                                type="button"
+                                size="sm"
+                                variant="ghost"
+                                className="h-7 text-xs text-destructive hover:text-destructive"
+                                disabled={isPending}
+                                onClick={() => handleDelete(img.id)}
+                              >
+                                Supprimer
+                              </Button>
+                            </>
+                          ) : color.variantId ? (
+                            <ColorUploadButton
+                              variantId={color.variantId}
+                              disabled={isPending}
+                              onUpload={handleUpload}
+                            />
+                          ) : (
+                            <span className="text-xs text-muted-foreground italic">
+                              Définissez le prix d&apos;abord
+                            </span>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* General images */}
       <div className="space-y-4">
-        <div>
-          <h3 className="text-sm font-semibold">Images</h3>
-          <p className="text-xs text-muted-foreground">
-            Ajoutez au moins une photo avant de publier.
-          </p>
+        <div className="flex items-center justify-between">
+          <h3 className="font-semibold">
+            {hasColors ? "Images générales" : "Images"}{" "}
+            ({generalImages.length})
+          </h3>
+          <ImageUpload productId={product.id} />
         </div>
 
-        {/* Amber hint if no images yet */}
-        {product.images.length === 0 && (
-          <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-200">
-            📸 Aucune image pour l&apos;instant. Au moins une image est
-            recommandée avant la publication.
+        {generalImages.length > 0 ? (
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4">
+            {generalImages.map((img) => (
+              <div
+                key={img.id}
+                className="group relative overflow-hidden rounded-lg border"
+                data-pending={isPending || undefined}
+              >
+                <Image
+                  src={getImageUrl(img.url)}
+                  alt={img.alt || ""}
+                  width={200}
+                  height={200}
+                  className="aspect-square w-full object-cover"
+                />
+                {img.is_primary === 1 && (
+                  <Badge className="absolute top-2 left-2">Principale</Badge>
+                )}
+                <div className="absolute inset-0 flex items-end bg-gradient-to-t from-black/60 to-transparent opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 touch-manipulation">
+                  <div className="flex w-full gap-1.5 p-2">
+                    {img.is_primary !== 1 && (
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        className="h-9 text-xs"
+                        disabled={isPending}
+                        onClick={() => handleSetPrimary(img.id)}
+                      >
+                        Principale
+                      </Button>
+                    )}
+                    <Button
+                      size="sm"
+                      variant="destructive"
+                      className="h-9 text-xs"
+                      disabled={isPending}
+                      onClick={() => handleDelete(img.id)}
+                    >
+                      Supprimer
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-lg border border-dashed p-8 text-center text-muted-foreground">
+            {hasColors
+              ? "Ajoutez des photos du packaging, accessoires, etc."
+              : "Aucune image. Cliquez sur « Ajouter une image » pour commencer."}
           </div>
         )}
-
-        <ImageManager productId={product.id} images={product.images} />
-      </div>
-
-      {/* Variantes */}
-      <div className="space-y-4">
-        <div>
-          <h3 className="text-sm font-semibold">Variantes</h3>
-          <p className="text-xs text-muted-foreground">
-            Ajoutez des variantes si ce produit existe en plusieurs versions
-            (couleur, stockage…).
-          </p>
-        </div>
-        <VariantList productId={product.id} variants={product.variants} />
       </div>
     </form>
+  );
+}
+
+/* ── Upload button per color ───────────────────────────────────── */
+
+function ColorUploadButton({
+  variantId,
+  disabled,
+  onUpload,
+}: {
+  variantId: string;
+  disabled: boolean;
+  onUpload: (file: File, variantId: string) => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) onUpload(file, variantId);
+          if (inputRef.current) inputRef.current.value = "";
+        }}
+      />
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        className="h-7 text-xs"
+        disabled={disabled}
+        onClick={() => inputRef.current?.click()}
+      >
+        {disabled ? "Upload..." : "Télécharger"}
+      </Button>
+    </>
   );
 }

--- a/components/admin/product-wizard/step-media.tsx
+++ b/components/admin/product-wizard/step-media.tsx
@@ -1,0 +1,55 @@
+// components/admin/product-wizard/step-media.tsx
+import dynamic from "next/dynamic";
+import type { ProductDetail } from "@/lib/db/types";
+
+const ImageManager = dynamic(() =>
+  import("@/components/admin/image-manager").then((m) => m.ImageManager),
+);
+const VariantList = dynamic(() =>
+  import("@/components/admin/variant-list").then((m) => m.VariantList),
+);
+
+interface StepMediaProps {
+  product: ProductDetail;
+  formRef: React.RefObject<HTMLFormElement | null>;
+}
+
+export function StepMedia({ product, formRef }: StepMediaProps) {
+  return (
+    <form ref={formRef} className="space-y-8">
+      <input type="hidden" name="_step" value="3" />
+
+      {/* Images */}
+      <div className="space-y-4">
+        <div>
+          <h3 className="text-sm font-semibold">Images</h3>
+          <p className="text-xs text-muted-foreground">
+            Ajoutez au moins une photo avant de publier.
+          </p>
+        </div>
+
+        {/* Amber hint if no images yet */}
+        {product.images.length === 0 && (
+          <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-200">
+            📸 Aucune image pour l&apos;instant. Au moins une image est
+            recommandée avant la publication.
+          </div>
+        )}
+
+        <ImageManager productId={product.id} images={product.images} />
+      </div>
+
+      {/* Variantes */}
+      <div className="space-y-4">
+        <div>
+          <h3 className="text-sm font-semibold">Variantes</h3>
+          <p className="text-xs text-muted-foreground">
+            Ajoutez des variantes si ce produit existe en plusieurs versions
+            (couleur, stockage…).
+          </p>
+        </div>
+        <VariantList productId={product.id} variants={product.variants} />
+      </div>
+    </form>
+  );
+}

--- a/components/admin/product-wizard/step-pricing.tsx
+++ b/components/admin/product-wizard/step-pricing.tsx
@@ -1,6 +1,10 @@
 // components/admin/product-wizard/step-pricing.tsx
+"use client";
+
+import { useMemo, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import {
   InputGroup,
   InputGroupAddon,
@@ -14,10 +18,117 @@ interface StepPricingProps {
   isPending: boolean;
 }
 
+type ColorInfo = { name: string; hex: string };
+
+/** Parse "Nom|#hex" format from product attributes */
+function parseColorValue(raw: string): ColorInfo {
+  const idx = raw.lastIndexOf("|");
+  if (idx !== -1 && raw[idx + 1] === "#") {
+    return { name: raw.slice(0, idx), hex: raw.slice(idx + 1) };
+  }
+  return { name: raw, hex: "#000000" };
+}
+
+/** Convert attribute color format "Nom|#hex" to variant format "Nom:#hex" */
+function toVariantColorValue(raw: string): string {
+  const { name, hex } = parseColorValue(raw);
+  return `${name}:${hex}`;
+}
+
 export function StepPricing({ product, formRef, isPending }: StepPricingProps) {
+  const colors = product.attributes
+    .filter((a) => a.name === "Couleur")
+    .map((a) => ({
+      raw: a.value,
+      ...parseColorValue(a.value),
+      variantColor: toVariantColorValue(a.value),
+    }));
+
+  const hasColors = colors.length > 0;
+
+  // Find existing variant for each color (match by color attribute)
+  function findVariantForColor(variantColor: string) {
+    return product.variants.find((v) => {
+      try {
+        const attrs = JSON.parse(v.attributes);
+        return attrs.color === variantColor;
+      } catch {
+        return false;
+      }
+    });
+  }
+
+  const [uniformPrice, setUniformPrice] = useState(() => {
+    if (!hasColors) return true;
+    // If all color variants have the same price, default to uniform
+    const prices = colors
+      .map((c) => findVariantForColor(c.variantColor)?.price)
+      .filter((p) => p != null);
+    if (prices.length <= 1) return true;
+    return prices.every((p) => p === prices[0]);
+  });
+
+  const [stocksRaw, setStocks] = useState<Record<string, string>>(() => {
+    const map: Record<string, string> = {};
+    for (const c of colors) {
+      const variant = findVariantForColor(c.variantColor);
+      map[c.variantColor] = String(variant?.stock_quantity ?? 0);
+    }
+    return map;
+  });
+
+  const [pricesRaw, setPrices] = useState<Record<string, string>>(() => {
+    const map: Record<string, string> = {};
+    for (const c of colors) {
+      const variant = findVariantForColor(c.variantColor);
+      map[c.variantColor] = variant?.price ? String(variant.price) : "";
+    }
+    return map;
+  });
+
+  // Merge raw state with defaults for any new colors — synchronous, no flicker
+  const stocks = useMemo(() => {
+    const merged: Record<string, string> = { ...stocksRaw };
+    for (const c of colors) {
+      if (!(c.variantColor in merged)) {
+        const variant = findVariantForColor(c.variantColor);
+        merged[c.variantColor] = String(variant?.stock_quantity ?? 0);
+      }
+    }
+    return merged;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stocksRaw, product.attributes, product.variants]);
+
+  const prices = useMemo(() => {
+    const merged: Record<string, string> = { ...pricesRaw };
+    for (const c of colors) {
+      if (!(c.variantColor in merged)) {
+        const variant = findVariantForColor(c.variantColor);
+        merged[c.variantColor] = variant?.price ? String(variant.price) : "";
+      }
+    }
+    return merged;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pricesRaw, product.attributes, product.variants]);
+
+  // Serialize variant data for the server action
+  const variantData = hasColors
+    ? JSON.stringify(
+        colors.map((c) => ({
+          color: c.variantColor,
+          colorName: c.name,
+          stock: parseInt(stocks[c.variantColor]) || 0,
+          // When uniform price, server will use base_price
+          price: uniformPrice ? null : (parseInt(prices[c.variantColor]) || null),
+        })),
+      )
+    : "";
+
   return (
     <form ref={formRef} className="space-y-6">
-      <input type="hidden" name="_step" value="2" />
+      <input type="hidden" name="_step" value="3" />
+      <input type="hidden" name="uniform_price" value={uniformPrice ? "1" : "0"} />
+      {hasColors && <input type="hidden" name="variants" value={variantData} />}
 
       {/* Prix */}
       <div className="grid gap-4 sm:grid-cols-2">
@@ -66,20 +177,113 @@ export function StepPricing({ product, formRef, isPending }: StepPricingProps) {
         </div>
       </div>
 
-      {/* Stock */}
-      <div className="grid gap-4 sm:grid-cols-2">
-        <div className="space-y-1.5">
-          <Label htmlFor="wiz-stock">Quantité en stock</Label>
-          <Input
-            id="wiz-stock"
-            name="stock_quantity"
-            type="number"
-            min={0}
-            step={1}
-            disabled={isPending}
-            defaultValue={product.stock_quantity}
-          />
+      {/* Per-color stock & pricing */}
+      {hasColors && (
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-semibold">Stock par couleur</h3>
+            <div className="flex items-center gap-2">
+              <Label htmlFor="wiz-uniform-price" className="text-xs text-muted-foreground">
+                Prix unique
+              </Label>
+              <Switch
+                id="wiz-uniform-price"
+                checked={uniformPrice}
+                onCheckedChange={setUniformPrice}
+                disabled={isPending}
+              />
+            </div>
+          </div>
+
+          <div className="rounded-lg border">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b bg-muted/50">
+                  <th className="px-3 py-2 text-left font-medium">Couleur</th>
+                  {!uniformPrice && (
+                    <th className="px-3 py-2 text-left font-medium">Prix (FCFA)</th>
+                  )}
+                  <th className="px-3 py-2 text-left font-medium">Stock</th>
+                </tr>
+              </thead>
+              <tbody>
+                {colors.map((c, i) => (
+                  <tr
+                    key={c.variantColor}
+                    className={i < colors.length - 1 ? "border-b" : ""}
+                  >
+                    <td className="px-3 py-2">
+                      <div className="flex items-center gap-2">
+                        <span
+                          className="size-4 shrink-0 rounded-full border border-black/10"
+                          style={{ backgroundColor: c.hex }}
+                        />
+                        <span>{c.name}</span>
+                      </div>
+                    </td>
+                    {!uniformPrice && (
+                      <td className="px-3 py-2">
+                        <Input
+                          type="number"
+                          min={0}
+                          step={1}
+                          disabled={isPending}
+                          value={prices[c.variantColor] ?? ""}
+                          onChange={(e) =>
+                            setPrices((prev) => ({
+                              ...prev,
+                              [c.variantColor]: e.target.value,
+                            }))
+                          }
+                          placeholder="Prix de vente"
+                          className="h-8 w-28"
+                        />
+                      </td>
+                    )}
+                    <td className="px-3 py-2">
+                      <Input
+                        type="number"
+                        min={0}
+                        step={1}
+                        disabled={isPending}
+                        value={stocks[c.variantColor] ?? "0"}
+                        onChange={(e) =>
+                          setStocks((prev) => ({
+                            ...prev,
+                            [c.variantColor]: e.target.value,
+                          }))
+                        }
+                        className="h-8 w-24"
+                      />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
+      )}
+
+      {/* Stock global (sans couleurs) */}
+      {!hasColors && (
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="wiz-stock">Quantité en stock</Label>
+            <Input
+              id="wiz-stock"
+              name="stock_quantity"
+              type="number"
+              min={0}
+              step={1}
+              disabled={isPending}
+              defaultValue={product.stock_quantity}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Seuil d'alerte */}
+      <div className="grid gap-4 sm:grid-cols-2">
         <div className="space-y-1.5">
           <div className="flex items-center gap-1.5">
             <Label htmlFor="wiz-threshold">Seuil d&apos;alerte stock</Label>
@@ -100,32 +304,6 @@ export function StepPricing({ product, formRef, isPending }: StepPricingProps) {
             defaultValue={product.low_stock_threshold}
           />
         </div>
-      </div>
-
-      {/* Poids */}
-      <div className="space-y-1.5">
-        <div className="flex items-center gap-1.5">
-          <Label htmlFor="wiz-weight">Poids</Label>
-          <span
-            className="inline-flex h-4 w-4 cursor-help items-center justify-center rounded-full bg-muted text-[10px] font-bold text-muted-foreground"
-            title="Utilisé pour le calcul des frais de livraison."
-          >
-            ?
-          </span>
-        </div>
-        <InputGroup>
-          <InputGroupInput
-            id="wiz-weight"
-            name="weight_grams"
-            type="number"
-            min={0}
-            step={1}
-            disabled={isPending}
-            defaultValue={product.weight_grams ?? ""}
-            placeholder="Optionnel"
-          />
-          <InputGroupAddon align="inline-end">g</InputGroupAddon>
-        </InputGroup>
       </div>
     </form>
   );

--- a/components/admin/product-wizard/step-pricing.tsx
+++ b/components/admin/product-wizard/step-pricing.tsx
@@ -1,0 +1,132 @@
+// components/admin/product-wizard/step-pricing.tsx
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "@/components/ui/input-group";
+import type { ProductDetail } from "@/lib/db/types";
+
+interface StepPricingProps {
+  product: ProductDetail;
+  formRef: React.RefObject<HTMLFormElement | null>;
+  isPending: boolean;
+}
+
+export function StepPricing({ product, formRef, isPending }: StepPricingProps) {
+  return (
+    <form ref={formRef} className="space-y-6">
+      <input type="hidden" name="_step" value="2" />
+
+      {/* Prix */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label htmlFor="wiz-base-price">
+            Prix de vente <span className="text-destructive">*</span>
+          </Label>
+          <InputGroup>
+            <InputGroupInput
+              id="wiz-base-price"
+              name="base_price"
+              type="number"
+              min={0}
+              step={1}
+              required
+              disabled={isPending}
+              defaultValue={product.base_price > 0 ? product.base_price : ""}
+              placeholder="ex: 125000"
+            />
+            <InputGroupAddon align="inline-end">FCFA</InputGroupAddon>
+          </InputGroup>
+        </div>
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-1.5">
+            <Label htmlFor="wiz-compare-price">Prix barré</Label>
+            <span
+              className="inline-flex h-4 w-4 cursor-help items-center justify-center rounded-full bg-muted text-[10px] font-bold text-muted-foreground"
+              title="Ancien prix avant promotion. Affiché barré sur la fiche produit."
+            >
+              ?
+            </span>
+          </div>
+          <InputGroup>
+            <InputGroupInput
+              id="wiz-compare-price"
+              name="compare_price"
+              type="number"
+              min={0}
+              step={1}
+              disabled={isPending}
+              defaultValue={product.compare_price ?? ""}
+              placeholder="Optionnel"
+            />
+            <InputGroupAddon align="inline-end">FCFA</InputGroupAddon>
+          </InputGroup>
+        </div>
+      </div>
+
+      {/* Stock */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label htmlFor="wiz-stock">Quantité en stock</Label>
+          <Input
+            id="wiz-stock"
+            name="stock_quantity"
+            type="number"
+            min={0}
+            step={1}
+            disabled={isPending}
+            defaultValue={product.stock_quantity}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-1.5">
+            <Label htmlFor="wiz-threshold">Seuil d&apos;alerte stock</Label>
+            <span
+              className="inline-flex h-4 w-4 cursor-help items-center justify-center rounded-full bg-muted text-[10px] font-bold text-muted-foreground"
+              title="Vous serez alerté lorsque le stock passe sous ce seuil."
+            >
+              ?
+            </span>
+          </div>
+          <Input
+            id="wiz-threshold"
+            name="low_stock_threshold"
+            type="number"
+            min={0}
+            step={1}
+            disabled={isPending}
+            defaultValue={product.low_stock_threshold}
+          />
+        </div>
+      </div>
+
+      {/* Poids */}
+      <div className="space-y-1.5">
+        <div className="flex items-center gap-1.5">
+          <Label htmlFor="wiz-weight">Poids</Label>
+          <span
+            className="inline-flex h-4 w-4 cursor-help items-center justify-center rounded-full bg-muted text-[10px] font-bold text-muted-foreground"
+            title="Utilisé pour le calcul des frais de livraison."
+          >
+            ?
+          </span>
+        </div>
+        <InputGroup>
+          <InputGroupInput
+            id="wiz-weight"
+            name="weight_grams"
+            type="number"
+            min={0}
+            step={1}
+            disabled={isPending}
+            defaultValue={product.weight_grams ?? ""}
+            placeholder="Optionnel"
+          />
+          <InputGroupAddon align="inline-end">g</InputGroupAddon>
+        </InputGroup>
+      </div>
+    </form>
+  );
+}

--- a/components/admin/product-wizard/wizard-stepper.tsx
+++ b/components/admin/product-wizard/wizard-stepper.tsx
@@ -1,0 +1,75 @@
+// components/admin/product-wizard/wizard-stepper.tsx
+interface WizardStep {
+  label: string;
+  subtitle: string;
+}
+
+interface WizardStepperProps {
+  steps: WizardStep[];
+  currentStep: number; // 0-indexed
+  onStepClick: (index: number) => void;
+}
+
+export function WizardStepper({
+  steps,
+  currentStep,
+  onStepClick,
+}: WizardStepperProps) {
+  return (
+    <div className="flex items-center border-b bg-muted/30 px-6 py-4">
+      {steps.map((step, index) => {
+        const isCompleted = index < currentStep;
+        const isCurrent = index === currentStep;
+
+        return (
+          <div key={index} className="flex min-w-0 flex-1 items-center">
+            {/* Step indicator */}
+            <button
+              type="button"
+              onClick={() => isCompleted && onStepClick(index)}
+              disabled={!isCompleted}
+              className="flex shrink-0 items-center gap-2.5 disabled:cursor-default"
+              aria-current={isCurrent ? "step" : undefined}
+            >
+              <span
+                className={[
+                  "flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-bold transition-colors",
+                  isCompleted
+                    ? "bg-[#183C78] text-white"
+                    : isCurrent
+                      ? "border-2 border-[#183C78] bg-white text-[#183C78]"
+                      : "bg-muted text-muted-foreground",
+                ].join(" ")}
+              >
+                {index + 1}
+              </span>
+              <span className="hidden min-w-0 text-left sm:block">
+                <span
+                  className={[
+                    "block text-xs font-semibold uppercase tracking-wide",
+                    isCurrent ? "text-[#183C78]" : isCompleted ? "text-foreground" : "text-muted-foreground",
+                  ].join(" ")}
+                >
+                  {step.label}
+                </span>
+                <span className="block truncate text-xs text-muted-foreground">
+                  {step.subtitle}
+                </span>
+              </span>
+            </button>
+
+            {/* Connector line (not after last step) */}
+            {index < steps.length - 1 && (
+              <div className="mx-3 h-0.5 flex-1 bg-border">
+                <div
+                  className="h-full bg-[#183C78] transition-all duration-300"
+                  style={{ width: isCompleted ? "100%" : "0%" }}
+                />
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/admin/product-wizard/wizard-stepper.tsx
+++ b/components/admin/product-wizard/wizard-stepper.tsx
@@ -28,7 +28,7 @@ export function WizardStepper({
               type="button"
               onClick={() => isCompleted && onStepClick(index)}
               disabled={!isCompleted}
-              className="flex shrink-0 items-center gap-2.5 disabled:cursor-default"
+              className="flex min-h-11 shrink-0 items-center gap-2.5 disabled:cursor-default"
               aria-current={isCurrent ? "step" : undefined}
             >
               <span

--- a/components/storefront/image-gallery.tsx
+++ b/components/storefront/image-gallery.tsx
@@ -9,10 +9,15 @@ import { getImageUrl } from "@/lib/utils/images";
 interface ImageGalleryProps {
   images: ProductImage[];
   children?: ReactNode;
+  /** Externally controlled selected index (overrides internal state) */
+  selectedIndex?: number;
+  onSelectedChange?: (index: number) => void;
 }
 
-export function ImageGallery({ images, children }: ImageGalleryProps) {
-  const [selected, setSelected] = useState(0);
+export function ImageGallery({ images, children, selectedIndex, onSelectedChange }: ImageGalleryProps) {
+  const [internalSelected, setInternalSelected] = useState(0);
+  const selected = selectedIndex ?? internalSelected;
+  const setSelected = onSelectedChange ?? setInternalSelected;
   const current = images[selected] ?? images[0];
 
   if (!current) {

--- a/components/storefront/product-details.tsx
+++ b/components/storefront/product-details.tsx
@@ -9,7 +9,8 @@ interface ProductDetailsProps {
 
 export function ProductDetails({ description, attributes }: ProductDetailsProps) {
   const hasDescription = !!description;
-  const hasAttributes = attributes.length > 0;
+  const filteredAttributes = attributes.filter((a) => a.name !== "Couleur");
+  const hasAttributes = filteredAttributes.length > 0;
 
   if (!hasDescription && !hasAttributes) return null;
 
@@ -27,7 +28,7 @@ export function ProductDetails({ description, attributes }: ProductDetailsProps)
     return (
       <section className="mt-10 border-t pt-8">
         <h2 className="mb-4 text-lg font-semibold">Caractéristiques</h2>
-        <AttributesTable attributes={attributes} />
+        <AttributesTable attributes={filteredAttributes} />
       </section>
     );
   }
@@ -50,7 +51,7 @@ export function ProductDetails({ description, attributes }: ProductDetailsProps)
         </TabsContent>
 
         <TabsContent value="characteristics">
-          <AttributesTable attributes={attributes} />
+          <AttributesTable attributes={filteredAttributes} />
         </TabsContent>
       </Tabs>
     </section>

--- a/components/storefront/product-gallery-with-variants.tsx
+++ b/components/storefront/product-gallery-with-variants.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import Image from "next/image";
+import type { ProductImage, ProductVariant } from "@/lib/db/types";
+import { getImageUrl } from "@/lib/utils/images";
+import { ImageGallery } from "./image-gallery";
+import { VariantSelector } from "./variant-selector";
+
+interface Props {
+  images: ProductImage[];
+  variants: ProductVariant[];
+  basePrice: number;
+  product: { id: string; name: string; slug: string; imageUrl: string | null };
+  children: React.ReactNode;
+}
+
+export function ProductGalleryWithVariants({
+  images,
+  variants,
+  basePrice,
+  product,
+  children,
+}: Props) {
+  const [selectedImage, setSelectedImage] = useState(0);
+
+  const handleVariantChange = useCallback(
+    (variantId: string) => {
+      const idx = images.findIndex((img) => img.variant_id === variantId);
+      if (idx !== -1) {
+        setSelectedImage(idx);
+      }
+    },
+    [images],
+  );
+
+  const primaryImage = images[0];
+
+  return (
+    <div className="grid gap-8 md:grid-cols-2">
+      <ImageGallery
+        images={images}
+        selectedIndex={selectedImage}
+        onSelectedChange={setSelectedImage}
+      >
+        {primaryImage && (
+          <Image
+            src={getImageUrl(primaryImage.url)}
+            alt={primaryImage.alt || product.name}
+            fill
+            priority
+            fetchPriority="high"
+            sizes="(max-width: 768px) 100vw, 50vw"
+            className="object-contain p-6"
+          />
+        )}
+      </ImageGallery>
+
+      <div className="space-y-4">
+        {children}
+        <VariantSelector
+          variants={variants}
+          basePrice={basePrice}
+          product={product}
+          onVariantChange={handleVariantChange}
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/storefront/variant-selector.tsx
+++ b/components/storefront/variant-selector.tsx
@@ -68,10 +68,12 @@ export function VariantSelector({
   variants,
   basePrice,
   product,
+  onVariantChange,
 }: {
   variants: ProductVariant[];
   basePrice: number;
   product: ProductInfo;
+  onVariantChange?: (variantId: string) => void;
 }) {
   const [selectedId, setSelectedId] = useState(variants[0]?.id ?? "");
 
@@ -144,7 +146,10 @@ export function VariantSelector({
         bestMatch = v;
       }
     }
-    if (bestMatch) setSelectedId(bestMatch.id);
+    if (bestMatch) {
+      setSelectedId(bestMatch.id);
+      onVariantChange?.(bestMatch.id);
+    }
   }
 
   const price = selectedVariant?.price ?? basePrice;

--- a/docs/superpowers/plans/2026-03-19-assisted-product-creation.md
+++ b/docs/superpowers/plans/2026-03-19-assisted-product-creation.md
@@ -1,0 +1,1503 @@
+# Assisted Product Creation — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the product creation form with a guided 4-step wizard (Identité → Prix & Stock → Médias → Finalisation) that includes placeholders, helper text, and tooltips to reduce friction.
+
+**Architecture:** A new `ProductWizard` client component replaces `ProductFormSections` for draft products (`is_draft = 1`). A new `saveDraftStep` server action handles partial saves between steps without publishing the product. The existing `updateProduct` action is reused for the final publish.
+
+**Tech Stack:** Next.js App Router, TypeScript, React `useTransition`, Zod, Drizzle/raw D1, Sonner toasts, shadcn/ui (Switch, Input, Label, Card, Textarea), Vitest
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `actions/admin/products.ts` | Modify | Add `saveDraftStep` + `applyDraftUpdate` helper |
+| `__tests__/unit/actions/admin-products-draft.test.ts` | Create | Unit tests for `saveDraftStep` |
+| `components/admin/product-wizard.tsx` | Create | Main wizard orchestrator (step state, save, navigate) |
+| `components/admin/product-wizard/wizard-stepper.tsx` | Create | Stepper bar (step indicators + connector lines) |
+| `components/admin/product-wizard/step-identity.tsx` | Create | Step 1: name, brand, SKU, category |
+| `components/admin/product-wizard/step-pricing.tsx` | Create | Step 2: prices, stock, weight |
+| `components/admin/product-wizard/step-media.tsx` | Create | Step 3: images + variants (existing components) |
+| `components/admin/product-wizard/step-finalization.tsx` | Create | Step 4: description, SEO, visibility toggles |
+| `app/(admin)/products/[id]/edit/page.tsx` | Modify | Conditional render wizard vs form sections |
+
+---
+
+## Chunk 1: `saveDraftStep` server action
+
+### Task 1: Add stub + write failing tests
+
+**Files:**
+- Modify: `actions/admin/products.ts`
+- Create: `__tests__/unit/actions/admin-products-draft.test.ts`
+
+- [ ] **Step 1.1: Add stub export to `actions/admin/products.ts`**
+
+Append at the end of the file (before the closing):
+
+```typescript
+export async function saveDraftStep(
+  _id: string,
+  _formData: FormData,
+): Promise<ActionResult> {
+  return { success: false, error: "not implemented" };
+}
+```
+
+- [ ] **Step 1.2: Create the test file**
+
+```typescript
+// __tests__/unit/actions/admin-products-draft.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockAdminSession } from "../../helpers/mocks";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  redirect: vi.fn((url: string): never => {
+    const error = new Error(`NEXT_REDIRECT: ${url}`) as Error & {
+      digest: string;
+    };
+    error.digest = `NEXT_REDIRECT;${url}`;
+    throw error;
+  }),
+  queryFirst: vi.fn(),
+  execute: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({ redirect: mocks.redirect }));
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/auth", () => ({
+  initAuth: vi
+    .fn()
+    .mockResolvedValue({ api: { getSession: mocks.getSession } }),
+}));
+vi.mock("@/lib/db", () => ({
+  queryFirst: mocks.queryFirst,
+  execute: mocks.execute,
+}));
+
+import { saveDraftStep } from "@/actions/admin/products";
+
+const DRAFT_PRODUCT = { slug: "draft-abc123" };
+
+function makeFormData(fields: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(fields)) fd.append(k, v);
+  return fd;
+}
+
+describe("saveDraftStep", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue(mockAdminSession);
+    mocks.queryFirst.mockResolvedValue(DRAFT_PRODUCT);
+    mocks.execute.mockResolvedValue(undefined);
+  });
+
+  // ── Auth & ID guards ──────────────────────────────────────────────────────
+
+  it("rejette un id vide", async () => {
+    const result = await saveDraftStep("", makeFormData({ _step: "1" }));
+    expect(result).toEqual({ success: false, error: expect.any(String) });
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
+  it("retourne une erreur si le produit est introuvable ou non-brouillon", async () => {
+    mocks.queryFirst.mockResolvedValue(null);
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({ _step: "1", name: "Test", category_id: "cat-1" }),
+    );
+    expect(result).toEqual({ success: false, error: "Produit introuvable" });
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
+  // ── Étape invalide ────────────────────────────────────────────────────────
+
+  it("retourne une erreur pour une étape invalide", async () => {
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({ _step: "99" }),
+    );
+    expect(result).toEqual({ success: false, error: "Étape invalide" });
+  });
+
+  // ── Étape 1 : Identité ────────────────────────────────────────────────────
+
+  it("étape 1 : réussit avec nom et catégorie valides", async () => {
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({
+        _step: "1",
+        name: "Samsung Galaxy A55",
+        category_id: "cat-1",
+        brand: "Samsung",
+        sku: "SGX-A55",
+      }),
+    );
+    expect(result).toEqual({ success: true });
+    expect(mocks.execute).toHaveBeenCalledOnce();
+    const sql: string = mocks.execute.mock.calls[0][0];
+    expect(sql).toContain("UPDATE products SET");
+    expect(sql).toContain("WHERE id = ? AND is_draft = 1");
+    expect(sql).not.toContain("is_draft = 0");
+  });
+
+  it("étape 1 : rejette si nom vide", async () => {
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({ _step: "1", name: "", category_id: "cat-1" }),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("nom");
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
+  it("étape 1 : rejette si category_id vide", async () => {
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({ _step: "1", name: "Test", category_id: "" }),
+    );
+    expect(result.success).toBe(false);
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
+  it("étape 1 : auto-dérive le slug depuis name si slug actuel commence par draft-", async () => {
+    // Second queryFirst call checks for slug collision
+    mocks.queryFirst
+      .mockResolvedValueOnce(DRAFT_PRODUCT) // product lookup
+      .mockResolvedValueOnce(null); // slug collision check (no collision)
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({
+        _step: "1",
+        name: "Samsung Galaxy A55",
+        category_id: "cat-1",
+      }),
+    );
+    expect(result).toEqual({ success: true });
+    const sql: string = mocks.execute.mock.calls[0][0];
+    expect(sql).toContain("slug = ?");
+  });
+
+  it("étape 1 : retourne erreur si slug collide avec un autre produit", async () => {
+    mocks.queryFirst
+      .mockResolvedValueOnce(DRAFT_PRODUCT)
+      .mockResolvedValueOnce({ id: "other-product" }); // collision
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({
+        _step: "1",
+        name: "Samsung Galaxy A55",
+        category_id: "cat-1",
+      }),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("slug");
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
+  it("étape 1 : ne dérive pas le slug si le slug actuel n'est pas un draft-slug", async () => {
+    mocks.queryFirst.mockResolvedValueOnce({ slug: "samsung-galaxy-a55" }); // already set
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({
+        _step: "1",
+        name: "Samsung Galaxy A55 modifié",
+        category_id: "cat-1",
+      }),
+    );
+    expect(result).toEqual({ success: true });
+    // Only one queryFirst call (product lookup), no collision check
+    expect(mocks.queryFirst).toHaveBeenCalledOnce();
+    const sql: string = mocks.execute.mock.calls[0][0];
+    expect(sql).not.toContain("slug = ?");
+  });
+
+  // ── Étape 2 : Prix & Stock ────────────────────────────────────────────────
+
+  it("étape 2 : réussit avec un prix valide", async () => {
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({ _step: "2", base_price: "125000" }),
+    );
+    expect(result).toEqual({ success: true });
+    expect(mocks.execute).toHaveBeenCalledOnce();
+  });
+
+  it("étape 2 : rejette un prix négatif", async () => {
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({ _step: "2", base_price: "-1" }),
+    );
+    expect(result.success).toBe(false);
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
+  it("étape 2 : rejette un prix non-entier", async () => {
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({ _step: "2", base_price: "125.50" }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  // ── Étape 3 : Médias (no-op) ──────────────────────────────────────────────
+
+  it("étape 3 : réussit sans appel DB (aucun champ à sauvegarder)", async () => {
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({ _step: "3" }),
+    );
+    expect(result).toEqual({ success: true });
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
+  // ── Étape 4 : Finalisation ────────────────────────────────────────────────
+
+  it("étape 4 : réussit avec des champs valides", async () => {
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({
+        _step: "4",
+        short_description: "Un super téléphone",
+        meta_title: "Samsung Galaxy A55 | Netereka",
+        meta_description: "Achetez le Samsung Galaxy A55",
+        is_active: "0",
+        is_featured: "0",
+      }),
+    );
+    expect(result).toEqual({ success: true });
+    expect(mocks.execute).toHaveBeenCalledOnce();
+  });
+
+  it("étape 4 : rejette meta_title > 60 caractères", async () => {
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({ _step: "4", meta_title: "a".repeat(61) }),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("60");
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
+  it("étape 4 : rejette meta_description > 160 caractères", async () => {
+    const result = await saveDraftStep(
+      "prod-1",
+      makeFormData({ _step: "4", meta_description: "a".repeat(161) }),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("160");
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
+  it("étape 4 : ne touche pas is_draft dans le SQL", async () => {
+    await saveDraftStep(
+      "prod-1",
+      makeFormData({ _step: "4", is_active: "1", is_featured: "0" }),
+    );
+    const sql: string = mocks.execute.mock.calls[0][0];
+    expect(sql).not.toContain("is_draft");
+  });
+});
+```
+
+- [ ] **Step 1.3: Run tests to confirm they fail**
+
+```bash
+npm run test -- --reporter=verbose __tests__/unit/actions/admin-products-draft.test.ts
+```
+
+Expected: multiple failures ("not implemented", various assertion errors).
+
+---
+
+### Task 2: Implement `saveDraftStep`
+
+**Files:**
+- Modify: `actions/admin/products.ts`
+
+- [ ] **Step 2.1: Replace the stub with the full implementation**
+
+Remove the stub added in Step 1.1 and replace with:
+
+```typescript
+export async function saveDraftStep(
+  id: string,
+  formData: FormData,
+): Promise<ActionResult> {
+  await requireAdmin();
+
+  const idResult = idSchema.safeParse(id);
+  if (!idResult.success) return { success: false, error: "ID produit invalide" };
+
+  const product = await queryFirst<{ slug: string }>(
+    "SELECT slug FROM products WHERE id = ? AND is_draft = 1",
+    [id],
+  );
+  if (!product) return { success: false, error: "Produit introuvable" };
+
+  const step = (formData.get("_step") as string) ?? "";
+  const raw = Object.fromEntries(formData);
+  delete raw._step;
+
+  if (step === "1") {
+    const parsed = z
+      .object({
+        name: z.string().min(1, "Le nom est requis"),
+        category_id: z.string().min(1, "La catégorie est requise"),
+        brand: z.string().optional().default(""),
+        sku: z.string().optional().default(""),
+      })
+      .safeParse(raw);
+    if (!parsed.success)
+      return {
+        success: false,
+        error: parsed.error.issues.map((e) => e.message).join(", "),
+      };
+    return applyDraftUpdate(id, parsed.data, product.slug);
+  }
+
+  if (step === "2") {
+    const parsed = z
+      .object({
+        base_price: z.coerce
+          .number()
+          .int("Le prix doit être un entier")
+          .min(0, "Le prix doit être positif"),
+        compare_price: z.coerce.number().int().min(0).optional(),
+        stock_quantity: z.coerce.number().int().min(0).default(0),
+        low_stock_threshold: z.coerce.number().int().min(0).default(5),
+        weight_grams: z.coerce.number().int().min(0).optional(),
+      })
+      .safeParse(raw);
+    if (!parsed.success)
+      return {
+        success: false,
+        error: parsed.error.issues.map((e) => e.message).join(", "),
+      };
+    return applyDraftUpdate(id, parsed.data, product.slug);
+  }
+
+  if (step === "3") {
+    return { success: true };
+  }
+
+  if (step === "4") {
+    const parsed = z
+      .object({
+        short_description: z.string().optional().default(""),
+        description: z.string().optional().default(""),
+        meta_title: z
+          .string()
+          .max(60, "Le titre SEO ne peut pas dépasser 60 caractères")
+          .optional()
+          .default(""),
+        meta_description: z
+          .string()
+          .max(160, "La méta-description ne peut pas dépasser 160 caractères")
+          .optional()
+          .default(""),
+        is_active: z.coerce.number().int().min(0).max(1).default(0),
+        is_featured: z.coerce.number().int().min(0).max(1).default(0),
+      })
+      .safeParse(raw);
+    if (!parsed.success)
+      return {
+        success: false,
+        error: parsed.error.issues.map((e) => e.message).join(", "),
+      };
+    return applyDraftUpdate(id, parsed.data, product.slug);
+  }
+
+  return { success: false, error: "Étape invalide" };
+}
+
+async function applyDraftUpdate(
+  id: string,
+  data: Record<string, unknown>,
+  currentSlug: string,
+): Promise<ActionResult> {
+  const sets: string[] = ["updated_at = datetime('now')"];
+  const values: unknown[] = [];
+
+  // Slug auto-derivation: only when name is set and current slug is a draft placeholder
+  if ("name" in data && data.name && currentSlug.startsWith("draft-")) {
+    const candidateSlug = slugify(data.name as string);
+    const collision = await queryFirst<{ id: string }>(
+      "SELECT id FROM products WHERE slug = ? AND id != ?",
+      [candidateSlug, id],
+    );
+    if (collision) {
+      return {
+        success: false,
+        error: `Un produit avec le slug "${candidateSlug}" existe déjà`,
+      };
+    }
+    sets.push("slug = ?");
+    values.push(candidateSlug);
+  }
+
+  // Fields that should be stored as NULL when empty string
+  const NULLABLE_FIELDS = new Set([
+    "brand",
+    "sku",
+    "compare_price",
+    "weight_grams",
+    "short_description",
+    "description",
+    "meta_title",
+    "meta_description",
+  ]);
+
+  // Only these columns are allowed in the partial update
+  const ALLOWED_COLUMNS = new Set([
+    "name",
+    "brand",
+    "sku",
+    "category_id",
+    "base_price",
+    "compare_price",
+    "stock_quantity",
+    "low_stock_threshold",
+    "weight_grams",
+    "short_description",
+    "description",
+    "meta_title",
+    "meta_description",
+    "is_active",
+    "is_featured",
+  ]);
+
+  for (const [key, val] of Object.entries(data)) {
+    if (!ALLOWED_COLUMNS.has(key)) continue;
+    sets.push(`${key} = ?`);
+    values.push(
+      NULLABLE_FIELDS.has(key) && (val === "" || val == null) ? null : val,
+    );
+  }
+
+  values.push(id);
+
+  await execute(
+    `UPDATE products SET ${sets.join(", ")} WHERE id = ? AND is_draft = 1`,
+    values,
+  );
+
+  return { success: true };
+}
+```
+
+- [ ] **Step 2.2: Run tests to confirm they all pass**
+
+```bash
+npm run test -- --reporter=verbose __tests__/unit/actions/admin-products-draft.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2.3: Run full test suite to verify no regressions**
+
+```bash
+npm run test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2.4: Commit**
+
+```bash
+git checkout -b feat/assisted-product-wizard
+git add actions/admin/products.ts "__tests__/unit/actions/admin-products-draft.test.ts"
+git commit -m "feat(admin): add saveDraftStep action for partial product saves"
+```
+
+---
+
+## Chunk 2: Wizard UI components
+
+### Task 3: Create `wizard-stepper.tsx`
+
+**Files:**
+- Create: `components/admin/product-wizard/wizard-stepper.tsx`
+
+- [ ] **Step 3.1: Create the file**
+
+```typescript
+// components/admin/product-wizard/wizard-stepper.tsx
+interface WizardStep {
+  label: string;
+  subtitle: string;
+}
+
+interface WizardStepperProps {
+  steps: WizardStep[];
+  currentStep: number; // 0-indexed
+  onStepClick: (index: number) => void;
+}
+
+export function WizardStepper({
+  steps,
+  currentStep,
+  onStepClick,
+}: WizardStepperProps) {
+  return (
+    <div className="flex items-center border-b bg-muted/30 px-6 py-4">
+      {steps.map((step, index) => {
+        const isCompleted = index < currentStep;
+        const isCurrent = index === currentStep;
+
+        return (
+          <div key={index} className="flex min-w-0 flex-1 items-center">
+            {/* Step indicator */}
+            <button
+              type="button"
+              onClick={() => isCompleted && onStepClick(index)}
+              disabled={!isCompleted}
+              className="flex shrink-0 items-center gap-2.5 disabled:cursor-default"
+              aria-current={isCurrent ? "step" : undefined}
+            >
+              <span
+                className={[
+                  "flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-bold transition-colors",
+                  isCompleted
+                    ? "bg-[#183C78] text-white"
+                    : isCurrent
+                      ? "border-2 border-[#183C78] bg-white text-[#183C78]"
+                      : "bg-muted text-muted-foreground",
+                ].join(" ")}
+              >
+                {index + 1}
+              </span>
+              <span className="hidden min-w-0 text-left sm:block">
+                <span
+                  className={[
+                    "block text-xs font-semibold uppercase tracking-wide",
+                    isCurrent ? "text-[#183C78]" : isCompleted ? "text-foreground" : "text-muted-foreground",
+                  ].join(" ")}
+                >
+                  {step.label}
+                </span>
+                <span className="block truncate text-xs text-muted-foreground">
+                  {step.subtitle}
+                </span>
+              </span>
+            </button>
+
+            {/* Connector line (not after last step) */}
+            {index < steps.length - 1 && (
+              <div className="mx-3 h-0.5 flex-1 bg-border">
+                <div
+                  className="h-full bg-[#183C78] transition-all duration-300"
+                  style={{ width: isCompleted ? "100%" : "0%" }}
+                />
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+---
+
+### Task 4: Create `step-identity.tsx`
+
+**Files:**
+- Create: `components/admin/product-wizard/step-identity.tsx`
+
+- [ ] **Step 4.1: Create the file**
+
+```typescript
+// components/admin/product-wizard/step-identity.tsx
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { CategoryCascadingSelect, type CategoryOption } from "@/components/admin/category-cascading-select";
+import type { ProductDetail } from "@/lib/db/types";
+
+interface StepIdentityProps {
+  product: ProductDetail;
+  categories: CategoryOption[];
+  formRef: React.RefObject<HTMLFormElement | null>;
+  isPending: boolean;
+}
+
+export function StepIdentity({
+  product,
+  categories,
+  formRef,
+  isPending,
+}: StepIdentityProps) {
+  return (
+    <form ref={formRef} className="space-y-6">
+      <input type="hidden" name="_step" value="1" />
+
+      {/* Nom du produit */}
+      <div className="space-y-1.5">
+        <div className="flex items-center gap-1.5">
+          <Label htmlFor="wiz-name">
+            Nom du produit <span className="text-destructive">*</span>
+          </Label>
+          <span
+            className="inline-flex h-4 w-4 cursor-help items-center justify-center rounded-full bg-muted text-[10px] font-bold text-muted-foreground"
+            title="Soyez précis : incluez la marque, le modèle, la capacité et la couleur si pertinent."
+          >
+            ?
+          </span>
+        </div>
+        <Input
+          id="wiz-name"
+          name="name"
+          required
+          disabled={isPending}
+          defaultValue={product.name}
+          placeholder="ex: Samsung Galaxy A55 128Go Noir"
+        />
+        <p className="text-xs text-muted-foreground">
+          Soyez précis : marque, modèle, capacité, couleur si pertinent.
+        </p>
+      </div>
+
+      {/* Marque + SKU */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label htmlFor="wiz-brand">Marque</Label>
+          <Input
+            id="wiz-brand"
+            name="brand"
+            disabled={isPending}
+            defaultValue={product.brand ?? ""}
+            placeholder="ex: Samsung"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-1.5">
+            <Label htmlFor="wiz-sku">SKU</Label>
+            <span
+              className="inline-flex h-4 w-4 cursor-help items-center justify-center rounded-full bg-muted text-[10px] font-bold text-muted-foreground"
+              title="Référence interne pour identifier ce produit dans vos stocks."
+            >
+              ?
+            </span>
+          </div>
+          <Input
+            id="wiz-sku"
+            name="sku"
+            disabled={isPending}
+            defaultValue={product.sku ?? ""}
+            placeholder="ex: SAM-A55-128-BLK"
+            className="bg-muted/40"
+          />
+          <p className="text-xs text-muted-foreground">
+            Laissez vide si vous n&apos;avez pas de référence interne.
+          </p>
+        </div>
+      </div>
+
+      {/* Catégorie */}
+      <div className="space-y-1.5">
+        <Label>
+          Catégorie <span className="text-destructive">*</span>
+        </Label>
+        <CategoryCascadingSelect
+          categories={categories}
+          defaultCategoryId={product.category_id || undefined}
+        />
+      </div>
+
+      {/* Step hint */}
+      <div className="rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800 dark:border-blue-900 dark:bg-blue-950 dark:text-blue-200">
+        💡 Le nom et la catégorie suffisent pour passer à l&apos;étape suivante.
+        Vous pourrez toujours revenir pour compléter.
+      </div>
+    </form>
+  );
+}
+```
+
+---
+
+### Task 5: Create `step-pricing.tsx`
+
+**Files:**
+- Create: `components/admin/product-wizard/step-pricing.tsx`
+
+- [ ] **Step 5.1: Create the file**
+
+```typescript
+// components/admin/product-wizard/step-pricing.tsx
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "@/components/ui/input-group";
+import type { ProductDetail } from "@/lib/db/types";
+
+interface StepPricingProps {
+  product: ProductDetail;
+  formRef: React.RefObject<HTMLFormElement | null>;
+  isPending: boolean;
+}
+
+export function StepPricing({ product, formRef, isPending }: StepPricingProps) {
+  return (
+    <form ref={formRef} className="space-y-6">
+      <input type="hidden" name="_step" value="2" />
+
+      {/* Prix */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label htmlFor="wiz-base-price">
+            Prix de vente <span className="text-destructive">*</span>
+          </Label>
+          <InputGroup>
+            <InputGroupInput
+              id="wiz-base-price"
+              name="base_price"
+              type="number"
+              min={0}
+              step={1}
+              required
+              disabled={isPending}
+              defaultValue={product.base_price > 0 ? product.base_price : ""}
+              placeholder="ex: 125000"
+            />
+            <InputGroupAddon align="inline-end">FCFA</InputGroupAddon>
+          </InputGroup>
+        </div>
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-1.5">
+            <Label htmlFor="wiz-compare-price">Prix barré</Label>
+            <span
+              className="inline-flex h-4 w-4 cursor-help items-center justify-center rounded-full bg-muted text-[10px] font-bold text-muted-foreground"
+              title="Ancien prix avant promotion. Affiché barré sur la fiche produit."
+            >
+              ?
+            </span>
+          </div>
+          <InputGroup>
+            <InputGroupInput
+              id="wiz-compare-price"
+              name="compare_price"
+              type="number"
+              min={0}
+              step={1}
+              disabled={isPending}
+              defaultValue={product.compare_price ?? ""}
+              placeholder="Optionnel"
+            />
+            <InputGroupAddon align="inline-end">FCFA</InputGroupAddon>
+          </InputGroup>
+        </div>
+      </div>
+
+      {/* Stock */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label htmlFor="wiz-stock">Quantité en stock</Label>
+          <Input
+            id="wiz-stock"
+            name="stock_quantity"
+            type="number"
+            min={0}
+            step={1}
+            disabled={isPending}
+            defaultValue={product.stock_quantity}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-1.5">
+            <Label htmlFor="wiz-threshold">Seuil d&apos;alerte stock</Label>
+            <span
+              className="inline-flex h-4 w-4 cursor-help items-center justify-center rounded-full bg-muted text-[10px] font-bold text-muted-foreground"
+              title="Vous serez alerté lorsque le stock passe sous ce seuil."
+            >
+              ?
+            </span>
+          </div>
+          <Input
+            id="wiz-threshold"
+            name="low_stock_threshold"
+            type="number"
+            min={0}
+            step={1}
+            disabled={isPending}
+            defaultValue={product.low_stock_threshold}
+          />
+        </div>
+      </div>
+
+      {/* Poids */}
+      <div className="space-y-1.5">
+        <div className="flex items-center gap-1.5">
+          <Label htmlFor="wiz-weight">Poids</Label>
+          <span
+            className="inline-flex h-4 w-4 cursor-help items-center justify-center rounded-full bg-muted text-[10px] font-bold text-muted-foreground"
+            title="Utilisé pour le calcul des frais de livraison."
+          >
+            ?
+          </span>
+        </div>
+        <InputGroup>
+          <InputGroupInput
+            id="wiz-weight"
+            name="weight_grams"
+            type="number"
+            min={0}
+            step={1}
+            disabled={isPending}
+            defaultValue={product.weight_grams ?? ""}
+            placeholder="Optionnel"
+          />
+          <InputGroupAddon align="inline-end">g</InputGroupAddon>
+        </InputGroup>
+      </div>
+    </form>
+  );
+}
+```
+
+---
+
+### Task 6: Create `step-media.tsx`
+
+**Files:**
+- Create: `components/admin/product-wizard/step-media.tsx`
+
+- [ ] **Step 6.1: Create the file**
+
+```typescript
+// components/admin/product-wizard/step-media.tsx
+import dynamic from "next/dynamic";
+import type { ProductDetail } from "@/lib/db/types";
+
+const ImageManager = dynamic(() =>
+  import("@/components/admin/image-manager").then((m) => m.ImageManager),
+);
+const VariantList = dynamic(() =>
+  import("@/components/admin/variant-list").then((m) => m.VariantList),
+);
+
+interface StepMediaProps {
+  product: ProductDetail;
+  formRef: React.RefObject<HTMLFormElement | null>;
+}
+
+export function StepMedia({ product, formRef }: StepMediaProps) {
+  return (
+    <form ref={formRef} className="space-y-8">
+      <input type="hidden" name="_step" value="3" />
+
+      {/* Images */}
+      <div className="space-y-4">
+        <div>
+          <h3 className="text-sm font-semibold">Images</h3>
+          <p className="text-xs text-muted-foreground">
+            Ajoutez au moins une photo avant de publier.
+          </p>
+        </div>
+
+        {/* Amber hint if no images yet */}
+        {product.images.length === 0 && (
+          <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-200">
+            📸 Aucune image pour l&apos;instant. Au moins une image est
+            recommandée avant la publication.
+          </div>
+        )}
+
+        <ImageManager productId={product.id} images={product.images} />
+      </div>
+
+      {/* Variantes */}
+      <div className="space-y-4">
+        <div>
+          <h3 className="text-sm font-semibold">Variantes</h3>
+          <p className="text-xs text-muted-foreground">
+            Ajoutez des variantes si ce produit existe en plusieurs versions
+            (couleur, stockage…).
+          </p>
+        </div>
+        <VariantList productId={product.id} variants={product.variants} />
+      </div>
+    </form>
+  );
+}
+```
+
+---
+
+### Task 7: Create `step-finalization.tsx`
+
+**Files:**
+- Create: `components/admin/product-wizard/step-finalization.tsx`
+
+- [ ] **Step 7.1: Create the file**
+
+```typescript
+// components/admin/product-wizard/step-finalization.tsx
+"use client";
+
+import { useRef, useState } from "react";
+import dynamic from "next/dynamic";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import type { ProductDetail } from "@/lib/db/types";
+
+const RichTextEditor = dynamic(() =>
+  import("@/components/admin/rich-text-editor").then((m) => m.RichTextEditor),
+);
+
+interface StepFinalizationProps {
+  product: ProductDetail;
+  formRef: React.RefObject<HTMLFormElement | null>;
+  isPending: boolean;
+}
+
+export function StepFinalization({
+  product,
+  formRef,
+  isPending,
+}: StepFinalizationProps) {
+  const [metaTitleLen, setMetaTitleLen] = useState(
+    (product.meta_title ?? "").length,
+  );
+  const [metaDescLen, setMetaDescLen] = useState(
+    (product.meta_description ?? "").length,
+  );
+  const isActiveRef = useRef<HTMLInputElement>(null);
+  const isFeaturedRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <form ref={formRef} className="space-y-6">
+      <input type="hidden" name="_step" value="4" />
+
+      {/* Hidden inputs: all fields required by updateProduct that aren't in this step */}
+      <input type="hidden" name="slug" value={product.slug} />
+      <input type="hidden" name="name" value={product.name} />
+      <input type="hidden" name="category_id" value={product.category_id ?? ""} />
+      <input type="hidden" name="base_price" value={product.base_price} />
+      <input type="hidden" name="stock_quantity" value={product.stock_quantity} />
+      <input
+        type="hidden"
+        name="low_stock_threshold"
+        value={product.low_stock_threshold}
+      />
+      {product.brand && (
+        <input type="hidden" name="brand" value={product.brand} />
+      )}
+      {product.sku && <input type="hidden" name="sku" value={product.sku} />}
+      {product.compare_price != null && (
+        <input
+          type="hidden"
+          name="compare_price"
+          value={product.compare_price}
+        />
+      )}
+      {product.weight_grams != null && (
+        <input
+          type="hidden"
+          name="weight_grams"
+          value={product.weight_grams}
+        />
+      )}
+
+      {/* Résumé court */}
+      <div className="space-y-1.5">
+        <Label htmlFor="wiz-short-desc">Résumé court</Label>
+        <Input
+          id="wiz-short-desc"
+          name="short_description"
+          disabled={isPending}
+          defaultValue={product.short_description ?? ""}
+          placeholder="ex: Smartphone 128Go avec triple caméra 50MP"
+        />
+      </div>
+
+      {/* Description riche */}
+      <div className="space-y-1.5">
+        <Label>Description</Label>
+        <RichTextEditor name="description" defaultValue={product.description} />
+      </div>
+
+      {/* SEO */}
+      <div className="space-y-4 rounded-lg border p-4">
+        <h3 className="text-sm font-semibold">SEO</h3>
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between">
+            <Label htmlFor="wiz-meta-title">Titre SEO</Label>
+            <span
+              className={`text-xs tabular-nums ${metaTitleLen > 55 ? "text-amber-600" : "text-muted-foreground"}`}
+            >
+              {metaTitleLen}/60
+            </span>
+          </div>
+          <Input
+            id="wiz-meta-title"
+            name="meta_title"
+            maxLength={60}
+            disabled={isPending}
+            defaultValue={product.meta_title ?? ""}
+            placeholder="Titre pour les moteurs de recherche"
+            onChange={(e) => setMetaTitleLen(e.target.value.length)}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between">
+            <Label htmlFor="wiz-meta-desc">Meta description</Label>
+            <span
+              className={`text-xs tabular-nums ${metaDescLen > 140 ? "text-amber-600" : "text-muted-foreground"}`}
+            >
+              {metaDescLen}/160
+            </span>
+          </div>
+          <Textarea
+            id="wiz-meta-desc"
+            name="meta_description"
+            rows={3}
+            maxLength={160}
+            disabled={isPending}
+            defaultValue={product.meta_description ?? ""}
+            placeholder="Description pour les moteurs de recherche"
+            onChange={(e) => setMetaDescLen(e.target.value.length)}
+          />
+        </div>
+      </div>
+
+      {/* Visibilité */}
+      <div className="space-y-4 rounded-lg border p-4">
+        <h3 className="text-sm font-semibold">Visibilité</h3>
+        <div className="flex items-center justify-between">
+          <div>
+            <Label>Publier immédiatement</Label>
+            <p className="text-xs text-muted-foreground">
+              Visible sur la boutique dès la publication
+            </p>
+          </div>
+          <input
+            type="hidden"
+            name="is_active"
+            ref={isActiveRef}
+            defaultValue={product.is_active}
+          />
+          <Switch
+            defaultChecked={product.is_active === 1}
+            onCheckedChange={(checked) => {
+              if (isActiveRef.current)
+                isActiveRef.current.value = checked ? "1" : "0";
+            }}
+          />
+        </div>
+        <div className="flex items-center justify-between">
+          <div>
+            <Label>Mettre en avant</Label>
+            <p className="text-xs text-muted-foreground">
+              Affiché dans la section vedette de la page d&apos;accueil
+            </p>
+          </div>
+          <input
+            type="hidden"
+            name="is_featured"
+            ref={isFeaturedRef}
+            defaultValue={product.is_featured}
+          />
+          <Switch
+            defaultChecked={product.is_featured === 1}
+            onCheckedChange={(checked) => {
+              if (isFeaturedRef.current)
+                isFeaturedRef.current.value = checked ? "1" : "0";
+            }}
+          />
+        </div>
+      </div>
+    </form>
+  );
+}
+```
+
+---
+
+### Task 8: Create `product-wizard.tsx`
+
+**Files:**
+- Create: `components/admin/product-wizard.tsx`
+
+- [ ] **Step 8.1: Create the file**
+
+```typescript
+// components/admin/product-wizard.tsx
+"use client";
+
+import { useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { saveDraftStep } from "@/actions/admin/products";
+import { updateProduct } from "@/actions/admin/products";
+import { WizardStepper } from "./product-wizard/wizard-stepper";
+import { StepIdentity } from "./product-wizard/step-identity";
+import { StepPricing } from "./product-wizard/step-pricing";
+import { StepMedia } from "./product-wizard/step-media";
+import { StepFinalization } from "./product-wizard/step-finalization";
+import type { ProductDetail } from "@/lib/db/types";
+import type { CategoryOption } from "./category-cascading-select";
+
+const STEPS = [
+  { label: "Identité", subtitle: "Nom · Marque · Catégorie" },
+  { label: "Prix & Stock", subtitle: "Prix · Quantité" },
+  { label: "Médias", subtitle: "Images · Variantes" },
+  { label: "Finalisation", subtitle: "Description · SEO" },
+];
+
+function getInitialStep(product: ProductDetail): number {
+  if (!product.name) return 0;
+  if (!product.category_id || product.base_price === 0) return 1;
+  if (!product.images.some((img) => img.is_primary === 1)) return 2;
+  return 3;
+}
+
+interface ProductWizardProps {
+  product: ProductDetail;
+  // CategoryOption from components/admin/category-cascading-select (4 fields: id, name, depth, parent_id)
+  categories: CategoryOption[];
+}
+
+export function ProductWizard({ product, categories }: ProductWizardProps) {
+  const [currentStep, setCurrentStep] = useState(getInitialStep(product));
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+  const formRef = useRef<HTMLFormElement | null>(null);
+
+  function handleNext() {
+    if (!formRef.current) return;
+    const formData = new FormData(formRef.current);
+    startTransition(async () => {
+      try {
+        const result = await saveDraftStep(product.id, formData);
+        if (result.success) {
+          setCurrentStep((prev) => prev + 1);
+        } else {
+          toast.error(result.error ?? "Une erreur est survenue");
+        }
+      } catch {
+        toast.error("Une erreur inattendue est survenue. Veuillez réessayer.");
+      }
+    });
+  }
+
+  function handlePublish() {
+    if (!formRef.current) return;
+    const formData = new FormData(formRef.current);
+    formData.set("is_active", "1");
+    startTransition(async () => {
+      try {
+        const result = await updateProduct(product.id, formData);
+        if (result.success) {
+          toast.success("Produit publié");
+          router.push("/products");
+        } else {
+          toast.error(result.error ?? "Une erreur est survenue");
+        }
+      } catch {
+        toast.error("Une erreur inattendue est survenue. Veuillez réessayer.");
+      }
+    });
+  }
+
+  function handleSaveDraft() {
+    if (!formRef.current) return;
+    const formData = new FormData(formRef.current);
+    startTransition(async () => {
+      try {
+        const result = await saveDraftStep(product.id, formData);
+        if (result.success) {
+          toast.success("Brouillon enregistré");
+          router.push("/products");
+        } else {
+          toast.error(result.error ?? "Une erreur est survenue");
+        }
+      } catch {
+        toast.error("Une erreur inattendue est survenue. Veuillez réessayer.");
+      }
+    });
+  }
+
+  const isLastStep = currentStep === STEPS.length - 1;
+
+  return (
+    <div className="flex flex-col">
+      {/* Stepper */}
+      <WizardStepper
+        steps={STEPS}
+        currentStep={currentStep}
+        onStepClick={setCurrentStep}
+      />
+
+      {/* Step content */}
+      <div className="mx-auto w-full max-w-2xl px-4 py-8">
+        {currentStep === 0 && (
+          <StepIdentity
+            product={product}
+            categories={categories}
+            formRef={formRef}
+            isPending={isPending}
+          />
+        )}
+        {currentStep === 1 && (
+          <StepPricing
+            product={product}
+            formRef={formRef}
+            isPending={isPending}
+          />
+        )}
+        {currentStep === 2 && (
+          <StepMedia product={product} formRef={formRef} />
+        )}
+        {currentStep === 3 && (
+          <StepFinalization
+            product={product}
+            formRef={formRef}
+            isPending={isPending}
+          />
+        )}
+
+        {/* Navigation footer */}
+        <div className="mt-8 flex items-center justify-between border-t pt-6">
+          <p className="text-xs text-muted-foreground">
+            {isPending ? "Enregistrement…" : "Brouillon sauvegardé automatiquement"}
+          </p>
+          <div className="flex gap-3">
+            {currentStep > 0 && (
+              <Button
+                type="button"
+                variant="outline"
+                disabled={isPending}
+                onClick={() => setCurrentStep((prev) => prev - 1)}
+              >
+                ← Précédent
+              </Button>
+            )}
+            {isLastStep ? (
+              <>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={isPending}
+                  onClick={handleSaveDraft}
+                >
+                  {isPending ? "…" : "Enregistrer comme brouillon"}
+                </Button>
+                <Button
+                  type="button"
+                  disabled={isPending}
+                  onClick={handlePublish}
+                >
+                  {isPending ? "…" : "Publier le produit"}
+                </Button>
+              </>
+            ) : (
+              <Button
+                type="button"
+                disabled={isPending}
+                onClick={handleNext}
+              >
+                {isPending ? "Enregistrement…" : "Suivant →"}
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 8.2: Run TypeScript check**
+
+```bash
+npx tsc --noEmit 2>&1 | head -40
+```
+
+Expected: no errors related to the new files. Fix any type errors before continuing.
+
+- [ ] **Step 8.3: Commit wizard components**
+
+```bash
+git add components/admin/product-wizard.tsx "components/admin/product-wizard/"
+git commit -m "feat(admin): add ProductWizard component with 4-step guided flow"
+```
+
+---
+
+## Chunk 3: Integration + verification
+
+### Task 9: Update edit page + verify
+
+**Files:**
+- Modify: `app/(admin)/products/[id]/edit/page.tsx`
+
+- [ ] **Step 9.1: Update the edit page to conditionally render wizard**
+
+Replace the current `ProductFormSections` render with the conditional:
+
+```typescript
+// app/(admin)/products/[id]/edit/page.tsx
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ArrowLeft02Icon } from "@hugeicons/core-free-icons";
+import { Button } from "@/components/ui/button";
+import { AdminPageHeader } from "@/components/admin/admin-page-header";
+import { ProductFormSections } from "@/components/admin/product-form-sections";
+import { ProductWizard } from "@/components/admin/product-wizard";
+import { getAdminProductById } from "@/lib/db/admin/products";
+import { getAllCategories } from "@/lib/db/admin/categories";
+import type { CategoryOption } from "@/components/admin/category-cascading-select";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+export default async function EditProductPage({ params }: Props) {
+  const { id } = await params;
+
+  const [product, categories] = await Promise.all([
+    getAdminProductById(id),
+    getAllCategories(),
+  ]);
+
+  if (!product) notFound();
+
+  const isNew = product.is_draft === 1;
+
+  const categoryOptions = categories.map(
+    (c): CategoryOption => ({
+      id: c.id,
+      name: c.name,
+      depth: c.depth,
+      parent_id: c.parent_id,
+    }),
+  );
+
+  return (
+    <div>
+      <AdminPageHeader>
+        <header className="flex items-center gap-3">
+          <Button
+            variant="ghost"
+            size="icon"
+            asChild
+            className="h-11 w-11 shrink-0"
+            aria-label="Retour aux produits"
+          >
+            <Link href="/products">
+              <HugeiconsIcon icon={ArrowLeft02Icon} size={20} />
+            </Link>
+          </Button>
+          <div className="min-w-0">
+            <h1 className="truncate text-lg font-bold sm:text-2xl">
+              {isNew ? "Nouveau produit" : product.name}
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              {isNew ? "Créer un produit" : "Modifier le produit"}
+            </p>
+          </div>
+        </header>
+      </AdminPageHeader>
+      {isNew ? (
+        <ProductWizard product={product} categories={categoryOptions} />
+      ) : (
+        <ProductFormSections product={product} categories={categoryOptions} />
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 9.2: Run TypeScript check**
+
+```bash
+npx tsc --noEmit 2>&1 | head -40
+```
+
+Expected: no errors. Fix any type errors before continuing.
+
+- [ ] **Step 9.3: Run full test suite**
+
+```bash
+npm run test
+```
+
+Expected: all tests pass including the new `admin-products-draft.test.ts`.
+
+- [ ] **Step 9.4: Start dev server and manually verify the wizard**
+
+```bash
+npm run dev
+```
+
+Open http://localhost:3000/products/new in the browser and verify:
+
+1. **Step 1 loads:** Wizard shows step 1 with name, brand, SKU, category fields and placeholder text
+2. **Validation:** Clicking "Suivant" with empty name shows error toast
+3. **Step advance:** Fill in name + category, click "Suivant" → moves to step 2
+4. **Stepper:** Step 1 indicator turns to completed (filled navy), step 2 becomes current
+5. **Navigate back:** Click step 1 in stepper → returns to step 1 with saved values
+6. **Step 2:** Fill in price, click "Suivant" → moves to step 3
+7. **Step 3:** Images and variants load, click "Suivant" → moves to step 4
+8. **Step 4:** Description, SEO fields, toggles, and two final buttons visible
+9. **Publish:** Click "Publier le produit" → redirects to /products with success toast
+10. **Existing product edit:** Navigate to an existing (non-draft) product → old ProductFormSections renders unchanged
+
+- [ ] **Step 9.5: Add `.superpowers/` to `.gitignore` if not already there**
+
+```bash
+grep -q ".superpowers" /home/superz/netereka/.gitignore || echo ".superpowers/" >> /home/superz/netereka/.gitignore
+```
+
+- [ ] **Step 9.6: Commit integration**
+
+```bash
+git add "app/(admin)/products/[id]/edit/page.tsx" .gitignore
+git commit -m "feat(admin): integrate product wizard into edit page for draft products"
+```
+
+- [ ] **Step 9.7: Push branch and create PR**
+
+```bash
+git push -u origin feat/assisted-product-wizard
+gh pr create \
+  --title "feat(admin): guided product creation wizard" \
+  --body "$(cat <<'EOF'
+## Summary
+- Replaces the flat 8-section product form with a guided 4-step wizard for new products
+- Adds `saveDraftStep` server action for partial saves (preserves `is_draft = 1`)
+- Steps: Identité → Prix & Stock → Médias → Finalisation with placeholders, helper text, and inline tooltips
+- Navigation: free navigation between completed steps via clickable stepper
+- Existing products (non-drafts) continue to use `ProductFormSections` unchanged
+
+## Test plan
+- [ ] Navigate to /products/new — wizard loads at step 1
+- [ ] Clicking Suivant with empty name shows error toast, does not advance
+- [ ] Filling name + category and clicking Suivant advances to step 2 and saves via saveDraftStep
+- [ ] Clicking a completed step in the stepper navigates back freely
+- [ ] Publishing from step 4 redirects to /products with success toast
+- [ ] Saving as draft from step 4 preserves is_draft = 1
+- [ ] Editing an existing published product still renders the old form
+- [ ] All unit tests pass: npm run test
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-03-19-assisted-product-creation-design.md
+++ b/docs/superpowers/specs/2026-03-19-assisted-product-creation-design.md
@@ -1,0 +1,113 @@
+# Assisted Product Creation — Design Spec
+
+**Date:** 2026-03-19
+**Status:** Approved
+
+## Context
+
+The current product creation flow presents a single long form with 8 sections (General Info, Category, Pricing, Specs, Images, Variants, SEO, Visibility). Admins report it feels intimidating, the order isn't always logical, and fields lack guidance. This spec redesigns the form as a guided 4-step wizard.
+
+No AI-assisted content generation in scope — that is deferred for a future iteration.
+
+## Design
+
+### Structure: 4-Step Wizard
+
+A step-by-step wizard replaces the scrolling 8-section form. The wizard renders inside the existing `/products/[id]/edit` page (the draft-first flow is preserved).
+
+#### Step 1 — Identité
+Fields:
+- **Nom du produit** (required) — placeholder: `ex: Samsung Galaxy A55 128Go Noir` — hint below: *Soyez précis : marque, modèle, capacité, couleur si pertinent.*
+- **Marque** (optional) — placeholder: `ex: Samsung`
+- **SKU** (optional) — labeled "auto-généré", placeholder: *Laissez vide pour générer automatiquement*, input disabled-style (light background)
+- **Catégorie** (required) — two-level cascading select (existing `CategoryCascadingSelect` component)
+
+Contextual hint (blue): *"Ces 3 champs suffisent pour passer à l'étape suivante. Vous pourrez toujours revenir pour compléter."*
+
+Validation to advance: `name` and `category_id` must be non-empty.
+
+#### Step 2 — Prix & Stock
+Fields:
+- **Prix de base** (required, integer XOF) — FCFA badge on input, placeholder: `ex: 125000`
+- **Prix barré** (optional) — tooltip: *Ancien prix avant promotion. Affiché barré sur la fiche produit.*
+- **Quantité en stock** (integer, default 0)
+- **Seuil d'alerte stock faible** (integer, default 5) — tooltip: *Vous recevrez une alerte lorsque le stock passe sous ce seuil.*
+- **Poids** (optional, grams) — tooltip: *Utilisé pour le calcul des frais de livraison.*
+
+Validation to advance: `base_price` must be a non-negative integer.
+
+#### Step 3 — Médias
+Two sub-sections:
+1. **Images** — existing `ImageManager` + `ImageUpload` components, unchanged
+2. **Variantes** — existing `VariantList` + `VariantForm` components, unchanged
+
+Contextual hint (amber): *"Au moins une image est recommandée avant publication."*
+
+This step is entirely optional — no validation required to advance.
+
+#### Step 4 — Finalisation
+Fields:
+- **Résumé court** (optional, single-line text) — placeholder: `ex: Smartphone 128Go avec triple caméra 50MP`
+- **Description** (optional) — existing `RichTextEditor` component
+- **Titre SEO** (optional, max 60 chars) — live character counter
+- **Meta-description** (optional, max 160 chars) — live character counter, textarea
+- **is_active** toggle — label: *Publier immédiatement*
+- **is_featured** toggle — label: *Mettre en avant sur la page d'accueil*
+
+Final button:
+- If `is_active = 1` → **"Publier le produit"**
+- If `is_active = 0` → **"Enregistrer comme brouillon"**
+
+### Navigation
+
+**Stepper bar** (top of wizard):
+- Each step shows number, title, and subtitle (e.g. *Nom · Marque · Catégorie*)
+- Completed steps: navy background, clickable
+- Current step: navy background, active state
+- Future steps: grey, not clickable
+- Connector lines between steps (grey, filled navy as steps complete)
+
+**Previous/Next buttons:**
+- "Suivant →" advances to next step (after validating current step's required fields)
+- "← Précédent" goes back (no validation required)
+- First step has no "Précédent" button
+- Last step replaces "Suivant" with the final publish/save button
+
+**Auto-save:**
+- Each "Suivant" click triggers `updateProduct(id, formData)` server action with the current step's fields
+- "Brouillon sauvegardé automatiquement" shown in footer of each step
+- If the server action fails, show an error toast (Sonner) and do not advance
+
+### Technical Approach
+
+**Preserved:** The draft-first flow is unchanged. Clicking "Nouveau produit" still calls `createDraftProduct()` and redirects to `/products/[id]/edit`.
+
+**New:** The `ProductFormSections` component is replaced by a new `ProductWizard` client component. The wizard manages current step state locally (`useState`). Each step is a separate sub-component.
+
+**Per-step save:** Each "Suivant" submits only the fields from the current step via `updateProduct`. The existing `productSchema` is reused with partial validation (only required fields for the current step are enforced client-side).
+
+**Publishing:** "Terminer" calls `updateProduct` with `is_active` and `is_featured` values, which clears `is_draft = 0` (existing behavior). The redirect after publish goes to the products list with a success toast.
+
+**Existing components reused as-is:**
+- `CategoryCascadingSelect`
+- `ImageManager` + `ImageUpload`
+- `VariantList` + `VariantForm`
+- `RichTextEditor`
+
+### Guidance Elements (per field)
+
+| Element | Purpose | Implementation |
+|---------|---------|----------------|
+| Placeholder | Show expected format/example | `placeholder` prop on input |
+| Helper text | Short hint below field | Small grey `<p>` under input |
+| Tooltip `?` | Explain non-obvious fields | Radix `Tooltip` component |
+| Step hint | Minimum required to advance | Blue info box at bottom of step body |
+| Character counter | Live feedback for SEO fields | Controlled input + `{n}/{max}` display |
+| Auto-save indicator | Reduce anxiety about losing work | Footer text, updated after each save |
+
+### Out of Scope
+
+- AI-generated descriptions or SEO suggestions (deferred)
+- Bulk product import (CSV, barcode)
+- Product templates by category
+- Mobile-optimized stepper (mobile gets stacked layout, same as today)

--- a/docs/superpowers/specs/2026-03-19-assisted-product-creation-design.md
+++ b/docs/superpowers/specs/2026-03-19-assisted-product-creation-design.md
@@ -9,22 +9,28 @@ The current product creation flow presents a single long form with 8 sections (G
 
 No AI-assisted content generation in scope — that is deferred for a future iteration.
 
+## Scope
+
+This wizard applies to **new product creation only** (products where `is_draft = 1`). Already-published products continue to use the existing `ProductFormSections` component unchanged. The two components coexist: the edit page renders `ProductWizard` when `product.is_draft === 1`, and `ProductFormSections` otherwise.
+
+**Migration note:** Any existing draft product accessed after this feature is deployed will use the wizard instead of the old form. This is the desired behavior — in-progress drafts will benefit from the guided flow.
+
 ## Design
 
 ### Structure: 4-Step Wizard
 
-A step-by-step wizard replaces the scrolling 8-section form. The wizard renders inside the existing `/products/[id]/edit` page (the draft-first flow is preserved).
+A step-by-step wizard renders inside the existing `/products/[id]/edit` page. The draft-first flow (`createDraftProduct()` → redirect to edit) is preserved.
 
 #### Step 1 — Identité
 Fields:
-- **Nom du produit** (required) — placeholder: `ex: Samsung Galaxy A55 128Go Noir` — hint below: *Soyez précis : marque, modèle, capacité, couleur si pertinent.*
+- **Nom du produit** (required) — placeholder: `ex: Samsung Galaxy A55 128Go Noir` — helper text: *Soyez précis : marque, modèle, capacité, couleur si pertinent.*
 - **Marque** (optional) — placeholder: `ex: Samsung`
-- **SKU** (optional) — labeled "auto-généré", placeholder: *Laissez vide pour générer automatiquement*, input disabled-style (light background)
-- **Catégorie** (required) — two-level cascading select (existing `CategoryCascadingSelect` component)
+- **SKU** (optional, editable) — helper text: *Laissez vide si vous n'avez pas de référence interne.* Light background styling but field remains fully editable — value appears in FormData when provided. No auto-generation.
+- **Catégorie** (required) — two-level cascading select (existing `CategoryCascadingSelect`)
 
 Contextual hint (blue): *"Ces 3 champs suffisent pour passer à l'étape suivante. Vous pourrez toujours revenir pour compléter."*
 
-Validation to advance: `name` and `category_id` must be non-empty.
+Validation to advance: `name` non-empty and `category_id` non-empty.
 
 #### Step 2 — Prix & Stock
 Fields:
@@ -34,7 +40,7 @@ Fields:
 - **Seuil d'alerte stock faible** (integer, default 5) — tooltip: *Vous recevrez une alerte lorsque le stock passe sous ce seuil.*
 - **Poids** (optional, grams) — tooltip: *Utilisé pour le calcul des frais de livraison.*
 
-Validation to advance: `base_price` must be a non-negative integer.
+Validation to advance: `base_price` is a non-negative integer.
 
 #### Step 3 — Médias
 Two sub-sections:
@@ -43,71 +49,137 @@ Two sub-sections:
 
 Contextual hint (amber): *"Au moins une image est recommandée avant publication."*
 
-This step is entirely optional — no validation required to advance.
+No validation required to advance. `ImageManager` and `VariantList` manage their own async flows independently — they are not disabled during the wizard's `useTransition` pending state (their mutations are fire-and-forget relative to the wizard).
 
 #### Step 4 — Finalisation
 Fields:
 - **Résumé court** (optional, single-line text) — placeholder: `ex: Smartphone 128Go avec triple caméra 50MP`
-- **Description** (optional) — existing `RichTextEditor` component
-- **Titre SEO** (optional, max 60 chars) — live character counter
-- **Meta-description** (optional, max 160 chars) — live character counter, textarea
-- **is_active** toggle — label: *Publier immédiatement*
-- **is_featured** toggle — label: *Mettre en avant sur la page d'accueil*
+- **Description** (optional) — existing `RichTextEditor`
+- **Titre SEO** (optional, max 60 chars) — live character counter `{n}/60`
+- **Meta-description** (optional, max 160 chars) — live character counter `{n}/160`, textarea
+- **Publier immédiatement** (`is_active`) toggle — default off
+- **Mettre en avant** (`is_featured`) toggle — default off
 
-Final button:
-- If `is_active = 1` → **"Publier le produit"**
-- If `is_active = 0` → **"Enregistrer comme brouillon"**
+Final buttons (two distinct actions):
+- **"Publier le produit"** — forces `is_active = 1` into FormData, then calls `updateProduct(id, formData)`. `updateProduct` sets `is_draft = 0` and `is_active = 1`. Client-side redirect to `/products` with success toast after receiving `{ success: true }`.
+- **"Enregistrer comme brouillon"** — calls `saveDraftStep(id, formData)` for Step 4 fields only, preserving `is_draft = 1`. Client-side redirect to `/products` with a "Brouillon enregistré" toast.
+
+The `is_active` toggle in Step 4 is only relevant for the "Publier" path. When saving as draft, `is_active` is saved via `saveDraftStep` (see table below) but `is_draft` remains 1 — the product stays invisible on the storefront regardless of `is_active`. The UI does not disable the toggle when saving as draft.
+
+Note: `updateProduct` unconditionally sets `is_draft = 0`. Therefore only "Publier" calls `updateProduct`. "Enregistrer comme brouillon" uses `saveDraftStep` to avoid inadvertently clearing the draft flag.
 
 ### Navigation
 
 **Stepper bar** (top of wizard):
-- Each step shows number, title, and subtitle (e.g. *Nom · Marque · Catégorie*)
-- Completed steps: navy background, clickable
-- Current step: navy background, active state
-- Future steps: grey, not clickable
-- Connector lines between steps (grey, filled navy as steps complete)
+- Completed steps (index < current): filled navy circle (#183C78), white number, clickable
+- Current step: navy outline circle (white fill, navy border), navy number, not clickable
+- Future steps (index > current): grey circle, grey number, not clickable
+- Connector lines: grey by default, filled navy when the step to the left is completed
 
-**Previous/Next buttons:**
-- "Suivant →" advances to next step (after validating current step's required fields)
-- "← Précédent" goes back (no validation required)
-- First step has no "Précédent" button
-- Last step replaces "Suivant" with the final publish/save button
+**Buttons:**
+- "Suivant →" advances (validates current step's required fields, then calls `saveDraftStep`). Shows inline spinner + disabled while the server action is in flight (`useTransition` + `isPending`). All form inputs in the current step are also disabled during pending.
+- "← Précédent" goes back — no save, no validation, instant
+- Step 1 has no "Précédent" button
+- Step 4 replaces "Suivant" with the two final buttons described above
 
-**Auto-save:**
-- Each "Suivant" click triggers `updateProduct(id, formData)` server action with the current step's fields
-- "Brouillon sauvegardé automatiquement" shown in footer of each step
-- If the server action fails, show an error toast (Sonner) and do not advance
+**Slug handling:**
+Slug is not exposed in the wizard UI. `saveDraftStep` auto-derives slug from `name` (via `slugify`) if name is provided and slug is currently empty, matching `updateProduct` behavior. Slug collision returns `{ success: false, error: "..." }` and shows an error toast — the user does not advance.
+
+### States
+
+**Loading:** "Suivant" button shows inline spinner and is disabled. Form inputs in the current step are disabled. Step 3 child components (`ImageManager`, `VariantList`) are unaffected.
+
+**Save error:** Sonner error toast with the server-returned message. Wizard stays on the current step. User can retry.
+
+**Navigate away:** No `beforeunload` prompt. Auto-save happens on each "Suivant" click. If the admin navigates away before clicking "Suivant", any unsaved edits in the current step are lost — this is acceptable. The draft persists in DB with the data from the last successful save. `cleanupDraftProducts()` only removes drafts older than 24 hours with `name = ''`, so partially-filled drafts survive.
+
+**Resume (returning to an in-progress draft):** The wizard loads with all previously saved values pre-filled. The starting step is determined as follows:
+- Step 1 if `name` is empty
+- Step 2 if `name` and `category_id` are set but `base_price` is 0
+- Step 3 if `name`, `category_id`, and `base_price > 0` are set but no primary image exists
+- Step 4 otherwise (all required fields set and at least one image uploaded)
 
 ### Technical Approach
 
-**Preserved:** The draft-first flow is unchanged. Clicking "Nouveau produit" still calls `createDraftProduct()` and redirects to `/products/[id]/edit`.
+**Preserved unchanged:** `createDraftProduct()`, `updateProduct()`, `ProductFormSections`.
 
-**New:** The `ProductFormSections` component is replaced by a new `ProductWizard` client component. The wizard manages current step state locally (`useState`). Each step is a separate sub-component.
+**New server action — `saveDraftStep(id: string, formData: FormData): Promise<ActionResult>`**
 
-**Per-step save:** Each "Suivant" submits only the fields from the current step via `updateProduct`. The existing `productSchema` is reused with partial validation (only required fields for the current step are enforced client-side).
+Handles partial saves during wizard navigation. Preserves `is_draft = 1`.
 
-**Publishing:** "Terminer" calls `updateProduct` with `is_active` and `is_featured` values, which clears `is_draft = 0` (existing behavior). The redirect after publish goes to the products list with a success toast.
+Accepted fields per step (only fields present in FormData are updated — absent fields are ignored via partial SQL):
+
+| Step | Fields saved |
+|------|-------------|
+| 1 | `name`, `brand`, `sku`, `category_id` |
+| 2 | `base_price`, `compare_price`, `stock_quantity`, `low_stock_threshold`, `weight_grams` |
+| 3 | *(no fields — media handled by existing image/variant actions)* |
+| 4 (draft) | `short_description`, `description`, `meta_title`, `meta_description`, `is_active`, `is_featured` |
+
+Validation per step:
+- Step 1: `name` non-empty, `category_id` non-empty
+- Step 2: `base_price` is a non-negative integer
+- Step 3: none
+- Step 4: `meta_title` max 60 chars, `meta_description` max 160 chars
+
+Slug behavior: if `name` is in the payload, `name` is non-empty, and the product's current slug starts with `draft-` (the format set by `createDraftProduct`), auto-derive new slug from `name` via `slugify`. Check for collision (excluding self). Return error on collision. If `name` is empty, skip slug derivation.
+
+`revalidatePath`: `saveDraftStep` does NOT call `revalidatePath`. Drafts are excluded from the storefront and the admin products list, so no cache invalidation is needed for partial saves.
+
+**Component structure:**
+```
+components/admin/
+  product-wizard.tsx            # Main wizard client component ("use client")
+  product-wizard/
+    step-identity.tsx           # Step 1
+    step-pricing.tsx            # Step 2
+    step-media.tsx              # Step 3
+    step-finalization.tsx       # Step 4
+    wizard-stepper.tsx          # Stepper bar
+```
+
+**`ProductWizard` props:**
+```typescript
+// CategoryOption imported from components/admin/category-cascading-select
+// (4-field version: id, name, depth, parent_id) — NOT the 2-field version from lib/db/types
+interface ProductWizardProps {
+  product: ProductDetail;
+  categories: CategoryOption[];
+}
+```
+
+**Conditional render in edit page:**
+```typescript
+// app/(admin)/products/[id]/edit/page.tsx
+{product.is_draft
+  ? <ProductWizard product={product} categories={categories} />
+  : <ProductFormSections product={product} categories={categories} />}
+```
+
+The edit page already fetches `categories` as `CategoryOption[]` — no change needed to data fetching.
 
 **Existing components reused as-is:**
-- `CategoryCascadingSelect`
-- `ImageManager` + `ImageUpload`
-- `VariantList` + `VariantForm`
-- `RichTextEditor`
+- `CategoryCascadingSelect` (Step 1)
+- `ImageManager` + `ImageUpload` (Step 3)
+- `VariantList` + `VariantForm` (Step 3)
+- `RichTextEditor` (Step 4)
 
-### Guidance Elements (per field)
+### Guidance Elements
 
 | Element | Purpose | Implementation |
 |---------|---------|----------------|
 | Placeholder | Show expected format/example | `placeholder` prop on input |
 | Helper text | Short hint below field | Small grey `<p>` under input |
 | Tooltip `?` | Explain non-obvious fields | Radix `Tooltip` component |
-| Step hint | Minimum required to advance | Blue info box at bottom of step body |
+| Step hint | Minimum required to advance | Blue or amber info box in step body |
 | Character counter | Live feedback for SEO fields | Controlled input + `{n}/{max}` display |
-| Auto-save indicator | Reduce anxiety about losing work | Footer text, updated after each save |
+| Loading state | Prevent double-submit | `isPending` from `useTransition`, spinner on button, inputs disabled |
 
 ### Out of Scope
 
 - AI-generated descriptions or SEO suggestions (deferred)
 - Bulk product import (CSV, barcode)
 - Product templates by category
-- Mobile-optimized stepper (mobile gets stacked layout, same as today)
+- Mobile-optimized stepper (mobile stacks linearly, same as today)
+- Wizard for editing already-published products
+- SKU auto-generation (not implemented in existing actions; field is optional, stored as NULL if empty)

--- a/drizzle/0004_rapid_norrin_radd.sql
+++ b/drizzle/0004_rapid_norrin_radd.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `product_images` ADD `variant_id` text REFERENCES product_variants(id);

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,2395 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "784c785f-b4cb-4459-9d44-d6bd242c1efa",
+  "prevId": "390518dd-9516-4a05-87e9-f74a3d6a091f",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_account_userId": {
+          "name": "idx_account_userId",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "idx_account_provider": {
+          "name": "idx_account_provider",
+          "columns": [
+            "providerId",
+            "accountId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "addresses": {
+      "name": "addresses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Domicile'"
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "street": {
+          "name": "street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commune": {
+          "name": "commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Abidjan'"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_addresses_user": {
+          "name": "idx_addresses_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "addresses_user_id_user_id_fk": {
+          "name": "addresses_user_id_user_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "addresses_zone_id_delivery_zones_id_fk": {
+          "name": "addresses_zone_id_delivery_zones_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "delivery_zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_audit_log_actor": {
+          "name": "idx_audit_log_actor",
+          "columns": [
+            "actor_id"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_log_action": {
+          "name": "idx_audit_log_action",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_log_created": {
+          "name": "idx_audit_log_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "banner_gradients": {
+      "name": "banner_gradients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_from": {
+          "name": "color_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_to": {
+          "name": "color_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "banners": {
+      "name": "banners",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "badge_text": {
+          "name": "badge_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "badge_color": {
+          "name": "badge_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'mint'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cta_text": {
+          "name": "cta_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Découvrir'"
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bg_gradient_from": {
+          "name": "bg_gradient_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#183C78'"
+        },
+        "bg_gradient_to": {
+          "name": "bg_gradient_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#1E4A8F'"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_banners_active_order": {
+          "name": "idx_banners_active_order",
+          "columns": [
+            "is_active",
+            "display_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "idx_categories_slug": {
+          "name": "idx_categories_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "idx_categories_parent": {
+          "name": "idx_categories_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "categories_parent_id_categories_id_fk": {
+          "name": "categories_parent_id_categories_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "delivery_zones": {
+      "name": "delivery_zones",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commune": {
+          "name": "commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fee": {
+          "name": "fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimated_hours": {
+          "name": "estimated_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 24
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "order_items": {
+      "name": "order_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_name": {
+          "name": "variant_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_order_items_order": {
+          "name": "idx_order_items_order",
+          "columns": [
+            "order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "order_items_order_id_orders_id_fk": {
+          "name": "order_items_order_id_orders_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_items_product_id_products_id_fk": {
+          "name": "order_items_product_id_products_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_items_variant_id_product_variants_id_fk": {
+          "name": "order_items_variant_id_product_variants_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "order_status_history": {
+      "name": "order_status_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_order_status_history_order": {
+          "name": "idx_order_status_history_order",
+          "columns": [
+            "order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "order_status_history_order_id_orders_id_fk": {
+          "name": "order_status_history_order_id_orders_id_fk",
+          "tableFrom": "order_status_history",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "orders": {
+      "name": "orders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_number": {
+          "name": "order_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_fee": {
+          "name": "delivery_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "promo_code_id": {
+          "name": "promo_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivery_address": {
+          "name": "delivery_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_commune": {
+          "name": "delivery_commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_phone": {
+          "name": "delivery_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_instructions": {
+          "name": "delivery_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "estimated_delivery": {
+          "name": "estimated_delivery",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "internal_notes": {
+          "name": "internal_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivery_person_id": {
+          "name": "delivery_person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivery_person_name": {
+          "name": "delivery_person_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preparing_at": {
+          "name": "preparing_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_at": {
+          "name": "shipping_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "returned_at": {
+          "name": "returned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "return_reason": {
+          "name": "return_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "orders_order_number_unique": {
+          "name": "orders_order_number_unique",
+          "columns": [
+            "order_number"
+          ],
+          "isUnique": true
+        },
+        "idx_orders_user": {
+          "name": "idx_orders_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_orders_status": {
+          "name": "idx_orders_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_orders_number": {
+          "name": "idx_orders_number",
+          "columns": [
+            "order_number"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "orders_user_id_user_id_fk": {
+          "name": "orders_user_id_user_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "orders_promo_code_id_promo_codes_id_fk": {
+          "name": "orders_promo_code_id_promo_codes_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "promo_codes",
+          "columnsFrom": [
+            "promo_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product_attributes": {
+      "name": "product_attributes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_product_attributes_product": {
+          "name": "idx_product_attributes_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "product_attributes_product_id_products_id_fk": {
+          "name": "product_attributes_product_id_products_id_fk",
+          "tableFrom": "product_attributes",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product_images": {
+      "name": "product_images",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_product_images_product": {
+          "name": "idx_product_images_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "product_images_product_id_products_id_fk": {
+          "name": "product_images_product_id_products_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_images_variant_id_product_variants_id_fk": {
+          "name": "product_images_variant_id_product_variants_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product_variants": {
+      "name": "product_variants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compare_price": {
+          "name": "compare_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "product_variants_sku_unique": {
+          "name": "product_variants_sku_unique",
+          "columns": [
+            "sku"
+          ],
+          "isUnique": true
+        },
+        "idx_product_variants_product": {
+          "name": "idx_product_variants_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "product_variants_product_id_products_id_fk": {
+          "name": "product_variants_product_id_products_id_fk",
+          "tableFrom": "product_variants",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "products": {
+      "name": "products",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "short_description": {
+          "name": "short_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_price": {
+          "name": "base_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compare_price": {
+          "name": "compare_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "low_stock_threshold": {
+          "name": "low_stock_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        },
+        "weight_grams": {
+          "name": "weight_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta_title": {
+          "name": "meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "products_slug_unique": {
+          "name": "products_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "products_sku_unique": {
+          "name": "products_sku_unique",
+          "columns": [
+            "sku"
+          ],
+          "isUnique": true
+        },
+        "idx_products_slug": {
+          "name": "idx_products_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "idx_products_category": {
+          "name": "idx_products_category",
+          "columns": [
+            "category_id"
+          ],
+          "isUnique": false
+        },
+        "idx_products_active": {
+          "name": "idx_products_active",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        },
+        "idx_products_featured": {
+          "name": "idx_products_featured",
+          "columns": [
+            "is_featured"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "products_category_id_categories_id_fk": {
+          "name": "products_category_id_categories_id_fk",
+          "tableFrom": "products",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "promo_codes": {
+      "name": "promo_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discount_value": {
+          "name": "discount_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "min_order_amount": {
+          "name": "min_order_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "promo_codes_code_unique": {
+          "name": "promo_codes_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reviews": {
+      "name": "reviews",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_verified_purchase": {
+          "name": "is_verified_purchase",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_reviews_product": {
+          "name": "idx_reviews_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        },
+        "idx_reviews_user": {
+          "name": "idx_reviews_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reviews_product_id_products_id_fk": {
+          "name": "reviews_product_id_products_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_user_id_user_id_fk": {
+          "name": "reviews_user_id_user_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "rating_range": {
+          "name": "rating_range",
+          "value": "\"reviews\".\"rating\" BETWEEN 1 AND 5"
+        }
+      }
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_session_userId": {
+          "name": "idx_session_userId",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'customer'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "banReason": {
+          "name": "banReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banExpires": {
+          "name": "banExpires",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'customer'"
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'email'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_phone_unique": {
+          "name": "users_phone_unique",
+          "columns": [
+            "phone"
+          ],
+          "isUnique": true
+        },
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "idx_users_phone": {
+          "name": "idx_users_phone",
+          "columns": [
+            "phone"
+          ],
+          "isUnique": false
+        },
+        "idx_users_is_active": {
+          "name": "idx_users_is_active",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wishlist": {
+      "name": "wishlist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "wishlist_user_product_unique": {
+          "name": "wishlist_user_product_unique",
+          "columns": [
+            "user_id",
+            "product_id"
+          ],
+          "isUnique": true
+        },
+        "idx_wishlist_user": {
+          "name": "idx_wishlist_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_wishlist_product": {
+          "name": "idx_wishlist_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wishlist_user_id_user_id_fk": {
+          "name": "wishlist_user_id_user_id_fk",
+          "tableFrom": "wishlist",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wishlist_product_id_products_id_fk": {
+          "name": "wishlist_product_id_products_id_fk",
+          "tableFrom": "wishlist",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1772453899477,
       "tag": "0003_brief_fantastic_four",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1774256834193,
+      "tag": "0004_rapid_norrin_radd",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -189,6 +189,7 @@ export const productVariants = sqliteTable("product_variants", {
 export const productImages = sqliteTable("product_images", {
   id: text("id").primaryKey(),
   product_id: text("product_id").notNull().references(() => products.id, { onDelete: "cascade" }),
+  variant_id: text("variant_id").references(() => productVariants.id, { onDelete: "set null" }),
   url: text("url").notNull(),
   alt: text("alt"),
   sort_order: integer("sort_order").notNull().default(0),

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -70,6 +70,7 @@ export interface ProductVariant {
 export interface ProductImage {
   id: string;
   product_id: string;
+  variant_id: string | null;
   url: string;
   alt: string | null;
   sort_order: number;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -52,6 +52,7 @@ export function formatDateLong(dateStr: string): string {
 export interface ActionResult {
   success: boolean;
   error?: string;
+  fieldErrors?: Record<string, string[]>;
   id?: string;
   url?: string;
 }


### PR DESCRIPTION
## Summary
- Replaces the flat 8-section product form with a guided 4-step wizard for new (draft) products
- Adds `saveDraftStep` server action for partial saves that preserve `is_draft = 1`
- Steps: Identité → Prix & Stock → Médias → Finalisation with placeholders, helper text, and inline tooltips
- Free navigation between completed steps via clickable stepper
- Existing products (non-drafts) continue to use `ProductFormSections` unchanged

## Test plan
- [ ] Navigate to /products/new — wizard loads at step 1 (Identité)
- [ ] Clicking Suivant with empty name shows error toast, does not advance
- [ ] Filling name + category and clicking Suivant advances to step 2 and saves via saveDraftStep
- [ ] Clicking a completed step in the stepper navigates back freely
- [ ] Publishing from step 4 redirects to /products with success toast
- [ ] Saving as draft from step 4 preserves is_draft = 1
- [ ] Editing an existing published product still renders the old form
- [ ] All unit tests pass: npm run test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a guided multi-step wizard for creating and editing draft products, with intuitive navigation and progress tracking.
  * Added ability to save product drafts and resume editing at any step.
  * Enabled variant-specific image uploads and gallery management.
  * Enhanced product gallery to display images matched to selected color variants.

* **Documentation**
  * Added design specifications and implementation plans for the assisted product creation feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->