### PR TITLE
feat: add store location map icon in header

### DIFF
--- a/components/storefront/header.tsx
+++ b/components/storefront/header.tsx
@@ -1,9 +1,14 @@
 import Link from "next/link";
 import Image from "next/image";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { StoreLocation01Icon } from "@hugeicons/core-free-icons";
 import { SITE_NAME } from "@/lib/utils/constants";
 import { HeaderAuth } from "@/components/storefront/header-auth";
 import { CartIcon } from "@/components/storefront/cart-icon";
 import { SearchAutocomplete } from "@/components/storefront/search-autocomplete";
+
+const STORE_GOOGLE_MAPS_URL =
+  "https://www.google.com/maps/place/NETEREKA/@5.2978885,-4.0074605,17z/data=!3m1!4b1!4m6!3m5!1s0xfc1ebc83e7573ef:0xc3d7dca5655f6b48!8m2!3d5.2978885!4d-4.0074605!16s%2Fg%2F11sv0z2l3v";
 
 export function Header() {
   return (
@@ -21,6 +26,15 @@ export function Header() {
         </Link>
         <nav className="flex items-center gap-1">
           <SearchAutocomplete />
+          <a
+            href={STORE_GOOGLE_MAPS_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex h-10 w-10 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            aria-label="Notre boutique — voir sur Google Maps"
+          >
+            <HugeiconsIcon icon={StoreLocation01Icon} size={20} />
+          </a>
           <CartIcon />
           <HeaderAuth />
         </nav>


### PR DESCRIPTION
## Summary
- Adds a **StoreLocation** icon (from HugeIcons) in the storefront header between the search bar and cart icon
- Clicking the icon opens the NETEREKA physical store location on Google Maps in a new tab
- Styled consistently with existing header icon buttons (same size, hover states, rounded)

## Test plan
- [ ] Verify the map icon appears in the header on desktop and mobile
- [ ] Click the icon and confirm it opens Google Maps to the correct NETEREKA location
- [ ] Verify the link opens in a new tab (`target="_blank"`)
- [ ] Check accessibility: icon has proper `aria-label`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a store location link in the header that opens Google Maps in a new tab for convenient access to store information.
  * Enhanced accessibility with improved labeling for the new location feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->