### PR TITLE
fix(whatsapp): decouple storefront buttons from bot is_active flag

### DIFF
--- a/lib/whatsapp/public-config.ts
+++ b/lib/whatsapp/public-config.ts
@@ -3,17 +3,22 @@ import { getDB } from "@/lib/cloudflare/context";
 
 /**
  * Read the public-facing WhatsApp number (for wa.me links) from whatsapp_config.
- * Returns null if WhatsApp is not configured or inactive.
+ *
+ * NOTE: This is independent of `is_active` — the public number only drives the
+ * storefront wa.me buttons, which should work even when the bot is disabled.
+ * The `is_active` flag gates the bot API integration, not the display number.
+ *
+ * Returns null if no number is configured or the stored value is malformed.
  * Cached per-request via React's cache().
  */
 export const getPublicWhatsAppNumber = cache(async (): Promise<string | null> => {
   try {
     const db = await getDB();
     const row = await db
-      .prepare("SELECT display_phone_number, is_active FROM whatsapp_config WHERE id = 1")
-      .first<{ display_phone_number: string | null; is_active: number }>();
+      .prepare("SELECT display_phone_number FROM whatsapp_config WHERE id = 1")
+      .first<{ display_phone_number: string | null }>();
 
-    if (!row || !row.is_active || !row.display_phone_number) return null;
+    if (!row || !row.display_phone_number) return null;
 
     // Defensive normalization: digits only (DB should already store normalized values)
     const digits = row.display_phone_number.replace(/\D/g, "");


### PR DESCRIPTION
## Bug

After PR #149 landed, configuring just the public WhatsApp number from the admin (without activating the bot) did not make the storefront buttons appear.

## Root cause

\`getPublicWhatsAppNumber()\` returned \`null\` when \`is_active = 0\`:

\`\`\`typescript
if (!row || !row.is_active || !row.display_phone_number) return null;
\`\`\`

But \`is_active\` was designed in PR #149 to gate the **bot integration** (webhooks, LLM replies), not the display number. The storefront buttons should work independently — that was the whole point of the refactor.

## Fix

Remove the \`is_active\` check from \`getPublicWhatsAppNumber()\`. Buttons now appear whenever a valid \`display_phone_number\` exists, regardless of the bot state.

## Test plan
- [x] Typecheck + tests pass
- [ ] Configure only the public number (bot inactive) → verify buttons appear
- [ ] Remove the number → verify buttons hide
- [ ] Activate the bot → verify buttons still appear (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WhatsApp phone number retrieval logic for more consistent and reliable functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->