### PR TITLE
fix(deploy): add R2 binding for OpenNext incremental cache

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -2,6 +2,7 @@ interface CloudflareEnv {
   DB: D1Database;
   KV: KVNamespace;
   R2: R2Bucket;
+  NEXT_INC_CACHE_R2_BUCKET: R2Bucket;
   ASSETS: Fetcher;
 
   // Auth (Better Auth)

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -29,6 +29,10 @@
     {
       "binding": "R2",
       "bucket_name": "netereka"
+    },
+    {
+      "binding": "NEXT_INC_CACHE_R2_BUCKET",
+      "bucket_name": "netereka-opennext-cache"
     }
   ],
 }


### PR DESCRIPTION
## Summary
- The `@opennextjs/cloudflare` upgrade (from #138) introduced a `populate-cache` deploy step requiring a `NEXT_INC_CACHE_R2_BUCKET` R2 binding
- Add the binding to `wrangler.jsonc` and `env.d.ts`
- Created the `netereka-opennext-cache` R2 bucket on Cloudflare

## Root cause
Deploy failed with: `Error: No R2 binding "NEXT_INC_CACHE_R2_BUCKET" found!` because `open-next.config.ts` uses `r2IncrementalCache` but the corresponding R2 bucket binding was missing from `wrangler.jsonc`.

## Test plan
- [x] `tsc --noEmit` passes
- [x] ESLint passes
- [x] All 631 tests pass
- [x] R2 bucket `netereka-opennext-cache` created on Cloudflare
- [ ] Verify deploy succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated caching infrastructure configuration to support enhanced storage capabilities for improved application performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->