### PR TITLE
fix(release): address CodeRabbit feedback on pipeline spec+plan

### DIFF
--- a/docs/superpowers/plans/2026-04-14-release-pipeline.md
+++ b/docs/superpowers/plans/2026-04-14-release-pipeline.md
@@ -882,9 +882,18 @@ jobs:
       - name: Capture currently-active version (before upload)
         id: current
         run: |
-          # Fetch the current deployment. If no deployment exists (fresh worker),
-          # leave previous_version_id empty — we'll treat as bootstrap.
-          DEPLOYMENTS_JSON=$(npx wrangler deployments list --json 2>/dev/null || echo "[]")
+          # Fetch the current deployment. Fail closed on wrangler errors (auth,
+          # network, Cloudflare API down) — otherwise we'd misclassify a transient
+          # failure as "fresh worker" and push the new version to 100% directly,
+          # skipping the canary. A clean empty-list result is a legitimate bootstrap.
+          set -o pipefail
+          if ! DEPLOYMENTS_JSON=$(npx wrangler deployments list --json 2>&1); then
+            echo "ERROR: 'wrangler deployments list' failed. Aborting to avoid " \
+                 "silently bootstrapping over an existing deployment."
+            echo "wrangler output was:"
+            echo "$DEPLOYMENTS_JSON"
+            exit 1
+          fi
           # Pick the baseline version:
           # 1) Preferred: the version currently at 100% (clean state after a completed promote).
           # 2) Fallback: the version with the highest traffic share (handles the case where a

--- a/docs/superpowers/plans/2026-04-14-release-pipeline.md
+++ b/docs/superpowers/plans/2026-04-14-release-pipeline.md
@@ -147,16 +147,20 @@ export const PATTERNS = [
   {
     id: "drop-unique-index",
     level: "error",
-    regex: /\bDROP\s+INDEX\b[^;]*\bUNIQUE\b/i,
+    // SQLite's DROP INDEX syntax doesn't include the UNIQUE keyword.
+    // Heuristic: match index names containing "unique" (Drizzle convention:
+    // unique indexes are named with suffix `_unique`, e.g. `categories_slug_unique`).
+    // No word boundary after `unique` because `_unique` is not a regex word boundary.
+    regex: /\bDROP\s+INDEX\b[^;]*unique/i,
     reason:
-      "DROP INDEX UNIQUE lève une contrainte critique. " +
+      "DROP INDEX sur un index dont le nom contient 'unique' — probablement une contrainte critique. " +
       "Vérifier explicitement avec le bypass marker si intentionnel.",
   },
   {
     id: "drop-index",
     level: "warning",
-    // non-unique DROP INDEX (signalé mais pas bloquant)
-    regex: /\bDROP\s+INDEX\b(?![^;]*\bUNIQUE\b)/i,
+    // Any other DROP INDEX (index name doesn't contain "unique")
+    regex: /\bDROP\s+INDEX\b(?![^;]*unique)/i,
     reason:
       "DROP INDEX détecté. Autorisé mais peut impacter les performances — vérifier.",
   },
@@ -372,8 +376,10 @@ describe("check-migration-safety — analyze()", () => {
     );
   });
 
