### PR TITLE
fix(storefront): redesign product card mobile actions to prevent overflow

### DIFF
--- a/components/storefront/product-card-actions.tsx
+++ b/components/storefront/product-card-actions.tsx
@@ -64,14 +64,14 @@ export function ProductCardActions({ product }: Props) {
   return (
     <>
       <div
-        className="flex items-center gap-2 border-t px-3 py-2"
+        className="flex flex-col gap-1.5 border-t px-3 py-2 sm:flex-row sm:items-center sm:gap-2"
         onClick={(e) => e.stopPropagation()}
       >
         <Button
           size="lg"
           variant={isOutOfStock ? "outline" : "default"}
           disabled={isOutOfStock}
-          className="flex-1"
+          className="w-full order-last sm:order-none sm:w-auto sm:flex-1"
           onClick={handleCartClick}
           aria-label={
             isOutOfStock
@@ -83,16 +83,19 @@ export function ProductCardActions({ product }: Props) {
           {isOutOfStock ? "Rupture de stock" : "Ajouter"}
         </Button>
 
-        <div onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}>
-          <WhatsAppProductButton
-            productName={product.name}
-            price={product.base_price}
-            slug={product.slug}
-            variant="icon"
-          />
-        </div>
-        <div onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}>
-          <WishlistButtonDynamic productId={product.id} />
+        <div className="flex gap-1.5 sm:contents">
+          <div className="flex-1 sm:flex-none" onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}>
+            <WhatsAppProductButton
+              productName={product.name}
+              price={product.base_price}
+              slug={product.slug}
+              variant="icon"
+              className="w-full sm:w-8"
+            />
+          </div>
+          <div className="flex-1 sm:flex-none" onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}>
+            <WishlistButtonDynamic productId={product.id} className="w-full sm:w-8" />
+          </div>
         </div>
       </div>
 

