### PR TITLE
feat(whatsapp): allow configuring public number without full API setup

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -52,7 +52,11 @@
       "Bash(git status:*)",
       "Bash(echo \"exit: $?\")",
       "Bash(.husky/pre-commit)",
-      "Skill(pr-review-toolkit:review-pr)"
+      "Skill(pr-review-toolkit:review-pr)",
+      "Bash(wait %1)",
+      "Read(//tmp/**)",
+      "Bash(gh issue create --title 'docs: fix markdownlint and typography issues in plan files' --body ':*)",
+      "Bash(python3 -c ':*)"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/actions/admin/whatsapp.ts
+++ b/actions/admin/whatsapp.ts
@@ -125,38 +125,6 @@ export async function saveWhatsAppConfig(
   const admin_phones_raw = String(formData.get("admin_phones") ?? "").trim();
   const is_active = formData.get("is_active") === "1" ? 1 : 0;
 
-  // Read existing row once — used for mask detection and effective-value validation.
-  const dbForValidation = await getDB();
-  const existingRow = await dbForValidation
-    .prepare("SELECT access_token, webhook_secret FROM whatsapp_config WHERE id = 1")
-    .first<{ access_token: string | null; webhook_secret: string | null }>();
-
-  // Detect masked values by exact equality with the mask we would have sent to the client.
-  // This avoids false positives if a real secret happens to start with bullet characters.
-  const expectedMaskedAccessToken = existingRow?.access_token ? maskSecret(existingRow.access_token) : null;
-  const expectedMaskedWebhookSecret = existingRow?.webhook_secret ? maskSecret(existingRow.webhook_secret) : null;
-  const accessTokenMasked = expectedMaskedAccessToken !== null && access_token_raw === expectedMaskedAccessToken;
-  const webhookSecretMasked = expectedMaskedWebhookSecret !== null && webhook_secret_raw === expectedMaskedWebhookSecret;
-
-  // Final values (null if empty, undefined if masked to preserve existing)
-  const access_token = accessTokenMasked ? undefined : (access_token_raw || null);
-  const verify_token = verify_token_raw || null;
-  const webhook_secret = webhookSecretMasked ? undefined : (webhook_secret_raw || null);
-
-  // If bot is being activated, require full API credentials (check effective values against DB).
-  if (is_active === 1) {
-    const effectiveAccessToken = accessTokenMasked ? existingRow?.access_token ?? null : access_token;
-    const effectiveWebhookSecret = webhookSecretMasked ? existingRow?.webhook_secret ?? null : webhook_secret;
-
-    if (!phone_number_id || !effectiveAccessToken || !verify_token || !effectiveWebhookSecret) {
-      return {
-        success: false,
-        error:
-          "Pour activer le bot, renseignez phone_number_id, access_token, verify_token et webhook_secret.",
-      };
-    }
-  }
-
   // Validate admin_phones is a valid JSON array (if provided)
   let admin_phones = "[]";
   if (admin_phones_raw) {
@@ -181,10 +149,38 @@ export async function saveWhatsAppConfig(
     const db = await getDB();
     const now = new Date().toISOString().replace("T", " ").slice(0, 19);
 
-    // Check if config row exists
-    const existing = await db
-      .prepare("SELECT id FROM whatsapp_config WHERE id = 1")
-      .first<{ id: number }>();
+    // Read existing row once — used for mask detection, validation, and existence check.
+    const existingRow = await db
+      .prepare("SELECT id, access_token, webhook_secret FROM whatsapp_config WHERE id = 1")
+      .first<{ id: number; access_token: string | null; webhook_secret: string | null }>();
+
+    // Detect masked values by exact equality with the mask we would have sent to the client.
+    // Avoids false positives if a real secret happens to start with bullet characters.
+    const expectedMaskedAccessToken = existingRow?.access_token ? maskSecret(existingRow.access_token) : null;
+    const expectedMaskedWebhookSecret = existingRow?.webhook_secret ? maskSecret(existingRow.webhook_secret) : null;
+    const accessTokenMasked = expectedMaskedAccessToken !== null && access_token_raw === expectedMaskedAccessToken;
+    const webhookSecretMasked = expectedMaskedWebhookSecret !== null && webhook_secret_raw === expectedMaskedWebhookSecret;
+
+    // Final values (null if empty, undefined if masked to preserve existing)
+    const access_token = accessTokenMasked ? undefined : (access_token_raw || null);
+    const verify_token = verify_token_raw || null;
+    const webhook_secret = webhookSecretMasked ? undefined : (webhook_secret_raw || null);
+
+    // If bot is being activated, require full API credentials (check effective values against DB).
+    if (is_active === 1) {
+      const effectiveAccessToken = accessTokenMasked ? existingRow?.access_token ?? null : access_token;
+      const effectiveWebhookSecret = webhookSecretMasked ? existingRow?.webhook_secret ?? null : webhook_secret;
+
+      if (!phone_number_id || !effectiveAccessToken || !verify_token || !effectiveWebhookSecret || !business_account_id) {
+        return {
+          success: false,
+          error:
+            "Pour activer le bot, renseignez phone_number_id, access_token, verify_token, webhook_secret et business_account_id.",
+        };
+      }
+    }
+
+    const existing = existingRow ? { id: existingRow.id } : null;
 
     if (existing) {
       // For masked secrets (access_token/webhook_secret = undefined), preserve existing DB values

--- a/actions/admin/whatsapp.ts
+++ b/actions/admin/whatsapp.ts
@@ -11,12 +11,12 @@ import type { ActionResult } from "@/lib/utils";
 
 export interface WhatsAppConfig {
   id: number;
-  phone_number_id: string;
+  phone_number_id: string | null;
   display_phone_number: string | null;
-  access_token: string;
-  verify_token: string;
-  webhook_secret: string;
-  business_account_id: string;
+  access_token: string | null;
+  verify_token: string | null;
+  webhook_secret: string | null;
+  business_account_id: string | null;
   admin_phones: string; // JSON array string
   is_active: number;
   created_at: string;
@@ -87,8 +87,8 @@ export async function getWhatsAppConfig(): Promise<WhatsAppConfig | null> {
     // Mask sensitive fields — secrets are write-only
     return {
       ...row,
-      access_token: maskSecret(row.access_token),
-      webhook_secret: maskSecret(row.webhook_secret),
+      access_token: row.access_token ? maskSecret(row.access_token) : null,
+      webhook_secret: row.webhook_secret ? maskSecret(row.webhook_secret) : null,
     };
   } catch (error) {
     console.error("[admin/whatsapp] getWhatsAppConfig error:", error);
@@ -101,7 +101,9 @@ export async function saveWhatsAppConfig(
 ): Promise<ActionResult> {
   await requireAdmin();
 
-  const phone_number_id = String(formData.get("phone_number_id") ?? "").trim();
+  const phone_number_id_raw = String(formData.get("phone_number_id") ?? "").trim();
+  const phone_number_id = phone_number_id_raw || null;
+
   const display_phone_number_raw = String(formData.get("display_phone_number") ?? "").trim();
   // Normalize: keep digits only (strips +, spaces, dashes, dots)
   const display_phone_number_normalized = display_phone_number_raw.replace(/\D/g, "");
@@ -114,33 +116,39 @@ export async function saveWhatsAppConfig(
       error: "Le numéro public doit contenir entre 8 et 15 chiffres (format international, ex: 2250700000001).",
     };
   }
-  const access_token = String(formData.get("access_token") ?? "").trim();
-  const verify_token = String(formData.get("verify_token") ?? "").trim();
-  const webhook_secret = String(formData.get("webhook_secret") ?? "").trim();
-  const business_account_id = String(
-    formData.get("business_account_id") ?? ""
-  ).trim();
+
+  const access_token_raw = String(formData.get("access_token") ?? "").trim();
+  const verify_token_raw = String(formData.get("verify_token") ?? "").trim();
+  const webhook_secret_raw = String(formData.get("webhook_secret") ?? "").trim();
+  const business_account_id_raw = String(formData.get("business_account_id") ?? "").trim();
+  const business_account_id = business_account_id_raw || null;
   const admin_phones_raw = String(formData.get("admin_phones") ?? "").trim();
   const is_active = formData.get("is_active") === "1" ? 1 : 0;
 
   // Check if secrets are masked (user didn't change them)
   const isMasked = (val: string) => val.startsWith("••");
-  const accessTokenMasked = isMasked(access_token);
-  const webhookSecretMasked = isMasked(webhook_secret);
+  const accessTokenMasked = isMasked(access_token_raw);
+  const webhookSecretMasked = isMasked(webhook_secret_raw);
 
-  // Validate required fields (masked values are OK for updates)
-  if (
-    !phone_number_id ||
-    (!access_token && !accessTokenMasked) ||
-    !verify_token ||
-    (!webhook_secret && !webhookSecretMasked) ||
-    !business_account_id
-  ) {
-    return {
-      success: false,
-      error:
-        "Les champs phone_number_id, access_token, verify_token, webhook_secret et business_account_id sont obligatoires.",
-    };
+  // Final values (null if empty, undefined if masked to preserve existing)
+  const access_token = accessTokenMasked ? undefined : (access_token_raw || null);
+  const verify_token = verify_token_raw || null;
+  const webhook_secret = webhookSecretMasked ? undefined : (webhook_secret_raw || null);
+
+  // If bot is being activated, require full API credentials
+  if (is_active === 1) {
+    const hasPhoneId = !!phone_number_id;
+    const hasAccessToken = accessTokenMasked || !!access_token;
+    const hasVerifyToken = !!verify_token;
+    const hasWebhookSecret = webhookSecretMasked || !!webhook_secret;
+
+    if (!hasPhoneId || !hasAccessToken || !hasVerifyToken || !hasWebhookSecret) {
+      return {
+        success: false,
+        error:
+          "Pour activer le bot, renseignez phone_number_id, access_token, verify_token et webhook_secret.",
+      };
+    }
   }
 
   // Validate admin_phones is a valid JSON array (if provided)
@@ -173,13 +181,13 @@ export async function saveWhatsAppConfig(
       .first<{ id: number }>();
 
     if (existing) {
-      // For masked secrets, preserve existing DB values
+      // For masked secrets (access_token/webhook_secret = undefined), preserve existing DB values
       const setClauses = [
         "phone_number_id = ?",
         "display_phone_number = ?",
-        accessTokenMasked ? "" : "access_token = ?",
+        access_token !== undefined ? "access_token = ?" : "",
         "verify_token = ?",
-        webhookSecretMasked ? "" : "webhook_secret = ?",
+        webhook_secret !== undefined ? "webhook_secret = ?" : "",
         "business_account_id = ?",
         "admin_phones = ?",
         "is_active = ?",
@@ -187,9 +195,9 @@ export async function saveWhatsAppConfig(
       ].filter(Boolean).join(", ");
 
       const bindings: unknown[] = [phone_number_id, display_phone_number];
-      if (!accessTokenMasked) bindings.push(access_token);
+      if (access_token !== undefined) bindings.push(access_token);
       bindings.push(verify_token);
-      if (!webhookSecretMasked) bindings.push(webhook_secret);
+      if (webhook_secret !== undefined) bindings.push(webhook_secret);
       bindings.push(business_account_id, admin_phones, is_active, now);
 
       await db
@@ -207,9 +215,9 @@ export async function saveWhatsAppConfig(
         .bind(
           phone_number_id,
           display_phone_number,
-          access_token,
+          access_token ?? null,
           verify_token,
-          webhook_secret,
+          webhook_secret ?? null,
           business_account_id,
           admin_phones,
           is_active,

--- a/actions/admin/whatsapp.ts
+++ b/actions/admin/whatsapp.ts
@@ -125,31 +125,28 @@ export async function saveWhatsAppConfig(
   const admin_phones_raw = String(formData.get("admin_phones") ?? "").trim();
   const is_active = formData.get("is_active") === "1" ? 1 : 0;
 
-  // Check if secrets are masked (user didn't change them)
-  const isMasked = (val: string) => val.startsWith("••");
-  const accessTokenMasked = isMasked(access_token_raw);
-  const webhookSecretMasked = isMasked(webhook_secret_raw);
+  // Read existing row once — used for mask detection and effective-value validation.
+  const dbForValidation = await getDB();
+  const existingRow = await dbForValidation
+    .prepare("SELECT access_token, webhook_secret FROM whatsapp_config WHERE id = 1")
+    .first<{ access_token: string | null; webhook_secret: string | null }>();
+
+  // Detect masked values by exact equality with the mask we would have sent to the client.
+  // This avoids false positives if a real secret happens to start with bullet characters.
+  const expectedMaskedAccessToken = existingRow?.access_token ? maskSecret(existingRow.access_token) : null;
+  const expectedMaskedWebhookSecret = existingRow?.webhook_secret ? maskSecret(existingRow.webhook_secret) : null;
+  const accessTokenMasked = expectedMaskedAccessToken !== null && access_token_raw === expectedMaskedAccessToken;
+  const webhookSecretMasked = expectedMaskedWebhookSecret !== null && webhook_secret_raw === expectedMaskedWebhookSecret;
 
   // Final values (null if empty, undefined if masked to preserve existing)
   const access_token = accessTokenMasked ? undefined : (access_token_raw || null);
   const verify_token = verify_token_raw || null;
   const webhook_secret = webhookSecretMasked ? undefined : (webhook_secret_raw || null);
 
-  // If bot is being activated, require full API credentials.
-  // For masked values we must check the *effective* value (incoming OR existing DB value),
-  // since a masked prefix doesn't guarantee the DB actually has a valid value.
+  // If bot is being activated, require full API credentials (check effective values against DB).
   if (is_active === 1) {
-    const dbInternal = await getDB();
-    const existingForValidation = await dbInternal
-      .prepare("SELECT access_token, webhook_secret FROM whatsapp_config WHERE id = 1")
-      .first<{ access_token: string | null; webhook_secret: string | null }>();
-
-    const effectiveAccessToken = accessTokenMasked
-      ? existingForValidation?.access_token ?? null
-      : access_token;
-    const effectiveWebhookSecret = webhookSecretMasked
-      ? existingForValidation?.webhook_secret ?? null
-      : webhook_secret;
+    const effectiveAccessToken = accessTokenMasked ? existingRow?.access_token ?? null : access_token;
+    const effectiveWebhookSecret = webhookSecretMasked ? existingRow?.webhook_secret ?? null : webhook_secret;
 
     if (!phone_number_id || !effectiveAccessToken || !verify_token || !effectiveWebhookSecret) {
       return {
@@ -209,10 +206,29 @@ export async function saveWhatsAppConfig(
       if (webhook_secret !== undefined) bindings.push(webhook_secret);
       bindings.push(business_account_id, admin_phones, is_active, now);
 
-      await db
-        .prepare(`UPDATE whatsapp_config SET ${setClauses} WHERE id = 1`)
+      // Atomic guard: when activating the bot, require existing creds to still be non-null
+      // at write time. Prevents a race where another admin nulls a cred between our SELECT
+      // and our UPDATE. The WHERE clauses only apply to masked fields (for unmasked values
+      // we're writing a new value directly, so the constraint is already satisfied).
+      const whereExtras: string[] = [];
+      if (is_active === 1) {
+        if (accessTokenMasked) whereExtras.push("access_token IS NOT NULL");
+        if (webhookSecretMasked) whereExtras.push("webhook_secret IS NOT NULL");
+      }
+      const whereClause = ["id = 1", ...whereExtras].join(" AND ");
+
+      const result = await db
+        .prepare(`UPDATE whatsapp_config SET ${setClauses} WHERE ${whereClause}`)
         .bind(...bindings)
         .run();
+
+      if (is_active === 1 && result.meta.changes === 0) {
+        return {
+          success: false,
+          error:
+            "Impossible d'activer le bot : les identifiants API ont été modifiés entre-temps. Rechargez la page et réessayez.",
+        };
+      }
     } else {
       await db
         .prepare(

--- a/actions/admin/whatsapp.ts
+++ b/actions/admin/whatsapp.ts
@@ -135,14 +135,23 @@ export async function saveWhatsAppConfig(
   const verify_token = verify_token_raw || null;
   const webhook_secret = webhookSecretMasked ? undefined : (webhook_secret_raw || null);
 
-  // If bot is being activated, require full API credentials
+  // If bot is being activated, require full API credentials.
+  // For masked values we must check the *effective* value (incoming OR existing DB value),
+  // since a masked prefix doesn't guarantee the DB actually has a valid value.
   if (is_active === 1) {
-    const hasPhoneId = !!phone_number_id;
-    const hasAccessToken = accessTokenMasked || !!access_token;
-    const hasVerifyToken = !!verify_token;
-    const hasWebhookSecret = webhookSecretMasked || !!webhook_secret;
+    const dbInternal = await getDB();
+    const existingForValidation = await dbInternal
+      .prepare("SELECT access_token, webhook_secret FROM whatsapp_config WHERE id = 1")
+      .first<{ access_token: string | null; webhook_secret: string | null }>();
 
-    if (!hasPhoneId || !hasAccessToken || !hasVerifyToken || !hasWebhookSecret) {
+    const effectiveAccessToken = accessTokenMasked
+      ? existingForValidation?.access_token ?? null
+      : access_token;
+    const effectiveWebhookSecret = webhookSecretMasked
+      ? existingForValidation?.webhook_secret ?? null
+      : webhook_secret;
+
+    if (!phone_number_id || !effectiveAccessToken || !verify_token || !effectiveWebhookSecret) {
       return {
         success: false,
         error:
@@ -428,12 +437,13 @@ export async function sendAdminMessage(
       .prepare(
         "SELECT phone_number_id, access_token FROM whatsapp_config WHERE id = 1"
       )
-      .first<{ phone_number_id: string; access_token: string }>();
+      .first<{ phone_number_id: string | null; access_token: string | null }>();
 
-    if (!config) {
+    if (!config || !config.phone_number_id || !config.access_token) {
       return {
         success: false,
-        error: "Configuration WhatsApp introuvable.",
+        error:
+          "L'intégration API WhatsApp n'est pas configurée. Renseignez phone_number_id et access_token dans la configuration.",
       };
     }
 

--- a/components/admin/whatsapp/whatsapp-config-form.tsx
+++ b/components/admin/whatsapp/whatsapp-config-form.tsx
@@ -38,28 +38,18 @@ export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
   return (
     <form action={handleSubmit}>
       <div className="space-y-6">
-        {/* API Credentials */}
+        {/* Public display — minimal config for storefront buttons */}
         <Card>
           <CardHeader>
-            <CardTitle>Identifiants API</CardTitle>
+            <CardTitle>Affichage public</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Numéro WhatsApp affiché aux clients via les boutons &ldquo;Commander sur WhatsApp&rdquo; du storefront.
+              Ce champ seul suffit pour activer les boutons (sans bot).
+            </p>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="phone_number_id">Phone Number ID</Label>
-              <Input
-                id="phone_number_id"
-                name="phone_number_id"
-                required
-                defaultValue={config?.phone_number_id ?? ""}
-                placeholder="Ex: 123456789012345"
-              />
-              <p className="text-xs text-muted-foreground">
-                ID opaque fourni par Meta (pas le numéro visible). Utilisé pour les appels API.
-              </p>
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="display_phone_number">Numéro public (affiché aux clients)</Label>
+              <Label htmlFor="display_phone_number">Numéro public</Label>
               <Input
                 id="display_phone_number"
                 name="display_phone_number"
@@ -67,8 +57,32 @@ export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
                 placeholder="Ex: 2250700000001"
               />
               <p className="text-xs text-muted-foreground">
-                Numéro WhatsApp Business au format international sans « + » (ex: 2250700000001).
-                Utilisé pour les liens wa.me sur les boutons de la boutique.
+                Format international sans « + », entre 8 et 15 chiffres. Utilisé pour les liens wa.me.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* API credentials — required for bot + webhooks */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Intégration API (Bot conversationnel)</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Ces champs sont requis uniquement si vous activez le bot WhatsApp conversationnel.
+              Obtenus depuis Meta Business Suite → WhatsApp → API Setup.
+            </p>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="phone_number_id">Phone Number ID</Label>
+              <Input
+                id="phone_number_id"
+                name="phone_number_id"
+                defaultValue={config?.phone_number_id ?? ""}
+                placeholder="Ex: 123456789012345"
+              />
+              <p className="text-xs text-muted-foreground">
+                ID opaque fourni par Meta (différent du numéro public).
               </p>
             </div>
 
@@ -89,7 +103,6 @@ export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
                   id="access_token"
                   name="access_token"
                   type={showAccessToken ? "text" : "password"}
-                  required
                   defaultValue={config?.access_token ?? ""}
                   placeholder="EAAxxxxxxxx..."
                   className="flex-1"
@@ -105,21 +118,12 @@ export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
                 </Button>
               </div>
             </div>
-          </CardContent>
-        </Card>
 
-        {/* Webhook */}
-        <Card>
-          <CardHeader>
-            <CardTitle>Webhook</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="verify_token">Verify Token</Label>
+              <Label htmlFor="verify_token">Verify Token (webhook)</Label>
               <Input
                 id="verify_token"
                 name="verify_token"
-                required
                 defaultValue={config?.verify_token ?? ""}
                 placeholder="Token de vérification du webhook"
               />
@@ -132,7 +136,6 @@ export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
                   id="webhook_secret"
                   name="webhook_secret"
                   type={showWebhookSecret ? "text" : "password"}
-                  required
                   defaultValue={config?.webhook_secret ?? ""}
                   placeholder="Secret HMAC pour valider les webhooks"
                   className="flex-1"
@@ -167,24 +170,24 @@ export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
                 placeholder='["2250700000001", "2250700000002"]'
               />
               <p className="text-muted-foreground text-xs">
-                Tableau JSON des numéros WhatsApp des administrateurs (avec indicatif pays, sans
-                le &quot;+&quot;). Ex&nbsp;: <code>[&quot;2250700000001&quot;]</code>
+                Tableau JSON des numéros WhatsApp qui recevront les alertes d&apos;escalade
+                (avec indicatif pays, sans « + »). Ex&nbsp;: <code>[&quot;2250700000001&quot;]</code>
               </p>
             </div>
           </CardContent>
         </Card>
 
-        {/* Publication */}
+        {/* Activation */}
         <Card>
           <CardHeader>
-            <CardTitle>Activation</CardTitle>
+            <CardTitle>Activation du bot</CardTitle>
           </CardHeader>
           <CardContent>
             <div className="flex items-center justify-between">
               <div>
-                <Label>Intégration active</Label>
+                <Label>Bot WhatsApp actif</Label>
                 <p className="text-muted-foreground text-sm">
-                  Active ou désactive l&apos;intégration WhatsApp sur la plateforme.
+                  Active le bot conversationnel (nécessite l&apos;intégration API complète).
                 </p>
               </div>
               <input

--- a/drizzle/0009_fast_karnak.sql
+++ b/drizzle/0009_fast_karnak.sql
@@ -1,0 +1,19 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_whatsapp_config` (
+	`id` integer PRIMARY KEY NOT NULL,
+	`phone_number_id` text,
+	`display_phone_number` text,
+	`access_token` text,
+	`verify_token` text,
+	`webhook_secret` text,
+	`business_account_id` text,
+	`admin_phones` text DEFAULT '[]' NOT NULL,
+	`is_active` integer DEFAULT 0 NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	`updated_at` text DEFAULT (datetime('now')) NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `__new_whatsapp_config`("id", "phone_number_id", "display_phone_number", "access_token", "verify_token", "webhook_secret", "business_account_id", "admin_phones", "is_active", "created_at", "updated_at") SELECT "id", "phone_number_id", "display_phone_number", "access_token", "verify_token", "webhook_secret", "business_account_id", "admin_phones", "is_active", "created_at", "updated_at" FROM `whatsapp_config`;--> statement-breakpoint
+DROP TABLE `whatsapp_config`;--> statement-breakpoint
+ALTER TABLE `__new_whatsapp_config` RENAME TO `whatsapp_config`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,2929 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ebbe5154-a5f4-452a-bc1f-450c48842165",
+  "prevId": "f3efb520-1cd6-43a2-a0c8-b4f9a095d995",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_account_userId": {
+          "name": "idx_account_userId",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "idx_account_provider": {
+          "name": "idx_account_provider",
+          "columns": [
+            "providerId",
+            "accountId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "addresses": {
+      "name": "addresses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Domicile'"
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "street": {
+          "name": "street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commune": {
+          "name": "commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Abidjan'"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_addresses_user": {
+          "name": "idx_addresses_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "addresses_user_id_user_id_fk": {
+          "name": "addresses_user_id_user_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "addresses_zone_id_delivery_zones_id_fk": {
+          "name": "addresses_zone_id_delivery_zones_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "delivery_zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_audit_log_actor": {
+          "name": "idx_audit_log_actor",
+          "columns": [
+            "actor_id"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_log_action": {
+          "name": "idx_audit_log_action",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_log_created": {
+          "name": "idx_audit_log_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "banner_gradients": {
+      "name": "banner_gradients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_from": {
+          "name": "color_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_to": {
+          "name": "color_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "banners": {
+      "name": "banners",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "badge_text": {
+          "name": "badge_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "badge_color": {
+          "name": "badge_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'mint'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cta_text": {
+          "name": "cta_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Découvrir'"
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bg_gradient_from": {
+          "name": "bg_gradient_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#183C78'"
+        },
+        "bg_gradient_to": {
+          "name": "bg_gradient_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#1E4A8F'"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_banners_active_order": {
+          "name": "idx_banners_active_order",
+          "columns": [
+            "is_active",
+            "display_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "idx_categories_slug": {
+          "name": "idx_categories_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "idx_categories_parent": {
+          "name": "idx_categories_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "categories_parent_id_categories_id_fk": {
+          "name": "categories_parent_id_categories_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "delivery_zones": {
+      "name": "delivery_zones",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commune": {
+          "name": "commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fee": {
+          "name": "fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimated_hours": {
+          "name": "estimated_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 24
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "order_items": {
+      "name": "order_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_name": {
+          "name": "variant_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_order_items_order": {
+          "name": "idx_order_items_order",
+          "columns": [
+            "order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "order_items_order_id_orders_id_fk": {
+          "name": "order_items_order_id_orders_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_items_product_id_products_id_fk": {
+          "name": "order_items_product_id_products_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_items_variant_id_product_variants_id_fk": {
+          "name": "order_items_variant_id_product_variants_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "order_status_history": {
+      "name": "order_status_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_order_status_history_order": {
+          "name": "idx_order_status_history_order",
+          "columns": [
+            "order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "order_status_history_order_id_orders_id_fk": {
+          "name": "order_status_history_order_id_orders_id_fk",
+          "tableFrom": "order_status_history",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "orders": {
+      "name": "orders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_number": {
+          "name": "order_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_fee": {
+          "name": "delivery_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "promo_code_id": {
+          "name": "promo_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'web'"
+        },
+        "delivery_address": {
+          "name": "delivery_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_commune": {
+          "name": "delivery_commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_phone": {
+          "name": "delivery_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_instructions": {
+          "name": "delivery_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "estimated_delivery": {
+          "name": "estimated_delivery",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "internal_notes": {
+          "name": "internal_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivery_person_id": {
+          "name": "delivery_person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivery_person_name": {
+          "name": "delivery_person_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preparing_at": {
+          "name": "preparing_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_at": {
+          "name": "shipping_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "returned_at": {
+          "name": "returned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "return_reason": {
+          "name": "return_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "orders_order_number_unique": {
+          "name": "orders_order_number_unique",
+          "columns": [
+            "order_number"
+          ],
+          "isUnique": true
+        },
+        "idx_orders_user": {
+          "name": "idx_orders_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_orders_status": {
+          "name": "idx_orders_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_orders_number": {
+          "name": "idx_orders_number",
+          "columns": [
+            "order_number"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "orders_user_id_user_id_fk": {
+          "name": "orders_user_id_user_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "orders_promo_code_id_promo_codes_id_fk": {
+          "name": "orders_promo_code_id_promo_codes_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "promo_codes",
+          "columnsFrom": [
+            "promo_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product_attributes": {
+      "name": "product_attributes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_product_attributes_product": {
+          "name": "idx_product_attributes_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "product_attributes_product_id_products_id_fk": {
+          "name": "product_attributes_product_id_products_id_fk",
+          "tableFrom": "product_attributes",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product_images": {
+      "name": "product_images",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_product_images_product": {
+          "name": "idx_product_images_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "product_images_product_id_products_id_fk": {
+          "name": "product_images_product_id_products_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_images_variant_id_product_variants_id_fk": {
+          "name": "product_images_variant_id_product_variants_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product_variants": {
+      "name": "product_variants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compare_price": {
+          "name": "compare_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "product_variants_sku_unique": {
+          "name": "product_variants_sku_unique",
+          "columns": [
+            "sku"
+          ],
+          "isUnique": true
+        },
+        "idx_product_variants_product": {
+          "name": "idx_product_variants_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "product_variants_product_id_products_id_fk": {
+          "name": "product_variants_product_id_products_id_fk",
+          "tableFrom": "product_variants",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "products": {
+      "name": "products",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description_type": {
+          "name": "description_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'richtext'"
+        },
+        "short_description": {
+          "name": "short_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_price": {
+          "name": "base_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compare_price": {
+          "name": "compare_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "low_stock_threshold": {
+          "name": "low_stock_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        },
+        "weight_grams": {
+          "name": "weight_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta_title": {
+          "name": "meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "products_slug_unique": {
+          "name": "products_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "products_sku_unique": {
+          "name": "products_sku_unique",
+          "columns": [
+            "sku"
+          ],
+          "isUnique": true
+        },
+        "idx_products_slug": {
+          "name": "idx_products_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "idx_products_category": {
+          "name": "idx_products_category",
+          "columns": [
+            "category_id"
+          ],
+          "isUnique": false
+        },
+        "idx_products_active": {
+          "name": "idx_products_active",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        },
+        "idx_products_featured": {
+          "name": "idx_products_featured",
+          "columns": [
+            "is_featured"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "products_category_id_categories_id_fk": {
+          "name": "products_category_id_categories_id_fk",
+          "tableFrom": "products",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "promo_codes": {
+      "name": "promo_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discount_value": {
+          "name": "discount_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "min_order_amount": {
+          "name": "min_order_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "promo_codes_code_unique": {
+          "name": "promo_codes_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reviews": {
+      "name": "reviews",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_verified_purchase": {
+          "name": "is_verified_purchase",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_reviews_product": {
+          "name": "idx_reviews_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        },
+        "idx_reviews_user": {
+          "name": "idx_reviews_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reviews_product_id_products_id_fk": {
+          "name": "reviews_product_id_products_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_user_id_user_id_fk": {
+          "name": "reviews_user_id_user_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "rating_range": {
+          "name": "rating_range",
+          "value": "\"reviews\".\"rating\" BETWEEN 1 AND 5"
+        }
+      }
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_session_userId": {
+          "name": "idx_session_userId",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stores": {
+      "name": "stores",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "google_maps_url": {
+          "name": "google_maps_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "opening_hours": {
+          "name": "opening_hours",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_stores_active_order": {
+          "name": "idx_stores_active_order",
+          "columns": [
+            "is_active",
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'customer'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "banReason": {
+          "name": "banReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banExpires": {
+          "name": "banExpires",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'customer'"
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'email'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_phone_unique": {
+          "name": "users_phone_unique",
+          "columns": [
+            "phone"
+          ],
+          "isUnique": true
+        },
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "idx_users_phone": {
+          "name": "idx_users_phone",
+          "columns": [
+            "phone"
+          ],
+          "isUnique": false
+        },
+        "idx_users_is_active": {
+          "name": "idx_users_is_active",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "whatsapp_carts": {
+      "name": "whatsapp_carts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_wa_carts_session": {
+          "name": "idx_wa_carts_session",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "whatsapp_carts_session_id_whatsapp_sessions_id_fk": {
+          "name": "whatsapp_carts_session_id_whatsapp_sessions_id_fk",
+          "tableFrom": "whatsapp_carts",
+          "tableTo": "whatsapp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "whatsapp_carts_product_id_products_id_fk": {
+          "name": "whatsapp_carts_product_id_products_id_fk",
+          "tableFrom": "whatsapp_carts",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "whatsapp_carts_variant_id_product_variants_id_fk": {
+          "name": "whatsapp_carts_variant_id_product_variants_id_fk",
+          "tableFrom": "whatsapp_carts",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "whatsapp_config": {
+      "name": "whatsapp_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_number_id": {
+          "name": "phone_number_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_phone_number": {
+          "name": "display_phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verify_token": {
+          "name": "verify_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "business_account_id": {
+          "name": "business_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "admin_phones": {
+          "name": "admin_phones",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "whatsapp_messages": {
+      "name": "whatsapp_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "wa_message_id": {
+          "name": "wa_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_wa_messages_session": {
+          "name": "idx_wa_messages_session",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_wa_messages_created": {
+          "name": "idx_wa_messages_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_wa_messages_wa_id": {
+          "name": "idx_wa_messages_wa_id",
+          "columns": [
+            "wa_message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "whatsapp_messages_session_id_whatsapp_sessions_id_fk": {
+          "name": "whatsapp_messages_session_id_whatsapp_sessions_id_fk",
+          "tableFrom": "whatsapp_messages",
+          "tableTo": "whatsapp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "whatsapp_sessions": {
+      "name": "whatsapp_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "wa_phone": {
+          "name": "wa_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "otp_code": {
+          "name": "otp_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "otp_expires_at": {
+          "name": "otp_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "whatsapp_sessions_wa_phone_unique": {
+          "name": "whatsapp_sessions_wa_phone_unique",
+          "columns": [
+            "wa_phone"
+          ],
+          "isUnique": true
+        },
+        "idx_wa_sessions_phone": {
+          "name": "idx_wa_sessions_phone",
+          "columns": [
+            "wa_phone"
+          ],
+          "isUnique": false
+        },
+        "idx_wa_sessions_user": {
+          "name": "idx_wa_sessions_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "whatsapp_sessions_user_id_user_id_fk": {
+          "name": "whatsapp_sessions_user_id_user_id_fk",
+          "tableFrom": "whatsapp_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wishlist": {
+      "name": "wishlist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "wishlist_user_product_unique": {
+          "name": "wishlist_user_product_unique",
+          "columns": [
+            "user_id",
+            "product_id"
+          ],
+          "isUnique": true
+        },
+        "idx_wishlist_user": {
+          "name": "idx_wishlist_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_wishlist_product": {
+          "name": "idx_wishlist_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wishlist_user_id_user_id_fk": {
+          "name": "wishlist_user_id_user_id_fk",
+          "tableFrom": "wishlist",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wishlist_product_id_products_id_fk": {
+          "name": "wishlist_product_id_products_id_fk",
+          "tableFrom": "wishlist",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1776125293845,
       "tag": "0008_eager_hairball",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1776157513310,
+      "tag": "0009_fast_karnak",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -412,14 +412,14 @@ export const stores = sqliteTable("stores", {
 // =============================================================================
 export const whatsappConfig = sqliteTable("whatsapp_config", {
   id: integer("id").primaryKey(),
-  phone_number_id: text("phone_number_id").notNull(),
+  phone_number_id: text("phone_number_id"),
   display_phone_number: text("display_phone_number"),
-  access_token: text("access_token").notNull(),
-  verify_token: text("verify_token").notNull(),
-  webhook_secret: text("webhook_secret").notNull(),
+  access_token: text("access_token"),
+  verify_token: text("verify_token"),
+  webhook_secret: text("webhook_secret"),
   business_account_id: text("business_account_id"),
   admin_phones: text("admin_phones").notNull().default("[]"),
-  is_active: integer("is_active").notNull().default(1),
+  is_active: integer("is_active").notNull().default(0),
   created_at: text("created_at").notNull().default(sql`(datetime('now'))`),
   updated_at: text("updated_at").notNull().default(sql`(datetime('now'))`),
 });

--- a/workers/whatsapp/src/index.ts
+++ b/workers/whatsapp/src/index.ts
@@ -16,15 +16,15 @@ export default {
     // GET: Meta webhook verification
     if (request.method === "GET") {
       const config = await getConfig(env.DB);
-      if (!config) return new Response("Not configured", { status: 503 });
+      if (!config || !config.verify_token) return new Response("Not configured", { status: 503 });
       return handleVerification(url, config.verify_token);
     }
 
     // POST: Incoming messages
     if (request.method === "POST") {
       const config = await getConfig(env.DB);
-      if (!config || !config.is_active) {
-        console.warn("[webhook] WhatsApp config missing or inactive, dropping message");
+      if (!config || !config.is_active || !config.webhook_secret || !config.phone_number_id || !config.access_token) {
+        console.warn("[webhook] WhatsApp config incomplete or inactive, dropping message");
         return new Response("OK", { status: 200 });
       }
 
@@ -67,10 +67,10 @@ export default {
 } satisfies ExportedHandler<Env>;
 
 interface WhatsAppConfig {
-  phone_number_id: string;
-  access_token: string;
-  verify_token: string;
-  webhook_secret: string;
+  phone_number_id: string | null;
+  access_token: string | null;
+  verify_token: string | null;
+  webhook_secret: string | null;
   admin_phones: string;
   is_active: number;
 }

--- a/workers/whatsapp/src/index.ts
+++ b/workers/whatsapp/src/index.ts
@@ -23,15 +23,26 @@ export default {
     // POST: Incoming messages
     if (request.method === "POST") {
       const config = await getConfig(env.DB);
-      if (!config || !config.is_active || !config.webhook_secret || !config.phone_number_id || !config.access_token) {
-        console.warn("[webhook] WhatsApp config incomplete or inactive, dropping message");
+      const missing = getMissingFields(config);
+      if (missing.length > 0 || !config) {
+        // Distinguish "intentionally off" from "active but broken" — return 200 to avoid Meta retry storms either way
+        if (config?.is_active) {
+          console.error(`[webhook] CRITICAL: is_active=1 but missing fields: ${missing.join(", ")}. Messages are being dropped!`);
+        } else {
+          console.warn(`[webhook] bot inactive or unconfigured (missing: ${missing.join(", ")}), dropping message`);
+        }
         return new Response("OK", { status: 200 });
       }
+
+      // TypeScript: after getMissingFields passed, all required API fields are non-null.
+      const phoneNumberId = config.phone_number_id!;
+      const accessToken = config.access_token!;
+      const webhookSecret = config.webhook_secret!;
 
       // Verify signature
       const body = await request.text();
       const signature = request.headers.get("x-hub-signature-256") ?? "";
-      const isValid = await verifySignature(body, signature, config.webhook_secret);
+      const isValid = await verifySignature(body, signature, webhookSecret);
       if (!isValid) {
         return new Response("Invalid signature", { status: 401 });
       }
@@ -51,7 +62,7 @@ export default {
         ctx.waitUntil(
           handleIncomingMessage(
             env,
-            { phoneNumberId: config.phone_number_id, accessToken: config.access_token },
+            { phoneNumberId, accessToken },
             msg
           ).catch((err) => {
             console.error("Error processing message:", err);
@@ -79,4 +90,14 @@ async function getConfig(db: D1Database): Promise<WhatsAppConfig | null> {
   return db
     .prepare("SELECT * FROM whatsapp_config WHERE id = 1")
     .first<WhatsAppConfig>();
+}
+
+function getMissingFields(config: WhatsAppConfig | null): string[] {
+  if (!config) return ["config row"];
+  const missing: string[] = [];
+  if (!config.is_active) missing.push("is_active=0");
+  if (!config.phone_number_id) missing.push("phone_number_id");
+  if (!config.access_token) missing.push("access_token");
+  if (!config.webhook_secret) missing.push("webhook_secret");
+  return missing;
 }


### PR DESCRIPTION
## Problem

Currently the admin config form requires all Meta Cloud API fields (`phone_number_id`, `access_token`, `verify_token`, `webhook_secret`, `business_account_id`) even when the admin just wants to display a WhatsApp contact button on the storefront. This blocks progressive adoption — you had to set up the full Meta API integration before anything WhatsApp-related could appear.

## Solution

Decouple the public WhatsApp number from the bot API credentials:

- **Affichage public** (storefront buttons): requires only `display_phone_number`
- **Intégration API (bot)**: requires full Meta credentials + `is_active = 1`

## Changes

- **Migration 0009**: make `phone_number_id`, `access_token`, `verify_token`, `webhook_secret` nullable
- Default `is_active` to `0` (bot opt-in)
- Split admin form into two sections with clear help text
- Server action: conditional validation (API fields required only when activating bot)
- Worker: defensive check for complete API config before processing messages
- Types: all affected fields marked `string | null`

## Behavior matrix

| Config | Storefront buttons | Bot |
|--------|:------------------:|:---:|
| Nothing set | — | — |
| `display_phone_number` only | ✅ | — |
| Full API + `is_active = 1` + `display_phone_number` | ✅ | ✅ |

## Test plan
- [x] Tests pass (696/696)
- [x] Typecheck clean
- [ ] Configure only the public number → verify buttons appear, bot disabled
- [ ] Add full API + activate → verify bot works
- [ ] Deactivate bot → verify buttons still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned WhatsApp settings: separate "Public display" and "API Integration" sections; display phone field renamed and activation text updated
  * WhatsApp bot integration now defaults to inactive for safer setup; credentials can be left blank to clear them

* **Bug Fixes**
  * Stronger webhook validation: clearer "not configured" responses and safer message acknowledgement when config is missing or incomplete
  * Secret handling preserves existing secrets when left masked and treats empty inputs as cleared

* **Chores**
  * Database migration and updated schema snapshot added
<!-- end of auto-generated comment: release notes by coderabbit.ai -->