-  it("blocks DROP INDEX ... UNIQUE as error", () => {
-    const sql = `DROP INDEX idx_users_email_unique UNIQUE;`;
+  it("blocks DROP INDEX on an index whose name contains 'unique' (Drizzle convention)", () => {
+    // Drizzle generates names like `categories_slug_unique` for unique indexes.
+    // SQLite's DROP INDEX syntax doesn't include a UNIQUE keyword, so we match on name.
+    const sql = `DROP INDEX categories_slug_unique;`;
     const { violations } = analyze(sql);
     const hit = violations.find(
       (v: { patternId: string }) => v.patternId === "drop-unique-index"
@@ -382,7 +388,7 @@ describe("check-migration-safety — analyze()", () => {
     expect(hit!.level).toBe("error");
   });
 
-  it("flags plain DROP INDEX as warning only", () => {
+  it("flags plain (non-unique) DROP INDEX as warning only", () => {
     const sql = `DROP INDEX idx_products_created_at;`;
     const { violations } = analyze(sql);
     const errors = violations.filter(
@@ -873,6 +879,26 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
+      - name: Capture currently-active version (before upload)
+        id: current
+        run: |
+          # Fetch the current deployment. If no deployment exists yet (fresh worker),
+          # leave previous_version_id empty — we'll treat as bootstrap.
+          DEPLOYMENTS_JSON=$(npx wrangler deployments list --json 2>/dev/null || echo "[]")
+          # Pick the version_id currently at 100% (or the first version of the most
+          # recent deployment if the structure differs between wrangler versions).
+          PREV_ID=$(echo "$DEPLOYMENTS_JSON" \
+            | jq -r 'if (. | length) == 0 then "" else (.[0].versions // [] | map(select((.percentage // 0) == 100)) | .[0].version_id // "") end')
+          echo "previous_version_id=${PREV_ID}" >> "$GITHUB_OUTPUT"
+          if [ -z "$PREV_ID" ]; then
+            echo "No active deployment found — will bootstrap at 100%."
+          else
+            echo "Previous active version: $PREV_ID"
+          fi
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
       - name: Upload new version
         id: upload
         run: |
@@ -897,18 +923,11 @@ jobs:
       - name: Determine deploy strategy (canary vs bootstrap)
         id: strategy
         run: |
-          VERSIONS_JSON=$(npx wrangler versions list --json 2>/dev/null || echo "[]")
-          COUNT=$(echo "$VERSIONS_JSON" | jq '. | length')
-          if [ "$COUNT" -lt 2 ]; then
+          if [ -z "${{ steps.current.outputs.previous_version_id }}" ]; then
             echo "mode=bootstrap" >> "$GITHUB_OUTPUT"
           else
-            PREV_ID=$(echo "$VERSIONS_JSON" | jq -r 'map(select(.id != "${{ steps.upload.outputs.version_id }}")) | .[0].id')
             echo "mode=canary" >> "$GITHUB_OUTPUT"
-            echo "previous_version_id=$PREV_ID" >> "$GITHUB_OUTPUT"
           fi
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Deploy at 100% (bootstrap)
         if: steps.strategy.outputs.mode == 'bootstrap'
@@ -923,7 +942,7 @@ jobs:
         run: |
           npx wrangler versions deploy \
             "${{ steps.upload.outputs.version_id }}@10%" \
-            "${{ steps.strategy.outputs.previous_version_id }}@90%" --yes
+            "${{ steps.current.outputs.previous_version_id }}@90%" --yes
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -1755,7 +1774,7 @@ Fermer les tâches du plan une fois tous les steps validés.
 
 **Type consistency :**
 - `version_id` (snake_case) cohérent dans tous les workflows et scripts.
-- `steps.upload.outputs.version_id` et `steps.strategy.outputs.previous_version_id` nommés cohéremment.
+- `steps.upload.outputs.version_id` (new) et `steps.current.outputs.previous_version_id` (captured before upload) nommés cohéremment. `steps.strategy.outputs.mode` est `bootstrap` ou `canary`.
 - Nom des patterns IDs dans `check-migration-safety.mjs` exportés et testés (`drop-column`, `drop-table`, `rename-column`, `alter-not-null-no-default`, `drop-unique-index`, `drop-index`).
 
 **Dépendances entre phases :**

--- a/docs/superpowers/plans/2026-04-14-release-pipeline.md
+++ b/docs/superpowers/plans/2026-04-14-release-pipeline.md
@@ -882,13 +882,23 @@ jobs:
       - name: Capture currently-active version (before upload)
         id: current
         run: |
-          # Fetch the current deployment. If no deployment exists yet (fresh worker),
+          # Fetch the current deployment. If no deployment exists (fresh worker),
           # leave previous_version_id empty — we'll treat as bootstrap.
           DEPLOYMENTS_JSON=$(npx wrangler deployments list --json 2>/dev/null || echo "[]")
-          # Pick the version_id currently at 100% (or the first version of the most
-          # recent deployment if the structure differs between wrangler versions).
-          PREV_ID=$(echo "$DEPLOYMENTS_JSON" \
-            | jq -r 'if (. | length) == 0 then "" else (.[0].versions // [] | map(select((.percentage // 0) == 100)) | .[0].version_id // "") end')
+          # Pick the baseline version:
+          # 1) Preferred: the version currently at 100% (clean state after a completed promote).
+          # 2) Fallback: the version with the highest traffic share (handles the case where a
+          #    previous canary 10/90 was never promoted — we treat the 90% as baseline).
+          # 3) Empty string → triggers bootstrap mode at 100%.
+          PREV_ID=$(echo "$DEPLOYMENTS_JSON" | jq -r '
+            if (. | length) == 0 then ""
+            else
+              (.[0].versions // [])
+              | (map(select((.percentage // 0) == 100)) | .[0].version_id)
+                // (max_by(.percentage // 0).version_id)
+                // ""
+            end
+          ')
           echo "previous_version_id=${PREV_ID}" >> "$GITHUB_OUTPUT"
           if [ -z "$PREV_ID" ]; then
             echo "No active deployment found — will bootstrap at 100%."
@@ -1774,7 +1784,7 @@ Fermer les tâches du plan une fois tous les steps validés.
 
 **Type consistency :**
 - `version_id` (snake_case) cohérent dans tous les workflows et scripts.
-- `steps.upload.outputs.version_id` (new) et `steps.current.outputs.previous_version_id` (captured before upload) nommés cohéremment. `steps.strategy.outputs.mode` est `bootstrap` ou `canary`.
+- `steps.upload.outputs.version_id` (new) et `steps.current.outputs.previous_version_id` (captured before upload) nommés de manière cohérente. `steps.strategy.outputs.mode` est `bootstrap` ou `canary`.
 - Nom des patterns IDs dans `check-migration-safety.mjs` exportés et testés (`drop-column`, `drop-table`, `rename-column`, `alter-not-null-no-default`, `drop-unique-index`, `drop-index`).
 
 **Dépendances entre phases :**

--- a/docs/superpowers/specs/2026-04-14-release-pipeline-design.md
+++ b/docs/superpowers/specs/2026-04-14-release-pipeline-design.md
@@ -180,7 +180,7 @@ Patterns bloqués :
 | `\bDROP\s+INDEX\b[^;]*unique` (case-insensitive, substring match) | error | Lève une contrainte critique. Heuristique basée sur la convention Drizzle qui nomme les unique indexes avec suffixe `_unique` (ex: `categories_slug_unique`) — détecté par match de substring `unique` (sans `\b` final car `_unique` n'a pas de word boundary en regex POSIX) |
 | `\bDROP\s+INDEX\b` (autre cas) | warning | Autorisé mais signalé. Peut impacter les performances ; vérifier manuellement qu'il n'y a pas de contrainte à préserver |
 
-**Limitation connue** : SQLite ne permet pas d'exprimer "UNIQUE" dans la syntaxe `DROP INDEX` (contrairement à certains dialectes). La détection repose donc sur le **nom de l'index** plutôt que sur un mot-clé SQL. Si un projet future n'utilise pas la convention de nommage Drizzle, adapter le pattern ou s'en remettre au bypass marker + relecture manuelle.
+**Limitation connue** : SQLite ne permet pas d'exprimer "UNIQUE" dans la syntaxe `DROP INDEX` (contrairement à certains dialectes). La détection repose donc sur le **nom de l'index** plutôt que sur un mot-clé SQL. Si un projet futur n'utilise pas la convention de nommage Drizzle, adapter le pattern ou s'en remettre au bypass marker + relecture manuelle.
 
 Bypass : toute ligne contenant `-- migration-safety: acknowledged reason="<text>"` dans le fichier SQL désactive le lint pour ce fichier **et logue l'acknowledgement** (contexte pour `git blame` futur).
 

--- a/docs/superpowers/specs/2026-04-14-release-pipeline-design.md
+++ b/docs/superpowers/specs/2026-04-14-release-pipeline-design.md
@@ -177,8 +177,10 @@ Patterns bloqués :
 | `\bDROP TABLE\b` | error | Idem |
 | `\bRENAME COLUMN\b` | error | Idem |
 | `\bALTER COLUMN\b.*\bNOT NULL\b` sans `\bDEFAULT\b` dans la même instruction | error | Échoue sur lignes existantes |
-| `\bDROP INDEX\b.*\bUNIQUE\b` | error | Lève une contrainte critique |
-| `\bDROP INDEX\b` (non unique) | warning | Autorisé mais signalé |
+| `\bDROP\s+INDEX\b[^;]*unique` (case-insensitive, substring match) | error | Lève une contrainte critique. Heuristique basée sur la convention Drizzle qui nomme les unique indexes avec suffixe `_unique` (ex: `categories_slug_unique`) — détecté par match de substring `unique` (sans `\b` final car `_unique` n'a pas de word boundary en regex POSIX) |
+| `\bDROP\s+INDEX\b` (autre cas) | warning | Autorisé mais signalé. Peut impacter les performances ; vérifier manuellement qu'il n'y a pas de contrainte à préserver |
+
+**Limitation connue** : SQLite ne permet pas d'exprimer "UNIQUE" dans la syntaxe `DROP INDEX` (contrairement à certains dialectes). La détection repose donc sur le **nom de l'index** plutôt que sur un mot-clé SQL. Si un projet future n'utilise pas la convention de nommage Drizzle, adapter le pattern ou s'en remettre au bypass marker + relecture manuelle.
 
 Bypass : toute ligne contenant `-- migration-safety: acknowledged reason="<text>"` dans le fichier SQL désactive le lint pour ce fichier **et logue l'acknowledgement** (contexte pour `git blame` futur).
 


### PR DESCRIPTION
## Summary

Follow-up to #153 — corrige les deux issues remontées par CodeRabbit.

### 1. 🟡 Spec — `DROP UNIQUE INDEX` pattern (line 180)

**Problème** : SQLite n'utilise pas le mot-clé `UNIQUE` dans sa syntaxe `DROP INDEX`. Le pattern `\bDROP INDEX\b.*\bUNIQUE\b` ne matchait donc jamais un vrai drop d'unique index.

**Fix** : heuristique basée sur le nom de l'index — on matche la substring \`unique\` dans le nom (convention Drizzle : suffix \`_unique\`, ex \`categories_slug_unique\`). Pas de word boundary après \`unique\` car \`_unique\` n'en a pas en regex POSIX.

Limitation documentée explicitement dans la spec pour les projets futurs qui ne suivraient pas la convention Drizzle.

### 2. 🔴 Plan — jq + sélection de la version précédente (line 911)

**Problème initial de CodeRabbit** : \`\${{ ... }}\` interpolation inside single-quoted jq. En pratique GitHub Actions substitue avant bash/jq donc ça fonctionne ; mais il y avait un vrai problème sémantique plus grave : mon filtre prenait \"une version récente qui n'est pas la nouvelle\", pas \"la version actuellement à 100%\".

**Fix** : nouveau step \`Capture currently-active version\` qui query \`wrangler deployments list --json\` **avant** l'upload pour capturer l'ID de la version à 100% (s'il y en a une). Utilisé ensuite dans le deploy canary \`@90%\`.

Avantages :
- Pas d'interpolation shell dans jq (jq pur, pas d'injection possible)
- On pose le vrai previous-version à 90% (pas un aléatoire)
- Si aucun deployment n'existe (fresh worker), bootstrap direct à 100% — détecté par \`previous_version_id\` vide

Tests et outputs mis à jour (\`steps.strategy.outputs.previous_version_id\` → \`steps.current.outputs.previous_version_id\`).

## Test plan

- [ ] Relecture des deux fichiers diff
- [ ] Pas de changement de code : aucun impact runtime avant PR B

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated SQL migration-safety guidance to rely on index-name heuristics for detecting unique-index drops, clarified limitation for SQLite, and added guidance for manual review or bypass.
  * Improved Cloudflare deployment docs to capture the currently active version and clarify bootstrap vs canary strategy behavior.
* **Tests**
  * Adjusted unit tests for the migration-safety checks to reflect the new detection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->