--- a/components/storefront/whatsapp-product-button.tsx
+++ b/components/storefront/whatsapp-product-button.tsx
@@ -3,6 +3,7 @@
 import { HugeiconsIcon } from "@hugeicons/react";
 import { WhatsappIcon } from "@hugeicons/core-free-icons";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { useWhatsAppNumber } from "@/components/storefront/whatsapp-number-provider";
 
 interface Props {
@@ -10,9 +11,10 @@ interface Props {
   price: number;
   slug: string;
   variant?: "icon" | "full";
+  className?: string;
 }
 
-export function WhatsAppProductButton({ productName, price, slug, variant = "icon" }: Props) {
+export function WhatsAppProductButton({ productName, price, slug, variant = "icon", className }: Props) {
   const whatsappNumber = useWhatsAppNumber();
   if (!whatsappNumber) return null;
 
@@ -28,7 +30,13 @@ export function WhatsAppProductButton({ productName, price, slug, variant = "ico
 
   if (variant === "icon") {
     return (
-      <Button size="icon-lg" variant="outline" onClick={handleClick} aria-label={`Commander sur WhatsApp: ${productName}`} className="border-[#25D366] text-[#25D366] hover:bg-[#25D366]/10">
+      <Button
+        size="icon-lg"
+        variant="outline"
+        onClick={handleClick}
+        aria-label={`Commander sur WhatsApp: ${productName}`}
+        className={cn("border-[#25D366] text-[#25D366] hover:bg-[#25D366]/10", className)}
+      >
         <HugeiconsIcon icon={WhatsappIcon} size={18} />
       </Button>
     );

--- a/components/storefront/wishlist-button-dynamic.tsx
+++ b/components/storefront/wishlist-button-dynamic.tsx
@@ -6,6 +6,7 @@ import { authClient } from "@/lib/auth/client";
 import { WishlistButton } from "@/components/storefront/wishlist-button";
 import { checkWishlist } from "@/actions/wishlist";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 const AuthDialog = dynamic(
   () =>
@@ -23,7 +24,7 @@ function prefetchAuthDialog(): void {
   void import("@/components/storefront/auth-dialog").catch(() => {});
 }
 
-export function WishlistButtonDynamic({ productId }: { productId: string }) {
+export function WishlistButtonDynamic({ productId, className }: { productId: string; className?: string }) {
   const session = authClient.useSession();
   const [isWishlisted, setIsWishlisted] = useState<boolean | undefined>(undefined);
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -47,6 +48,7 @@ export function WishlistButtonDynamic({ productId }: { productId: string }) {
         productId={productId}
         isWishlisted={isWishlisted}
         onToggled={setIsWishlisted}
+        className={className}
       />
     );
   }
@@ -59,7 +61,7 @@ export function WishlistButtonDynamic({ productId }: { productId: string }) {
           type="button"
           size="icon-lg"
           variant="outline"
-          className="hover:text-destructive hover:border-destructive/50"
+          className={cn("hover:text-destructive hover:border-destructive/50", className)}
           onMouseEnter={prefetchAuthDialog}
           onFocus={prefetchAuthDialog}
           onClick={(e) => {

--- a/docs/superpowers/plans/2026-04-16-product-card-mobile-actions-redesign.md
+++ b/docs/superpowers/plans/2026-04-16-product-card-mobile-actions-redesign.md
@@ -1,0 +1,666 @@
+# ProductCard Mobile Actions Redesign — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the truncation hack from PR #171 (closed) with a responsive layout that stacks the product card actions vertically on mobile (icons row on top, full-width primary CTA below) while preserving the current single-row layout on tablet/desktop (sm+).
+
+**Architecture:** Pure CSS responsive refactor using Tailwind utilities (`flex-col sm:flex-row`, `order-last sm:order-none`, `display: contents` via `sm:contents`). Two helper components (`WhatsAppProductButton`, `WishlistButtonDynamic`) gain an opt-in `className?: string` prop so the parent can drive responsive sizing without forking the components. Zero behavior change — only layout.
+
+**Tech Stack:** Next.js 16 App Router (RSC + client components), Tailwind CSS 4 with `tailwind-merge` via `cn()`, shadcn/ui Button (CVA variants).
+
+**Reference spec:** `docs/superpowers/specs/2026-04-16-product-card-mobile-actions-redesign.md`
+
+---
+
+## File Structure
+
+| File | Type | Responsibility |
+|---|---|---|
+| `components/storefront/whatsapp-product-button.tsx` | Modify | Add `className?: string` prop on the icon variant; merge with existing classes via `cn()`. |
+| `components/storefront/wishlist-button-dynamic.tsx` | Modify | Add `className?: string` prop; forward to both internal Button (guest state) and `<WishlistButton>` (authenticated state). |
+| `components/storefront/product-card-actions.tsx` | Modify | Refactor the actions `<div>`: container becomes `flex-col sm:flex-row`, icons wrapped in `flex sm:contents` sub-div, primary CTA reordered with `order-last sm:order-none`. Pass `flex-1 sm:flex-none` and `w-full sm:w-auto` to icon button wrappers/buttons. |
+
+No new files. No tests added (purely visual responsive change; existing 710-test suite re-runs via pre-commit hook to guard against regressions). No changes to `wishlist-button.tsx` (already accepts `className`).
+
+---
+
+## Task 1: Add `className` prop to `WhatsAppProductButton` (icon variant)
+
+**Files:**
+- Modify: `components/storefront/whatsapp-product-button.tsx`
+
+- [ ] **Step 1: Add `cn` import**
+
+In the import block at the top of the file, after the `Button` import, add:
+
+```tsx
+import { cn } from "@/lib/utils";
+```
+
+The full import section should now read:
+
+```tsx
+"use client";
+
+import { HugeiconsIcon } from "@hugeicons/react";
+import { WhatsappIcon } from "@hugeicons/core-free-icons";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useWhatsAppNumber } from "@/components/storefront/whatsapp-number-provider";
+```
+
+- [ ] **Step 2: Add `className` to Props interface**
+
+Replace:
+
+```tsx
+interface Props {
+  productName: string;
+  price: number;
+  slug: string;
+  variant?: "icon" | "full";
+}
+```
+
+with:
+
+```tsx
+interface Props {
+  productName: string;
+  price: number;
+  slug: string;
+  variant?: "icon" | "full";
+  className?: string;
+}
+```
+
+- [ ] **Step 3: Destructure `className` in the function signature**
+
+Replace:
+
+```tsx
+export function WhatsAppProductButton({ productName, price, slug, variant = "icon" }: Props) {
+```
+
+with:
+
+```tsx
+export function WhatsAppProductButton({ productName, price, slug, variant = "icon", className }: Props) {
+```
+
+- [ ] **Step 4: Merge `className` into the icon variant Button**
+
+Find the icon variant return (around line 31):
+
+```tsx
+if (variant === "icon") {
+  return (
+    <Button size="icon-lg" variant="outline" onClick={handleClick} aria-label={`Commander sur WhatsApp: ${productName}`} className="border-[#25D366] text-[#25D366] hover:bg-[#25D366]/10">
+      <HugeiconsIcon icon={WhatsappIcon} size={18} />
+    </Button>
+  );
+}
+```
+
+Replace the `className` attribute on the `<Button>` with:
+
+```tsx
+className={cn("border-[#25D366] text-[#25D366] hover:bg-[#25D366]/10", className)}
+```
+
+The full block becomes:
+
+```tsx
+if (variant === "icon") {
+  return (
+    <Button
+      size="icon-lg"
+      variant="outline"
+      onClick={handleClick}
+      aria-label={`Commander sur WhatsApp: ${productName}`}
+      className={cn("border-[#25D366] text-[#25D366] hover:bg-[#25D366]/10", className)}
+    >
+      <HugeiconsIcon icon={WhatsappIcon} size={18} />
+    </Button>
+  );
+}
+```
+
+The `"full"` variant (the `<button>` below) is intentionally **not** modified — only `variant="icon"` callers consume the className.
+
+- [ ] **Step 5: Verify with grep that the prop is wired**
+
+Run:
+
+```bash
+grep -n "className" components/storefront/whatsapp-product-button.tsx
+```
+
+Expected output (lines may differ slightly):
+
+```
+Props interface line containing `className?: string;`
+Function signature destructuring `className`
+className={cn(... className)} on the icon Button
+```
+
+If any of these are missing, fix before proceeding.
+
+---
+
+## Task 2: Add `className` prop to `WishlistButtonDynamic` and forward to children
+
+**Files:**
+- Modify: `components/storefront/wishlist-button-dynamic.tsx`
+
+- [ ] **Step 1: Add `cn` import**
+
+After the `Button` import, add:
+
+```tsx
+import { cn } from "@/lib/utils";
+```
+
+The import block should now contain (in addition to the existing imports):
+
+```tsx
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+```
+
+- [ ] **Step 2: Add `className` to props and destructure it**
+
+Replace:
+
+```tsx
+export function WishlistButtonDynamic({ productId }: { productId: string }) {
+```
+
+with:
+
+```tsx
+export function WishlistButtonDynamic({ productId, className }: { productId: string; className?: string }) {
+```
+
+- [ ] **Step 3: Forward `className` to `<WishlistButton>` (authenticated state)**
+
+Find the authenticated-state return (around line 44):
+
+```tsx
+if (isAuthenticated && isWishlisted !== undefined) {
+  return (
+    <WishlistButton
+      productId={productId}
+      isWishlisted={isWishlisted}
+      onToggled={setIsWishlisted}
+    />
+  );
+}
+```
+
+Replace with:
+
+```tsx
+if (isAuthenticated && isWishlisted !== undefined) {
+  return (
+    <WishlistButton
+      productId={productId}
+      isWishlisted={isWishlisted}
+      onToggled={setIsWishlisted}
+      className={className}
+    />
+  );
+}
+```
+
+(`WishlistButton` already accepts `className` and merges it via `cn()` — no change needed in that file.)
+
+- [ ] **Step 4: Forward `className` to the guest-state `<Button>`**
+
+Find the guest-state return (around line 56):
+
+```tsx
+if (!isAuthenticated) {
+  return (
+    <>
+      <Button
+        type="button"
+        size="icon-lg"
+        variant="outline"
+        className="hover:text-destructive hover:border-destructive/50"
+        onMouseEnter={prefetchAuthDialog}
+```
+
+Replace the `className` attribute with:
+
+```tsx
+className={cn("hover:text-destructive hover:border-destructive/50", className)}
+```
+
+The Button block becomes:
+
+```tsx
+<Button
+  type="button"
+  size="icon-lg"
+  variant="outline"
+  className={cn("hover:text-destructive hover:border-destructive/50", className)}
+  onMouseEnter={prefetchAuthDialog}
+  onFocus={prefetchAuthDialog}
+  onClick={(e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDialogOpen(true);
+  }}
+  aria-label="Ajouter aux favoris"
+>
+```
+
+- [ ] **Step 5: Verify with grep**
+
+Run:
+
+```bash
+grep -n "className" components/storefront/wishlist-button-dynamic.tsx
+```
+
+Expected: at least 3 occurrences — destructured prop, forwarded to WishlistButton, merged via cn() on guest Button.
+
+---
+
+## Task 3: Refactor `ProductCardActions` for responsive stacked layout
+
+**Files:**
+- Modify: `components/storefront/product-card-actions.tsx`
+
+- [ ] **Step 1: Update the actions container `<div>` className**
+
+Find the actions container (currently line 66-69):
+
+```tsx
+<div
+  className="flex items-center gap-2 border-t px-3 py-2"
+  onClick={(e) => e.stopPropagation()}
+>
+```
+
+Replace the className with the responsive variant:
+
+```tsx
+<div
+  className="flex flex-col gap-1.5 border-t px-3 py-2 sm:flex-row sm:items-center sm:gap-2"
+  onClick={(e) => e.stopPropagation()}
+>
+```
+
+**Why:** mobile = vertical stack with tight 1.5 gap; sm+ = original horizontal row with gap-2 and centered alignment.
+
+- [ ] **Step 2: Add responsive ordering and width to the primary `<Button>`**
+
+Find the primary Button (currently line 70-84):
+
+```tsx
+<Button
+  size="lg"
+  variant={isOutOfStock ? "outline" : "default"}
+  disabled={isOutOfStock}
+  className="flex-1"
+  onClick={handleCartClick}
+  aria-label={
+    isOutOfStock
+      ? "Rupture de stock"
+      : `Ajouter ${product.name} au panier`
+  }
+>
+  <HugeiconsIcon icon={ShoppingCart02Icon} size={16} />
+  {isOutOfStock ? "Rupture de stock" : "Ajouter"}
+</Button>
+```
+
+Replace the `className` with:
+
+```tsx
+className="w-full order-last sm:order-none sm:w-auto sm:flex-1"
+```
+
+The full Button becomes:
+
+```tsx
+<Button
+  size="lg"
+  variant={isOutOfStock ? "outline" : "default"}
+  disabled={isOutOfStock}
+  className="w-full order-last sm:order-none sm:w-auto sm:flex-1"
+  onClick={handleCartClick}
+  aria-label={
+    isOutOfStock
+      ? "Rupture de stock"
+      : `Ajouter ${product.name} au panier`
+  }
+>
+  <HugeiconsIcon icon={ShoppingCart02Icon} size={16} />
+  {isOutOfStock ? "Rupture de stock" : "Ajouter"}
+</Button>
+```
+
+**Why:** on mobile, `w-full` makes the button span the card; `order-last` pushes it to the bottom of the column flex despite being first in JSX. On sm+, `sm:order-none` resets ordering, `sm:w-auto` returns to default width, `sm:flex-1` restores original behavior.
+
+- [ ] **Step 3: Wrap the two icon button wrappers in a sub-div with `sm:contents`**
+
+Find the two icon button wrappers (currently lines 86-96):
+
+```tsx
+<div onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}>
+  <WhatsAppProductButton
+    productName={product.name}
+    price={product.base_price}
+    slug={product.slug}
+    variant="icon"
+  />
+</div>
+<div onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}>
+  <WishlistButtonDynamic productId={product.id} />
+</div>
+```
+
+Replace this entire block with:
+
+```tsx
+<div className="flex gap-1.5 sm:contents">
+  <div className="flex-1 sm:flex-none" onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}>
+    <WhatsAppProductButton
+      productName={product.name}
+      price={product.base_price}
+      slug={product.slug}
+      variant="icon"
+      className="w-full sm:w-auto"
+    />
+  </div>
+  <div className="flex-1 sm:flex-none" onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}>
+    <WishlistButtonDynamic productId={product.id} className="w-full sm:w-auto" />
+  </div>
+</div>
+```
+
+**Why:** outer sub-div is `flex gap-1.5` on mobile (forms the icons row) but `display: contents` on sm+ (effectively unwraps itself, so the inner wrapper divs become direct children of the parent flex). Inner wrapper divs are `flex-1` on mobile (split 50/50 width) and `flex-none` on sm+ (intrinsic width = button width). Buttons inside use the new `className` prop with `w-full sm:w-auto` so they fill the wrapper on mobile and revert to native `icon-lg` 32×32 on sm+.
+
+- [ ] **Step 4: Sanity check the full JSX**
+
+Open `components/storefront/product-card-actions.tsx` and confirm the full `return` structure matches:
+
+```tsx
+return (
+  <>
+    <div
+      className="flex flex-col gap-1.5 border-t px-3 py-2 sm:flex-row sm:items-center sm:gap-2"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <Button
+        size="lg"
+        variant={isOutOfStock ? "outline" : "default"}
+        disabled={isOutOfStock}
+        className="w-full order-last sm:order-none sm:w-auto sm:flex-1"
+        onClick={handleCartClick}
+        aria-label={
+          isOutOfStock
+            ? "Rupture de stock"
+            : `Ajouter ${product.name} au panier`
+        }
+      >
+        <HugeiconsIcon icon={ShoppingCart02Icon} size={16} />
+        {isOutOfStock ? "Rupture de stock" : "Ajouter"}
+      </Button>
+
+      <div className="flex gap-1.5 sm:contents">
+        <div className="flex-1 sm:flex-none" onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}>
+          <WhatsAppProductButton
+            productName={product.name}
+            price={product.base_price}
+            slug={product.slug}
+            variant="icon"
+            className="w-full sm:w-auto"
+          />
+        </div>
+        <div className="flex-1 sm:flex-none" onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}>
+          <WishlistButtonDynamic productId={product.id} className="w-full sm:w-auto" />
+        </div>
+      </div>
+    </div>
+
+    {hasVariants && (
+      <VariantPickerDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        product={product}
+      />
+    )}
+  </>
+);
+```
+
+The rest of the file (imports, dynamic loaders, state, `handleCartClick`) is **unchanged**.
+
+---
+
+## Task 4: Pre-commit verification (catch regressions before committing)
+
+**Files:** None (commands only)
+
+- [ ] **Step 1: Run TypeScript type check**
+
+Run:
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no output (clean exit). If type errors appear, they are most likely a typo in one of the className strings or a missing prop forwarding — re-check Tasks 1-3.
+
+- [ ] **Step 2: Run ESLint on the three modified files**
+
+Run:
+
+```bash
+npx eslint components/storefront/whatsapp-product-button.tsx components/storefront/wishlist-button-dynamic.tsx components/storefront/product-card-actions.tsx
+```
+
+Expected: no output (clean exit).
+
+- [ ] **Step 3: Run the full test suite**
+
+Run:
+
+```bash
+npm run test
+```
+
+Expected: `Test Files 52 passed (52)` and `Tests 710 passed (710)`. The pre-commit hook will re-run this anyway, but doing it now isolates the failure to the change rather than the commit-message step.
+
+If a test fails: read the failure carefully. If it's unrelated to the storefront changes (flaky test, environment issue), retry once. If it's related, return to Task 1-3 and fix.
+
+---
+
+## Task 5: Single commit + push branch
+
+**Files:** None (git commands)
+
+- [ ] **Step 1: Confirm we're on the correct branch**
+
+Run:
+
+```bash
+git branch --show-current
+```
+
+Expected: `fix/product-card-mobile-actions-redesign`
+
+If not, stop and ask — do not commit on the wrong branch.
+
+- [ ] **Step 2: Stage only the three modified component files**
+
+Run:
+
+```bash
+git add components/storefront/whatsapp-product-button.tsx components/storefront/wishlist-button-dynamic.tsx components/storefront/product-card-actions.tsx
+```
+
+**Do NOT** use `git add .` or `git add -A` — there are untracked AI-tool folders at the repo root that must not be committed (per CLAUDE.md gotcha).
+
+- [ ] **Step 3: Verify the staged changes look right**
+
+Run:
+
+```bash
+git diff --cached --stat
+```
+
+Expected: 3 files modified, around 30-50 lines of insertions/deletions total.
+
+- [ ] **Step 4: Create the commit**
+
+Run:
+
+```bash
+git commit -m "$(cat <<'EOF'
+fix(storefront): redesign product card mobile actions to prevent overflow
+
+On mobile (<sm/640px), the 2-column product grid leaves cards ~158px
+wide. Three buttons on a single row (Ajouter + WhatsApp + wishlist)
+overflowed because the primary button has whitespace-nowrap + shrink-0
+inherited from buttonVariants and the "Rupture de stock" label is wide.
+
+Restructure the actions row as a responsive layout: vertical stack on
+mobile (icons row on top via flex-1, full-width "Ajouter au panier" on
+the bottom via order-last), original single row preserved on sm+ via
+display: contents trick on the icons sub-wrapper. The full label fits
+in every state, the primary CTA sits in the thumb zone on mobile, and
+the desktop layout is byte-for-byte unchanged.
+
+Two helper components gain an opt-in className prop (WhatsAppProductButton
+icon variant, WishlistButtonDynamic) so the parent can drive responsive
+sizing without forking — their PDP usages remain visually identical.
+
+Replaces #171 (closed) which used a min-w-0 + truncate hack that left
+the label visibly cut off on small screens.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+The pre-commit hook will run tsc + eslint + vitest + migration-safety. Expected: all green, commit created.
+
+- [ ] **Step 5: Push to origin**
+
+Run:
+
+```bash
+git push -u origin fix/product-card-mobile-actions-redesign
+```
+
+Expected: branch pushed, GitHub URL printed for opening a PR.
+
+---
+
+## Task 6: Manual browser validation
+
+**Files:** None (visual checks only)
+
+- [ ] **Step 1: Confirm dev server is running**
+
+The dev server was started earlier in this session on port 3000. Verify:
+
+```bash
+curl -sI http://localhost:3000 | head -1
+```
+
+Expected: `HTTP/1.1 200 OK`. If not, restart with `npm run dev` in a background bash task.
+
+- [ ] **Step 2: Open the homepage and run through the responsive checklist**
+
+Navigate to **http://localhost:3000** in the browser. Open DevTools (F12), enable device toolbar (Ctrl+Shift+M), then verify each of the following — at each breakpoint, look at one in-stock product and one out-of-stock product if available:
+
+- [ ] **320px wide** (smallest mobile): three buttons fit in the card, no horizontal overflow. Icons row above, "Ajouter au panier" full width below. "Rupture de stock" displays in full (no ellipsis).
+- [ ] **360px wide** (Android average): same as above.
+- [ ] **375px wide** (iPhone SE / 12 mini): same as above.
+- [ ] **640px wide** (sm breakpoint exact): layout switches to single row — `[Ajouter] [WA] [♥]`. No vertical stacking visible.
+- [ ] **768px (md)** and **1024px (lg)** widths: single-row layout identical to before this PR.
+
+- [ ] **Step 3: Functional spot-check**
+
+- [ ] Click "Ajouter" on a product with no variants — item added to cart (toast or cart drawer should react).
+- [ ] Click "Ajouter" on a product with variants (e.g. a phone with multiple storage options) — variant picker dialog opens.
+- [ ] Click the WhatsApp icon — opens `wa.me` link in a new tab with the product context message.
+- [ ] Click the wishlist icon **as a guest** (sign out first if needed) — auth dialog opens.
+- [ ] Click the wishlist icon **as an authenticated customer** — heart fills/unfills, optimistic update visible.
+
+- [ ] **Step 4: PDP non-regression**
+
+Navigate to a product detail page (`/p/<some-slug>`). Verify:
+
+- The standalone wishlist button next to the product title is the original size (32×32) and styling.
+- The full-width "Commander sur WhatsApp" button below "Ajouter au panier" still renders in full-width green styling, not affected by the new `className` prop.
+
+- [ ] **Step 5: Browser console check**
+
+In DevTools console, look for any new warnings or errors — particularly hydration mismatches. Hydration mismatches on a fresh page load after this change indicate the server-rendered HTML and client HTML diverge; investigate before opening the PR.
+
+---
+
+## Task 7: Open the pull request
+
+**Files:** None (gh CLI)
+
+- [ ] **Step 1: Create the PR**
+
+Run:
+
+```bash
+gh pr create --title "fix(storefront): redesign product card mobile actions to prevent overflow" --body "$(cat <<'EOF'
+## Summary
+
+Replaces #171 (closed) with a proper responsive refactor instead of a `min-w-0 + truncate` hack that left the label visibly cut off.
+
+**Mobile (< sm/640px):** vertical stack — WhatsApp + wishlist icons on top (each `flex-1`, ~50% card width), "Ajouter au panier" full-width below. Primary CTA in the thumb zone, full label always visible.
+
+**Tablette / Desktop (sm+):** unchanged — `[Ajouter (flex-1)] [WhatsApp 32px] [♥ 32px]` on a single row, byte-for-byte identical to before this PR.
+
+CSS strategy: container `flex-col sm:flex-row`; primary button `order-last sm:order-none`; icons wrapped in a sub-div that is `flex gap-1.5` on mobile and `display: contents` on sm+ (effectively unwraps so the icons become direct flex children of the parent on desktop). Two helper components (`WhatsAppProductButton` icon variant, `WishlistButtonDynamic`) gain an opt-in `className?: string` prop so the parent can drive responsive sizing — their PDP usages remain visually identical.
+
+Spec: \`docs/superpowers/specs/2026-04-16-product-card-mobile-actions-redesign.md\`
+
+## Test plan
+
+### Responsive layout
+- [ ] **320px** : pas de débordement, label « Rupture de stock » entier
+- [ ] **360px** : pas de débordement, label entier
+- [ ] **375px** (iPhone SE / 12 mini) : pas de débordement, label entier
+- [ ] **640px** : transition mobile → desktop, single-row visible
+- [ ] **768px / 1024px** : layout single-row identique à \`main\`
+
+### Interactions
+- [ ] « Ajouter » sur produit sans variant → item ajouté au panier
+- [ ] « Ajouter » sur produit avec variants → variant picker s'ouvre
+- [ ] WhatsApp → ouvre wa.me dans un nouvel onglet
+- [ ] Wishlist guest → ouvre l'auth dialog
+- [ ] Wishlist authentifié → toggle optimiste
+
+### Non-régression PDP
+- [ ] Wishlist standalone à côté du titre produit : taille / style inchangés
+- [ ] WhatsApp \`variant="full"\` sous « Ajouter au panier » : pleine largeur verte inchangée
+
+### Console
+- [ ] Aucun warning d'hydratation sur la home ni la PDP
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2: Capture and report the PR URL**
+
+The `gh pr create` command prints the new PR URL on its last line. Report this URL to the user.
+
+- [ ] **Step 3: Stop. Wait for explicit merge approval.**
+
+Per project workflow rules: **never merge without explicit user approval**. Do not run `gh pr merge` or anything similar. Wait for the user to say "merge" (or equivalent).

--- a/docs/superpowers/plans/2026-04-16-product-card-mobile-actions-redesign.md
+++ b/docs/superpowers/plans/2026-04-16-product-card-mobile-actions-redesign.md
@@ -18,7 +18,7 @@
 |---|---|---|
 | `components/storefront/whatsapp-product-button.tsx` | Modify | Add `className?: string` prop on the icon variant; merge with existing classes via `cn()`. |
 | `components/storefront/wishlist-button-dynamic.tsx` | Modify | Add `className?: string` prop; forward to both internal Button (guest state) and `<WishlistButton>` (authenticated state). |
-| `components/storefront/product-card-actions.tsx` | Modify | Refactor the actions `<div>`: container becomes `flex-col sm:flex-row`, icons wrapped in `flex sm:contents` sub-div, primary CTA reordered with `order-last sm:order-none`. Pass `flex-1 sm:flex-none` and `w-full sm:w-auto` to icon button wrappers/buttons. |
+| `components/storefront/product-card-actions.tsx` | Modify | Refactor the actions `<div>`: container becomes `flex-col sm:flex-row`, icons wrapped in `flex sm:contents` sub-div, primary CTA reordered with `order-last sm:order-none`. Pass `flex-1 sm:flex-none` to icon button wrappers and `w-full sm:w-8` to the buttons inside. |
 
 No new files. No tests added (purely visual responsive change; existing 710-test suite re-runs via pre-commit hook to guard against regressions). No changes to `wishlist-button.tsx` (already accepts `className`).
 
@@ -373,16 +373,16 @@ Replace this entire block with:
       price={product.base_price}
       slug={product.slug}
       variant="icon"
-      className="w-full sm:w-auto"
+      className="w-full sm:w-8"
     />
   </div>
   <div className="flex-1 sm:flex-none" onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}>
-    <WishlistButtonDynamic productId={product.id} className="w-full sm:w-auto" />
+    <WishlistButtonDynamic productId={product.id} className="w-full sm:w-8" />
   </div>
 </div>
 ```
 
-**Why:** outer sub-div is `flex gap-1.5` on mobile (forms the icons row) but `display: contents` on sm+ (effectively unwraps itself, so the inner wrapper divs become direct children of the parent flex). Inner wrapper divs are `flex-1` on mobile (split 50/50 width) and `flex-none` on sm+ (intrinsic width = button width). Buttons inside use the new `className` prop with `w-full sm:w-auto` so they fill the wrapper on mobile and revert to native `icon-lg` 32×32 on sm+.
+**Why:** outer sub-div is `flex gap-1.5` on mobile (forms the icons row) but `display: contents` on sm+ (effectively unwraps itself, so the inner wrapper divs become direct children of the parent flex). Inner wrapper divs are `flex-1` on mobile (split 50/50 width) and `flex-none` on sm+ (intrinsic width = button width). Buttons inside use the new `className` prop with `w-full sm:w-8` so they fill the wrapper on mobile and explicitly restore the 32px width on sm+ — `sm:w-8` rather than `sm:w-auto` because `size-8` from the `icon-lg` CVA can't override `w-full` cleanly via `tailwind-merge` (caught during code review; see the PR commit body).
 
 - [ ] **Step 4: Sanity check the full JSX**
 
@@ -418,11 +418,11 @@ return (
             price={product.base_price}
             slug={product.slug}
             variant="icon"
-            className="w-full sm:w-auto"
+            className="w-full sm:w-8"
           />
         </div>
         <div className="flex-1 sm:flex-none" onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}>
-          <WishlistButtonDynamic productId={product.id} className="w-full sm:w-auto" />
+          <WishlistButtonDynamic productId={product.id} className="w-full sm:w-8" />
         </div>
       </div>
     </div>

--- a/docs/superpowers/plans/2026-04-16-product-card-mobile-actions-redesign.md
+++ b/docs/superpowers/plans/2026-04-16-product-card-mobile-actions-redesign.md
@@ -138,7 +138,7 @@ grep -n "className" components/storefront/whatsapp-product-button.tsx
 
 Expected output (lines may differ slightly):
 
-```
+```text
 Props interface line containing `className?: string;`
 Function signature destructuring `className`
 className={cn(... className)} on the icon Button

--- a/docs/superpowers/specs/2026-04-16-product-card-mobile-actions-redesign.md
+++ b/docs/superpowers/specs/2026-04-16-product-card-mobile-actions-redesign.md
@@ -1,0 +1,128 @@
+# ProductCard — Refonte de la barre d'actions sur mobile
+
+**Date** : 2026-04-16
+**Statut** : Approuvé (brainstorming)
+**Auteur** : Claude + @kkzakaria
+
+## Contexte
+
+Sur les viewports mobile (< 640px), la grille produits passe en 2 colonnes (`grid-cols-2 gap-3` dans `components/storefront/product-grid.tsx:14`). À 360px de largeur, chaque carte mesure ~158px. La barre d'actions actuelle (`components/storefront/product-card-actions.tsx`) place trois boutons sur une seule ligne :
+
+```
+[Ajouter (flex-1)] [WhatsApp icon-lg = 32px] [Wishlist icon-lg = 32px]
+```
+
+Le bouton principal a `whitespace-nowrap` + `shrink-0` hérités de `buttonVariants` ; combiné avec le label « Rupture de stock » (≈130px de besoin), les icônes WhatsApp et wishlist débordent hors de la carte.
+
+Une première PR (kkzakaria/netereka#171) a tenté un fix minimal (`min-w-0` + `truncate` + label raccourci en « Épuisé »). Le débordement disparaît mais le label se retrouve tronqué visuellement, ce qui est inacceptable en pratique. Cette PR sera **fermée sans merger** au profit de la refonte décrite ici.
+
+## Objectif
+
+Éliminer le débordement **et** la troncature en repensant la disposition mobile, sans régression desktop ni sur la PDP.
+
+## Décisions structurantes
+
+| Dimension | Choix | Raison |
+|---|---|---|
+| Disposition mobile | Stack vertical : icônes en haut, CTA principal en bas | CTA principal en zone pouce, place pour le label complet |
+| Périmètre responsive | Mobile uniquement (< sm/640px) | Le débordement n'existe pas au-delà ; pas de régression de densité desktop |
+| Largeur des icônes mobile | `flex-1` (étalées) | Cibles tactiles plus généreuses, parallèle visuel avec le bouton dessous |
+| Label en rupture de stock | « Rupture de stock » restauré | La place est là maintenant, plus besoin de raccourcir |
+| Stratégie PR | Fermer #171, ouvrir une nouvelle PR avec la refonte complète | Évite de laisser le hack `truncate`/`min-w-0` dans le code |
+
+## Disposition cible
+
+### Mobile (< 640px)
+
+```
+┌──────────────────────────────────┐
+│ [WhatsApp flex-1] [Wishlist flex-1]│  ← rangée d'icônes (top)
+│ [   Ajouter au panier (full)    ] │  ← CTA principal full-width (bas)
+└──────────────────────────────────┘
+```
+
+- Container : `flex-col` avec `gap-1.5`
+- Rangée icônes : sub-flex, `gap-1.5`, chaque icône `flex-1` (largeur ~50% de la carte)
+- Bouton principal : `w-full`, hauteur conservée (`size="lg"`)
+
+### Tablette / Desktop (sm+)
+
+Disposition actuelle **inchangée** :
+
+```
+┌────────────────────────────────────────────────┐
+│ [Ajouter (flex-1)]  [WhatsApp 32px]  [♥ 32px] │
+└────────────────────────────────────────────────┘
+```
+
+- Container : `flex-row items-center gap-2`
+- Bouton principal en premier (gauche), icônes 32×32 en suite
+
+### Mécanique CSS — sub-container `sm:contents`
+
+Pour réordonner sans dupliquer le markup, on utilise :
+
+```tsx
+<div className="flex flex-col gap-1.5 border-t px-3 py-2 sm:flex-row sm:items-center sm:gap-2">
+  <Button className="w-full order-last sm:order-none sm:flex-1">Ajouter</Button>
+  <div className="flex gap-1.5 sm:contents">
+    <WhatsAppButton className="flex-1 sm:flex-none" />
+    <WishlistButton className="flex-1 sm:flex-none" />
+  </div>
+</div>
+```
+
+- **Mobile** : container vertical ; le sub-div icônes garde `flex gap-1.5` ; `order-last` pousse le bouton principal en bas malgré sa position en premier dans le JSX.
+- **sm+** : container horizontal ; `sm:contents` fait disparaître le sub-div du layout (les icônes deviennent enfants directs du parent flex) ; `sm:flex-none` rétablit la largeur intrinsèque `icon-lg` ; ordre JSX = ordre visuel.
+
+## Comportements préservés (no-op)
+
+- Wishlist visible pour les guests, clic ouvre `AuthDialog`
+- WhatsApp + wishlist restent fonctionnels en rupture de stock
+- Bouton principal désactivé + variant `outline` en rupture
+- Variant picker dialog s'ouvre au clic sur Ajouter quand `variant_count > 1`
+- `WhatsAppProductButton variant="full"` (utilisé sur la PDP) inchangé
+- `WishlistButtonDynamic` standalone (utilisé sur la PDP, lignes 267 et 294 de `app/(storefront)/p/[slug]/page.tsx`) inchangé — la prop `className` est opt-in
+
+## Fichiers modifiés
+
+| Fichier | Nature du changement |
+|---|---|
+| `components/storefront/product-card-actions.tsx` | Refonte du `<div>` actions : container responsive `flex-col sm:flex-row`, sub-div icônes `flex sm:contents`, ordering via `order-last sm:order-none`. Restaure « Rupture de stock » en label complet, retire `min-w-0` et `<span className="truncate">`. |
+| `components/storefront/whatsapp-product-button.tsx` | Ajoute prop `className?: string` (variante `icon` uniquement) ; transmise au `<Button>` via `cn()`. |
+| `components/storefront/wishlist-button-dynamic.tsx` | Ajoute prop `className?: string`. Forwarded vers le `<Button>` interne (état guest) **et** vers `<WishlistButton>` (état authentifié, qui a déjà cette prop). |
+
+Aucun changement requis dans `components/storefront/wishlist-button.tsx` (la prop `className` existe déjà).
+
+## Tests
+
+Pas de tests existants sur `product-card-actions.tsx` (vérifié via `npm run test -- components/storefront` — aucun fichier matching). Le changement étant purement visuel/responsive, **pas de nouveau test unitaire** requis. La validation passe par :
+
+- `npm run dev` + DevTools mobile (320, 360, 375, 768px)
+- Pre-commit hook : `tsc --noEmit` + `eslint` + `vitest run` (suite existante 710 tests)
+- Vérification manuelle PDP : icônes WhatsApp full + wishlist standalone inchangées
+
+## Implications
+
+- **+36px de hauteur** sur les cartes mobile (deux rangées d'actions au lieu d'une) → impact accepté sur la longueur de scroll des pages catalogue
+- **Aucune régression desktop / tablette** : sm+ identique à l'existant
+- **Aucune régression PDP** : les composants WhatsApp/wishlist gardent leurs styles par défaut
+- **`min-w-0 + truncate + « Épuisé »` du fix #171 retirés** : la place est là, plus besoin du hack
+
+## Stratégie PR
+
+1. Fermer (sans merger) **kkzakaria/netereka#171** avec un commentaire pointant vers la nouvelle PR.
+2. Repartir de `main` (pas de `fix/product-card-mobile-overflow` — le commit du hack est abandonné).
+3. Nouvelle branche : `fix/product-card-mobile-actions-redesign`.
+4. Commit unique scope `storefront` : `fix(storefront): redesign product card mobile actions to prevent overflow`.
+5. PR avec test plan détaillé (320px, 360px, 375px, 768px ; rupture de stock ; guest vs authentifié ; PDP non régressée).
+
+## Critères d'acceptation
+
+- [ ] À 360px et 320px : les trois boutons tiennent dans la carte sans débordement
+- [ ] À 360px et 320px : le label « Rupture de stock » s'affiche en entier sans troncature
+- [ ] À 768px+ : disposition single-row identique à aujourd'hui
+- [ ] PDP : icône WhatsApp full-width et wishlist standalone visuellement identiques à avant
+- [ ] CTA principal en bas du stack mobile cliquable au pouce (pas de scroll forcé pour atteindre)
+- [ ] Aucun warning d'hydratation
+- [ ] Pre-commit hook OK (tsc + eslint + 710 tests)


### PR DESCRIPTION
## Summary

Replaces #171 (closed) with a proper responsive refactor instead of a `min-w-0 + truncate` hack that left the label visibly cut off.

**Mobile (< sm/640px) :** stack vertical — WhatsApp + wishlist en haut (chacun `flex-1`, ~50% de la largeur de carte), « Ajouter au panier » full-width en bas. CTA principal en zone pouce, label complet toujours visible.

**Tablette / Desktop (sm+) :** inchangé — `[Ajouter (flex-1)] [WhatsApp 32px] [♥ 32px]` sur une ligne, byte-for-byte identique à `main`.

### Mécanique CSS

- Container : `flex-col sm:flex-row` (+ `gap-1.5 sm:gap-2`)
- Bouton principal : `w-full order-last sm:order-none sm:w-auto sm:flex-1` (poussé en bas sur mobile via `order-last`, retrouve sa place sur sm+)
- Icônes wrappées dans un sub-div `flex gap-1.5 sm:contents` — `display: contents` sur sm+ "déplie" le wrapper et les icônes deviennent enfants directs du flex parent (layout desktop préservé exactement)
- Wrappers internes : `flex-1 sm:flex-none` ; les boutons reçoivent `w-full sm:w-8` via la nouvelle prop `className`

Deux composants helpers (`WhatsAppProductButton` icon variant, `WishlistButtonDynamic`) gagnent une prop opt-in `className?: string` — leurs usages PDP restent visuellement identiques (ils ne passent pas la prop).

### Détail catché en review

Initialement le plan utilisait `sm:w-auto` sur les icônes pour "revenir au size par défaut". Le code review a remarqué que `size-8` (= `w-8 h-8`) du variant `icon-lg` ne tient pas face à `w-full sm:w-auto` dans la cascade tailwind-merge — le bouton aurait collapse à ~16px (largeur de l'icône) sur sm+. Corrigé en `sm:w-8` qui restaure explicitement le carré 32×32.

Spec & plan : \`docs/superpowers/specs/2026-04-16-product-card-mobile-actions-redesign.md\`, \`docs/superpowers/plans/2026-04-16-product-card-mobile-actions-redesign.md\`.

## Test plan

### Layout responsive
- [ ] **320px** : pas de débordement, label « Rupture de stock » entier
- [ ] **360px** : pas de débordement, label entier
- [ ] **375px** (iPhone SE / 12 mini) : pas de débordement, label entier
- [ ] **640px** : transition mobile → desktop, single-row visible
- [ ] **768px / 1024px** : layout single-row identique à \`main\`, icônes WhatsApp/♥ font bien 32×32

### Interactions
- [ ] « Ajouter » sur produit sans variant → item ajouté au panier
- [ ] « Ajouter » sur produit avec variants → variant picker s'ouvre
- [ ] WhatsApp → ouvre wa.me dans un nouvel onglet
- [ ] Wishlist guest → ouvre l'auth dialog
- [ ] Wishlist authentifié → toggle optimiste

### Non-régression PDP
- [ ] Wishlist standalone à côté du titre produit : taille / style inchangés
- [ ] WhatsApp \`variant="full"\` sous « Ajouter au panier » : pleine largeur verte inchangée

### Console
- [ ] Aucun warning d'hydratation sur la home ni la PDP

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Product card actions are now responsive: icon actions appear above and the cart button becomes full-width on mobile; desktop/tablet keep the inline layout.
  * Icon action components accept optional styling hooks so their sizing and ordering adapt across breakpoints.

* **Documentation**
  * Added spec and implementation-plan docs describing the mobile actions redesign and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->