### PR TITLE
fix(ci): deploy.yml picks wrong baseline + deploy-whatsapp OpenNext conflict

### DIFF
--- a/.github/workflows/deploy-whatsapp.yml
+++ b/.github/workflows/deploy-whatsapp.yml
@@ -27,11 +27,21 @@ jobs:
 
       - run: npm ci
 
+      # The root package.json installs @opennextjs/cloudflare for the main
+      # storefront worker. Wrangler auto-detects OpenNext when it finds
+      # (next.config.*, open-next.config.*, @opennextjs/cloudflare) at the
+      # project root, and intercepts `wrangler deploy` to call
+      # `opennextjs-cloudflare deploy` instead — which looks for a compiled
+      # `.open-next/worker.js` that doesn't exist for this Worker.
+      # OPEN_NEXT_DEPLOY=1 short-circuits that delegation (wrangler's
+      # `getOpenNextDeployFromEnv()` reads it) so the WhatsApp worker deploys
+      # as a plain wrangler Worker, which is what we want.
       - name: Deploy
         run: npx wrangler deploy --config workers/whatsapp/wrangler.jsonc
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          OPEN_NEXT_DEPLOY: "1"
 
       # Meta's webhook endpoint must respond to HEAD/GET. A successful deploy
       # should answer 200 (verify callback handler) or 405 (method not allowed

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,7 +84,15 @@ jobs:
             echo "$DEPLOYMENTS_JSON"
             exit 1
           fi
-          # Pick the baseline version:
+          # Pick the baseline version from the MOST RECENT deployment.
+          #
+          # `wrangler deployments list --json` returns deployments in ASCENDING
+          # order (oldest first). `.[0]` would give us the very first deploy
+          # ever made — a critical bug that caused a canary to route 90% of
+          # traffic to a 2-day-old version. Sort explicitly by `created_on`
+          # descending and take the most recent.
+          #
+          # Selection within that deployment:
           # 1) Preferred: the version currently at 100% (clean state after a completed promote).
           # 2) Fallback: the version with the highest traffic share (handles the case where a
           #    previous canary 10/90 was never promoted — we treat the 90% as baseline).
@@ -92,7 +100,7 @@ jobs:
           PREV_ID=$(echo "$DEPLOYMENTS_JSON" | jq -r '
             if (. | length) == 0 then ""
             else
-              (.[0].versions // [])
+              (sort_by(.created_on) | reverse | .[0].versions // [])
               | (map(select((.percentage // 0) == 100)) | .[0].version_id)
                 // (max_by(.percentage // 0).version_id)
                 // ""

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "db:seed-catalogue": "npx wrangler d1 execute netereka-db --local --file=db/seeds/catalogue.sql",
     "db:sync": "bash scripts/sync-local-db.sh",
     "whatsapp:dev": "npx wrangler dev --config workers/whatsapp/wrangler.jsonc",
-    "whatsapp:deploy": "npx wrangler deploy --config workers/whatsapp/wrangler.jsonc",
+    "whatsapp:deploy": "OPEN_NEXT_DEPLOY=1 npx wrangler deploy --config workers/whatsapp/wrangler.jsonc",
     "whatsapp:tail": "npx wrangler tail --config workers/whatsapp/wrangler.jsonc",
     "prepare": "husky",
     "postinstall": "node scripts/patch-opennext.mjs"


### PR DESCRIPTION
## 🚨 Hotfix — two production-impacting bugs

Discovered after the merge of PR #158 triggered the first real runs of all new workflows.

### 1. 🚨 **Critical** — deploy.yml was picking the OLDEST deployment as baseline

**Impact** : current prod canary routes **90% of traffic to a 2-day-old version** (\`b8221217\` from 2026-04-13).

**Root cause** : \`wrangler deployments list --json\` returns deployments in **ascending** chronological order (oldest first). The \`Capture currently-active version\` step used \`.[0]\`, matching the oldest-ever deployment rather than the current.

**Fix** : \`sort_by(.created_on) | reverse | .[0]\` — pick the most recent deployment, then apply the same "prefer 100%, fallback to max percentage" logic within it.

**Verified** : tested the fixed jq against live deployments data. Returns \`b8221217\` (the 90% of the broken canary), which is the correct safe baseline for the NEXT deploy.

### 2. 🟠 **Major** — deploy-whatsapp.yml failed on OpenNext auto-detection

**Impact** : first run of \`deploy-whatsapp.yml\` (triggered by the workflow-file self-match after PR #158) failed immediately at the deploy step.

**Root cause** : wrangler detects OpenNext projects via (next.config.*, open-next.config.*, @opennextjs/cloudflare) at the project root, and delegates \`wrangler deploy\` to \`opennextjs-cloudflare deploy\` which looks for \`.open-next/worker.js\` (not present for the WhatsApp worker, which is a plain \`src/index.ts\`).

**Fix** : set \`OPEN_NEXT_DEPLOY=1\` in the step env. Wrangler's \`getOpenNextDeployFromEnv()\` reads this and short-circuits the delegation. Same env var added to the local \`npm run whatsapp:deploy\` script for parity.

## Required user action after merge

**Before merging**: promote the current canary to 100% via \`Actions → Promote to 100%\` (or Cloudflare dashboard) to restore prod to latest code.

**After merging**: deploy.yml will run correctly, starting a fresh canary with the (now-correct) baseline. deploy-whatsapp.yml will run correctly without the OpenNext error.

## Commits

- \`0034ea3\` fix(ci): deploy.yml picks wrong baseline + deploy-whatsapp hits OpenNext

## Test plan

- [x] YAML parse OK for both workflows
- [x] Fixed jq verified against live \`wrangler deployments list\` data
- [x] Local pre-commit passes (tsc + lint + vitest + migration-safety)
- [ ] **After merge** : deploy.yml canary correctly picks recent baseline (check \`Previous active version:\` log line)
- [ ] **After merge** : deploy-whatsapp.yml succeeds (may still fail smoke check if \`WHATSAPP_WORKER_URL\` repo variable isn't set — that's configuration, not code)

## Not in scope

The third failure on PR #158 merge — \`release-please\` reporting \"GitHub Actions is not permitted to create or approve pull requests\" despite the setting being enabled — is a **repo setting** question, not a code change. User to double-check \`Settings → Actions → General → Workflow permissions → Allow GitHub Actions to create and approve pull requests\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment workflow reliability for WhatsApp integration by refining version tracking logic
  * Enhanced deployment environment configuration for more explicit and consistent release handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->