### PR TITLE
refactor: use Dialog instead of Sheet for store form

### DIFF
--- a/app/(admin)/stores/store-form-dialog.tsx
+++ b/app/(admin)/stores/store-form-dialog.tsx
@@ -52,7 +52,7 @@ export function StoreFormDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+      <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>
             {isEditing ? "Modifier la boutique" : "Nouvelle boutique"}

--- a/app/(admin)/stores/store-form-dialog.tsx
+++ b/app/(admin)/stores/store-form-dialog.tsx
@@ -6,26 +6,27 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { createStore, updateStore } from "@/actions/admin/stores";
 import type { Store } from "@/lib/db/types";
 
-interface StoreFormSheetProps {
+interface StoreFormDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   store: Store | null;
 }
 
-export function StoreFormSheet({
+export function StoreFormDialog({
   open,
   onOpenChange,
   store,
-}: StoreFormSheetProps) {
+}: StoreFormDialogProps) {
   const isEditing = store !== null;
   const [isPending, startTransition] = useTransition();
 
@@ -50,20 +51,20 @@ export function StoreFormSheet({
   }
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent className="overflow-y-auto">
-        <SheetHeader>
-          <SheetTitle>
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
             {isEditing ? "Modifier la boutique" : "Nouvelle boutique"}
-          </SheetTitle>
-          <SheetDescription>
+          </DialogTitle>
+          <DialogDescription>
             {isEditing
               ? "Modifiez les informations de la boutique."
               : "Ajoutez une nouvelle boutique physique."}
-          </SheetDescription>
-        </SheetHeader>
+          </DialogDescription>
+        </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
             <Label htmlFor="name">Nom *</Label>
             <Input
@@ -142,7 +143,7 @@ export function StoreFormSheet({
             </div>
           )}
 
-          <div className="flex justify-end gap-2 pt-4">
+          <DialogFooter>
             <Button
               type="button"
               variant="outline"
@@ -157,9 +158,9 @@ export function StoreFormSheet({
                   ? "Mettre à jour"
                   : "Créer"}
             </Button>
-          </div>
+          </DialogFooter>
         </form>
-      </SheetContent>
-    </Sheet>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/app/(admin)/stores/stores-page-client.tsx
+++ b/app/(admin)/stores/stores-page-client.tsx
@@ -35,18 +35,18 @@ import type { Store } from "@/lib/db/types";
 
 export function StoresPageClient({ stores }: { stores: Store[] }) {
   const [editingStore, setEditingStore] = useState<Store | null>(null);
-  const [sheetOpen, setSheetOpen] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
   function handleCreate() {
     setEditingStore(null);
-    setSheetOpen(true);
+    setDialogOpen(true);
   }
 
   function handleEdit(store: Store) {
     setEditingStore(store);
-    setSheetOpen(true);
+    setDialogOpen(true);
   }
 
   function handleToggle(id: string) {
@@ -212,8 +212,8 @@ export function StoresPageClient({ stores }: { stores: Store[] }) {
 
       {/* Dialog for create/edit */}
       <StoreFormDialog
-        open={sheetOpen}
-        onOpenChange={setSheetOpen}
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
         store={editingStore}
       />
 

--- a/app/(admin)/stores/stores-page-client.tsx
+++ b/app/(admin)/stores/stores-page-client.tsx
@@ -30,7 +30,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { toggleStoreActive, deleteStore } from "@/actions/admin/stores";
-import { StoreFormSheet } from "./store-form-sheet";
+import { StoreFormDialog } from "./store-form-dialog";
 import type { Store } from "@/lib/db/types";
 
 export function StoresPageClient({ stores }: { stores: Store[] }) {
@@ -210,8 +210,8 @@ export function StoresPageClient({ stores }: { stores: Store[] }) {
         ))}
       </div>
 
-      {/* Sheet for create/edit */}
-      <StoreFormSheet
+      {/* Dialog for create/edit */}
+      <StoreFormDialog
         open={sheetOpen}
         onOpenChange={setSheetOpen}
         store={editingStore}


### PR DESCRIPTION
## Summary
- Remplace le **Sheet** (panneau latéral) par un **Dialog** (modale centrée) pour le formulaire de création/édition de boutique
- Renomme `store-form-sheet.tsx` → `store-form-dialog.tsx` et le composant `StoreFormSheet` → `StoreFormDialog`
- Utilise `DialogFooter` pour les boutons d'action
- Ajoute `max-h-[85vh] overflow-y-auto` pour gérer le scroll sur petits écrans

## Test plan
- [ ] Cliquer "Ajouter une boutique" → Dialog s'ouvre au centre
- [ ] Remplir et soumettre → boutique créée, dialog se ferme
- [ ] Cliquer modifier sur une boutique → Dialog avec valeurs pré-remplies
- [ ] Vérifier le scroll sur mobile (7 champs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Store creation and editing forms now appear as modal dialogs instead of slide-out sheets, offering a more focused, organized interface and improved sizing/scroll behavior.
* **Refactor**
  * Internal form component and its props were updated to align with the dialog-based UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->