### PR TITLE
fix(admin): editor dimensions and HTML preview in sheet

### DIFF
--- a/components/admin/html-editor.css
+++ b/components/admin/html-editor.css
@@ -1,5 +1,4 @@
 .html-editor-container {
-  width: 100%;
   border: 1px solid hsl(var(--border));
   border-radius: var(--radius);
   overflow: hidden;
@@ -7,13 +6,7 @@
   max-height: 500px;
 }
 
-.html-editor-code {
-  width: 100%;
-  height: 100%;
-}
-
 .html-editor-code .cm-editor {
-  width: 100%;
   height: 100%;
   min-height: 200px;
   max-height: 500px;

--- a/components/admin/html-editor.css
+++ b/components/admin/html-editor.css
@@ -1,20 +1,22 @@
 .html-editor-container {
-  display: flex;
-  gap: 0;
+  width: 100%;
   border: 1px solid hsl(var(--border));
   border-radius: var(--radius);
   overflow: hidden;
-  min-height: 400px;
+  min-height: 200px;
+  max-height: 500px;
 }
 
 .html-editor-code {
-  flex: 1;
-  min-width: 0;
-  overflow: auto;
+  width: 100%;
+  height: 100%;
 }
 
 .html-editor-code .cm-editor {
+  width: 100%;
   height: 100%;
+  min-height: 200px;
+  max-height: 500px;
 }
 
 .html-editor-code .cm-editor .cm-scroller {
@@ -23,30 +25,4 @@
 
 .html-editor-code .cm-editor.cm-focused {
   outline: none;
-}
-
-.html-editor-preview {
-  flex: 1;
-  min-width: 0;
-  border-left: 1px solid hsl(var(--border));
-}
-
-.html-editor-preview iframe {
-  width: 100%;
-  height: 100%;
-  border: none;
-  background: white;
-}
-
-@media (max-width: 767px) {
-  .html-editor-container {
-    flex-direction: column;
-  }
-  .html-editor-preview {
-    border-left: none;
-    border-top: 1px solid hsl(var(--border));
-  }
-  .html-editor-container[data-fullscreen="true"] .html-editor-preview {
-    display: none;
-  }
 }

--- a/components/admin/html-editor.tsx
+++ b/components/admin/html-editor.tsx
@@ -7,6 +7,13 @@ import { html } from "@codemirror/lang-html";
 import { css } from "@codemirror/lang-css";
 import { type ViewUpdate } from "@codemirror/view";
 import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
 import "./html-editor.css";
 
 interface HtmlEditorProps {
@@ -21,9 +28,11 @@ export function HtmlEditor({ name, defaultValue, placeholder }: HtmlEditorProps)
   const viewRef = useRef<EditorView | null>(null);
   const hiddenRef = useRef<HTMLInputElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
-  const [isFullscreen, setIsFullscreen] = useState(false);
+  const contentRef = useRef(defaultValue ?? "");
+  const [previewOpen, setPreviewOpen] = useState(false);
 
   const updatePreview = useCallback((content: string) => {
+    contentRef.current = content;
     const iframe = previewRef.current;
     if (!iframe) return;
     const doc = iframe.contentDocument;
@@ -47,6 +56,7 @@ export function HtmlEditor({ name, defaultValue, placeholder }: HtmlEditorProps)
     (update: ViewUpdate) => {
       if (!update.docChanged) return;
       const content = update.state.doc.toString();
+      contentRef.current = content;
       if (hiddenRef.current) hiddenRef.current.value = content;
       if (debounceRef.current) clearTimeout(debounceRef.current);
       debounceRef.current = setTimeout(() => updatePreview(content), 300);
@@ -80,7 +90,6 @@ export function HtmlEditor({ name, defaultValue, placeholder }: HtmlEditorProps)
       });
 
       if (hiddenRef.current) hiddenRef.current.value = startDoc;
-      updatePreview(startDoc);
     } catch (err) {
       console.error("[html-editor] CodeMirror initialization failed", err);
     }
@@ -92,30 +101,38 @@ export function HtmlEditor({ name, defaultValue, placeholder }: HtmlEditorProps)
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  const handlePreviewOpen = useCallback((open: boolean) => {
+    setPreviewOpen(open);
+    if (open) {
+      // Defer so the iframe is mounted before writing
+      setTimeout(() => updatePreview(contentRef.current), 0);
+    }
+  }, [updatePreview]);
+
   return (
-    <div>
-      <div className="mb-2 flex items-center justify-end gap-2 md:hidden">
-        <Button
-          type="button"
-          variant="outline"
-          size="xs"
-          onClick={() => setIsFullscreen(!isFullscreen)}
-        >
-          {isFullscreen ? "Afficher preview" : "Masquer preview"}
-        </Button>
-      </div>
-      <div
-        className="html-editor-container"
-        data-fullscreen={isFullscreen}
-      >
+    <div className="w-full space-y-2">
+      <div className="html-editor-container">
         <div className="html-editor-code" ref={editorRef} />
-        <div className="html-editor-preview">
-          <iframe
-            ref={previewRef}
-            sandbox="allow-styles"
-            title="Preview HTML"
-          />
-        </div>
+      </div>
+      <div className="flex justify-end">
+        <Sheet open={previewOpen} onOpenChange={handlePreviewOpen}>
+          <SheetTrigger asChild>
+            <Button type="button" variant="outline" size="xs">
+              Aperçu
+            </Button>
+          </SheetTrigger>
+          <SheetContent side="right" className="sm:max-w-xl md:max-w-2xl lg:max-w-4xl">
+            <SheetHeader>
+              <SheetTitle>Aperçu HTML</SheetTitle>
+            </SheetHeader>
+            <iframe
+              ref={previewRef}
+              sandbox="allow-styles"
+              title="Aperçu HTML"
+              className="h-full w-full border-none"
+            />
+          </SheetContent>
+        </Sheet>
       </div>
       <input type="hidden" name={name} ref={hiddenRef} />
     </div>

--- a/components/admin/html-editor.tsx
+++ b/components/admin/html-editor.tsx
@@ -8,12 +8,12 @@ import { css } from "@codemirror/lang-css";
 import { type ViewUpdate } from "@codemirror/view";
 import { Button } from "@/components/ui/button";
 import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from "@/components/ui/sheet";
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import "./html-editor.css";
 
 interface HtmlEditorProps {
@@ -31,10 +31,7 @@ export function HtmlEditor({ name, defaultValue, placeholder }: HtmlEditorProps)
   const contentRef = useRef(defaultValue ?? "");
   const [previewOpen, setPreviewOpen] = useState(false);
 
-  const updatePreview = useCallback((content: string) => {
-    contentRef.current = content;
-    const iframe = previewRef.current;
-    if (!iframe) return;
+  const writeToIframe = useCallback((iframe: HTMLIFrameElement, content: string) => {
     const doc = iframe.contentDocument;
     if (!doc) return;
     try {
@@ -52,6 +49,11 @@ export function HtmlEditor({ name, defaultValue, placeholder }: HtmlEditorProps)
     }
   }, []);
 
+  const previewCallbackRef = useCallback((iframe: HTMLIFrameElement | null) => {
+    previewRef.current = iframe;
+    if (iframe) writeToIframe(iframe, contentRef.current);
+  }, [writeToIframe]);
+
   const onUpdate = useCallback(
     (update: ViewUpdate) => {
       if (!update.docChanged) return;
@@ -59,9 +61,11 @@ export function HtmlEditor({ name, defaultValue, placeholder }: HtmlEditorProps)
       contentRef.current = content;
       if (hiddenRef.current) hiddenRef.current.value = content;
       if (debounceRef.current) clearTimeout(debounceRef.current);
-      debounceRef.current = setTimeout(() => updatePreview(content), 300);
+      debounceRef.current = setTimeout(() => {
+        if (previewRef.current) writeToIframe(previewRef.current, content);
+      }, 300);
     },
-    [updatePreview],
+    [writeToIframe],
   );
 
   useEffect(() => {
@@ -101,38 +105,30 @@ export function HtmlEditor({ name, defaultValue, placeholder }: HtmlEditorProps)
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const handlePreviewOpen = useCallback((open: boolean) => {
-    setPreviewOpen(open);
-    if (open) {
-      // Defer so the iframe is mounted before writing
-      setTimeout(() => updatePreview(contentRef.current), 0);
-    }
-  }, [updatePreview]);
-
   return (
     <div className="w-full space-y-2">
       <div className="html-editor-container">
         <div className="html-editor-code" ref={editorRef} />
       </div>
       <div className="flex justify-end">
-        <Sheet open={previewOpen} onOpenChange={handlePreviewOpen}>
-          <SheetTrigger asChild>
+        <Dialog open={previewOpen} onOpenChange={setPreviewOpen}>
+          <DialogTrigger asChild>
             <Button type="button" variant="outline" size="xs">
               Aperçu
             </Button>
-          </SheetTrigger>
-          <SheetContent side="right" className="sm:max-w-xl md:max-w-2xl lg:max-w-4xl">
-            <SheetHeader>
-              <SheetTitle>Aperçu HTML</SheetTitle>
-            </SheetHeader>
+          </DialogTrigger>
+          <DialogContent className="flex h-[80vh] max-w-4xl flex-col p-0">
+            <DialogHeader className="px-6 pt-6">
+              <DialogTitle>Aperçu HTML</DialogTitle>
+            </DialogHeader>
             <iframe
-              ref={previewRef}
+              ref={previewCallbackRef}
               sandbox="allow-styles"
               title="Aperçu HTML"
-              className="h-full w-full border-none"
+              className="min-h-0 flex-1 border-none"
             />
-          </SheetContent>
-        </Sheet>
+          </DialogContent>
+        </Dialog>
       </div>
       <input type="hidden" name={name} ref={hiddenRef} />
     </div>

--- a/components/admin/html-editor.tsx
+++ b/components/admin/html-editor.tsx
@@ -8,7 +8,51 @@ import { css } from "@codemirror/lang-css";
 import { type ViewUpdate } from "@codemirror/view";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import "./html-editor.css";
+
+// Security note: the regex character class [a-zA-Z0-9_-] is intentionally
+// restrictive to prevent attribute injection via the scope class value.
+const SCOPE_CLASS_RE = /\.(desc-[a-zA-Z0-9_-]+)\s/;
+
+/**
+ * Build an HTML document for the preview iframe's srcDoc.
+ * Extracts <style> blocks and places them in <head>, then wraps the remaining
+ * body content in a scoped div (e.g. <div class="desc-xyz">) to match how
+ * the storefront renders product descriptions (see product-details.tsx).
+ */
+function buildSrcDoc(content: string) {
+  const scopeMatch = content.match(SCOPE_CLASS_RE);
+  const scopeClass = scopeMatch?.[1] ?? "";
+
+  // Separate <style> blocks from body content so styles go in <head>
+  // and body content gets wrapped in the scope div.
+  const styles: string[] = [];
+  const bodyHtml = content.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, (match) => {
+    styles.push(match);
+    return "";
+  });
+
+  const wrappedBody = scopeClass
+    ? `<div class="${scopeClass}">${bodyHtml}</div>`
+    : bodyHtml;
+
+  return `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<style>body{font-family:system-ui,sans-serif;padding:16px;margin:0;color:#1a1a1a;line-height:1.6}img{max-width:100%;height:auto}</style>
+${styles.join("\n")}
+</head>
+<body>${wrappedBody}</body>
+</html>`;
+}
+
+const TOAST_ID = "html-editor-init-error";
 
 interface HtmlEditorProps {
   name: string;
@@ -24,24 +68,6 @@ export function HtmlEditor({ name, defaultValue, placeholder }: HtmlEditorProps)
   const [initError, setInitError] = useState(false);
   const [previewOpen, setPreviewOpen] = useState(false);
   const [previewSrcDoc, setPreviewSrcDoc] = useState("");
-
-  function buildSrcDoc(content: string) {
-    // Extract the scope class (e.g. "desc-xyz") from CSS selectors so the
-    // preview wraps content in a matching div, just like the storefront does.
-    const scopeMatch = content.match(/\.(desc-[a-zA-Z0-9_-]+)\s/);
-    const scopeClass = scopeMatch?.[1] ?? "";
-    const bodyContent = scopeClass
-      ? `<div class="${scopeClass}">${content}</div>`
-      : content;
-
-    return `<!DOCTYPE html>
-<html>
-<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<style>body{font-family:system-ui,sans-serif;padding:16px;margin:0;color:#1a1a1a;line-height:1.6}img{max-width:100%;height:auto}</style>
-</head>
-<body>${bodyContent}</body>
-</html>`;
-  }
 
   const onUpdate = useCallback(
     (update: ViewUpdate) => {
@@ -81,13 +107,19 @@ export function HtmlEditor({ name, defaultValue, placeholder }: HtmlEditorProps)
       if (hiddenRef.current) hiddenRef.current.value = startDoc;
     } catch (err) {
       console.error("[html-editor] CodeMirror initialization failed", err);
+      // queueMicrotask avoids React "Cannot update a component while rendering" warning
+      // since this runs inside a useEffect that React may batch with renders.
       queueMicrotask(() => {
         setInitError(true);
-        toast.error("L'éditeur HTML n'a pas pu se charger. Rechargez la page. Ne sauvegardez pas le formulaire.", { duration: Infinity });
+        toast.error(
+          "L'éditeur HTML n'a pas pu se charger. Rechargez la page. Ne sauvegardez pas le formulaire.",
+          { id: TOAST_ID, duration: Infinity },
+        );
       });
     }
 
     return () => {
+      toast.dismiss(TOAST_ID);
       viewRef.current?.destroy();
       viewRef.current = null;
     };
@@ -104,29 +136,29 @@ export function HtmlEditor({ name, defaultValue, placeholder }: HtmlEditorProps)
         <div className="html-editor-code" ref={editorRef} />
       </div>
       <div className="flex justify-end">
-        <Button type="button" variant="outline" size="xs" onClick={() => { setPreviewSrcDoc(buildSrcDoc(contentRef.current)); setPreviewOpen(true); }}>
+        <Button
+          type="button"
+          variant="outline"
+          size="xs"
+          onClick={() => { setPreviewSrcDoc(buildSrcDoc(contentRef.current)); setPreviewOpen(true); }}
+        >
           Aperçu
         </Button>
       </div>
-      {previewOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80">
-          <div className="flex h-[80%] w-[80%] flex-col overflow-hidden rounded-xl border bg-background shadow-lg">
-            <div className="flex items-center justify-between px-6 py-4">
-              <h3 className="text-sm font-medium">Aperçu HTML</h3>
-              <Button type="button" variant="ghost" size="xs" onClick={() => setPreviewOpen(false)}>
-                Fermer
-              </Button>
-            </div>
-            <iframe
-              srcDoc={previewSrcDoc}
-              sandbox="allow-styles"
-              title="Aperçu HTML"
-              className="flex-1 border-none"
-            />
-          </div>
-        </div>
-      )}
-      <input type="hidden" name={name} ref={hiddenRef} />
+      <Dialog open={previewOpen} onOpenChange={setPreviewOpen}>
+        <DialogContent className="flex h-[80vh] max-w-4xl flex-col p-0">
+          <DialogHeader className="px-6 pt-6">
+            <DialogTitle>Aperçu HTML</DialogTitle>
+          </DialogHeader>
+          <iframe
+            srcDoc={previewSrcDoc}
+            sandbox="allow-styles"
+            title="Aperçu HTML"
+            className="min-h-0 flex-1 border-none"
+          />
+        </DialogContent>
+      </Dialog>
+      <input type="hidden" name={name} ref={hiddenRef} disabled={initError} />
     </div>
   );
 }

--- a/components/admin/html-editor.tsx
+++ b/components/admin/html-editor.tsx
@@ -139,20 +139,20 @@ export function HtmlEditor({ name, defaultValue, placeholder }: HtmlEditorProps)
         <Button
           type="button"
           variant="outline"
-          size="xs"
+          size="sm"
           onClick={() => { setPreviewSrcDoc(buildSrcDoc(contentRef.current)); setPreviewOpen(true); }}
         >
           Aperçu
         </Button>
       </div>
       <Dialog open={previewOpen} onOpenChange={setPreviewOpen}>
-        <DialogContent className="flex h-[80vh] max-w-4xl flex-col p-0">
+        <DialogContent className="flex h-[80vh] max-w-6xl sm:max-w-6xl flex-col p-0">
           <DialogHeader className="px-6 pt-6">
             <DialogTitle>Aperçu HTML</DialogTitle>
           </DialogHeader>
           <iframe
             srcDoc={previewSrcDoc}
-            sandbox="allow-styles"
+            sandbox=""
             title="Aperçu HTML"
             className="min-h-0 flex-1 border-none"
           />

--- a/components/admin/html-editor.tsx
+++ b/components/admin/html-editor.tsx
@@ -8,13 +8,6 @@ import { css } from "@codemirror/lang-css";
 import { type ViewUpdate } from "@codemirror/view";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
 import "./html-editor.css";
 
 interface HtmlEditorProps {
@@ -25,43 +18,30 @@ interface HtmlEditorProps {
 
 export function HtmlEditor({ name, defaultValue, placeholder }: HtmlEditorProps) {
   const editorRef = useRef<HTMLDivElement>(null);
-  const previewRef = useRef<HTMLIFrameElement>(null);
   const viewRef = useRef<EditorView | null>(null);
   const hiddenRef = useRef<HTMLInputElement>(null);
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
   const contentRef = useRef(defaultValue ?? "");
   const [initError, setInitError] = useState(false);
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const [previewSrcDoc, setPreviewSrcDoc] = useState("");
 
-  const writeToIframe = useCallback((iframe: HTMLIFrameElement, content: string) => {
-    const doc = iframe.contentDocument;
-    if (!doc) {
-      console.warn("[html-editor] iframe.contentDocument is null — preview cannot render");
-      return;
-    }
-    try {
-      doc.open();
-      doc.write(`<!DOCTYPE html>
+  function buildSrcDoc(content: string) {
+    // Extract the scope class (e.g. "desc-xyz") from CSS selectors so the
+    // preview wraps content in a matching div, just like the storefront does.
+    const scopeMatch = content.match(/\.(desc-[a-zA-Z0-9_-]+)\s/);
+    const scopeClass = scopeMatch?.[1] ?? "";
+    const bodyContent = scopeClass
+      ? `<div class="${scopeClass}">${content}</div>`
+      : content;
+
+    return `<!DOCTYPE html>
 <html>
 <head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <style>body{font-family:system-ui,sans-serif;padding:16px;margin:0;color:#1a1a1a;line-height:1.6}img{max-width:100%;height:auto}</style>
 </head>
-<body>${content}</body>
-</html>`);
-      doc.close();
-    } catch (err) {
-      console.error("[html-editor] Preview update failed", err);
-      try {
-        doc.open();
-        doc.write("<p style='color:red;padding:16px'>Impossible d'afficher l'aperçu. Vérifiez votre code HTML.</p>");
-        doc.close();
-      } catch { /* already logged */ }
-    }
-  }, []);
-
-  const previewCallbackRef = useCallback((iframe: HTMLIFrameElement | null) => {
-    previewRef.current = iframe;
-    if (iframe) writeToIframe(iframe, contentRef.current);
-  }, [writeToIframe]);
+<body>${bodyContent}</body>
+</html>`;
+  }
 
   const onUpdate = useCallback(
     (update: ViewUpdate) => {
@@ -69,12 +49,8 @@ export function HtmlEditor({ name, defaultValue, placeholder }: HtmlEditorProps)
       const content = update.state.doc.toString();
       contentRef.current = content;
       if (hiddenRef.current) hiddenRef.current.value = content;
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-      debounceRef.current = setTimeout(() => {
-        if (previewRef.current) writeToIframe(previewRef.current, content);
-      }, 300);
     },
-    [writeToIframe],
+    [],
   );
 
   useEffect(() => {
@@ -112,7 +88,6 @@ export function HtmlEditor({ name, defaultValue, placeholder }: HtmlEditorProps)
     }
 
     return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
       viewRef.current?.destroy();
       viewRef.current = null;
     };
@@ -129,25 +104,28 @@ export function HtmlEditor({ name, defaultValue, placeholder }: HtmlEditorProps)
         <div className="html-editor-code" ref={editorRef} />
       </div>
       <div className="flex justify-end">
-        <Dialog>
-          <DialogTrigger asChild>
-            <Button type="button" variant="outline" size="xs">
-              Aperçu
-            </Button>
-          </DialogTrigger>
-          <DialogContent className="flex h-[80vh] max-w-4xl flex-col p-0">
-            <DialogHeader className="px-6 pt-6">
-              <DialogTitle>Aperçu HTML</DialogTitle>
-            </DialogHeader>
+        <Button type="button" variant="outline" size="xs" onClick={() => { setPreviewSrcDoc(buildSrcDoc(contentRef.current)); setPreviewOpen(true); }}>
+          Aperçu
+        </Button>
+      </div>
+      {previewOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80">
+          <div className="flex h-[80%] w-[80%] flex-col overflow-hidden rounded-xl border bg-background shadow-lg">
+            <div className="flex items-center justify-between px-6 py-4">
+              <h3 className="text-sm font-medium">Aperçu HTML</h3>
+              <Button type="button" variant="ghost" size="xs" onClick={() => setPreviewOpen(false)}>
+                Fermer
+              </Button>
+            </div>
             <iframe
-              ref={previewCallbackRef}
+              srcDoc={previewSrcDoc}
               sandbox="allow-styles"
               title="Aperçu HTML"
-              className="min-h-0 flex-1 border-none"
+              className="flex-1 border-none"
             />
-          </DialogContent>
-        </Dialog>
-      </div>
+          </div>
+        </div>
+      )}
       <input type="hidden" name={name} ref={hiddenRef} />
     </div>
   );

--- a/components/admin/html-editor.tsx
+++ b/components/admin/html-editor.tsx
@@ -7,6 +7,7 @@ import { html } from "@codemirror/lang-html";
 import { css } from "@codemirror/lang-css";
 import { type ViewUpdate } from "@codemirror/view";
 import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
 import {
   Dialog,
   DialogContent,
@@ -29,11 +30,14 @@ export function HtmlEditor({ name, defaultValue, placeholder }: HtmlEditorProps)
   const hiddenRef = useRef<HTMLInputElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
   const contentRef = useRef(defaultValue ?? "");
-  const [previewOpen, setPreviewOpen] = useState(false);
+  const [initError, setInitError] = useState(false);
 
   const writeToIframe = useCallback((iframe: HTMLIFrameElement, content: string) => {
     const doc = iframe.contentDocument;
-    if (!doc) return;
+    if (!doc) {
+      console.warn("[html-editor] iframe.contentDocument is null — preview cannot render");
+      return;
+    }
     try {
       doc.open();
       doc.write(`<!DOCTYPE html>
@@ -46,6 +50,11 @@ export function HtmlEditor({ name, defaultValue, placeholder }: HtmlEditorProps)
       doc.close();
     } catch (err) {
       console.error("[html-editor] Preview update failed", err);
+      try {
+        doc.open();
+        doc.write("<p style='color:red;padding:16px'>Impossible d'afficher l'aperçu. Vérifiez votre code HTML.</p>");
+        doc.close();
+      } catch { /* already logged */ }
     }
   }, []);
 
@@ -96,6 +105,10 @@ export function HtmlEditor({ name, defaultValue, placeholder }: HtmlEditorProps)
       if (hiddenRef.current) hiddenRef.current.value = startDoc;
     } catch (err) {
       console.error("[html-editor] CodeMirror initialization failed", err);
+      queueMicrotask(() => {
+        setInitError(true);
+        toast.error("L'éditeur HTML n'a pas pu se charger. Rechargez la page. Ne sauvegardez pas le formulaire.", { duration: Infinity });
+      });
     }
 
     return () => {
@@ -107,11 +120,16 @@ export function HtmlEditor({ name, defaultValue, placeholder }: HtmlEditorProps)
 
   return (
     <div className="w-full space-y-2">
+      {initError && (
+        <div className="rounded-md border border-destructive bg-destructive/10 p-3 text-sm text-destructive">
+          L&apos;éditeur HTML n&apos;a pas pu se charger. Rechargez la page. Ne sauvegardez pas le formulaire.
+        </div>
+      )}
       <div className="html-editor-container">
         <div className="html-editor-code" ref={editorRef} />
       </div>
       <div className="flex justify-end">
-        <Dialog open={previewOpen} onOpenChange={setPreviewOpen}>
+        <Dialog>
           <DialogTrigger asChild>
             <Button type="button" variant="outline" size="xs">
               Aperçu

--- a/components/admin/rich-text-editor.tsx
+++ b/components/admin/rich-text-editor.tsx
@@ -121,7 +121,7 @@ export function RichTextEditor({
   if (!mounted) {
     return (
       <div className="rounded-md border">
-        <div className="min-h-[200px] p-3" />
+        <div className="min-h-[200px] max-h-[500px] p-3" />
         <input type="hidden" name={name} value={jsonValue} />
       </div>
     );
@@ -134,7 +134,7 @@ export function RichTextEditor({
         <div className="editor relative">
           <RichTextPlugin
             contentEditable={
-              <ContentEditable className="min-h-[200px] p-3 text-sm outline-none" />
+              <ContentEditable className="min-h-[200px] max-h-[500px] overflow-y-auto p-3 text-sm outline-none" />
             }
             placeholder={
               <div className="pointer-events-none absolute left-3 top-3 text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- Add min/max height (200px–500px) and scroll to HTML editor (CodeMirror) and rich-text editor (Lexical)
- Move HTML preview from inline side-by-side to a modal overlay (click "Aperçu" button)
- Use `srcDoc` on iframe for reliable rendering (no sandbox/timing issues)
- Auto-detect CSS scope class (e.g. `desc-xyz`) and wrap content in matching div, mirroring storefront rendering
- Add error handling for CodeMirror init failures (toast + inline banner)

## Test plan
- [x] `tsc --noEmit` passes
- [x] ESLint passes
- [x] All 631 tests pass
- [x] HTML editor renders with proper dimensions and scroll
- [x] Preview modal shows styled HTML with CSS correctly applied
- [x] Scoped CSS classes (e.g. `.desc-{productId}`) render correctly in preview
- [x] Preview works on re-open (no stale content)
- [x] Tested in incognito browser to confirm no cache issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Constrained HTML and rich-text editor heights (min 200px, max 500px) and enabled internal vertical scrolling; removed legacy inline preview pane layout.
* **New Features**
  * Added a dialog-driven HTML preview activated by a dedicated "Aperçu" button.
* **Bug Fixes**
  * Safer preview generation with srcDoc-driven iframes and explicit editor initialization error handling and messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->