### PR TITLE
feat(storefront): Apple-like Product Story template

### DIFF
--- a/__tests__/unit/actions/admin-products.test.ts
+++ b/__tests__/unit/actions/admin-products.test.ts
@@ -4,17 +4,31 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const mocks = vi.hoisted(() => ({
   requireAdmin: vi.fn(),
   queryFirst: vi.fn(),
-  execute: vi.fn(),
   revalidatePath: vi.fn(),
   nanoid: vi.fn(),
   slugify: vi.fn(),
+  // Drizzle: `db.update(table).set(values).where(cond)` — set captures values, where executes.
+  drizzleSet: vi.fn(),
+  drizzleWhere: vi.fn(),
 }));
 
 vi.mock("@/lib/auth/guards", () => ({ requireAdmin: mocks.requireAdmin }));
 vi.mock("@/lib/db", () => ({
   queryFirst: mocks.queryFirst,
-  execute: mocks.execute,
+  execute: vi.fn(),
   query: vi.fn(),
+}));
+vi.mock("@/lib/db/drizzle", () => ({
+  getDrizzle: vi.fn(async () => ({
+    update: () => ({
+      set: (values: unknown) => {
+        mocks.drizzleSet(values);
+        return {
+          where: (cond: unknown) => mocks.drizzleWhere(cond),
+        };
+      },
+    }),
+  })),
 }));
 vi.mock("next/cache", () => ({ revalidatePath: mocks.revalidatePath }));
 vi.mock("nanoid", () => ({ nanoid: mocks.nanoid }));
@@ -48,7 +62,7 @@ describe("updateProduct", () => {
       expect(result.success).toBe(false);
       expect(result.error).toBeTruthy();
       expect(mocks.queryFirst).not.toHaveBeenCalled();
-      expect(mocks.execute).not.toHaveBeenCalled();
+      expect(mocks.drizzleWhere).not.toHaveBeenCalled();
     });
   });
 
@@ -57,51 +71,49 @@ describe("updateProduct", () => {
       mocks.queryFirst.mockResolvedValueOnce(null);
       const result = await updateProduct("prod-1", baseFormData());
       expect(result).toEqual({ success: false, error: "Produit introuvable" });
-      expect(mocks.execute).not.toHaveBeenCalled();
+      expect(mocks.drizzleWhere).not.toHaveBeenCalled();
     });
   });
 
   describe("produit déjà publié (is_draft = 0)", () => {
     it("préserve le slug existant sans le régénérer", async () => {
       mocks.queryFirst.mockResolvedValueOnce({ slug: "iphone-15-pro", sku: "NET-ABCD1234", is_draft: 0 });
-      mocks.execute.mockResolvedValueOnce(undefined);
+      mocks.drizzleWhere.mockResolvedValueOnce(undefined);
       const result = await updateProduct("prod-1", baseFormData());
       expect(result.success).toBe(true);
-      expect(mocks.execute).toHaveBeenCalledWith(
-        expect.stringContaining("UPDATE products"),
-        expect.arrayContaining(["iphone-15-pro"])
+      expect(mocks.drizzleSet).toHaveBeenCalledWith(
+        expect.objectContaining({ slug: "iphone-15-pro" }),
       );
       expect(mocks.slugify).not.toHaveBeenCalled();
     });
 
     it("préserve le SKU existant sans le régénérer", async () => {
       mocks.queryFirst.mockResolvedValueOnce({ slug: "iphone-15-pro", sku: "NET-ABCD1234", is_draft: 0 });
-      mocks.execute.mockResolvedValueOnce(undefined);
+      mocks.drizzleWhere.mockResolvedValueOnce(undefined);
       await updateProduct("prod-1", baseFormData());
-      expect(mocks.execute).toHaveBeenCalledWith(
-        expect.stringContaining("UPDATE products"),
-        expect.arrayContaining(["NET-ABCD1234"])
+      expect(mocks.drizzleSet).toHaveBeenCalledWith(
+        expect.objectContaining({ sku: "NET-ABCD1234" }),
       );
       expect(mocks.nanoid).not.toHaveBeenCalled();
     });
 
     it("n'appelle pas revalidatePath sur /p/ si produit déjà publié", async () => {
       mocks.queryFirst.mockResolvedValueOnce({ slug: "iphone-15-pro", sku: "NET-ABCD1234", is_draft: 0 });
-      mocks.execute.mockResolvedValueOnce(undefined);
+      mocks.drizzleWhere.mockResolvedValueOnce(undefined);
       await updateProduct("prod-1", baseFormData());
       expect(mocks.revalidatePath).not.toHaveBeenCalledWith("/p/iphone-15-pro");
     });
 
     it("retourne une erreur de conflit slug si execute lève une contrainte slug (produit publié)", async () => {
       mocks.queryFirst.mockResolvedValueOnce({ slug: "iphone-15-pro", sku: "NET-ABCD1234", is_draft: 0 });
-      mocks.execute.mockRejectedValueOnce(new Error("UNIQUE constraint failed: products.slug"));
+      mocks.drizzleWhere.mockRejectedValueOnce(new Error("UNIQUE constraint failed: products.slug"));
       const result = await updateProduct("prod-1", baseFormData());
       expect(result).toEqual({ success: false, error: "Un conflit de slug s'est produit (collision concurrente). Enregistrez à nouveau pour résoudre le conflit." });
     });
 
     it("propage une erreur DB inattendue pour un produit publié avec SKU existant", async () => {
       mocks.queryFirst.mockResolvedValueOnce({ slug: "iphone-15-pro", sku: "NET-ABCD1234", is_draft: 0 });
-      mocks.execute.mockRejectedValueOnce(new Error("D1 unavailable"));
+      mocks.drizzleWhere.mockRejectedValueOnce(new Error("D1 unavailable"));
       await expect(updateProduct("prod-1", baseFormData())).rejects.toThrow("D1 unavailable");
     });
   });
@@ -113,12 +125,11 @@ describe("updateProduct", () => {
         .mockResolvedValueOnce(null); // slug "iphone-15-pro" libre
       mocks.slugify.mockReturnValue("iphone-15-pro");
       mocks.nanoid.mockReturnValue("ABCD1234");
-      mocks.execute.mockResolvedValueOnce(undefined);
+      mocks.drizzleWhere.mockResolvedValueOnce(undefined);
       const result = await updateProduct("prod-1", baseFormData());
       expect(result.success).toBe(true);
-      expect(mocks.execute).toHaveBeenCalledWith(
-        expect.stringContaining("UPDATE products"),
-        expect.arrayContaining(["iphone-15-pro"])
+      expect(mocks.drizzleSet).toHaveBeenCalledWith(
+        expect.objectContaining({ slug: "iphone-15-pro" }),
       );
     });
 
@@ -129,12 +140,11 @@ describe("updateProduct", () => {
         .mockResolvedValueOnce(null); // "iphone-15-pro-2" libre
       mocks.slugify.mockReturnValue("iphone-15-pro");
       mocks.nanoid.mockReturnValue("ABCD1234");
-      mocks.execute.mockResolvedValueOnce(undefined);
+      mocks.drizzleWhere.mockResolvedValueOnce(undefined);
       const result = await updateProduct("prod-1", baseFormData());
       expect(result.success).toBe(true);
-      expect(mocks.execute).toHaveBeenCalledWith(
-        expect.stringContaining("UPDATE products"),
-        expect.arrayContaining(["iphone-15-pro-2"])
+      expect(mocks.drizzleSet).toHaveBeenCalledWith(
+        expect.objectContaining({ slug: "iphone-15-pro-2" }),
       );
     });
 
@@ -143,7 +153,7 @@ describe("updateProduct", () => {
       mocks.slugify.mockReturnValue("");
       const result = await updateProduct("prod-1", baseFormData());
       expect(result).toEqual({ success: false, error: "Le nom ne permet pas de générer un slug valide" });
-      expect(mocks.execute).not.toHaveBeenCalled();
+      expect(mocks.drizzleWhere).not.toHaveBeenCalled();
     });
 
     it("génère un SKU au format NET-XXXXXXXX si sku = null", async () => {
@@ -152,12 +162,11 @@ describe("updateProduct", () => {
         .mockResolvedValueOnce(null);
       mocks.slugify.mockReturnValue("iphone-15-pro");
       mocks.nanoid.mockReturnValue("abcd1234");
-      mocks.execute.mockResolvedValueOnce(undefined);
+      mocks.drizzleWhere.mockResolvedValueOnce(undefined);
       const result = await updateProduct("prod-1", baseFormData());
       expect(result.success).toBe(true);
-      expect(mocks.execute).toHaveBeenCalledWith(
-        expect.stringContaining("UPDATE products"),
-        expect.arrayContaining(["NET-ABCD1234"])
+      expect(mocks.drizzleSet).toHaveBeenCalledWith(
+        expect.objectContaining({ sku: "NET-ABCD1234" }),
       );
     });
 
@@ -169,15 +178,14 @@ describe("updateProduct", () => {
       mocks.nanoid
         .mockReturnValueOnce("aaaaaaaa") // 1er SKU — collision
         .mockReturnValueOnce("bbbbbbbb"); // 2e SKU — succès
-      mocks.execute
+      mocks.drizzleWhere
         .mockRejectedValueOnce(new Error("UNIQUE constraint failed: products.sku"))
         .mockResolvedValueOnce(undefined);
       const result = await updateProduct("prod-1", baseFormData());
       expect(result.success).toBe(true);
-      expect(mocks.execute).toHaveBeenCalledTimes(2);
-      expect(mocks.execute).toHaveBeenLastCalledWith(
-        expect.stringContaining("UPDATE products"),
-        expect.arrayContaining(["NET-BBBBBBBB"])
+      expect(mocks.drizzleWhere).toHaveBeenCalledTimes(2);
+      expect(mocks.drizzleSet).toHaveBeenLastCalledWith(
+        expect.objectContaining({ sku: "NET-BBBBBBBB" }),
       );
     });
 
@@ -187,10 +195,10 @@ describe("updateProduct", () => {
         .mockResolvedValueOnce(null);
       mocks.slugify.mockReturnValue("iphone-15-pro");
       mocks.nanoid.mockReturnValue("xxxxxxxx");
-      mocks.execute.mockRejectedValue(new Error("UNIQUE constraint failed: products.sku"));
+      mocks.drizzleWhere.mockRejectedValue(new Error("UNIQUE constraint failed: products.sku"));
       const result = await updateProduct("prod-1", baseFormData());
       expect(result).toEqual({ success: false, error: "Impossible de générer un SKU unique. Veuillez contacter le support." });
-      expect(mocks.execute).toHaveBeenCalledTimes(3);
+      expect(mocks.drizzleWhere).toHaveBeenCalledTimes(3);
     });
 
     it("propage les erreurs execute non liées à une contrainte unique", async () => {
@@ -199,7 +207,7 @@ describe("updateProduct", () => {
         .mockResolvedValueOnce(null);
       mocks.slugify.mockReturnValue("iphone-15-pro");
       mocks.nanoid.mockReturnValue("abcd1234");
-      mocks.execute.mockRejectedValue(new Error("D1 unavailable"));
+      mocks.drizzleWhere.mockRejectedValue(new Error("D1 unavailable"));
       await expect(updateProduct("prod-1", baseFormData())).rejects.toThrow("D1 unavailable");
     });
 
@@ -209,7 +217,7 @@ describe("updateProduct", () => {
         .mockResolvedValueOnce(null);
       mocks.slugify.mockReturnValue("iphone-15-pro");
       mocks.nanoid.mockReturnValue("abcd1234");
-      mocks.execute.mockRejectedValue(new Error("UNIQUE constraint failed: products.slug"));
+      mocks.drizzleWhere.mockRejectedValue(new Error("UNIQUE constraint failed: products.slug"));
       const result = await updateProduct("prod-1", baseFormData());
       expect(result).toEqual({ success: false, error: "Un conflit de slug s'est produit (collision concurrente). Enregistrez à nouveau pour résoudre le conflit." });
     });
@@ -220,7 +228,7 @@ describe("updateProduct", () => {
         .mockResolvedValueOnce(null);
       mocks.slugify.mockReturnValue("iphone-15-pro");
       mocks.nanoid.mockReturnValue("abcd1234");
-      mocks.execute.mockResolvedValueOnce(undefined);
+      mocks.drizzleWhere.mockResolvedValueOnce(undefined);
       await updateProduct("prod-1", baseFormData());
       expect(mocks.revalidatePath).toHaveBeenCalledWith("/p/iphone-15-pro");
     });
@@ -230,12 +238,11 @@ describe("updateProduct", () => {
         .mockResolvedValueOnce({ slug: "draft-abc", sku: "NET-EXISTING1", is_draft: 1 })
         .mockResolvedValueOnce(null); // slug libre
       mocks.slugify.mockReturnValue("iphone-15-pro");
-      mocks.execute.mockResolvedValueOnce(undefined);
+      mocks.drizzleWhere.mockResolvedValueOnce(undefined);
       const result = await updateProduct("prod-1", baseFormData());
       expect(result.success).toBe(true);
-      expect(mocks.execute).toHaveBeenCalledWith(
-        expect.stringContaining("UPDATE products"),
-        expect.arrayContaining(["NET-EXISTING1"])
+      expect(mocks.drizzleSet).toHaveBeenCalledWith(
+        expect.objectContaining({ sku: "NET-EXISTING1" }),
       );
       expect(mocks.nanoid).not.toHaveBeenCalled();
     });
@@ -247,17 +254,15 @@ describe("updateProduct", () => {
         .mockResolvedValueOnce(null); // slug "iphone-15-pro" is free (own draft excluded)
       mocks.slugify.mockReturnValue("iphone-15-pro");
       mocks.nanoid.mockReturnValue("abcd1234");
-      mocks.execute.mockResolvedValueOnce(undefined);
+      mocks.drizzleWhere.mockResolvedValueOnce(undefined);
       const result = await updateProduct("prod-1", baseFormData());
       expect(result.success).toBe(true);
       // Must use bare slug, not "iphone-15-pro-2"
-      expect(mocks.execute).toHaveBeenCalledWith(
-        expect.stringContaining("UPDATE products"),
-        expect.arrayContaining(["iphone-15-pro"])
+      expect(mocks.drizzleSet).toHaveBeenCalledWith(
+        expect.objectContaining({ slug: "iphone-15-pro" }),
       );
-      expect(mocks.execute).not.toHaveBeenCalledWith(
-        expect.stringContaining("UPDATE products"),
-        expect.arrayContaining(["iphone-15-pro-2"])
+      expect(mocks.drizzleSet).not.toHaveBeenCalledWith(
+        expect.objectContaining({ slug: "iphone-15-pro-2" }),
       );
       // Only 2 queryFirst calls: 1 for existing product + 1 for slug check
       expect(mocks.queryFirst).toHaveBeenCalledTimes(2);
@@ -271,7 +276,7 @@ describe("updateProduct", () => {
       mocks.slugify.mockReturnValue("samsung-galaxy");
       const result = await updateProduct("prod-1", baseFormData());
       expect(result).toEqual({ success: false, error: "Impossible de générer un slug unique pour ce nom" });
-      expect(mocks.execute).not.toHaveBeenCalled();
+      expect(mocks.drizzleWhere).not.toHaveBeenCalled();
       // 1 fetch for existing product + 100 slug uniqueness checks = 101 total
       expect(mocks.queryFirst).toHaveBeenCalledTimes(101);
     });
@@ -281,32 +286,27 @@ describe("updateProduct", () => {
     it("génère un SKU pour un produit publié sans SKU (données migrées)", async () => {
       mocks.queryFirst.mockResolvedValueOnce({ slug: "old-product", sku: null, is_draft: 0 });
       mocks.nanoid.mockReturnValue("migrated1");
-      mocks.execute.mockResolvedValueOnce(undefined);
+      mocks.drizzleWhere.mockResolvedValueOnce(undefined);
       const result = await updateProduct("prod-1", baseFormData());
       expect(result.success).toBe(true);
-      expect(mocks.execute).toHaveBeenCalledWith(
-        expect.stringContaining("UPDATE products"),
-        expect.arrayContaining(["NET-MIGRATED1"])
+      expect(mocks.drizzleSet).toHaveBeenCalledWith(
+        expect.objectContaining({ sku: "NET-MIGRATED1", slug: "old-product" }),
       );
       // slug preserved, no revalidatePath on /p/ since is_draft was already 0
-      expect(mocks.execute).toHaveBeenCalledWith(
-        expect.stringContaining("UPDATE products"),
-        expect.arrayContaining(["old-product"])
-      );
       expect(mocks.revalidatePath).not.toHaveBeenCalledWith(expect.stringContaining("/p/"));
       expect(mocks.slugify).not.toHaveBeenCalled();
     });
 
     it("ignore tout slug soumis manuellement dans le FormData", async () => {
       mocks.queryFirst.mockResolvedValueOnce({ slug: "existing-slug", sku: "NET-ABCD1234", is_draft: 0 });
-      mocks.execute.mockResolvedValueOnce(undefined);
+      mocks.drizzleWhere.mockResolvedValueOnce(undefined);
       const result = await updateProduct("prod-1", baseFormData({ slug: "my-manual-slug" }));
       expect(result.success).toBe(true);
-      // The manually submitted slug must NOT appear in the UPDATE params
-      const executeCall = mocks.execute.mock.calls[0];
-      expect(executeCall[1]).not.toContain("my-manual-slug");
+      // The manually submitted slug must NOT appear in the UPDATE values
+      const setCall = mocks.drizzleSet.mock.calls[0][0] as { slug: string };
+      expect(setCall.slug).not.toBe("my-manual-slug");
       // The existing slug IS preserved
-      expect(executeCall[1]).toContain("existing-slug");
+      expect(setCall.slug).toBe("existing-slug");
     });
   });
 });

--- a/__tests__/unit/product-story-icons.test.ts
+++ b/__tests__/unit/product-story-icons.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { resolveHighlightIcon, HIGHLIGHT_ICON_MAP } from "@/components/storefront/product-story/icons";
+import { HIGHLIGHT_ICON_NAMES } from "@/lib/validations/product-story";
+
+describe("HIGHLIGHT_ICON_MAP", () => {
+  it("exposes every name in the validation shortlist", () => {
+    for (const name of HIGHLIGHT_ICON_NAMES) {
+      expect(HIGHLIGHT_ICON_MAP[name]).toBeDefined();
+    }
+  });
+});
+
+describe("resolveHighlightIcon", () => {
+  it("returns the mapped icon for a valid name", () => {
+    const icon = resolveHighlightIcon("battery");
+    expect(icon).toBeDefined();
+  });
+  it("returns the fallback icon for an unknown name", () => {
+    const fallback = resolveHighlightIcon("unknown-name-xyz");
+    expect(fallback).toBeDefined();
+    // should equal the star fallback
+    expect(fallback).toBe(HIGHLIGHT_ICON_MAP["star"]);
+  });
+});

--- a/__tests__/unit/product-story-icons.test.ts
+++ b/__tests__/unit/product-story-icons.test.ts
@@ -13,7 +13,7 @@ describe("HIGHLIGHT_ICON_MAP", () => {
 describe("resolveHighlightIcon", () => {
   it("returns the mapped icon for a valid name", () => {
     const icon = resolveHighlightIcon("battery");
-    expect(icon).toBeDefined();
+    expect(icon).toBe(HIGHLIGHT_ICON_MAP["battery"]);
   });
   it("returns the fallback icon for an unknown name", () => {
     const fallback = resolveHighlightIcon("unknown-name-xyz");

--- a/__tests__/unit/product-story-parse.test.ts
+++ b/__tests__/unit/product-story-parse.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  parseHighlights,
+  parseFeatureBlocks,
+  parseFaq,
+  hydrateProductStoryFields,
+} from "@/lib/utils/product-story";
+
+describe("parseHighlights", () => {
+  it("returns null for null / empty / invalid JSON", () => {
+    expect(parseHighlights(null)).toBeNull();
+    expect(parseHighlights("")).toBeNull();
+    expect(parseHighlights("nope")).toBeNull();
+  });
+
+  it("returns null for JSON that does not match the shape", () => {
+    expect(parseHighlights(JSON.stringify({ foo: "bar" }))).toBeNull();
+    expect(parseHighlights(JSON.stringify([{ icon: "x" }]))).toBeNull();
+  });
+
+  it("returns parsed array for valid JSON", () => {
+    const raw = JSON.stringify([
+      { icon: "battery", label: "6000 mAh" },
+      { icon: "camera", label: "108 MP" },
+      { icon: "bolt", label: "Charge rapide" },
+    ]);
+    expect(parseHighlights(raw)).toEqual([
+      { icon: "battery", label: "6000 mAh" },
+      { icon: "camera", label: "108 MP" },
+      { icon: "bolt", label: "Charge rapide" },
+    ]);
+  });
+});
+
+describe("parseFeatureBlocks", () => {
+  it("returns null for invalid JSON", () => {
+    expect(parseFeatureBlocks("{{")).toBeNull();
+  });
+  it("accepts blocks with optional image fields", () => {
+    const raw = JSON.stringify([
+      { title: "A", body: "B" },
+      { title: "C", body: "D", image_url: "x.jpg", image_alt: "alt" },
+    ]);
+    expect(parseFeatureBlocks(raw)).toEqual([
+      { title: "A", body: "B" },
+      { title: "C", body: "D", image_url: "x.jpg", image_alt: "alt" },
+    ]);
+  });
+});
+
+describe("parseFaq", () => {
+  it("returns null for invalid JSON", () => {
+    expect(parseFaq("nope")).toBeNull();
+  });
+  it("accepts an empty array", () => {
+    expect(parseFaq("[]")).toEqual([]);
+  });
+});
+
+describe("hydrateProductStoryFields", () => {
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    errSpy.mockRestore();
+  });
+
+  it("replaces raw JSON strings with parsed arrays/objects, preserving null", () => {
+    const row = {
+      id: "p1",
+      tagline: "Hello",
+      highlights: JSON.stringify([
+        { icon: "battery", label: "L" },
+        { icon: "battery", label: "L" },
+        { icon: "battery", label: "L" },
+      ]),
+      feature_blocks: null,
+      faq: JSON.stringify([]),
+    };
+
+    const hydrated = hydrateProductStoryFields(row);
+
+    expect(hydrated.tagline).toBe("Hello");
+    expect(hydrated.highlights).toHaveLength(3);
+    expect(hydrated.feature_blocks).toBeNull();
+    expect(hydrated.faq).toEqual([]);
+  });
+
+  it("logs and falls back to null when JSON is malformed", () => {
+    const row = {
+      id: "p1",
+      tagline: null,
+      highlights: "definitely not json",
+      feature_blocks: null,
+      faq: null,
+    };
+
+    const hydrated = hydrateProductStoryFields(row);
+    expect(hydrated.highlights).toBeNull();
+    expect(errSpy).toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/product-story-validation.test.ts
+++ b/__tests__/unit/product-story-validation.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import {
+  taglineSchema,
+  highlightsSchema,
+  featureBlocksSchema,
+  faqSchema,
+  HIGHLIGHT_ICON_NAMES,
+} from "@/lib/validations/product-story";
+
+describe("taglineSchema", () => {
+  it("accepts null", () => {
+    expect(taglineSchema.parse(null)).toBeNull();
+  });
+  it("accepts an empty string as null", () => {
+    expect(taglineSchema.parse("")).toBeNull();
+  });
+  it("accepts a short string", () => {
+    expect(taglineSchema.parse("Un iPhone qui dure.")).toBe("Un iPhone qui dure.");
+  });
+  it("rejects > 200 chars", () => {
+    expect(() => taglineSchema.parse("x".repeat(201))).toThrow();
+  });
+});
+
+describe("highlightsSchema", () => {
+  const validIcon = HIGHLIGHT_ICON_NAMES[0];
+  it("accepts null (block disabled)", () => {
+    expect(highlightsSchema.parse(null)).toBeNull();
+  });
+  it("rejects 1 or 2 items", () => {
+    expect(() =>
+      highlightsSchema.parse([{ icon: validIcon, label: "a" }]),
+    ).toThrow();
+  });
+  it("accepts 3 items", () => {
+    const items = Array.from({ length: 3 }, () => ({ icon: validIcon, label: "ok" }));
+    expect(highlightsSchema.parse(items)).toHaveLength(3);
+  });
+  it("accepts 6 items", () => {
+    const items = Array.from({ length: 6 }, () => ({ icon: validIcon, label: "ok" }));
+    expect(highlightsSchema.parse(items)).toHaveLength(6);
+  });
+  it("rejects 7 items", () => {
+    const items = Array.from({ length: 7 }, () => ({ icon: validIcon, label: "ok" }));
+    expect(() => highlightsSchema.parse(items)).toThrow();
+  });
+  it("rejects an unknown icon", () => {
+    expect(() =>
+      highlightsSchema.parse([{ icon: "not-a-real-icon", label: "ok" }, { icon: validIcon, label: "ok" }, { icon: validIcon, label: "ok" }]),
+    ).toThrow();
+  });
+  it("rejects a label > 80 chars", () => {
+    expect(() =>
+      highlightsSchema.parse([
+        { icon: validIcon, label: "x".repeat(81) },
+        { icon: validIcon, label: "ok" },
+        { icon: validIcon, label: "ok" },
+      ]),
+    ).toThrow();
+  });
+});
+
+describe("featureBlocksSchema", () => {
+  const ok = { title: "T", body: "B" };
+  it("accepts null", () => {
+    expect(featureBlocksSchema.parse(null)).toBeNull();
+  });
+  it("rejects 1 item", () => {
+    expect(() => featureBlocksSchema.parse([ok])).toThrow();
+  });
+  it("accepts 2 to 4 items", () => {
+    expect(featureBlocksSchema.parse([ok, ok])).toHaveLength(2);
+    expect(featureBlocksSchema.parse([ok, ok, ok, ok])).toHaveLength(4);
+  });
+  it("rejects 5 items", () => {
+    expect(() => featureBlocksSchema.parse([ok, ok, ok, ok, ok])).toThrow();
+  });
+  it("rejects body > 600 chars", () => {
+    expect(() =>
+      featureBlocksSchema.parse([
+        { title: "T", body: "x".repeat(601) },
+        { title: "T", body: "B" },
+      ]),
+    ).toThrow();
+  });
+  it("accepts image_url and image_alt as optional", () => {
+    const parsed = featureBlocksSchema.parse([
+      { title: "T", body: "B", image_url: "products/abc/hero.jpg", image_alt: "alt" },
+      { title: "T", body: "B" },
+    ]);
+    expect(parsed?.[0].image_url).toBe("products/abc/hero.jpg");
+    expect(parsed?.[1].image_url).toBeUndefined();
+  });
+});
+
+describe("faqSchema", () => {
+  it("accepts null", () => {
+    expect(faqSchema.parse(null)).toBeNull();
+  });
+  it("accepts an empty array (block disabled)", () => {
+    expect(faqSchema.parse([])).toEqual([]);
+  });
+  it("accepts 5 items", () => {
+    const items = Array.from({ length: 5 }, () => ({ question: "q", answer: "a" }));
+    expect(faqSchema.parse(items)).toHaveLength(5);
+  });
+  it("rejects 6 items", () => {
+    const items = Array.from({ length: 6 }, () => ({ question: "q", answer: "a" }));
+    expect(() => faqSchema.parse(items)).toThrow();
+  });
+});

--- a/__tests__/unit/product-story-validation.test.ts
+++ b/__tests__/unit/product-story-validation.test.ts
@@ -27,6 +27,9 @@ describe("highlightsSchema", () => {
   it("accepts null (block disabled)", () => {
     expect(highlightsSchema.parse(null)).toBeNull();
   });
+  it("rejects an empty array", () => {
+    expect(() => highlightsSchema.parse([])).toThrow();
+  });
   it("rejects 1 or 2 items", () => {
     expect(() =>
       highlightsSchema.parse([{ icon: validIcon, label: "a" }]),

--- a/actions/admin/products.ts
+++ b/actions/admin/products.ts
@@ -74,8 +74,9 @@ export async function createProduct(formData: FormData): Promise<ActionResult> {
 
   const parsed = productSchema.safeParse(raw);
   if (!parsed.success) {
+    const flat = parsed.error.flatten();
     const msg = parsed.error.issues.map((e: { message: string }) => e.message).join(", ");
-    return { success: false, error: msg };
+    return { success: false, error: msg, fieldErrors: flat.fieldErrors };
   }
 
   const data = parsed.data;
@@ -140,8 +141,9 @@ export async function updateProduct(
 
   const parsed = productSchema.safeParse(raw);
   if (!parsed.success) {
+    const flat = parsed.error.flatten();
     const msg = parsed.error.issues.map((e: { message: string }) => e.message).join(", ");
-    return { success: false, error: msg };
+    return { success: false, error: msg, fieldErrors: flat.fieldErrors };
   }
 
   const data = parsed.data;

--- a/actions/admin/products.ts
+++ b/actions/admin/products.ts
@@ -8,6 +8,12 @@ import { execute, query, queryFirst } from "@/lib/db";
 import { slugify, type ActionResult } from "@/lib/utils";
 import { deleteFromR2 } from "@/lib/storage/images";
 import { sanitizeDescriptionHtml } from "@/lib/utils/sanitize-html";
+import {
+  taglineSchema,
+  highlightsSchema,
+  featureBlocksSchema,
+  faqSchema,
+} from "@/lib/validations/product-story";
 
 const DB_CONSTRAINT_SKU = "UNIQUE constraint failed: products.sku";
 const DB_CONSTRAINT_SLUG = "UNIQUE constraint failed: products.slug";
@@ -30,6 +36,25 @@ const productSchema = z.object({
   meta_description: z.string().max(160).optional().default(""),
   is_active: z.coerce.number().int().min(0).max(1).default(1),
   is_featured: z.coerce.number().int().min(0).max(1).default(0),
+  tagline: z.preprocess(
+    (v) => (v == null || (typeof v === "string" && v.trim() === "") ? null : v),
+    taglineSchema,
+  ),
+  highlights: z.preprocess((v) => {
+    if (v == null || (typeof v === "string" && v.trim() === "")) return null;
+    if (typeof v !== "string") return "__invalid__";
+    try { return JSON.parse(v); } catch { return "__invalid__"; }
+  }, highlightsSchema),
+  feature_blocks: z.preprocess((v) => {
+    if (v == null || (typeof v === "string" && v.trim() === "")) return null;
+    if (typeof v !== "string") return "__invalid__";
+    try { return JSON.parse(v); } catch { return "__invalid__"; }
+  }, featureBlocksSchema),
+  faq: z.preprocess((v) => {
+    if (v == null || (typeof v === "string" && v.trim() === "")) return null;
+    if (typeof v !== "string") return "__invalid__";
+    try { return JSON.parse(v); } catch { return "__invalid__"; }
+  }, faqSchema),
 });
 
 /** @deprecated Never called from the UI — product creation now goes through createDraftProduct() + updateProduct(). Scheduled for removal once the draft flow is confirmed stable in production. */
@@ -165,6 +190,7 @@ export async function updateProduct(
      base_price = ?, compare_price = ?, sku = ?, brand = ?,
      is_active = ?, is_featured = ?, stock_quantity = ?,
      low_stock_threshold = ?, weight_grams = ?, meta_title = ?, meta_description = ?,
+     tagline = ?, highlights = ?, feature_blocks = ?, faq = ?,
      is_draft = 0, -- Clear draft flag (product becomes live if is_active = 1)
      updated_at = datetime('now')
    WHERE id = ?`;
@@ -187,6 +213,10 @@ export async function updateProduct(
     data.weight_grams ?? null,
     data.meta_title || null,
     data.meta_description || null,
+    data.tagline ?? null,
+    data.highlights == null ? null : JSON.stringify(data.highlights),
+    data.feature_blocks == null ? null : JSON.stringify(data.feature_blocks),
+    data.faq == null ? null : JSON.stringify(data.faq),
     id,
   ];
 

--- a/actions/admin/products.ts
+++ b/actions/admin/products.ts
@@ -3,8 +3,11 @@
 import { revalidatePath } from "next/cache";
 import { nanoid } from "nanoid";
 import { z } from "zod";
+import { eq, sql } from "drizzle-orm";
 import { requireAdmin } from "@/lib/auth/guards";
 import { execute, query, queryFirst } from "@/lib/db";
+import { getDrizzle } from "@/lib/db/drizzle";
+import { products } from "@/lib/db/schema";
 import { slugify, type ActionResult } from "@/lib/utils";
 import { deleteFromR2 } from "@/lib/storage/images";
 import { sanitizeDescriptionHtml } from "@/lib/utils/sanitize-html";
@@ -187,40 +190,35 @@ export async function updateProduct(
     ? sanitizeDescriptionHtml(data.description, id)
     : data.description || null;
 
-  const updateSql = `UPDATE products SET
-     category_id = ?, name = ?, slug = ?, description = ?, description_type = ?, short_description = ?,
-     base_price = ?, compare_price = ?, sku = ?, brand = ?,
-     is_active = ?, is_featured = ?, stock_quantity = ?,
-     low_stock_threshold = ?, weight_grams = ?, meta_title = ?, meta_description = ?,
-     tagline = ?, highlights = ?, feature_blocks = ?, faq = ?,
-     is_draft = 0, -- Clear draft flag (product becomes live if is_active = 1)
-     updated_at = datetime('now')
-   WHERE id = ?`;
-
-  const buildParams = (sku: string) => [
-    data.category_id,
-    data.name,
-    finalSlug,
-    finalDescription,
-    data.description_type,
-    data.short_description || null,
-    data.base_price,
-    data.compare_price ?? null,
+  const db = await getDrizzle();
+  const buildValues = (sku: string) => ({
+    category_id: data.category_id,
+    name: data.name,
+    slug: finalSlug,
+    description: finalDescription,
+    description_type: data.description_type,
+    short_description: data.short_description || null,
+    base_price: data.base_price,
+    compare_price: data.compare_price ?? null,
     sku,
-    data.brand || null,
-    data.is_active,
-    data.is_featured,
-    data.stock_quantity,
-    data.low_stock_threshold,
-    data.weight_grams ?? null,
-    data.meta_title || null,
-    data.meta_description || null,
-    data.tagline ?? null,
-    data.highlights == null ? null : JSON.stringify(data.highlights),
-    data.feature_blocks == null ? null : JSON.stringify(data.feature_blocks),
-    data.faq == null ? null : JSON.stringify(data.faq),
-    id,
-  ];
+    brand: data.brand || null,
+    is_active: data.is_active,
+    is_featured: data.is_featured,
+    stock_quantity: data.stock_quantity,
+    low_stock_threshold: data.low_stock_threshold,
+    weight_grams: data.weight_grams ?? null,
+    meta_title: data.meta_title || null,
+    meta_description: data.meta_description || null,
+    tagline: data.tagline ?? null,
+    highlights: data.highlights == null ? null : JSON.stringify(data.highlights),
+    feature_blocks: data.feature_blocks == null ? null : JSON.stringify(data.feature_blocks),
+    faq: data.faq == null ? null : JSON.stringify(data.faq),
+    is_draft: 0,
+    updated_at: sql`datetime('now')`,
+  });
+
+  const runUpdate = (sku: string) =>
+    db.update(products).set(buildValues(sku)).where(eq(products.id, id));
 
   // SKU: auto-generate when null (covers both draft-flow products and pre-existing rows that predate SKU auto-assignment)
   const existingSku = existing.sku;
@@ -229,7 +227,7 @@ export async function updateProduct(
     for (let attempt = 0; attempt < 3; attempt++) {
       const generatedSku = `NET-${nanoid(8).toUpperCase()}`;
       try {
-        await execute(updateSql, buildParams(generatedSku));
+        await runUpdate(generatedSku);
         skuWritten = true;
         break;
       } catch (err) {
@@ -251,7 +249,7 @@ export async function updateProduct(
     }
   } else {
     try {
-      await execute(updateSql, buildParams(existingSku));
+      await runUpdate(existingSku);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (msg.includes(DB_CONSTRAINT_SLUG)) {

--- a/actions/admin/products.ts
+++ b/actions/admin/products.ts
@@ -20,6 +20,20 @@ const DB_CONSTRAINT_SLUG = "UNIQUE constraint failed: products.slug";
 
 const idSchema = z.string().min(1, "ID requis");
 
+// Sentinel string used to force Zod validation failure for non-parseable JSON inputs.
+const INVALID_JSON_SENTINEL = "__invalid__";
+
+/** FormData-safe JSON preprocessor: null/empty → null, valid JSON string → parsed, otherwise sentinel. */
+function parseNullableJsonString(value: unknown): unknown {
+  if (value == null || (typeof value === "string" && value.trim() === "")) return null;
+  if (typeof value !== "string") return INVALID_JSON_SENTINEL;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return INVALID_JSON_SENTINEL;
+  }
+}
+
 const productSchema = z.object({
   name: z.string().min(1, "Le nom est requis"),
   category_id: z.string().min(1, "La catégorie est requise"),
@@ -40,21 +54,9 @@ const productSchema = z.object({
     (v) => (v == null || (typeof v === "string" && v.trim() === "") ? null : v),
     taglineSchema,
   ),
-  highlights: z.preprocess((v) => {
-    if (v == null || (typeof v === "string" && v.trim() === "")) return null;
-    if (typeof v !== "string") return "__invalid__";
-    try { return JSON.parse(v); } catch { return "__invalid__"; }
-  }, highlightsSchema),
-  feature_blocks: z.preprocess((v) => {
-    if (v == null || (typeof v === "string" && v.trim() === "")) return null;
-    if (typeof v !== "string") return "__invalid__";
-    try { return JSON.parse(v); } catch { return "__invalid__"; }
-  }, featureBlocksSchema),
-  faq: z.preprocess((v) => {
-    if (v == null || (typeof v === "string" && v.trim() === "")) return null;
-    if (typeof v !== "string") return "__invalid__";
-    try { return JSON.parse(v); } catch { return "__invalid__"; }
-  }, faqSchema),
+  highlights: z.preprocess(parseNullableJsonString, highlightsSchema),
+  feature_blocks: z.preprocess(parseNullableJsonString, featureBlocksSchema),
+  faq: z.preprocess(parseNullableJsonString, faqSchema),
 });
 
 /** @deprecated Never called from the UI — product creation now goes through createDraftProduct() + updateProduct(). Scheduled for removal once the draft flow is confirmed stable in production. */

--- a/actions/admin/story.ts
+++ b/actions/admin/story.ts
@@ -1,0 +1,54 @@
+"use server";
+
+import { nanoid } from "nanoid";
+import { z } from "zod";
+import { requireAdmin } from "@/lib/auth/guards";
+import { queryFirst } from "@/lib/db";
+import { uploadToR2 } from "@/lib/storage/images";
+import type { ActionResult } from "@/lib/utils";
+
+const idSchema = z.string().min(1, "ID requis");
+
+export async function uploadStoryImage(
+  productId: string,
+  formData: FormData,
+): Promise<ActionResult> {
+  await requireAdmin();
+
+  const idResult = idSchema.safeParse(productId);
+  if (!idResult.success) return { success: false, error: "ID produit invalide" };
+
+  // Verify product exists
+  const product = await queryFirst<{ id: string }>(
+    "SELECT id FROM products WHERE id = ?",
+    [productId],
+  );
+  if (!product) {
+    return { success: false, error: "Produit introuvable" };
+  }
+
+  const file = formData.get("file") as File | null;
+  if (!file || file.size === 0) {
+    return { success: false, error: "Aucun fichier sélectionné" };
+  }
+
+  if (!file.type.startsWith("image/")) {
+    return { success: false, error: "Le fichier doit être une image" };
+  }
+
+  if (file.size > 5 * 1024 * 1024) {
+    return { success: false, error: "L'image ne doit pas dépasser 5 Mo" };
+  }
+
+  const ext = file.name.split(".").pop() || "jpg";
+  const key = `products/${productId}/story/${nanoid()}.${ext}`;
+
+  try {
+    await uploadToR2(file, key);
+  } catch (error) {
+    console.error(`[admin/story] R2 upload failed for product="${productId}":`, error);
+    return { success: false, error: "Erreur lors de l'upload de l'image" };
+  }
+
+  return { success: true, url: key };
+}

--- a/actions/admin/story.ts
+++ b/actions/admin/story.ts
@@ -2,12 +2,23 @@
 
 import { nanoid } from "nanoid";
 import { z } from "zod";
+import { eq } from "drizzle-orm";
 import { requireAdmin } from "@/lib/auth/guards";
-import { queryFirst } from "@/lib/db";
+import { getDrizzle } from "@/lib/db/drizzle";
+import { products } from "@/lib/db/schema";
 import { uploadToR2 } from "@/lib/storage/images";
 import type { ActionResult } from "@/lib/utils";
 
 const idSchema = z.string().min(1, "ID requis");
+
+const ALLOWED_IMAGE_EXTENSIONS = new Set([
+  "jpg",
+  "jpeg",
+  "png",
+  "gif",
+  "webp",
+  "avif",
+]);
 
 export async function uploadStoryImage(
   productId: string,
@@ -18,11 +29,11 @@ export async function uploadStoryImage(
   const idResult = idSchema.safeParse(productId);
   if (!idResult.success) return { success: false, error: "ID produit invalide" };
 
-  // Verify product exists
-  const product = await queryFirst<{ id: string }>(
-    "SELECT id FROM products WHERE id = ?",
-    [productId],
-  );
+  const db = await getDrizzle();
+  const product = await db.query.products.findFirst({
+    where: eq(products.id, productId),
+    columns: { id: true },
+  });
   if (!product) {
     return { success: false, error: "Produit introuvable" };
   }
@@ -40,7 +51,8 @@ export async function uploadStoryImage(
     return { success: false, error: "L'image ne doit pas dépasser 5 Mo" };
   }
 
-  const ext = file.name.split(".").pop() || "jpg";
+  const rawExt = (file.name.split(".").pop() ?? "").toLowerCase();
+  const ext = ALLOWED_IMAGE_EXTENSIONS.has(rawExt) ? rawExt : "jpg";
   const key = `products/${productId}/story/${nanoid()}.${ext}`;
 
   try {

--- a/actions/admin/story.ts
+++ b/actions/admin/story.ts
@@ -52,8 +52,10 @@ export async function uploadStoryImage(
   }
 
   const rawExt = (file.name.split(".").pop() ?? "").toLowerCase();
-  const ext = ALLOWED_IMAGE_EXTENSIONS.has(rawExt) ? rawExt : "jpg";
-  const key = `products/${productId}/story/${nanoid()}.${ext}`;
+  if (!ALLOWED_IMAGE_EXTENSIONS.has(rawExt)) {
+    return { success: false, error: "Format d'image non pris en charge" };
+  }
+  const key = `products/${productId}/story/${nanoid()}.${rawExt}`;
 
   try {
     await uploadToR2(file, key);

--- a/app/(admin)/products/[id]/edit/page.tsx
+++ b/app/(admin)/products/[id]/edit/page.tsx
@@ -37,7 +37,12 @@ export default async function EditProductPage({ params }: Props) {
   );
 
   if (isNew) {
-    return <ProductWizard product={product} categories={categoryOptions} />;
+    // Counter main's p-4 sm:p-6 so the wizard sticky header can sit flush with main's top edge.
+    return (
+      <div className="-m-4 sm:-m-6">
+        <ProductWizard product={product} categories={categoryOptions} />
+      </div>
+    );
   }
 
   return (

--- a/app/(admin)/products/[id]/edit/page.tsx
+++ b/app/(admin)/products/[id]/edit/page.tsx
@@ -37,11 +37,7 @@ export default async function EditProductPage({ params }: Props) {
   );
 
   if (isNew) {
-    return (
-      <div className="flex h-full flex-col overflow-hidden">
-        <ProductWizard product={product} categories={categoryOptions} />
-      </div>
-    );
+    return <ProductWizard product={product} categories={categoryOptions} />;
   }
 
   return (

--- a/app/(admin)/products/[id]/edit/page.tsx
+++ b/app/(admin)/products/[id]/edit/page.tsx
@@ -37,9 +37,11 @@ export default async function EditProductPage({ params }: Props) {
   );
 
   if (isNew) {
-    // Counter main's p-4 sm:p-6 so the wizard sticky header can sit flush with main's top edge.
+    // Escape main's p-4 sm:p-6 via absolute positioning so the wizard sticky
+    // header can sit flush with main's top edge (sticky top-0 otherwise sticks
+    // at main's padding-box interior, leaving a 24px blank strip above).
     return (
-      <div className="-m-4 sm:-m-6">
+      <div className="absolute inset-0 overflow-y-auto">
         <ProductWizard product={product} categories={categoryOptions} />
       </div>
     );

--- a/app/(storefront)/p/[slug]/page.tsx
+++ b/app/(storefront)/p/[slug]/page.tsx
@@ -11,7 +11,8 @@ import { AddToCartButton } from "@/components/storefront/add-to-cart-button";
 import { WhatsAppProductButton } from "@/components/storefront/whatsapp-product-button";
 import { HorizontalSection } from "@/components/storefront/horizontal-section";
 import { WishlistButtonDynamic } from "@/components/storefront/wishlist-button-dynamic";
-import { ProductDetails } from "@/components/storefront/product-details";
+import { ProductSpecs } from "@/components/storefront/product-details";
+import { ProductStory } from "@/components/storefront/product-story";
 import { StarRating } from "@/components/storefront/star-rating";
 import { JsonLd } from "@/components/seo/json-ld";
 import { BreadcrumbSchema } from "@/components/seo/breadcrumb-schema";
@@ -219,69 +220,43 @@ export default async function ProductPage({ params }: Props) {
   ];
 
   return (
-    <div className="mx-auto max-w-7xl px-4 py-6">
+    <>
       <JsonLd data={productSchema} />
       <BreadcrumbSchema items={breadcrumbItems} />
 
-      {/* Breadcrumb */}
-      <nav className="mb-4 text-sm text-muted-foreground">
-        <Link href="/" className="hover:text-foreground">
-          Accueil
-        </Link>
-        <span className="mx-1.5">/</span>
-        {product.category_slug ? (
-          <>
-            <Link
-              href={`/c/${product.category_slug}`}
-              className="hover:text-foreground"
-            >
-              {product.category_name}
-            </Link>
-            <span className="mx-1.5">/</span>
-          </>
-        ) : null}
-        <span className="text-foreground">{product.name}</span>
-      </nav>
+      <div className="mx-auto max-w-7xl px-4 py-6">
+        {/* Breadcrumb */}
+        <nav className="mb-4 text-sm text-muted-foreground">
+          <Link href="/" className="hover:text-foreground">
+            Accueil
+          </Link>
+          <span className="mx-1.5">/</span>
+          {product.category_slug ? (
+            <>
+              <Link
+                href={`/c/${product.category_slug}`}
+                className="hover:text-foreground"
+              >
+                {product.category_name}
+              </Link>
+              <span className="mx-1.5">/</span>
+            </>
+          ) : null}
+          <span className="text-foreground">{product.name}</span>
+        </nav>
 
-      {product.variants.length > 0 ? (
-        <ProductGalleryWithVariants
-          images={product.images}
-          variants={product.variants}
-          basePrice={product.base_price}
-          product={{
-            id: product.id,
-            name: product.name,
-            slug: product.slug,
-            imageUrl: product.image_url ?? product.images[0]?.url ?? null,
-          }}
-        >
-          <div className="flex items-start justify-between gap-2">
-            <div>
-              {product.brand ? (
-                <span className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
-                  {product.brand}
-                </span>
-              ) : null}
-              <h1 className="text-2xl font-bold sm:text-3xl">{product.name}</h1>
-            </div>
-            <WishlistButtonDynamic productId={product.id} />
-          </div>
-        </ProductGalleryWithVariants>
-      ) : (
-        <div className="grid gap-8 md:grid-cols-2">
-          <ImageGallery images={product.images}>
-            <Image
-              src={getImageUrl(product.images[0]?.url)}
-              alt={product.images[0]?.alt || product.name}
-              fill
-              priority
-              fetchPriority="high"
-              sizes="(max-width: 768px) 100vw, 50vw"
-              className="object-contain p-6"
-            />
-          </ImageGallery>
-
-          <div className="space-y-4">
+        {product.variants.length > 0 ? (
+          <ProductGalleryWithVariants
+            images={product.images}
+            variants={product.variants}
+            basePrice={product.base_price}
+            product={{
+              id: product.id,
+              name: product.name,
+              slug: product.slug,
+              imageUrl: product.image_url ?? product.images[0]?.url ?? null,
+            }}
+          >
             <div className="flex items-start justify-between gap-2">
               <div>
                 {product.brand ? (
@@ -293,72 +268,107 @@ export default async function ProductPage({ params }: Props) {
               </div>
               <WishlistButtonDynamic productId={product.id} />
             </div>
+          </ProductGalleryWithVariants>
+        ) : (
+          <div className="grid gap-8 md:grid-cols-2">
+            <ImageGallery images={product.images}>
+              <Image
+                src={getImageUrl(product.images[0]?.url)}
+                alt={product.images[0]?.alt || product.name}
+                fill
+                priority
+                fetchPriority="high"
+                sizes="(max-width: 768px) 100vw, 50vw"
+                className="object-contain p-6"
+              />
+            </ImageGallery>
 
             <div className="space-y-4">
-              <div>
-                <div className="flex items-center gap-3">
-                  <p className="text-2xl font-bold">
-                    {formatPrice(product.base_price)}
-                  </p>
-                  {hasDiscount && (
-                    <span className="rounded-md bg-destructive px-2 py-0.5 text-xs font-bold text-white">
-                      -{discountPercent}%
+              <div className="flex items-start justify-between gap-2">
+                <div>
+                  {product.brand ? (
+                    <span className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+                      {product.brand}
                     </span>
+                  ) : null}
+                  <h1 className="text-2xl font-bold sm:text-3xl">{product.name}</h1>
+                </div>
+                <WishlistButtonDynamic productId={product.id} />
+              </div>
+
+              <div className="space-y-4">
+                <div>
+                  <div className="flex items-center gap-3">
+                    <p className="text-2xl font-bold">
+                      {formatPrice(product.base_price)}
+                    </p>
+                    {hasDiscount && (
+                      <span className="rounded-md bg-destructive px-2 py-0.5 text-xs font-bold text-white">
+                        -{discountPercent}%
+                      </span>
+                    )}
+                  </div>
+                  {hasDiscount && (
+                    <p className="text-sm text-muted-foreground line-through">
+                      {formatPrice(comparePrice)}
+                    </p>
                   )}
                 </div>
-                {hasDiscount && (
-                  <p className="text-sm text-muted-foreground line-through">
-                    {formatPrice(comparePrice)}
-                  </p>
+                {isOutOfStock && (
+                  <p className="text-sm font-medium text-destructive">Rupture de stock</p>
                 )}
+                <AddToCartButton
+                  disabled={isOutOfStock}
+                  item={{
+                    productId: product.id,
+                    variantId: null,
+                    name: product.name,
+                    variantName: null,
+                    price: product.base_price,
+                    imageUrl: product.image_url ?? product.images[0]?.url ?? null,
+                    slug: product.slug,
+                  }}
+                />
+                <WhatsAppProductButton
+                  productName={product.name}
+                  price={product.base_price}
+                  slug={product.slug}
+                  variant="full"
+                />
               </div>
-              {isOutOfStock && (
-                <p className="text-sm font-medium text-destructive">Rupture de stock</p>
-              )}
-              <AddToCartButton
-                disabled={isOutOfStock}
-                item={{
-                  productId: product.id,
-                  variantId: null,
-                  name: product.name,
-                  variantName: null,
-                  price: product.base_price,
-                  imageUrl: product.image_url ?? product.images[0]?.url ?? null,
-                  slug: product.slug,
-                }}
-              />
-              <WhatsAppProductButton
-                productName={product.name}
-                price={product.base_price}
-                slug={product.slug}
-                variant="full"
-              />
             </div>
           </div>
-        </div>
-      )}
+        )}
+      </div>
 
-      {/* Description & Characteristics */}
-      <ProductDetails
+      {/* Full-width Product Story (OUTSIDE max-w-7xl) */}
+      <ProductStory
+        tagline={product.tagline}
+        highlights={product.highlights}
+        featureBlocks={product.feature_blocks}
+        faq={product.faq}
         description={product.description}
         descriptionType={product.description_type}
         productId={product.id}
-        attributes={product.attributes}
       />
 
-      {/* Reviews */}
-      <Suspense fallback={null}>
-        <ProductReviews productId={product.id} />
-      </Suspense>
+      <div className="mx-auto max-w-7xl px-4 py-6">
+        <ProductSpecs attributes={product.attributes} />
 
-      {/* Related */}
-      <Suspense fallback={<RelatedProductsSkeleton />}>
-        <RelatedProducts
-          productId={product.id}
-          categoryId={product.category_id ?? ""}
-          categorySlug={product.category_slug}
-        />
-      </Suspense>
-    </div>
+        {/* Reviews */}
+        <Suspense fallback={null}>
+          <ProductReviews productId={product.id} />
+        </Suspense>
+
+        {/* Related */}
+        <Suspense fallback={<RelatedProductsSkeleton />}>
+          <RelatedProducts
+            productId={product.id}
+            categoryId={product.category_id ?? ""}
+            categorySlug={product.category_slug}
+          />
+        </Suspense>
+      </div>
+    </>
   );
 }

--- a/components/admin/product-form-sections.tsx
+++ b/components/admin/product-form-sections.tsx
@@ -18,11 +18,6 @@ import {
 } from "@/components/ui/input-group";
 import { ColorPicker } from "@/components/admin/color-picker";
 import { ImageUpload } from "@/components/admin/image-upload";
-import dynamic from "next/dynamic";
-const DescriptionEditor = dynamic(
-  () => import("./description-editor").then((m) => m.DescriptionEditor),
-  { ssr: false },
-);
 import { getImageUrl } from "@/lib/utils/images";
 import type { ProductDetail } from "@/lib/db/types";
 import {
@@ -208,17 +203,9 @@ export function ProductFormSections({
                   defaultValue={product.short_description ?? ""}
                 />
               </div>
-              <div className="space-y-2">
-                <Label>Contenu complémentaire</Label>
-                <p className="text-xs text-muted-foreground">
-                  S&apos;affiche dans le bloc « zone libre » de la Story, sous les blocs structurés.
-                </p>
-                <DescriptionEditor
-                  name="description"
-                  descriptionType={product.description_type}
-                  defaultValue={product.description}
-                />
-              </div>
+              {/* Preserve existing description on save (legacy content renders in Story free-content block) */}
+              <input type="hidden" name="description" value={product.description ?? ""} />
+              <input type="hidden" name="description_type" value={product.description_type ?? "richtext"} />
             </CardContent>
           </Card>
 

--- a/components/admin/product-form-sections.tsx
+++ b/components/admin/product-form-sections.tsx
@@ -40,12 +40,14 @@ import {
   type CategoryOption,
 } from "./category-cascading-select";
 import { SectionNav, type SectionDef } from "./section-nav";
+import { ProductStorySection } from "./product-story-section";
 
 
 const SECTIONS: SectionDef[] = [
   { id: "section-general", label: "Informations" },
   { id: "section-category", label: "Catégorie" },
   { id: "section-specs", label: "Caractéristiques" },
+  { id: "section-story", label: "Story" },
   { id: "section-pricing", label: "Tarification" },
   { id: "section-images", label: "Images" },
   { id: "section-seo", label: "SEO" },
@@ -207,7 +209,10 @@ export function ProductFormSections({
                 />
               </div>
               <div className="space-y-2">
-                <Label>Description</Label>
+                <Label>Contenu complémentaire</Label>
+                <p className="text-xs text-muted-foreground">
+                  S&apos;affiche dans le bloc « zone libre » de la Story, sous les blocs structurés.
+                </p>
                 <DescriptionEditor
                   name="description"
                   descriptionType={product.description_type}
@@ -237,6 +242,37 @@ export function ProductFormSections({
             </CardHeader>
             <CardContent>
               <AttributesSection product={product} />
+            </CardContent>
+          </Card>
+
+          {/* Section: Story */}
+          <Card id="section-story">
+            <CardHeader>
+              <div className="flex items-start justify-between gap-3">
+                <div className="space-y-1">
+                  <CardTitle>Story produit</CardTitle>
+                  <p className="text-sm text-muted-foreground">
+                    Blocs éditoriaux rendus en pleine largeur sur la fiche produit.
+                    Tous les blocs sont optionnels.
+                  </p>
+                </div>
+                {!isNew && product.slug && (
+                  <Button variant="outline" size="sm" asChild className="shrink-0">
+                    <a href={`/p/${product.slug}`} target="_blank" rel="noopener noreferrer">
+                      Aperçu
+                    </a>
+                  </Button>
+                )}
+              </div>
+            </CardHeader>
+            <CardContent>
+              <ProductStorySection
+                productId={product.id}
+                tagline={product.tagline}
+                highlights={product.highlights}
+                featureBlocks={product.feature_blocks}
+                faq={product.faq}
+              />
             </CardContent>
           </Card>
 

--- a/components/admin/product-form-sections.tsx
+++ b/components/admin/product-form-sections.tsx
@@ -244,7 +244,7 @@ export function ProductFormSections({
                   </p>
                 </div>
                 {!isNew && product.slug && (
-                  <Button variant="outline" size="sm" asChild className="shrink-0">
+                  <Button variant="outline" size="touch" asChild className="shrink-0">
                     <a href={`/p/${product.slug}`} target="_blank" rel="noopener noreferrer">
                       Aperçu
                     </a>

--- a/components/admin/product-story-section.tsx
+++ b/components/admin/product-story-section.tsx
@@ -14,7 +14,7 @@ import type {
   ProductFeatureBlock,
   ProductFaqItem,
 } from "@/lib/db/types";
-import { HIGHLIGHT_ICON_NAMES } from "@/lib/validations/product-story";
+import { HIGHLIGHT_ICON_NAMES, type HighlightIconName } from "@/lib/validations/product-story";
 
 interface ProductStorySectionProps {
   productId: string;
@@ -29,7 +29,23 @@ const MAX_HL = 6;
 const MIN_FB = 2;
 const MAX_FB = 4;
 const MAX_FAQ = 5;
-const DEFAULT_ICON = HIGHLIGHT_ICON_NAMES[0];
+const DEFAULT_ICON: HighlightIconName = HIGHLIGHT_ICON_NAMES[0];
+
+type Row<T> = { uid: string; data: T };
+
+function newUid(): string {
+  return typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function wrapRows<T>(items: T[] | null): Row<T>[] {
+  return (items ?? []).map((data) => ({ uid: newUid(), data }));
+}
+
+function stripRows<T>(rows: Row<T>[]): T[] {
+  return rows.map((r) => r.data);
+}
 
 export function ProductStorySection({
   productId,
@@ -39,23 +55,23 @@ export function ProductStorySection({
   faq: initialFaq,
 }: ProductStorySectionProps) {
   const [tagline, setTagline] = useState<string>(initialTagline ?? "");
-  const [highlights, setHighlights] = useState<ProductHighlight[]>(
-    () => initialHighlights ?? [],
+  const [highlights, setHighlights] = useState<Row<ProductHighlight>[]>(() =>
+    wrapRows(initialHighlights),
   );
-  const [featureBlocks, setFeatureBlocks] = useState<ProductFeatureBlock[]>(
-    () => initialFeatureBlocks ?? [],
+  const [featureBlocks, setFeatureBlocks] = useState<Row<ProductFeatureBlock>[]>(
+    () => wrapRows(initialFeatureBlocks),
   );
-  const [faq, setFaq] = useState<ProductFaqItem[]>(() => initialFaq ?? []);
+  const [faq, setFaq] = useState<Row<ProductFaqItem>[]>(() => wrapRows(initialFaq));
 
   // Serialized hidden-input values sent with the main form submit.
   const hiddenValues = useMemo(
     () => ({
       tagline: tagline.trim(),
       highlights_json:
-        highlights.length === 0 ? "" : JSON.stringify(highlights),
+        highlights.length === 0 ? "" : JSON.stringify(stripRows(highlights)),
       feature_blocks_json:
-        featureBlocks.length === 0 ? "" : JSON.stringify(featureBlocks),
-      faq_json: faq.length === 0 ? "" : JSON.stringify(faq),
+        featureBlocks.length === 0 ? "" : JSON.stringify(stripRows(featureBlocks)),
+      faq_json: faq.length === 0 ? "" : JSON.stringify(stripRows(faq)),
     }),
     [tagline, highlights, featureBlocks, faq],
   );
@@ -92,35 +108,41 @@ export function ProductStorySection({
           </p>
         </div>
         <div className="space-y-2">
-          {highlights.map((h, i) => (
-            <div key={i} className="flex items-center gap-2">
+          {highlights.map((row) => (
+            <div key={row.uid} className="flex items-center gap-2">
               <StoryIconPicker
-                value={h.icon}
+                value={row.data.icon as HighlightIconName}
                 onChange={(icon) => {
                   setHighlights((prev) =>
-                    prev.map((x, idx) => (idx === i ? { ...x, icon } : x)),
+                    prev.map((x) =>
+                      x.uid === row.uid ? { ...x, data: { ...x.data, icon } } : x,
+                    ),
                   );
                 }}
               />
               <Input
-                value={h.label}
+                value={row.data.label}
                 maxLength={80}
                 placeholder="Ex. Charge rapide 33 W"
                 onChange={(e) => {
                   const label = e.target.value;
                   setHighlights((prev) =>
-                    prev.map((x, idx) => (idx === i ? { ...x, label } : x)),
+                    prev.map((x) =>
+                      x.uid === row.uid ? { ...x, data: { ...x.data, label } } : x,
+                    ),
                   );
                 }}
               />
               <Button
                 type="button"
                 variant="ghost"
-                size="icon-sm"
+                size="icon-touch"
                 aria-label="Supprimer le point fort"
-                onClick={() => setHighlights((prev) => prev.filter((_, idx) => idx !== i))}
+                onClick={() =>
+                  setHighlights((prev) => prev.filter((x) => x.uid !== row.uid))
+                }
               >
-                <HugeiconsIcon icon={Delete02Icon} size={16} />
+                <HugeiconsIcon icon={Delete02Icon} size={20} />
               </Button>
             </div>
           ))}
@@ -130,7 +152,12 @@ export function ProductStorySection({
           variant="outline"
           size="sm"
           disabled={highlights.length >= MAX_HL}
-          onClick={() => setHighlights((prev) => [...prev, { icon: DEFAULT_ICON, label: "" }])}
+          onClick={() =>
+            setHighlights((prev) => [
+              ...prev,
+              { uid: newUid(), data: { icon: DEFAULT_ICON, label: "" } },
+            ])
+          }
         >
           <HugeiconsIcon icon={Add01Icon} size={14} className="mr-1.5" />
           Ajouter un point fort
@@ -151,18 +178,20 @@ export function ProductStorySection({
           </p>
         </div>
         <div className="space-y-3">
-          {featureBlocks.map((block, i) => (
+          {featureBlocks.map((row, i) => (
             <StoryFeatureBlockEditor
-              key={i}
+              key={row.uid}
               productId={productId}
-              block={block}
+              block={row.data}
               index={i}
               canRemove={featureBlocks.length > 0}
               onChange={(next) =>
-                setFeatureBlocks((prev) => prev.map((x, idx) => (idx === i ? next : x)))
+                setFeatureBlocks((prev) =>
+                  prev.map((x) => (x.uid === row.uid ? { ...x, data: next } : x)),
+                )
               }
               onRemove={() =>
-                setFeatureBlocks((prev) => prev.filter((_, idx) => idx !== i))
+                setFeatureBlocks((prev) => prev.filter((x) => x.uid !== row.uid))
               }
             />
           ))}
@@ -173,7 +202,10 @@ export function ProductStorySection({
           size="sm"
           disabled={featureBlocks.length >= MAX_FB}
           onClick={() =>
-            setFeatureBlocks((prev) => [...prev, { title: "", body: "" }])
+            setFeatureBlocks((prev) => [
+              ...prev,
+              { uid: newUid(), data: { title: "", body: "" } },
+            ])
           }
         >
           <HugeiconsIcon icon={Add01Icon} size={14} className="mr-1.5" />
@@ -193,8 +225,8 @@ export function ProductStorySection({
           <p className="text-xs text-muted-foreground">Jusqu&apos;à {MAX_FAQ} questions</p>
         </div>
         <div className="space-y-3">
-          {faq.map((item, i) => (
-            <div key={i} className="space-y-2 rounded-lg border bg-muted/30 p-4">
+          {faq.map((row, i) => (
+            <div key={row.uid} className="space-y-2 rounded-lg border bg-muted/30 p-4">
               <div className="flex items-center justify-between">
                 <span className="text-sm font-semibold text-muted-foreground">
                   Question {i + 1}
@@ -202,30 +234,40 @@ export function ProductStorySection({
                 <Button
                   type="button"
                   variant="ghost"
-                  size="icon-sm"
+                  size="icon-touch"
                   aria-label="Supprimer la question"
-                  onClick={() => setFaq((prev) => prev.filter((_, idx) => idx !== i))}
+                  onClick={() =>
+                    setFaq((prev) => prev.filter((x) => x.uid !== row.uid))
+                  }
                 >
-                  <HugeiconsIcon icon={Delete02Icon} size={16} />
+                  <HugeiconsIcon icon={Delete02Icon} size={20} />
                 </Button>
               </div>
               <Input
-                value={item.question}
+                value={row.data.question}
                 maxLength={160}
                 placeholder="La question"
                 onChange={(e) => {
                   const question = e.target.value;
-                  setFaq((prev) => prev.map((x, idx) => (idx === i ? { ...x, question } : x)));
+                  setFaq((prev) =>
+                    prev.map((x) =>
+                      x.uid === row.uid ? { ...x, data: { ...x.data, question } } : x,
+                    ),
+                  );
                 }}
               />
               <Textarea
-                value={item.answer}
+                value={row.data.answer}
                 rows={3}
                 maxLength={600}
                 placeholder="La réponse"
                 onChange={(e) => {
                   const answer = e.target.value;
-                  setFaq((prev) => prev.map((x, idx) => (idx === i ? { ...x, answer } : x)));
+                  setFaq((prev) =>
+                    prev.map((x) =>
+                      x.uid === row.uid ? { ...x, data: { ...x.data, answer } } : x,
+                    ),
+                  );
                 }}
               />
             </div>
@@ -236,7 +278,12 @@ export function ProductStorySection({
           variant="outline"
           size="sm"
           disabled={faq.length >= MAX_FAQ}
-          onClick={() => setFaq((prev) => [...prev, { question: "", answer: "" }])}
+          onClick={() =>
+            setFaq((prev) => [
+              ...prev,
+              { uid: newUid(), data: { question: "", answer: "" } },
+            ])
+          }
         >
           <HugeiconsIcon icon={Add01Icon} size={14} className="mr-1.5" />
           Ajouter une question

--- a/components/admin/product-story-section.tsx
+++ b/components/admin/product-story-section.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Add01Icon, Delete02Icon } from "@hugeicons/core-free-icons";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { StoryIconPicker } from "./story-icon-picker";
+import { StoryFeatureBlockEditor } from "./story-feature-block-editor";
+import type {
+  ProductHighlight,
+  ProductFeatureBlock,
+  ProductFaqItem,
+} from "@/lib/db/types";
+import { HIGHLIGHT_ICON_NAMES } from "@/lib/validations/product-story";
+
+interface ProductStorySectionProps {
+  productId: string;
+  tagline: string | null;
+  highlights: ProductHighlight[] | null;
+  featureBlocks: ProductFeatureBlock[] | null;
+  faq: ProductFaqItem[] | null;
+}
+
+const MIN_HL = 3;
+const MAX_HL = 6;
+const MIN_FB = 2;
+const MAX_FB = 4;
+const MAX_FAQ = 5;
+const DEFAULT_ICON = HIGHLIGHT_ICON_NAMES[0];
+
+export function ProductStorySection({
+  productId,
+  tagline: initialTagline,
+  highlights: initialHighlights,
+  featureBlocks: initialFeatureBlocks,
+  faq: initialFaq,
+}: ProductStorySectionProps) {
+  const [tagline, setTagline] = useState<string>(initialTagline ?? "");
+  const [highlights, setHighlights] = useState<ProductHighlight[]>(
+    () => initialHighlights ?? [],
+  );
+  const [featureBlocks, setFeatureBlocks] = useState<ProductFeatureBlock[]>(
+    () => initialFeatureBlocks ?? [],
+  );
+  const [faq, setFaq] = useState<ProductFaqItem[]>(() => initialFaq ?? []);
+
+  // Serialized hidden-input values sent with the main form submit.
+  const hiddenValues = useMemo(
+    () => ({
+      tagline: tagline.trim(),
+      highlights_json:
+        highlights.length === 0 ? "" : JSON.stringify(highlights),
+      feature_blocks_json:
+        featureBlocks.length === 0 ? "" : JSON.stringify(featureBlocks),
+      faq_json: faq.length === 0 ? "" : JSON.stringify(faq),
+    }),
+    [tagline, highlights, featureBlocks, faq],
+  );
+
+  return (
+    <div className="space-y-8">
+      <input type="hidden" name="tagline" value={hiddenValues.tagline} />
+      <input type="hidden" name="highlights" value={hiddenValues.highlights_json} />
+      <input type="hidden" name="feature_blocks" value={hiddenValues.feature_blocks_json} />
+      <input type="hidden" name="faq" value={hiddenValues.faq_json} />
+
+      {/* Tagline */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label htmlFor="story-tagline">Accroche</Label>
+          <span className="text-xs text-muted-foreground">{tagline.length}/200</span>
+        </div>
+        <Textarea
+          id="story-tagline"
+          rows={2}
+          value={tagline}
+          maxLength={200}
+          onChange={(e) => setTagline(e.target.value)}
+          placeholder="Ex. Un écran plus grand, une autonomie qui dure."
+        />
+      </div>
+
+      {/* Highlights */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label>Points forts</Label>
+          <p className="text-xs text-muted-foreground">
+            Entre {MIN_HL} et {MAX_HL} — ou laisse vide pour masquer ce bloc
+          </p>
+        </div>
+        <div className="space-y-2">
+          {highlights.map((h, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <StoryIconPicker
+                value={h.icon}
+                onChange={(icon) => {
+                  setHighlights((prev) =>
+                    prev.map((x, idx) => (idx === i ? { ...x, icon } : x)),
+                  );
+                }}
+              />
+              <Input
+                value={h.label}
+                maxLength={80}
+                placeholder="Ex. Charge rapide 33 W"
+                onChange={(e) => {
+                  const label = e.target.value;
+                  setHighlights((prev) =>
+                    prev.map((x, idx) => (idx === i ? { ...x, label } : x)),
+                  );
+                }}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Supprimer le point fort"
+                onClick={() => setHighlights((prev) => prev.filter((_, idx) => idx !== i))}
+              >
+                <HugeiconsIcon icon={Delete02Icon} size={16} />
+              </Button>
+            </div>
+          ))}
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={highlights.length >= MAX_HL}
+          onClick={() => setHighlights((prev) => [...prev, { icon: DEFAULT_ICON, label: "" }])}
+        >
+          <HugeiconsIcon icon={Add01Icon} size={14} className="mr-1.5" />
+          Ajouter un point fort
+        </Button>
+        {highlights.length > 0 && highlights.length < MIN_HL && (
+          <p className="text-xs text-destructive">
+            Ajoute au moins {MIN_HL} points forts ou supprime-les tous pour masquer le bloc.
+          </p>
+        )}
+      </div>
+
+      {/* Feature blocks */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label>Feature blocks</Label>
+          <p className="text-xs text-muted-foreground">
+            Entre {MIN_FB} et {MAX_FB} — ou laisse vide pour masquer ce bloc
+          </p>
+        </div>
+        <div className="space-y-3">
+          {featureBlocks.map((block, i) => (
+            <StoryFeatureBlockEditor
+              key={i}
+              productId={productId}
+              block={block}
+              index={i}
+              canRemove={featureBlocks.length > 0}
+              onChange={(next) =>
+                setFeatureBlocks((prev) => prev.map((x, idx) => (idx === i ? next : x)))
+              }
+              onRemove={() =>
+                setFeatureBlocks((prev) => prev.filter((_, idx) => idx !== i))
+              }
+            />
+          ))}
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={featureBlocks.length >= MAX_FB}
+          onClick={() =>
+            setFeatureBlocks((prev) => [...prev, { title: "", body: "" }])
+          }
+        >
+          <HugeiconsIcon icon={Add01Icon} size={14} className="mr-1.5" />
+          Ajouter un bloc
+        </Button>
+        {featureBlocks.length > 0 && featureBlocks.length < MIN_FB && (
+          <p className="text-xs text-destructive">
+            Ajoute au moins {MIN_FB} blocs ou supprime-les tous pour masquer le bloc.
+          </p>
+        )}
+      </div>
+
+      {/* FAQ */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label>FAQ</Label>
+          <p className="text-xs text-muted-foreground">Jusqu&apos;à {MAX_FAQ} questions</p>
+        </div>
+        <div className="space-y-3">
+          {faq.map((item, i) => (
+            <div key={i} className="space-y-2 rounded-lg border bg-muted/30 p-4">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-semibold text-muted-foreground">
+                  Question {i + 1}
+                </span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label="Supprimer la question"
+                  onClick={() => setFaq((prev) => prev.filter((_, idx) => idx !== i))}
+                >
+                  <HugeiconsIcon icon={Delete02Icon} size={16} />
+                </Button>
+              </div>
+              <Input
+                value={item.question}
+                maxLength={160}
+                placeholder="La question"
+                onChange={(e) => {
+                  const question = e.target.value;
+                  setFaq((prev) => prev.map((x, idx) => (idx === i ? { ...x, question } : x)));
+                }}
+              />
+              <Textarea
+                value={item.answer}
+                rows={3}
+                maxLength={600}
+                placeholder="La réponse"
+                onChange={(e) => {
+                  const answer = e.target.value;
+                  setFaq((prev) => prev.map((x, idx) => (idx === i ? { ...x, answer } : x)));
+                }}
+              />
+            </div>
+          ))}
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={faq.length >= MAX_FAQ}
+          onClick={() => setFaq((prev) => [...prev, { question: "", answer: "" }])}
+        >
+          <HugeiconsIcon icon={Add01Icon} size={14} className="mr-1.5" />
+          Ajouter une question
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/product-wizard.tsx
+++ b/components/admin/product-wizard.tsx
@@ -145,7 +145,7 @@ export function ProductWizard({ product, categories }: ProductWizardProps) {
     <div className="flex flex-col">
       {/* Integrated header: back button + description + stepper.
          Sticky so it stays visible while main (the admin layout scroll container) scrolls. */}
-      <div className="sticky top-0 z-20 -mx-4 -mt-4 bg-background border-b sm:-mx-6 sm:-mt-6">
+      <div className="sticky top-0 z-20 bg-background border-b">
         <div className="flex items-center gap-2 px-4 pt-4 pb-2 sm:px-6 sm:pt-5">
           <Button variant="ghost" size="icon" asChild className="shrink-0">
             <Link href="/products" aria-label="Retour aux produits">

--- a/components/admin/product-wizard.tsx
+++ b/components/admin/product-wizard.tsx
@@ -144,7 +144,7 @@ export function ProductWizard({ product, categories }: ProductWizardProps) {
   return (
     <div className="flex flex-1 flex-col min-h-0 overflow-hidden">
       {/* Integrated header: back button + description + stepper */}
-      <div className="-mx-4 -mt-4 bg-background sm:-mx-6 sm:-mt-6">
+      <div className="shrink-0 -mx-4 -mt-4 bg-background sm:-mx-6 sm:-mt-6">
         <div className="flex items-center gap-2 px-4 pt-4 pb-2 sm:px-6 sm:pt-5">
           <Button variant="ghost" size="icon" asChild className="shrink-0">
             <Link href="/products" aria-label="Retour aux produits">

--- a/components/admin/product-wizard.tsx
+++ b/components/admin/product-wizard.tsx
@@ -142,9 +142,10 @@ export function ProductWizard({ product, categories }: ProductWizardProps) {
   const isLastStep = currentStep === STEPS.length - 1;
 
   return (
-    <div className="flex flex-1 flex-col min-h-0 overflow-hidden">
-      {/* Integrated header: back button + description + stepper */}
-      <div className="shrink-0 -mx-4 -mt-4 bg-background sm:-mx-6 sm:-mt-6">
+    <div className="flex flex-col">
+      {/* Integrated header: back button + description + stepper.
+         Sticky so it stays visible while main (the admin layout scroll container) scrolls. */}
+      <div className="sticky top-0 z-20 -mx-4 -mt-4 bg-background border-b sm:-mx-6 sm:-mt-6">
         <div className="flex items-center gap-2 px-4 pt-4 pb-2 sm:px-6 sm:pt-5">
           <Button variant="ghost" size="icon" asChild className="shrink-0">
             <Link href="/products" aria-label="Retour aux produits">
@@ -160,8 +161,7 @@ export function ProductWizard({ product, categories }: ProductWizardProps) {
         />
       </div>
 
-      {/* Step content — internal scroll */}
-      <div className="flex-1 min-h-0 overflow-y-auto">
+      {/* Step content — flows inside main's scroll */}
       <div className="mx-auto w-full max-w-2xl px-4 py-8">
         {currentStep === 0 && (
           <StepIdentity
@@ -241,7 +241,6 @@ export function ProductWizard({ product, categories }: ProductWizardProps) {
             )}
           </div>
         </div>
-      </div>
       </div>
     </div>
   );

--- a/components/admin/product-wizard/step-finalization.tsx
+++ b/components/admin/product-wizard/step-finalization.tsx
@@ -76,9 +76,9 @@ export function StepFinalization({
       </div>
 
       {/* Story produit */}
-      <div className="space-y-1.5">
-        <Label>Story produit</Label>
-        <p className="text-xs text-muted-foreground">
+      <div data-slot="story-section" className="space-y-1.5">
+        <Label data-slot="story-section-label">Story produit</Label>
+        <p data-slot="story-section-help" className="text-xs text-muted-foreground">
           Blocs éditoriaux rendus en pleine largeur sur la fiche produit. Tous optionnels.
         </p>
         <ProductStorySection

--- a/components/admin/product-wizard/step-finalization.tsx
+++ b/components/admin/product-wizard/step-finalization.tsx
@@ -2,17 +2,12 @@
 "use client";
 
 import { useRef, useState } from "react";
-import dynamic from "next/dynamic";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
 import type { ProductDetail } from "@/lib/db/types";
-
-const DescriptionEditor = dynamic(
-  () => import("@/components/admin/description-editor").then((m) => m.DescriptionEditor),
-  { ssr: false },
-);
+import { ProductStorySection } from "@/components/admin/product-story-section";
 
 interface StepFinalizationProps {
   product: ProductDetail;
@@ -80,15 +75,22 @@ export function StepFinalization({
         />
       </div>
 
-      {/* Description */}
+      {/* Story produit */}
       <div className="space-y-1.5">
-        <Label>Description</Label>
-        <DescriptionEditor
-          name="description"
-          descriptionType={product.description_type}
-          defaultValue={product.description}
+        <Label>Story produit</Label>
+        <p className="text-xs text-muted-foreground">
+          Blocs éditoriaux rendus en pleine largeur sur la fiche produit. Tous optionnels.
+        </p>
+        <ProductStorySection
+          productId={product.id}
+          tagline={product.tagline}
+          highlights={product.highlights}
+          featureBlocks={product.feature_blocks}
+          faq={product.faq}
         />
       </div>
+      <input type="hidden" name="description" value={product.description ?? ""} />
+      <input type="hidden" name="description_type" value={product.description_type ?? "richtext"} />
 
       {/* SEO */}
       <div className="space-y-4 rounded-lg border p-4">

--- a/components/admin/story-feature-block-editor.tsx
+++ b/components/admin/story-feature-block-editor.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import Image from "next/image";
+import { toast } from "sonner";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Delete02Icon, Upload04Icon } from "@hugeicons/core-free-icons";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { getImageUrl } from "@/lib/utils/images";
+import { uploadStoryImage } from "@/actions/admin/story";
+import type { ProductFeatureBlock } from "@/lib/db/types";
+
+interface StoryFeatureBlockEditorProps {
+  productId: string;
+  block: ProductFeatureBlock;
+  index: number;
+  onChange: (next: ProductFeatureBlock) => void;
+  onRemove: () => void;
+  canRemove: boolean;
+}
+
+export function StoryFeatureBlockEditor({
+  productId,
+  block,
+  index,
+  onChange,
+  onRemove,
+  canRemove,
+}: StoryFeatureBlockEditorProps) {
+  const [isUploading, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function handleFile(file: File) {
+    setError(null);
+    const fd = new FormData();
+    fd.set("file", file);
+    startTransition(async () => {
+      try {
+        const result = await uploadStoryImage(productId, fd);
+        if (result.success && result.url) {
+          onChange({ ...block, image_url: result.url });
+          toast.success("Image téléchargée");
+        } else {
+          setError(result.error || "Erreur lors de l'upload");
+          toast.error(result.error || "Erreur lors de l'upload");
+        }
+      } catch (err) {
+        console.error("[StoryFeatureBlockEditor] upload failed", err);
+        toast.error("Erreur inattendue");
+      }
+    });
+  }
+
+  return (
+    <div className="space-y-3 rounded-lg border bg-muted/30 p-4">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-semibold text-muted-foreground">
+          Bloc {index + 1}
+        </span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          disabled={!canRemove}
+          onClick={onRemove}
+          aria-label="Supprimer le bloc"
+        >
+          <HugeiconsIcon icon={Delete02Icon} size={16} />
+        </Button>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor={`block-${index}-title`}>Titre</Label>
+        <Input
+          id={`block-${index}-title`}
+          value={block.title}
+          maxLength={120}
+          onChange={(e) => onChange({ ...block, title: e.target.value })}
+          placeholder="Un argument, une phrase"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label htmlFor={`block-${index}-body`}>Texte</Label>
+          <span className="text-xs text-muted-foreground">
+            {block.body.length}/600
+          </span>
+        </div>
+        <Textarea
+          id={`block-${index}-body`}
+          value={block.body}
+          maxLength={600}
+          rows={4}
+          onChange={(e) => onChange({ ...block, body: e.target.value })}
+          placeholder="Décris l'argument en 2-4 phrases"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label>Image (optionnelle)</Label>
+        {block.image_url ? (
+          <div className="relative h-40 w-full overflow-hidden rounded-md border">
+            <Image
+              src={getImageUrl(block.image_url)}
+              alt={block.image_alt ?? ""}
+              fill
+              sizes="(max-width: 768px) 100vw, 50vw"
+              className="object-cover"
+            />
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              className="absolute right-2 top-2"
+              onClick={() => onChange({ ...block, image_url: undefined, image_alt: undefined })}
+            >
+              Retirer
+            </Button>
+          </div>
+        ) : (
+          <label className="flex h-24 cursor-pointer items-center justify-center gap-2 rounded-md border border-dashed border-border text-sm text-muted-foreground hover:bg-accent/50">
+            <HugeiconsIcon icon={Upload04Icon} size={18} />
+            {isUploading ? "Téléchargement..." : "Télécharger une image"}
+            <input
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file) handleFile(file);
+                e.target.value = ""; // allow re-selecting same file
+              }}
+            />
+          </label>
+        )}
+        {error && <p className="text-sm text-destructive">{error}</p>}
+      </div>
+
+      {block.image_url && (
+        <div className="space-y-2">
+          <Label htmlFor={`block-${index}-alt`}>Texte alternatif</Label>
+          <Input
+            id={`block-${index}-alt`}
+            value={block.image_alt ?? ""}
+            maxLength={200}
+            onChange={(e) => onChange({ ...block, image_alt: e.target.value })}
+            placeholder="Description de l'image pour l'accessibilité"
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/admin/story-feature-block-editor.tsx
+++ b/components/admin/story-feature-block-editor.tsx
@@ -63,17 +63,22 @@ export function StoryFeatureBlockEditor({
         <Button
           type="button"
           variant="ghost"
-          size="icon-sm"
+          size="icon-touch"
           disabled={!canRemove}
           onClick={onRemove}
           aria-label="Supprimer le bloc"
         >
-          <HugeiconsIcon icon={Delete02Icon} size={16} />
+          <HugeiconsIcon icon={Delete02Icon} size={20} />
         </Button>
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor={`block-${index}-title`}>Titre</Label>
+        <div className="flex items-center justify-between">
+          <Label htmlFor={`block-${index}-title`}>Titre</Label>
+          <span className="text-xs text-muted-foreground">
+            {block.title.length}/120
+          </span>
+        </div>
         <Input
           id={`block-${index}-title`}
           value={block.title}

--- a/components/admin/story-icon-picker.tsx
+++ b/components/admin/story-icon-picker.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState } from "react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { HIGHLIGHT_ICON_NAMES } from "@/lib/validations/product-story";
+import { HIGHLIGHT_ICON_MAP } from "@/components/storefront/product-story/icons";
+
+interface StoryIconPickerProps {
+  value: string;
+  onChange: (name: string) => void;
+  className?: string;
+}
+
+export function StoryIconPicker({ value, onChange, className }: StoryIconPickerProps) {
+  const [open, setOpen] = useState(false);
+  const icon = HIGHLIGHT_ICON_MAP[value as keyof typeof HIGHLIGHT_ICON_MAP]
+    ?? HIGHLIGHT_ICON_MAP["star"];
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className={cn("h-10 w-10 shrink-0", className)}
+          aria-label="Choisir une icône"
+        >
+          <HugeiconsIcon icon={icon} size={20} strokeWidth={1.5} />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-80 p-2">
+        <div className="grid grid-cols-6 gap-1">
+          {HIGHLIGHT_ICON_NAMES.map((name) => {
+            const isSelected = name === value;
+            return (
+              <button
+                key={name}
+                type="button"
+                title={name}
+                aria-label={name}
+                aria-pressed={isSelected}
+                className={cn(
+                  "flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground transition hover:bg-accent hover:text-foreground",
+                  isSelected && "bg-accent text-foreground ring-2 ring-primary",
+                )}
+                onClick={() => {
+                  onChange(name);
+                  setOpen(false);
+                }}
+              >
+                <HugeiconsIcon
+                  icon={HIGHLIGHT_ICON_MAP[name]}
+                  size={20}
+                  strokeWidth={1.5}
+                />
+              </button>
+            );
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/components/admin/story-icon-picker.tsx
+++ b/components/admin/story-icon-picker.tsx
@@ -9,19 +9,18 @@ import {
 } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { HIGHLIGHT_ICON_NAMES } from "@/lib/validations/product-story";
+import { HIGHLIGHT_ICON_NAMES, type HighlightIconName } from "@/lib/validations/product-story";
 import { HIGHLIGHT_ICON_MAP } from "@/components/storefront/product-story/icons";
 
 interface StoryIconPickerProps {
-  value: string;
-  onChange: (name: string) => void;
+  value: HighlightIconName | "";
+  onChange: (name: HighlightIconName) => void;
   className?: string;
 }
 
 export function StoryIconPicker({ value, onChange, className }: StoryIconPickerProps) {
   const [open, setOpen] = useState(false);
-  const icon = HIGHLIGHT_ICON_MAP[value as keyof typeof HIGHLIGHT_ICON_MAP]
-    ?? HIGHLIGHT_ICON_MAP["star"];
+  const icon = value ? HIGHLIGHT_ICON_MAP[value] : HIGHLIGHT_ICON_MAP["star"];
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -29,8 +28,8 @@ export function StoryIconPicker({ value, onChange, className }: StoryIconPickerP
         <Button
           type="button"
           variant="outline"
-          size="icon"
-          className={cn("h-10 w-10 shrink-0", className)}
+          size="icon-touch"
+          className={cn("shrink-0", className)}
           aria-label="Choisir une icône"
         >
           <HugeiconsIcon icon={icon} size={20} strokeWidth={1.5} />
@@ -48,7 +47,7 @@ export function StoryIconPicker({ value, onChange, className }: StoryIconPickerP
                 aria-label={name}
                 aria-pressed={isSelected}
                 className={cn(
-                  "flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground transition hover:bg-accent hover:text-foreground",
+                  "flex h-11 w-11 items-center justify-center rounded-md text-muted-foreground transition hover:bg-accent hover:text-foreground",
                   isSelected && "bg-accent text-foreground ring-2 ring-primary",
                 )}
                 onClick={() => {

--- a/components/storefront/product-details.tsx
+++ b/components/storefront/product-details.tsx
@@ -1,106 +1,34 @@
 import type { ProductAttribute } from "@/lib/db/types";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { descriptionToHtml } from "@/lib/utils/description-to-html";
 
-interface ProductDetailsProps {
-  description: string | null;
-  descriptionType?: string;
-  productId?: string;
+interface ProductSpecsProps {
   attributes: ProductAttribute[];
 }
 
-export function ProductDetails({ description, descriptionType, productId, attributes }: ProductDetailsProps) {
-  const hasDescription = !!description;
-  const filteredAttributes = attributes.filter((a) => a.name !== "Couleur");
-  const hasAttributes = filteredAttributes.length > 0;
+/**
+ * Product characteristics section. Renders a 2-column key/value grid.
+ * Returns null if there are no displayable attributes (the "Couleur"
+ * attribute is filtered out because it's surfaced by the color variant UI).
+ */
+export function ProductSpecs({ attributes }: ProductSpecsProps) {
+  const filtered = attributes.filter((a) => a.name !== "Couleur");
+  if (filtered.length === 0) return null;
 
-  if (!hasDescription && !hasAttributes) return null;
-
-  // If only one section exists, render it directly without tabs
-  if (!hasAttributes && hasDescription) {
-    return (
-      <section className="mt-10 border-t pt-8">
-        <h2 className="mb-4 text-lg font-semibold">Description</h2>
-        <DescriptionContent description={description} descriptionType={descriptionType} productId={productId} />
-      </section>
-    );
-  }
-
-  if (hasAttributes && !hasDescription) {
-    return (
-      <section className="mt-10 border-t pt-8">
-        <h2 className="mb-4 text-lg font-semibold">Caractéristiques</h2>
-        <AttributesTable attributes={filteredAttributes} />
-      </section>
-    );
-  }
-
-  // Both exist: show tabs
   return (
-    <section className="mt-10 border-t pt-8">
-      <Tabs defaultValue="description">
-        <TabsList variant="line" className="mb-6">
-          <TabsTrigger value="description" className="text-sm">
-            Description
-          </TabsTrigger>
-          <TabsTrigger value="characteristics" className="text-sm">
-            Caractéristiques
-          </TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="description">
-          <DescriptionContent description={description!} descriptionType={descriptionType} productId={productId} />
-        </TabsContent>
-
-        <TabsContent value="characteristics">
-          <AttributesTable attributes={filteredAttributes} />
-        </TabsContent>
-      </Tabs>
+    <section className="mt-12 border-t pt-10">
+      <h2 className="mb-6 text-2xl font-semibold tracking-tight">
+        Caractéristiques
+      </h2>
+      <dl className="grid grid-cols-1 gap-px overflow-hidden rounded-lg border bg-border sm:grid-cols-2">
+        {filtered.map((attr) => (
+          <div
+            key={attr.id}
+            className="flex items-baseline gap-4 bg-background px-4 py-3"
+          >
+            <dt className="shrink-0 text-sm text-muted-foreground">{attr.name}</dt>
+            <dd className="ml-auto text-right text-sm font-medium">{attr.value}</dd>
+          </div>
+        ))}
+      </dl>
     </section>
-  );
-}
-
-
-function DescriptionContent({
-  description,
-  descriptionType,
-  productId,
-}: {
-  description: string | null;
-  descriptionType?: string;
-  productId?: string;
-}) {
-  if (!description) return null;
-  const html = descriptionToHtml(description, descriptionType);
-  if (!html) return null;
-
-  const scopeClass =
-    descriptionType === "html" && productId ? `desc-${productId}` : undefined;
-
-  return (
-    <div
-      className={`prose prose-sm max-w-prose dark:prose-invert ${scopeClass ?? ""}`}
-      dangerouslySetInnerHTML={{ __html: html }}
-    />
-  );
-}
-
-function AttributesTable({ attributes }: { attributes: ProductAttribute[] }) {
-  return (
-    <dl className="grid grid-cols-1 gap-px overflow-hidden rounded-lg border bg-border sm:grid-cols-2">
-      {attributes.map((attr) => (
-        <div
-          key={attr.id}
-          className="flex items-baseline gap-4 bg-background px-4 py-3"
-        >
-          <dt className="shrink-0 text-sm text-muted-foreground">
-            {attr.name}
-          </dt>
-          <dd className="ml-auto text-right text-sm font-medium">
-            {attr.value}
-          </dd>
-        </div>
-      ))}
-    </dl>
   );
 }

--- a/components/storefront/product-story/icons.ts
+++ b/components/storefront/product-story/icons.ts
@@ -117,7 +117,7 @@ export const HIGHLIGHT_ICON_MAP: Record<HighlightIconName, IconSvgElement> = {
 };
 
 export function resolveHighlightIcon(name: string): IconSvgElement {
-  if (name in HIGHLIGHT_ICON_MAP) {
+  if (Object.hasOwn(HIGHLIGHT_ICON_MAP, name)) {
     return HIGHLIGHT_ICON_MAP[name as HighlightIconName];
   }
   console.warn(`[product-story] unknown highlight icon "${name}" — falling back to "star"`);

--- a/components/storefront/product-story/icons.ts
+++ b/components/storefront/product-story/icons.ts
@@ -1,0 +1,125 @@
+import type { IconSvgElement } from "@hugeicons/react";
+import {
+  // battery
+  BatteryFullIcon,
+  BatteryCharging01Icon,
+  // connectivity
+  BluetoothIcon,
+  WifiConnected01Icon,
+  UsbIcon,
+  // bolt / zap / flash / charge-fast
+  ZapIcon,
+  FlashIcon,
+  CloudIcon,
+  // camera / video / display / tv
+  Camera01Icon,
+  VideoReplayIcon,
+  ComputerIcon,
+  Tv01Icon,
+  // control & input
+  DashboardSquare01Icon,
+  FingerPrintIcon,
+  EyeIcon,
+  Key01Icon,
+  LockIcon,
+  Shield02Icon,
+  Shield01Icon,
+  // misc
+  CpuIcon,
+  GameController01Icon,
+  GiftIcon,
+  GlobalIcon,
+  CompassIcon,
+  GpsSignal01Icon,
+  HeadphonesIcon,
+  FavouriteIcon,
+  HourglassIcon,
+  Leaf01Icon,
+  MedalFirstPlaceIcon,
+  Mic01Icon,
+  Moon02Icon,
+  MusicNote01Icon,
+  NotificationCircleIcon,
+  PackageIcon,
+  PaintBoardIcon,
+  PrinterIcon,
+  RulerIcon,
+  SdCardIcon,
+  ShoppingBag01Icon,
+  SmartPhone01Icon,
+  SparklesIcon,
+  SpeakerIcon,
+  StarIcon,
+  Sun03Icon,
+  ToolsIcon,
+  TruckDeliveryIcon,
+  VolumeHighIcon,
+  DropletIcon,
+} from "@hugeicons/core-free-icons";
+import type { HighlightIconName } from "@/lib/validations/product-story";
+
+/**
+ * Map every name in `HIGHLIGHT_ICON_NAMES` (validation) to a Hugeicons component.
+ * Must stay in sync with that list. The build/test fails if a name is missing.
+ */
+export const HIGHLIGHT_ICON_MAP: Record<HighlightIconName, IconSvgElement> = {
+  "battery": BatteryFullIcon,
+  "battery-charging": BatteryCharging01Icon,
+  "bluetooth": BluetoothIcon,
+  "bolt": ZapIcon,
+  "camera": Camera01Icon,
+  "charge-fast": ZapIcon,
+  "cloud": CloudIcon,
+  "compass": CompassIcon,
+  "cpu": CpuIcon,
+  "dashboard": DashboardSquare01Icon,
+  "display": ComputerIcon,
+  "eye": EyeIcon,
+  "fingerprint": FingerPrintIcon,
+  "flash": FlashIcon,
+  "gaming-pad": GameController01Icon,
+  "gift": GiftIcon,
+  "globe": GlobalIcon,
+  "gps": GpsSignal01Icon,
+  "headphones": HeadphonesIcon,
+  "heart": FavouriteIcon,
+  "hourglass": HourglassIcon,
+  "key": Key01Icon,
+  "leaf": Leaf01Icon,
+  "lock": LockIcon,
+  "medal": MedalFirstPlaceIcon,
+  "microphone": Mic01Icon,
+  "moon": Moon02Icon,
+  "music-note": MusicNote01Icon,
+  "notification": NotificationCircleIcon,
+  "package": PackageIcon,
+  "palette": PaintBoardIcon,
+  "printer": PrinterIcon,
+  "ruler": RulerIcon,
+  "sd-card": SdCardIcon,
+  "shield": Shield02Icon,
+  "shield-check": Shield01Icon,
+  "shopping-bag": ShoppingBag01Icon,
+  "smart-phone": SmartPhone01Icon,
+  "sparkle": SparklesIcon,
+  "speaker": SpeakerIcon,
+  "star": StarIcon,
+  "sun": Sun03Icon,
+  "tools": ToolsIcon,
+  "truck": TruckDeliveryIcon,
+  "tv": Tv01Icon,
+  "usb": UsbIcon,
+  "video": VideoReplayIcon,
+  "volume": VolumeHighIcon,
+  "water-resistant": DropletIcon,
+  "wifi": WifiConnected01Icon,
+  "zap": ZapIcon,
+};
+
+export function resolveHighlightIcon(name: string): IconSvgElement {
+  if (name in HIGHLIGHT_ICON_MAP) {
+    return HIGHLIGHT_ICON_MAP[name as HighlightIconName];
+  }
+  console.warn(`[product-story] unknown highlight icon "${name}" — falling back to "star"`);
+  return HIGHLIGHT_ICON_MAP["star"];
+}

--- a/components/storefront/product-story/index.tsx
+++ b/components/storefront/product-story/index.tsx
@@ -66,7 +66,7 @@ export function ProductStory({
       {hasFeatureBlocks &&
         featureBlocks!.map((block, i) => (
           <div
-            key={i}
+            key={`feature-${i}-${block.title.slice(0, 40)}`}
             className={i % 2 === 0 ? "py-16 sm:py-24" : "bg-muted/30 py-16 sm:py-24"}
           >
             <StoryFeatureBlock block={block} index={i} />

--- a/components/storefront/product-story/index.tsx
+++ b/components/storefront/product-story/index.tsx
@@ -1,0 +1,91 @@
+import type {
+  ProductHighlight,
+  ProductFeatureBlock,
+  ProductFaqItem,
+} from "@/lib/db/types";
+import { descriptionToHtml } from "@/lib/utils/description-to-html";
+import { StoryTagline } from "./story-tagline";
+import { StoryHighlights } from "./story-highlights";
+import { StoryFeatureBlock } from "./story-feature-block";
+import { StoryFaq } from "./story-faq";
+import { StoryFreeContent } from "./story-free-content";
+
+interface ProductStoryProps {
+  tagline: string | null;
+  highlights: ProductHighlight[] | null;
+  featureBlocks: ProductFeatureBlock[] | null;
+  faq: ProductFaqItem[] | null;
+  description: string | null;
+  descriptionType?: string;
+  productId?: string;
+}
+
+function hasFreeContent(description: string | null, descriptionType?: string): boolean {
+  if (!description) return false;
+  return !!descriptionToHtml(description, descriptionType);
+}
+
+/**
+ * Full-width product story. Renders nothing if every block is empty.
+ * The root <section> is expected to live OUTSIDE the page's max-w-7xl wrapper.
+ */
+export function ProductStory({
+  tagline,
+  highlights,
+  featureBlocks,
+  faq,
+  description,
+  descriptionType,
+  productId,
+}: ProductStoryProps) {
+  const hasTagline = !!tagline;
+  const hasHighlights = !!highlights && highlights.length > 0;
+  const hasFeatureBlocks = !!featureBlocks && featureBlocks.length > 0;
+  const hasFaq = !!faq && faq.length > 0;
+  const hasFree = hasFreeContent(description, descriptionType);
+
+  if (!hasTagline && !hasHighlights && !hasFeatureBlocks && !hasFaq && !hasFree) {
+    return null;
+  }
+
+  // Alternate feature-block backgrounds to create rhythm.
+  // Intro (tagline + highlights) share the base background;
+  // feature blocks alternate; FAQ + free content share base again.
+  return (
+    <section className="w-full">
+      {hasTagline && (
+        <div className="py-16 sm:py-24">
+          <StoryTagline tagline={tagline!} />
+        </div>
+      )}
+      {hasHighlights && (
+        <div className="bg-muted/30 py-16 sm:py-24">
+          <StoryHighlights highlights={highlights!} />
+        </div>
+      )}
+      {hasFeatureBlocks &&
+        featureBlocks!.map((block, i) => (
+          <div
+            key={i}
+            className={i % 2 === 0 ? "py-16 sm:py-24" : "bg-muted/30 py-16 sm:py-24"}
+          >
+            <StoryFeatureBlock block={block} index={i} />
+          </div>
+        ))}
+      {hasFaq && (
+        <div className="py-16 sm:py-24">
+          <StoryFaq faq={faq!} />
+        </div>
+      )}
+      {hasFree && (
+        <div className="py-16 sm:py-24">
+          <StoryFreeContent
+            description={description!}
+            descriptionType={descriptionType}
+            productId={productId}
+          />
+        </div>
+      )}
+    </section>
+  );
+}

--- a/components/storefront/product-story/story-faq.tsx
+++ b/components/storefront/product-story/story-faq.tsx
@@ -19,16 +19,19 @@ export function StoryFaq({ faq }: StoryFaqProps) {
         Questions fréquentes
       </h2>
       <Accordion type="single" collapsible className="w-full">
-        {faq.map((item, i) => (
-          <AccordionItem key={i} value={`item-${i}`}>
-            <AccordionTrigger className="text-left text-lg font-medium">
-              {item.question}
-            </AccordionTrigger>
-            <AccordionContent className="whitespace-pre-line text-base leading-relaxed text-muted-foreground">
-              {item.answer}
-            </AccordionContent>
-          </AccordionItem>
-        ))}
+        {faq.map((item, i) => {
+          const id = `faq-${i}-${item.question.slice(0, 40)}`;
+          return (
+            <AccordionItem key={id} value={id}>
+              <AccordionTrigger className="text-left text-lg font-medium">
+                {item.question}
+              </AccordionTrigger>
+              <AccordionContent className="whitespace-pre-line text-base leading-relaxed text-muted-foreground">
+                {item.answer}
+              </AccordionContent>
+            </AccordionItem>
+          );
+        })}
       </Accordion>
     </div>
   );

--- a/components/storefront/product-story/story-faq.tsx
+++ b/components/storefront/product-story/story-faq.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import type { ProductFaqItem } from "@/lib/db/types";
+
+interface StoryFaqProps {
+  faq: ProductFaqItem[];
+}
+
+export function StoryFaq({ faq }: StoryFaqProps) {
+  return (
+    <div className="mx-auto max-w-3xl px-6">
+      <h2 className="mb-8 text-3xl font-semibold tracking-tight sm:text-4xl">
+        Questions fréquentes
+      </h2>
+      <Accordion type="single" collapsible className="w-full">
+        {faq.map((item, i) => (
+          <AccordionItem key={i} value={`item-${i}`}>
+            <AccordionTrigger className="text-left text-lg font-medium">
+              {item.question}
+            </AccordionTrigger>
+            <AccordionContent className="whitespace-pre-line text-base leading-relaxed text-muted-foreground">
+              {item.answer}
+            </AccordionContent>
+          </AccordionItem>
+        ))}
+      </Accordion>
+    </div>
+  );
+}

--- a/components/storefront/product-story/story-feature-block.tsx
+++ b/components/storefront/product-story/story-feature-block.tsx
@@ -1,0 +1,56 @@
+import Image from "next/image";
+import { cn } from "@/lib/utils";
+import type { ProductFeatureBlock } from "@/lib/db/types";
+import { getImageUrl } from "@/lib/utils/images";
+
+interface StoryFeatureBlockProps {
+  block: ProductFeatureBlock;
+  /** 0-indexed position among feature blocks — determines zig-zag direction */
+  index: number;
+}
+
+export function StoryFeatureBlock({ block, index }: StoryFeatureBlockProps) {
+  const hasImage = !!block.image_url;
+  const isOdd = index % 2 === 1;
+
+  return (
+    <div className="mx-auto max-w-6xl px-6">
+      {hasImage ? (
+        <div
+          className={cn(
+            "grid items-center gap-8 md:grid-cols-2 md:gap-12 lg:gap-16",
+            // zig-zag on md+: odd indices (2nd, 4th, …) invert image/text order
+            isOdd && "md:[&>*:first-child]:order-2",
+          )}
+        >
+          <div className="relative aspect-[4/3] w-full overflow-hidden rounded-xl bg-muted">
+            <Image
+              src={getImageUrl(block.image_url!)}
+              alt={block.image_alt ?? ""}
+              fill
+              sizes="(max-width: 768px) 100vw, 50vw"
+              className="object-cover"
+            />
+          </div>
+          <div className="space-y-4">
+            <h3 className="text-2xl font-semibold leading-tight tracking-tight sm:text-3xl lg:text-4xl">
+              {block.title}
+            </h3>
+            <p className="whitespace-pre-line text-lg leading-relaxed text-muted-foreground">
+              {block.body}
+            </p>
+          </div>
+        </div>
+      ) : (
+        <div className="mx-auto max-w-2xl space-y-4 text-center">
+          <h3 className="text-2xl font-semibold leading-tight tracking-tight sm:text-3xl lg:text-4xl">
+            {block.title}
+          </h3>
+          <p className="whitespace-pre-line text-lg leading-relaxed text-muted-foreground">
+            {block.body}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/storefront/product-story/story-feature-block.tsx
+++ b/components/storefront/product-story/story-feature-block.tsx
@@ -26,7 +26,7 @@ export function StoryFeatureBlock({ block, index }: StoryFeatureBlockProps) {
           <div className="relative aspect-[4/3] w-full overflow-hidden rounded-xl bg-muted">
             <Image
               src={getImageUrl(block.image_url!)}
-              alt={block.image_alt ?? ""}
+              alt={block.image_alt || block.title}
               fill
               sizes="(max-width: 768px) 100vw, 50vw"
               className="object-cover"

--- a/components/storefront/product-story/story-free-content.tsx
+++ b/components/storefront/product-story/story-free-content.tsx
@@ -1,0 +1,26 @@
+import { descriptionToHtml } from "@/lib/utils/description-to-html";
+
+interface StoryFreeContentProps {
+  description: string;
+  descriptionType?: string;
+  productId?: string;
+}
+
+export function StoryFreeContent({
+  description,
+  descriptionType,
+  productId,
+}: StoryFreeContentProps) {
+  const html = descriptionToHtml(description, descriptionType);
+  if (!html) return null;
+  const scopeClass =
+    descriptionType === "html" && productId ? `desc-${productId}` : undefined;
+  return (
+    <div className="mx-auto max-w-3xl px-6">
+      <div
+        className={`prose prose-lg max-w-none dark:prose-invert ${scopeClass ?? ""}`}
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </div>
+  );
+}

--- a/components/storefront/product-story/story-free-content.tsx
+++ b/components/storefront/product-story/story-free-content.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/lib/utils";
 import { descriptionToHtml } from "@/lib/utils/description-to-html";
 
 interface StoryFreeContentProps {
@@ -18,7 +19,7 @@ export function StoryFreeContent({
   return (
     <div className="mx-auto max-w-3xl px-6">
       <div
-        className={`prose prose-lg max-w-none dark:prose-invert ${scopeClass ?? ""}`}
+        className={cn("prose prose-lg max-w-none dark:prose-invert", scopeClass)}
         dangerouslySetInnerHTML={{ __html: html }}
       />
     </div>

--- a/components/storefront/product-story/story-highlights.tsx
+++ b/components/storefront/product-story/story-highlights.tsx
@@ -1,0 +1,32 @@
+import { HugeiconsIcon } from "@hugeicons/react";
+import type { ProductHighlight } from "@/lib/db/types";
+import { resolveHighlightIcon } from "./icons";
+
+interface StoryHighlightsProps {
+  highlights: ProductHighlight[];
+}
+
+export function StoryHighlights({ highlights }: StoryHighlightsProps) {
+  return (
+    <div className="mx-auto max-w-6xl px-6">
+      <div className="grid grid-cols-1 gap-10 sm:grid-cols-2 md:grid-cols-3">
+        {highlights.map((item, idx) => (
+          <div
+            key={`${item.icon}-${idx}`}
+            className="flex flex-col items-center text-center"
+          >
+            <HugeiconsIcon
+              icon={resolveHighlightIcon(item.icon)}
+              size={40}
+              strokeWidth={1.5}
+              className="text-foreground"
+            />
+            <p className="mt-4 text-base font-medium leading-snug">
+              {item.label}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/storefront/product-story/story-tagline.tsx
+++ b/components/storefront/product-story/story-tagline.tsx
@@ -1,0 +1,13 @@
+interface StoryTaglineProps {
+  tagline: string;
+}
+
+export function StoryTagline({ tagline }: StoryTaglineProps) {
+  return (
+    <div className="mx-auto max-w-[800px] px-6 text-center">
+      <p className="text-4xl font-light leading-[1.1] tracking-tight sm:text-5xl lg:text-6xl">
+        {tagline}
+      </p>
+    </div>
+  );
+}

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import * as React from "react"
+import { Accordion as AccordionPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { HugeiconsIcon } from "@hugeicons/react"
+import { ArrowDown01Icon, ArrowUp01Icon } from "@hugeicons/core-free-icons"
+
+function Accordion({
+  className,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Root>) {
+  return (
+    <AccordionPrimitive.Root
+      data-slot="accordion"
+      className={cn(
+        "flex w-full flex-col overflow-hidden rounded-md border",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AccordionItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Item>) {
+  return (
+    <AccordionPrimitive.Item
+      data-slot="accordion-item"
+      className={cn("not-last:border-b data-open:bg-muted/50", className)}
+      {...props}
+    />
+  )
+}
+
+function AccordionTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
+  return (
+    <AccordionPrimitive.Header className="flex">
+      <AccordionPrimitive.Trigger
+        data-slot="accordion-trigger"
+        className={cn(
+          "group/accordion-trigger relative flex flex-1 items-start justify-between gap-6 border border-transparent p-2 text-left text-xs/relaxed font-medium transition-all outline-none hover:underline disabled:pointer-events-none disabled:opacity-50 **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 **:data-[slot=accordion-trigger-icon]:text-muted-foreground",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <HugeiconsIcon icon={ArrowDown01Icon} strokeWidth={2} data-slot="accordion-trigger-icon" className="pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden" />
+        <HugeiconsIcon icon={ArrowUp01Icon} strokeWidth={2} data-slot="accordion-trigger-icon" className="pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline" />
+      </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+  )
+}
+
+function AccordionContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Content>) {
+  return (
+    <AccordionPrimitive.Content
+      data-slot="accordion-content"
+      className="overflow-hidden px-2 text-xs/relaxed data-open:animate-accordion-down data-closed:animate-accordion-up"
+      {...props}
+    >
+      <div
+        className={cn(
+          "h-(--radix-accordion-content-height) pt-0 pb-4 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
+          className
+        )}
+      >
+        {children}
+      </div>
+    </AccordionPrimitive.Content>
+  )
+}
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -46,7 +46,7 @@ function AccordionTrigger({
       <AccordionPrimitive.Trigger
         data-slot="accordion-trigger"
         className={cn(
-          "group/accordion-trigger relative flex flex-1 items-start justify-between gap-6 border border-transparent p-2 text-left text-xs/relaxed font-medium transition-all outline-none hover:underline disabled:pointer-events-none disabled:opacity-50 **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 **:data-[slot=accordion-trigger-icon]:text-muted-foreground",
+          "group/accordion-trigger relative flex min-h-11 flex-1 items-start justify-between gap-6 border border-transparent px-3 py-2.5 text-left text-sm/relaxed font-medium transition-all outline-none hover:underline disabled:pointer-events-none disabled:opacity-50 **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 **:data-[slot=accordion-trigger-icon]:text-muted-foreground",
           className
         )}
         {...props}

--- a/docs/superpowers/plans/2026-04-16-product-story-template.md
+++ b/docs/superpowers/plans/2026-04-16-product-story-template.md
@@ -1,0 +1,2563 @@
+# Product Story Template — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement a structured, Apple-like product description template (tagline + highlights + feature blocks + FAQ + free content) that replaces the current free-form description section on the storefront, with a matching admin editor.
+
+**Architecture:** Extend the `products` table with four nullable JSON/text columns. Render a new `<ProductStory>` full-width section on the product page that composes five optional sub-components. In the admin, add a new "Story" section to the product form that edits the new fields, with feature-block image uploads going through R2 exactly like existing product images.
+
+**Tech Stack:** Drizzle ORM + D1 (expand-only migration), Next.js 16 App Router, React Server Components, Zod validation, shadcn/ui (Accordion), Hugeicons for highlight icons, Cloudflare R2 via `lib/storage/images.ts`, Vitest 4 for unit tests.
+
+**Spec:** [`docs/superpowers/specs/2026-04-16-product-story-template-design.md`](../specs/2026-04-16-product-story-template-design.md)
+
+**Branch:** `feat/product-story-template` (already created)
+
+---
+
+## File Structure
+
+### New files
+
+```
+drizzle/
+└── 0010_product_story.sql                               # schema migration
+
+lib/
+├── validations/
+│   └── product-story.ts                                 # Zod schemas
+└── utils/
+    └── product-story.ts                                 # safeParseJson helper
+
+components/
+├── ui/
+│   └── accordion.tsx                                    # shadcn/ui component
+├── storefront/
+│   └── product-story/
+│       ├── index.tsx                                    # <ProductStory> root
+│       ├── story-tagline.tsx
+│       ├── story-highlights.tsx
+│       ├── story-feature-block.tsx
+│       ├── story-faq.tsx
+│       ├── story-free-content.tsx
+│       └── icons.ts                                     # 50-icon shortlist
+└── admin/
+    ├── product-story-section.tsx                        # main admin card
+    ├── story-icon-picker.tsx                            # popover icon picker
+    └── story-feature-block-editor.tsx                   # feature block sub-form
+
+actions/
+└── admin/
+    └── story.ts                                         # uploadStoryImage
+
+__tests__/unit/
+├── product-story-validation.test.ts
+├── product-story-parse.test.ts
+└── product-story-icons.test.ts
+```
+
+### Modified files
+
+```
+lib/db/schema.ts                                         # add 4 columns
+lib/db/types.ts                                          # add types + extend Product
+lib/db/products.ts                                       # deserialize JSON in getProductBySlug
+lib/db/admin/products.ts                                 # deserialize JSON in getAdminProductById
+app/(storefront)/p/[slug]/page.tsx                       # restructure layout
+components/storefront/product-details.tsx                # split into ProductSpecs
+actions/admin/products.ts                                # extend productSchema + updateProduct
+components/admin/product-form-sections.tsx               # add Story section entry
+```
+
+---
+
+## Task 1 — Add shadcn Accordion component
+
+Needed for the FAQ block.
+
+**Files:**
+- Create: `components/ui/accordion.tsx`
+- Modify: `package.json` (dependency `@radix-ui/react-accordion` if missing)
+
+- [ ] **Step 1.1: Check for existing accordion and install via shadcn CLI**
+
+```bash
+ls components/ui/accordion.tsx 2>/dev/null && echo "already present" || npx shadcn@latest add accordion --yes
+```
+
+Expected: either "already present" OR the CLI adds `components/ui/accordion.tsx` and installs `@radix-ui/react-accordion`.
+
+- [ ] **Step 1.2: Verify build passes**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no new errors (there may be pre-existing warnings; confirm none mention `accordion`).
+
+- [ ] **Step 1.3: Commit**
+
+```bash
+git add components/ui/accordion.tsx package.json package-lock.json
+git commit -m "feat(storefront): add shadcn accordion component for product story FAQ"
+```
+
+---
+
+## Task 2 — Add Drizzle schema columns for the 4 new fields
+
+**Files:**
+- Modify: `lib/db/schema.ts:139-166` (products table)
+- Create: `drizzle/0010_product_story.sql` (generated)
+- Modify: `drizzle/meta/_journal.json` (auto-updated by drizzle-kit)
+
+- [ ] **Step 2.1: Edit `lib/db/schema.ts` — add 4 nullable text columns to `products`**
+
+Insert these four lines immediately **after** `meta_description: text("meta_description"),` (around line 158) and **before** `created_at:` (around line 159):
+
+```ts
+  tagline: text("tagline"),
+  highlights: text("highlights"),
+  feature_blocks: text("feature_blocks"),
+  faq: text("faq"),
+```
+
+Only the 4 added lines are new; the rest of the `products` table definition must remain untouched.
+
+- [ ] **Step 2.2: Generate the migration**
+
+```bash
+npm run db:generate
+```
+
+Expected: drizzle-kit prints something like *"✓ Your SQL migration file ➜ drizzle/0010_<name>.sql 🚀"* and updates `drizzle/meta/*.json`.
+
+Open the generated file and **verify** it contains exactly these statements (names and column order must match):
+
+```sql
+ALTER TABLE `products` ADD `tagline` text;--> statement-breakpoint
+ALTER TABLE `products` ADD `highlights` text;--> statement-breakpoint
+ALTER TABLE `products` ADD `feature_blocks` text;--> statement-breakpoint
+ALTER TABLE `products` ADD `faq` text;
+```
+
+If drizzle-kit assigned a different filename than `0010_product_story.sql`, that's fine — keep whatever name it generates. No need to rename.
+
+- [ ] **Step 2.3: Verify migration safety gate passes**
+
+```bash
+node scripts/check-migration-safety.mjs
+```
+
+Expected output includes *"OK"* or equivalent success for this migration. `ALTER TABLE ... ADD COLUMN` without NOT NULL is always safe → the gate should be silent about it.
+
+- [ ] **Step 2.4: Apply the migration locally**
+
+```bash
+npm run db:migrate
+```
+
+Expected: migrations apply without errors. Double-check with:
+
+```bash
+npx wrangler d1 execute netereka-db --local --command "SELECT sql FROM sqlite_master WHERE name='products'" | grep -E "(tagline|highlights|feature_blocks|faq)"
+```
+
+Expected: all four column names appear in the CREATE TABLE output.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add lib/db/schema.ts drizzle/
+git commit -m "feat(db): add tagline/highlights/feature_blocks/faq columns to products"
+```
+
+---
+
+## Task 3 — TypeScript types for the story fields
+
+**Files:**
+- Modify: `lib/db/types.ts:13-40` (Product interface)
+
+- [ ] **Step 3.1: Add new interfaces in `lib/db/types.ts` immediately before `export interface Product {`**
+
+Insert the following interfaces just before line 13 (`export interface Product {`). They describe the **parsed** runtime shape (arrays of objects), not the raw JSON string stored in D1.
+
+```ts
+export interface ProductHighlight {
+  icon: string;
+  label: string;
+}
+
+export interface ProductFeatureBlock {
+  title: string;
+  body: string;
+  image_url?: string | null;
+  image_alt?: string | null;
+}
+
+export interface ProductFaqItem {
+  question: string;
+  answer: string;
+}
+```
+
+- [ ] **Step 3.2: Extend the `Product` interface with the 4 new fields**
+
+In the `Product` interface (starting line 13), add these four properties immediately after `meta_description: string | null;`:
+
+```ts
+  tagline: string | null;
+  highlights: ProductHighlight[] | null;
+  feature_blocks: ProductFeatureBlock[] | null;
+  faq: ProductFaqItem[] | null;
+```
+
+- [ ] **Step 3.3: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: errors surface on every query site that selects `products.*` but deserializes into `Product` (because the raw row has `string | null` for JSON fields, not arrays). We'll fix these in Task 5. Make note of the error count — it should be small (< 10 sites).
+
+If the count exceeds 10 errors, stop and investigate: there may be unexpected consumers.
+
+- [ ] **Step 3.4: Commit (even though tsc errors exist — they'll be fixed in Task 5)**
+
+Skip the commit for now; Task 5 fixes these errors and we commit both together.
+
+---
+
+## Task 4 — Zod validation schemas + shortlist registration
+
+**Files:**
+- Create: `lib/validations/product-story.ts`
+- Create: `__tests__/unit/product-story-validation.test.ts`
+
+- [ ] **Step 4.1: Write failing tests first**
+
+Create `__tests__/unit/product-story-validation.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  taglineSchema,
+  highlightsSchema,
+  featureBlocksSchema,
+  faqSchema,
+  HIGHLIGHT_ICON_NAMES,
+} from "@/lib/validations/product-story";
+
+describe("taglineSchema", () => {
+  it("accepts null", () => {
+    expect(taglineSchema.parse(null)).toBeNull();
+  });
+  it("accepts an empty string as null", () => {
+    expect(taglineSchema.parse("")).toBeNull();
+  });
+  it("accepts a short string", () => {
+    expect(taglineSchema.parse("Un iPhone qui dure.")).toBe("Un iPhone qui dure.");
+  });
+  it("rejects > 200 chars", () => {
+    expect(() => taglineSchema.parse("x".repeat(201))).toThrow();
+  });
+});
+
+describe("highlightsSchema", () => {
+  const validIcon = HIGHLIGHT_ICON_NAMES[0];
+  it("accepts null (block disabled)", () => {
+    expect(highlightsSchema.parse(null)).toBeNull();
+  });
+  it("rejects 1 or 2 items", () => {
+    expect(() =>
+      highlightsSchema.parse([{ icon: validIcon, label: "a" }]),
+    ).toThrow();
+  });
+  it("accepts 3 items", () => {
+    const items = Array.from({ length: 3 }, () => ({ icon: validIcon, label: "ok" }));
+    expect(highlightsSchema.parse(items)).toHaveLength(3);
+  });
+  it("accepts 6 items", () => {
+    const items = Array.from({ length: 6 }, () => ({ icon: validIcon, label: "ok" }));
+    expect(highlightsSchema.parse(items)).toHaveLength(6);
+  });
+  it("rejects 7 items", () => {
+    const items = Array.from({ length: 7 }, () => ({ icon: validIcon, label: "ok" }));
+    expect(() => highlightsSchema.parse(items)).toThrow();
+  });
+  it("rejects an unknown icon", () => {
+    expect(() =>
+      highlightsSchema.parse([{ icon: "not-a-real-icon", label: "ok" }, { icon: validIcon, label: "ok" }, { icon: validIcon, label: "ok" }]),
+    ).toThrow();
+  });
+  it("rejects a label > 80 chars", () => {
+    expect(() =>
+      highlightsSchema.parse([
+        { icon: validIcon, label: "x".repeat(81) },
+        { icon: validIcon, label: "ok" },
+        { icon: validIcon, label: "ok" },
+      ]),
+    ).toThrow();
+  });
+});
+
+describe("featureBlocksSchema", () => {
+  const ok = { title: "T", body: "B" };
+  it("accepts null", () => {
+    expect(featureBlocksSchema.parse(null)).toBeNull();
+  });
+  it("rejects 1 item", () => {
+    expect(() => featureBlocksSchema.parse([ok])).toThrow();
+  });
+  it("accepts 2 to 4 items", () => {
+    expect(featureBlocksSchema.parse([ok, ok])).toHaveLength(2);
+    expect(featureBlocksSchema.parse([ok, ok, ok, ok])).toHaveLength(4);
+  });
+  it("rejects 5 items", () => {
+    expect(() => featureBlocksSchema.parse([ok, ok, ok, ok, ok])).toThrow();
+  });
+  it("rejects body > 600 chars", () => {
+    expect(() =>
+      featureBlocksSchema.parse([
+        { title: "T", body: "x".repeat(601) },
+        { title: "T", body: "B" },
+      ]),
+    ).toThrow();
+  });
+  it("accepts image_url and image_alt as optional", () => {
+    const parsed = featureBlocksSchema.parse([
+      { title: "T", body: "B", image_url: "products/abc/hero.jpg", image_alt: "alt" },
+      { title: "T", body: "B" },
+    ]);
+    expect(parsed?.[0].image_url).toBe("products/abc/hero.jpg");
+    expect(parsed?.[1].image_url).toBeUndefined();
+  });
+});
+
+describe("faqSchema", () => {
+  it("accepts null", () => {
+    expect(faqSchema.parse(null)).toBeNull();
+  });
+  it("accepts an empty array (block disabled)", () => {
+    expect(faqSchema.parse([])).toEqual([]);
+  });
+  it("accepts 5 items", () => {
+    const items = Array.from({ length: 5 }, () => ({ question: "q", answer: "a" }));
+    expect(faqSchema.parse(items)).toHaveLength(5);
+  });
+  it("rejects 6 items", () => {
+    const items = Array.from({ length: 6 }, () => ({ question: "q", answer: "a" }));
+    expect(() => faqSchema.parse(items)).toThrow();
+  });
+});
+```
+
+- [ ] **Step 4.2: Run tests — expect failure**
+
+```bash
+npx vitest run __tests__/unit/product-story-validation.test.ts
+```
+
+Expected: module-not-found error — validation file doesn't exist yet.
+
+- [ ] **Step 4.3: Create `lib/validations/product-story.ts`**
+
+```ts
+import { z } from "zod";
+
+/**
+ * Curated shortlist of Hugeicons names used in product highlights.
+ * Storefront icons module (`components/storefront/product-story/icons.ts`) must
+ * expose a component for every name in this list. Removing a name here must
+ * be coordinated with a DB cleanup of any product still referencing it.
+ */
+export const HIGHLIGHT_ICON_NAMES = [
+  "battery",
+  "battery-charging",
+  "bluetooth",
+  "bolt",
+  "camera",
+  "charge-fast",
+  "cloud",
+  "compass",
+  "cpu",
+  "dashboard",
+  "display",
+  "eye",
+  "fingerprint",
+  "flash",
+  "gaming-pad",
+  "gift",
+  "globe",
+  "gps",
+  "headphones",
+  "heart",
+  "hourglass",
+  "key",
+  "leaf",
+  "lock",
+  "medal",
+  "microphone",
+  "moon",
+  "music-note",
+  "notification",
+  "package",
+  "palette",
+  "printer",
+  "ruler",
+  "sd-card",
+  "shield",
+  "shield-check",
+  "shopping-bag",
+  "smart-phone",
+  "sparkle",
+  "speaker",
+  "star",
+  "sun",
+  "tools",
+  "truck",
+  "tv",
+  "usb",
+  "video",
+  "volume",
+  "water-resistant",
+  "wifi",
+  "zap",
+] as const;
+
+export type HighlightIconName = (typeof HIGHLIGHT_ICON_NAMES)[number];
+
+const iconSchema = z.enum(HIGHLIGHT_ICON_NAMES);
+
+/** tagline → trimmed, empty → null, max 200 chars */
+export const taglineSchema = z
+  .union([z.string(), z.null()])
+  .transform((v) => (v == null ? null : v.trim()))
+  .transform((v) => (v === "" ? null : v))
+  .pipe(z.string().max(200, "La tagline doit faire moins de 200 caractères").nullable());
+
+export const highlightSchema = z.object({
+  icon: iconSchema,
+  label: z.string().min(1, "Libellé requis").max(80, "Max 80 caractères"),
+});
+
+/** highlights → null (disabled) OR 3–6 items */
+export const highlightsSchema = z
+  .array(highlightSchema)
+  .min(3, "Au moins 3 points forts")
+  .max(6, "Au plus 6 points forts")
+  .nullable();
+
+export const featureBlockSchema = z.object({
+  title: z.string().min(1, "Titre requis").max(120, "Max 120 caractères"),
+  body: z.string().min(1, "Texte requis").max(600, "Max 600 caractères"),
+  image_url: z.string().min(1).max(500).optional(),
+  image_alt: z.string().max(200).optional(),
+});
+
+/** feature_blocks → null (disabled) OR 2–4 items */
+export const featureBlocksSchema = z
+  .array(featureBlockSchema)
+  .min(2, "Au moins 2 blocs")
+  .max(4, "Au plus 4 blocs")
+  .nullable();
+
+export const faqItemSchema = z.object({
+  question: z.string().min(1, "Question requise").max(160, "Max 160 caractères"),
+  answer: z.string().min(1, "Réponse requise").max(600, "Max 600 caractères"),
+});
+
+/** faq → null OR 0–5 items (empty array treated as "no faq") */
+export const faqSchema = z
+  .array(faqItemSchema)
+  .max(5, "Au plus 5 questions")
+  .nullable();
+
+/** Aggregate shape sent from the admin form */
+export const productStorySchema = z.object({
+  tagline: taglineSchema,
+  highlights: highlightsSchema,
+  feature_blocks: featureBlocksSchema,
+  faq: faqSchema,
+});
+
+export type ProductStoryInput = z.infer<typeof productStorySchema>;
+```
+
+- [ ] **Step 4.4: Run tests — expect pass**
+
+```bash
+npx vitest run __tests__/unit/product-story-validation.test.ts
+```
+
+Expected: all ~20 tests pass.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add lib/validations/product-story.ts __tests__/unit/product-story-validation.test.ts
+git commit -m "feat(storefront): add zod validation for product story fields"
+```
+
+---
+
+## Task 5 — Safe JSON parse helper + deserialization in query helpers
+
+**Files:**
+- Create: `lib/utils/product-story.ts`
+- Modify: `lib/db/products.ts:32-58` (getProductBySlug)
+- Modify: `lib/db/admin/products.ts:101-129` (getAdminProductById)
+- Create: `__tests__/unit/product-story-parse.test.ts`
+
+- [ ] **Step 5.1: Write failing tests for the parser**
+
+Create `__tests__/unit/product-story-parse.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  parseHighlights,
+  parseFeatureBlocks,
+  parseFaq,
+  hydrateProductStoryFields,
+} from "@/lib/utils/product-story";
+
+describe("parseHighlights", () => {
+  it("returns null for null / empty / invalid JSON", () => {
+    expect(parseHighlights(null)).toBeNull();
+    expect(parseHighlights("")).toBeNull();
+    expect(parseHighlights("nope")).toBeNull();
+  });
+
+  it("returns null for JSON that does not match the shape", () => {
+    expect(parseHighlights(JSON.stringify({ foo: "bar" }))).toBeNull();
+    expect(parseHighlights(JSON.stringify([{ icon: "x" }]))).toBeNull();
+  });
+
+  it("returns parsed array for valid JSON", () => {
+    const raw = JSON.stringify([
+      { icon: "battery", label: "6000 mAh" },
+      { icon: "camera", label: "108 MP" },
+    ]);
+    expect(parseHighlights(raw)).toEqual([
+      { icon: "battery", label: "6000 mAh" },
+      { icon: "camera", label: "108 MP" },
+    ]);
+  });
+});
+
+describe("parseFeatureBlocks", () => {
+  it("returns null for invalid JSON", () => {
+    expect(parseFeatureBlocks("{{")).toBeNull();
+  });
+  it("accepts blocks with optional image fields", () => {
+    const raw = JSON.stringify([
+      { title: "A", body: "B" },
+      { title: "C", body: "D", image_url: "x.jpg", image_alt: "alt" },
+    ]);
+    expect(parseFeatureBlocks(raw)).toEqual([
+      { title: "A", body: "B" },
+      { title: "C", body: "D", image_url: "x.jpg", image_alt: "alt" },
+    ]);
+  });
+});
+
+describe("parseFaq", () => {
+  it("returns null for invalid JSON", () => {
+    expect(parseFaq("nope")).toBeNull();
+  });
+  it("accepts an empty array", () => {
+    expect(parseFaq("[]")).toEqual([]);
+  });
+});
+
+describe("hydrateProductStoryFields", () => {
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    errSpy.mockRestore();
+  });
+
+  it("replaces raw JSON strings with parsed arrays/objects, preserving null", () => {
+    const row = {
+      id: "p1",
+      tagline: "Hello",
+      highlights: JSON.stringify([
+        { icon: "battery", label: "L" },
+        { icon: "battery", label: "L" },
+        { icon: "battery", label: "L" },
+      ]),
+      feature_blocks: null,
+      faq: JSON.stringify([]),
+    };
+
+    const hydrated = hydrateProductStoryFields(row);
+
+    expect(hydrated.tagline).toBe("Hello");
+    expect(hydrated.highlights).toHaveLength(3);
+    expect(hydrated.feature_blocks).toBeNull();
+    expect(hydrated.faq).toEqual([]);
+  });
+
+  it("logs and falls back to null when JSON is malformed", () => {
+    const row = {
+      id: "p1",
+      tagline: null,
+      highlights: "definitely not json",
+      feature_blocks: null,
+      faq: null,
+    };
+
+    const hydrated = hydrateProductStoryFields(row);
+    expect(hydrated.highlights).toBeNull();
+    expect(errSpy).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 5.2: Run tests — expect failure**
+
+```bash
+npx vitest run __tests__/unit/product-story-parse.test.ts
+```
+
+Expected: module-not-found.
+
+- [ ] **Step 5.3: Create `lib/utils/product-story.ts`**
+
+```ts
+import {
+  highlightsSchema,
+  featureBlocksSchema,
+  faqSchema,
+} from "@/lib/validations/product-story";
+import type {
+  ProductHighlight,
+  ProductFeatureBlock,
+  ProductFaqItem,
+} from "@/lib/db/types";
+
+/**
+ * Row shape as returned by raw D1 queries: JSON columns are strings.
+ * After hydration, they become typed arrays (or null on absence / malformed JSON).
+ */
+export interface StoryRawFields {
+  tagline: string | null;
+  highlights: string | null;
+  feature_blocks: string | null;
+  faq: string | null;
+}
+
+export interface StoryHydratedFields {
+  tagline: string | null;
+  highlights: ProductHighlight[] | null;
+  feature_blocks: ProductFeatureBlock[] | null;
+  faq: ProductFaqItem[] | null;
+}
+
+function parseWith<T>(
+  raw: string | null,
+  schema: { safeParse: (input: unknown) => { success: boolean; data?: T } },
+  label: string,
+): T | null {
+  if (raw == null || raw === "") return null;
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch (err) {
+    console.error(`[product-story] malformed JSON in column ${label} — falling back to null`, err);
+    return null;
+  }
+  const result = schema.safeParse(json);
+  if (!result.success) {
+    console.error(`[product-story] JSON failed ${label} schema validation — falling back to null`, {
+      raw: raw.slice(0, 120),
+    });
+    return null;
+  }
+  return result.data ?? null;
+}
+
+export function parseHighlights(raw: string | null): ProductHighlight[] | null {
+  return parseWith(raw, highlightsSchema, "highlights");
+}
+
+export function parseFeatureBlocks(raw: string | null): ProductFeatureBlock[] | null {
+  return parseWith(raw, featureBlocksSchema, "feature_blocks");
+}
+
+export function parseFaq(raw: string | null): ProductFaqItem[] | null {
+  return parseWith(raw, faqSchema, "faq");
+}
+
+/**
+ * Takes a DB row that still has JSON strings in the story columns and returns
+ * the same object with those columns hydrated to typed arrays (or null).
+ * Used by `getProductBySlug` and `getAdminProductById`.
+ */
+export function hydrateProductStoryFields<T extends StoryRawFields>(
+  row: T,
+): Omit<T, keyof StoryRawFields> & StoryHydratedFields {
+  return {
+    ...row,
+    tagline: row.tagline ?? null,
+    highlights: parseHighlights(row.highlights),
+    feature_blocks: parseFeatureBlocks(row.feature_blocks),
+    faq: parseFaq(row.faq),
+  };
+}
+```
+
+- [ ] **Step 5.4: Wire the helper into `lib/db/products.ts`**
+
+In `lib/db/products.ts`, modify `getProductBySlug` (around line 32). The current return is `{ ...product, images, variants, attributes }`. Replace with hydration:
+
+At the top of the file, add the import:
+
+```ts
+import { hydrateProductStoryFields } from "@/lib/utils/product-story";
+```
+
+Then change the final `return` in `getProductBySlug` from:
+
+```ts
+  return { ...product, images, variants, attributes };
+```
+
+to:
+
+```ts
+  return { ...hydrateProductStoryFields(product), images, variants, attributes };
+```
+
+Also update the raw row type parameter to reflect the raw JSON columns. The current `queryFirst<Product>(...)` assumes arrays; update it to a raw shape. Replace the `queryFirst<Product>` line near line 33 with:
+
+```ts
+  const product = await queryFirst<Omit<Product, "highlights" | "feature_blocks" | "faq"> & {
+    highlights: string | null;
+    feature_blocks: string | null;
+    faq: string | null;
+  }>(
+```
+
+- [ ] **Step 5.5: Same change in `lib/db/admin/products.ts` (`getAdminProductById`, line 101)**
+
+Add the same import at top, change the return to spread through `hydrateProductStoryFields`, and update the `queryFirst<Product>` type parameter identically.
+
+- [ ] **Step 5.6: Run tests — expect pass**
+
+```bash
+npx vitest run __tests__/unit/product-story-parse.test.ts
+npx tsc --noEmit
+```
+
+Expected: all parse tests pass, `tsc` reports no errors related to products/types (the Task-3 transient errors are now fixed).
+
+- [ ] **Step 5.7: Commit**
+
+```bash
+git add lib/utils/product-story.ts lib/db/types.ts lib/db/products.ts lib/db/admin/products.ts __tests__/unit/product-story-parse.test.ts
+git commit -m "feat(db): hydrate product story JSON columns in query helpers"
+```
+
+---
+
+## Task 6 — Storefront icon shortlist module
+
+**Files:**
+- Create: `components/storefront/product-story/icons.ts`
+- Create: `__tests__/unit/product-story-icons.test.ts`
+
+- [ ] **Step 6.1: Write a failing test**
+
+Create `__tests__/unit/product-story-icons.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { resolveHighlightIcon, HIGHLIGHT_ICON_MAP } from "@/components/storefront/product-story/icons";
+import { HIGHLIGHT_ICON_NAMES } from "@/lib/validations/product-story";
+
+describe("HIGHLIGHT_ICON_MAP", () => {
+  it("exposes every name in the validation shortlist", () => {
+    for (const name of HIGHLIGHT_ICON_NAMES) {
+      expect(HIGHLIGHT_ICON_MAP[name]).toBeDefined();
+    }
+  });
+});
+
+describe("resolveHighlightIcon", () => {
+  it("returns the mapped icon for a valid name", () => {
+    const icon = resolveHighlightIcon("battery");
+    expect(icon).toBeDefined();
+  });
+  it("returns the fallback icon for an unknown name", () => {
+    const fallback = resolveHighlightIcon("unknown-name-xyz");
+    expect(fallback).toBeDefined();
+    // should equal the star fallback
+    expect(fallback).toBe(HIGHLIGHT_ICON_MAP["star"]);
+  });
+});
+```
+
+- [ ] **Step 6.2: Run test — expect failure**
+
+```bash
+npx vitest run __tests__/unit/product-story-icons.test.ts
+```
+
+Expected: module-not-found.
+
+- [ ] **Step 6.3: Create `components/storefront/product-story/icons.ts`**
+
+Map every name in `HIGHLIGHT_ICON_NAMES` to a Hugeicons free icon component. Use the names already available in `@hugeicons/core-free-icons` — when a 1:1 match is unclear, pick the closest-matching free icon.
+
+```ts
+import type { IconSvgElement } from "@hugeicons/react";
+import {
+  // battery
+  BatteryFullIcon,
+  BatteryChargingIcon,
+  // connectivity
+  BluetoothIcon,
+  WifiConnectedIcon,
+  UsbIcon,
+  // bolt / zap / flash / charge-fast
+  ThunderboltIcon,
+  Flash01Icon,
+  CloudIcon,
+  // camera / video / display / tv
+  Camera01Icon,
+  VideoReplayIcon,
+  ComputerIcon,
+  Tv01Icon,
+  // control & input
+  DashboardSquare01Icon,
+  FingerPrintIcon,
+  EyeIcon,
+  Key01Icon,
+  LockIcon,
+  ShieldIcon,
+  Shield01Icon as ShieldCheckIcon,
+  // misc
+  Cpu01Icon as CpuIcon,
+  GameController01Icon,
+  Gift01Icon,
+  GlobalIcon,
+  CompassIcon,
+  GpsSignalIcon,
+  HeadphonesIcon,
+  Heart01Icon,
+  HourglassIcon,
+  Leaf01Icon,
+  MedalFirstPlaceIcon,
+  Mic01Icon,
+  Moon02Icon,
+  MusicNote01Icon,
+  NotificationCircleIcon,
+  PackageIcon,
+  PaintBoardIcon as PaletteIcon,
+  Printer01Icon,
+  Ruler01Icon as RulerIcon,
+  SdCardIcon,
+  ShoppingBag01Icon,
+  SmartPhone01Icon,
+  Sparkles01Icon as SparkleIcon,
+  SpeakerIcon,
+  Star01Icon,
+  Sun03Icon,
+  Tools01Icon as ToolsIcon,
+  TruckDeliveryIcon,
+  VolumeHighIcon,
+  Droplet01Icon as WaterResistantIcon,
+} from "@hugeicons/core-free-icons";
+import type { HighlightIconName } from "@/lib/validations/product-story";
+
+/**
+ * Map every name in `HIGHLIGHT_ICON_NAMES` (validation) to a Hugeicons component.
+ * Must stay in sync with that list. The build/test fails if a name is missing.
+ */
+export const HIGHLIGHT_ICON_MAP: Record<HighlightIconName, IconSvgElement> = {
+  "battery": BatteryFullIcon,
+  "battery-charging": BatteryChargingIcon,
+  "bluetooth": BluetoothIcon,
+  "bolt": ThunderboltIcon,
+  "camera": Camera01Icon,
+  "charge-fast": ThunderboltIcon,
+  "cloud": CloudIcon,
+  "compass": CompassIcon,
+  "cpu": CpuIcon,
+  "dashboard": DashboardSquare01Icon,
+  "display": ComputerIcon,
+  "eye": EyeIcon,
+  "fingerprint": FingerPrintIcon,
+  "flash": Flash01Icon,
+  "gaming-pad": GameController01Icon,
+  "gift": Gift01Icon,
+  "globe": GlobalIcon,
+  "gps": GpsSignalIcon,
+  "headphones": HeadphonesIcon,
+  "heart": Heart01Icon,
+  "hourglass": HourglassIcon,
+  "key": Key01Icon,
+  "leaf": Leaf01Icon,
+  "lock": LockIcon,
+  "medal": MedalFirstPlaceIcon,
+  "microphone": Mic01Icon,
+  "moon": Moon02Icon,
+  "music-note": MusicNote01Icon,
+  "notification": NotificationCircleIcon,
+  "package": PackageIcon,
+  "palette": PaletteIcon,
+  "printer": Printer01Icon,
+  "ruler": RulerIcon,
+  "sd-card": SdCardIcon,
+  "shield": ShieldIcon,
+  "shield-check": ShieldCheckIcon,
+  "shopping-bag": ShoppingBag01Icon,
+  "smart-phone": SmartPhone01Icon,
+  "sparkle": SparkleIcon,
+  "speaker": SpeakerIcon,
+  "star": Star01Icon,
+  "sun": Sun03Icon,
+  "tools": ToolsIcon,
+  "truck": TruckDeliveryIcon,
+  "tv": Tv01Icon,
+  "usb": UsbIcon,
+  "video": VideoReplayIcon,
+  "volume": VolumeHighIcon,
+  "water-resistant": WaterResistantIcon,
+  "wifi": WifiConnectedIcon,
+  "zap": ThunderboltIcon,
+};
+
+export function resolveHighlightIcon(name: string): IconSvgElement {
+  if (name in HIGHLIGHT_ICON_MAP) {
+    return HIGHLIGHT_ICON_MAP[name as HighlightIconName];
+  }
+  console.warn(`[product-story] unknown highlight icon "${name}" — falling back to "star"`);
+  return HIGHLIGHT_ICON_MAP["star"];
+}
+```
+
+**Note on import names:** the exact free-icon names above are educated guesses from the Hugeicons free-icons package. If `tsc` reports a missing export for any import, check the actual export names in `node_modules/@hugeicons/core-free-icons/dist/index.d.ts` and substitute the closest match. Keep the **key names** (the left side of each entry) identical to `HIGHLIGHT_ICON_NAMES` — only the imported component may change.
+
+- [ ] **Step 6.4: Run tests + tsc**
+
+```bash
+npx tsc --noEmit
+npx vitest run __tests__/unit/product-story-icons.test.ts
+```
+
+Expected: both pass. If `tsc` fails on missing Hugeicons exports, fix imports (see note above) and re-run.
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add components/storefront/product-story/icons.ts __tests__/unit/product-story-icons.test.ts
+git commit -m "feat(storefront): add highlight icon shortlist for product story"
+```
+
+---
+
+## Task 7 — Storefront: StoryTagline component
+
+**Files:**
+- Create: `components/storefront/product-story/story-tagline.tsx`
+
+- [ ] **Step 7.1: Create the component**
+
+```tsx
+interface StoryTaglineProps {
+  tagline: string;
+}
+
+export function StoryTagline({ tagline }: StoryTaglineProps) {
+  return (
+    <div className="mx-auto max-w-[800px] px-6 text-center">
+      <p className="text-4xl font-light leading-[1.1] tracking-tight sm:text-5xl lg:text-6xl">
+        {tagline}
+      </p>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 7.2: Verify it compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 7.3: Commit**
+
+```bash
+git add components/storefront/product-story/story-tagline.tsx
+git commit -m "feat(storefront): add StoryTagline component"
+```
+
+---
+
+## Task 8 — Storefront: StoryHighlights component
+
+**Files:**
+- Create: `components/storefront/product-story/story-highlights.tsx`
+
+- [ ] **Step 8.1: Create the component**
+
+```tsx
+import { HugeiconsIcon } from "@hugeicons/react";
+import type { ProductHighlight } from "@/lib/db/types";
+import { resolveHighlightIcon } from "./icons";
+
+interface StoryHighlightsProps {
+  highlights: ProductHighlight[];
+}
+
+export function StoryHighlights({ highlights }: StoryHighlightsProps) {
+  return (
+    <div className="mx-auto max-w-6xl px-6">
+      <div className="grid grid-cols-1 gap-10 sm:grid-cols-2 md:grid-cols-3">
+        {highlights.map((item, idx) => (
+          <div
+            key={`${item.icon}-${idx}`}
+            className="flex flex-col items-center text-center"
+          >
+            <HugeiconsIcon
+              icon={resolveHighlightIcon(item.icon)}
+              size={40}
+              strokeWidth={1.5}
+              className="text-foreground"
+            />
+            <p className="mt-4 text-base font-medium leading-snug">
+              {item.label}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 8.2: Verify tsc + commit**
+
+```bash
+npx tsc --noEmit
+git add components/storefront/product-story/story-highlights.tsx
+git commit -m "feat(storefront): add StoryHighlights component"
+```
+
+---
+
+## Task 9 — Storefront: StoryFeatureBlock component
+
+**Files:**
+- Create: `components/storefront/product-story/story-feature-block.tsx`
+
+- [ ] **Step 9.1: Create the component**
+
+```tsx
+import Image from "next/image";
+import { cn } from "@/lib/utils";
+import type { ProductFeatureBlock } from "@/lib/db/types";
+import { getImageUrl } from "@/lib/utils/images";
+
+interface StoryFeatureBlockProps {
+  block: ProductFeatureBlock;
+  /** 0-indexed position among feature blocks — determines zig-zag direction */
+  index: number;
+}
+
+export function StoryFeatureBlock({ block, index }: StoryFeatureBlockProps) {
+  const hasImage = !!block.image_url;
+  const isOdd = index % 2 === 1;
+
+  return (
+    <div className="mx-auto max-w-6xl px-6">
+      {hasImage ? (
+        <div
+          className={cn(
+            "grid items-center gap-8 md:grid-cols-2 md:gap-12 lg:gap-16",
+            // zig-zag on md+: odd indices (2nd, 4th, …) invert image/text order
+            isOdd && "md:[&>*:first-child]:order-2",
+          )}
+        >
+          <div className="relative aspect-[4/3] w-full overflow-hidden rounded-xl bg-muted">
+            <Image
+              src={getImageUrl(block.image_url!)}
+              alt={block.image_alt ?? ""}
+              fill
+              sizes="(max-width: 768px) 100vw, 50vw"
+              className="object-cover"
+            />
+          </div>
+          <div className="space-y-4">
+            <h3 className="text-2xl font-semibold leading-tight tracking-tight sm:text-3xl lg:text-4xl">
+              {block.title}
+            </h3>
+            <p className="whitespace-pre-line text-lg leading-relaxed text-muted-foreground">
+              {block.body}
+            </p>
+          </div>
+        </div>
+      ) : (
+        <div className="mx-auto max-w-2xl space-y-4 text-center">
+          <h3 className="text-2xl font-semibold leading-tight tracking-tight sm:text-3xl lg:text-4xl">
+            {block.title}
+          </h3>
+          <p className="whitespace-pre-line text-lg leading-relaxed text-muted-foreground">
+            {block.body}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 9.2: Verify tsc + commit**
+
+```bash
+npx tsc --noEmit
+git add components/storefront/product-story/story-feature-block.tsx
+git commit -m "feat(storefront): add StoryFeatureBlock zig-zag component"
+```
+
+---
+
+## Task 10 — Storefront: StoryFaq component
+
+**Files:**
+- Create: `components/storefront/product-story/story-faq.tsx`
+
+- [ ] **Step 10.1: Create the component**
+
+```tsx
+"use client";
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import type { ProductFaqItem } from "@/lib/db/types";
+
+interface StoryFaqProps {
+  faq: ProductFaqItem[];
+}
+
+export function StoryFaq({ faq }: StoryFaqProps) {
+  return (
+    <div className="mx-auto max-w-3xl px-6">
+      <h2 className="mb-8 text-3xl font-semibold tracking-tight sm:text-4xl">
+        Questions fréquentes
+      </h2>
+      <Accordion type="single" collapsible className="w-full">
+        {faq.map((item, i) => (
+          <AccordionItem key={i} value={`item-${i}`}>
+            <AccordionTrigger className="text-left text-lg font-medium">
+              {item.question}
+            </AccordionTrigger>
+            <AccordionContent className="whitespace-pre-line text-base leading-relaxed text-muted-foreground">
+              {item.answer}
+            </AccordionContent>
+          </AccordionItem>
+        ))}
+      </Accordion>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 10.2: Verify tsc + commit**
+
+```bash
+npx tsc --noEmit
+git add components/storefront/product-story/story-faq.tsx
+git commit -m "feat(storefront): add StoryFaq accordion component"
+```
+
+---
+
+## Task 11 — Storefront: StoryFreeContent component
+
+**Files:**
+- Create: `components/storefront/product-story/story-free-content.tsx`
+
+- [ ] **Step 11.1: Create the component**
+
+```tsx
+import { descriptionToHtml } from "@/lib/utils/description-to-html";
+
+interface StoryFreeContentProps {
+  description: string;
+  descriptionType?: string;
+  productId?: string;
+}
+
+export function StoryFreeContent({
+  description,
+  descriptionType,
+  productId,
+}: StoryFreeContentProps) {
+  const html = descriptionToHtml(description, descriptionType);
+  if (!html) return null;
+  const scopeClass =
+    descriptionType === "html" && productId ? `desc-${productId}` : undefined;
+  return (
+    <div className="mx-auto max-w-3xl px-6">
+      <div
+        className={`prose prose-lg max-w-none dark:prose-invert ${scopeClass ?? ""}`}
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 11.2: Verify tsc + commit**
+
+```bash
+npx tsc --noEmit
+git add components/storefront/product-story/story-free-content.tsx
+git commit -m "feat(storefront): add StoryFreeContent wrapper"
+```
+
+---
+
+## Task 12 — Storefront: ProductStory root component
+
+**Files:**
+- Create: `components/storefront/product-story/index.tsx`
+
+- [ ] **Step 12.1: Create the orchestrator**
+
+```tsx
+import type {
+  ProductHighlight,
+  ProductFeatureBlock,
+  ProductFaqItem,
+} from "@/lib/db/types";
+import { descriptionToHtml } from "@/lib/utils/description-to-html";
+import { StoryTagline } from "./story-tagline";
+import { StoryHighlights } from "./story-highlights";
+import { StoryFeatureBlock } from "./story-feature-block";
+import { StoryFaq } from "./story-faq";
+import { StoryFreeContent } from "./story-free-content";
+
+interface ProductStoryProps {
+  tagline: string | null;
+  highlights: ProductHighlight[] | null;
+  featureBlocks: ProductFeatureBlock[] | null;
+  faq: ProductFaqItem[] | null;
+  description: string | null;
+  descriptionType?: string;
+  productId?: string;
+}
+
+function hasFreeContent(description: string | null, descriptionType?: string): boolean {
+  if (!description) return false;
+  return !!descriptionToHtml(description, descriptionType);
+}
+
+/**
+ * Full-width product story. Renders nothing if every block is empty.
+ * The root <section> is expected to live OUTSIDE the page's max-w-7xl wrapper.
+ */
+export function ProductStory({
+  tagline,
+  highlights,
+  featureBlocks,
+  faq,
+  description,
+  descriptionType,
+  productId,
+}: ProductStoryProps) {
+  const hasTagline = !!tagline;
+  const hasHighlights = !!highlights && highlights.length > 0;
+  const hasFeatureBlocks = !!featureBlocks && featureBlocks.length > 0;
+  const hasFaq = !!faq && faq.length > 0;
+  const hasFree = hasFreeContent(description, descriptionType);
+
+  if (!hasTagline && !hasHighlights && !hasFeatureBlocks && !hasFaq && !hasFree) {
+    return null;
+  }
+
+  // Alternate feature-block backgrounds to create rhythm.
+  // Intro (tagline + highlights) share the base background;
+  // feature blocks alternate; FAQ + free content share base again.
+  return (
+    <section className="w-full">
+      {hasTagline && (
+        <div className="py-16 sm:py-24">
+          <StoryTagline tagline={tagline!} />
+        </div>
+      )}
+      {hasHighlights && (
+        <div className="bg-muted/30 py-16 sm:py-24">
+          <StoryHighlights highlights={highlights!} />
+        </div>
+      )}
+      {hasFeatureBlocks &&
+        featureBlocks!.map((block, i) => (
+          <div
+            key={i}
+            className={i % 2 === 0 ? "py-16 sm:py-24" : "bg-muted/30 py-16 sm:py-24"}
+          >
+            <StoryFeatureBlock block={block} index={i} />
+          </div>
+        ))}
+      {hasFaq && (
+        <div className="py-16 sm:py-24">
+          <StoryFaq faq={faq!} />
+        </div>
+      )}
+      {hasFree && (
+        <div className="py-16 sm:py-24">
+          <StoryFreeContent
+            description={description!}
+            descriptionType={descriptionType}
+            productId={productId}
+          />
+        </div>
+      )}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 12.2: Verify tsc + commit**
+
+```bash
+npx tsc --noEmit
+git add components/storefront/product-story/index.tsx
+git commit -m "feat(storefront): add ProductStory orchestrator component"
+```
+
+---
+
+## Task 13 — Split ProductDetails into a standalone ProductSpecs component
+
+The current `product-details.tsx` does two jobs (description + attributes). After Task 14 the description is handled by `<ProductStory>`; we just need the attributes table as its own section.
+
+**Files:**
+- Modify: `components/storefront/product-details.tsx` (replace with a thin `ProductSpecs`)
+
+- [ ] **Step 13.1: Rewrite `components/storefront/product-details.tsx`**
+
+Replace the entire file with:
+
+```tsx
+import type { ProductAttribute } from "@/lib/db/types";
+
+interface ProductSpecsProps {
+  attributes: ProductAttribute[];
+}
+
+/**
+ * Product characteristics section. Renders a 2-column key/value grid.
+ * Returns null if there are no displayable attributes (the "Couleur"
+ * attribute is filtered out because it's surfaced by the color variant UI).
+ */
+export function ProductSpecs({ attributes }: ProductSpecsProps) {
+  const filtered = attributes.filter((a) => a.name !== "Couleur");
+  if (filtered.length === 0) return null;
+
+  return (
+    <section className="mt-12 border-t pt-10">
+      <h2 className="mb-6 text-2xl font-semibold tracking-tight">
+        Caractéristiques
+      </h2>
+      <dl className="grid grid-cols-1 gap-px overflow-hidden rounded-lg border bg-border sm:grid-cols-2">
+        {filtered.map((attr) => (
+          <div
+            key={attr.id}
+            className="flex items-baseline gap-4 bg-background px-4 py-3"
+          >
+            <dt className="shrink-0 text-sm text-muted-foreground">{attr.name}</dt>
+            <dd className="ml-auto text-right text-sm font-medium">{attr.value}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}
+```
+
+The old export `ProductDetails` is removed. The product page import will change in Task 14.
+
+- [ ] **Step 13.2: Verify tsc**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: one error in `app/(storefront)/p/[slug]/page.tsx` because it still imports `ProductDetails`. We fix that in Task 14.
+
+- [ ] **Step 13.3: Commit**
+
+Skip the commit for now — it ships alongside Task 14.
+
+---
+
+## Task 14 — Integrate ProductStory + ProductSpecs into the product page
+
+**Files:**
+- Modify: `app/(storefront)/p/[slug]/page.tsx`
+
+- [ ] **Step 14.1: Edit imports at top of `app/(storefront)/p/[slug]/page.tsx`**
+
+Replace:
+
+```ts
+import { ProductDetails } from "@/components/storefront/product-details";
+```
+
+with:
+
+```ts
+import { ProductSpecs } from "@/components/storefront/product-details";
+import { ProductStory } from "@/components/storefront/product-story";
+```
+
+- [ ] **Step 14.2: Restructure the return of `ProductPage` to split hero / story / rest**
+
+The current return wraps everything in a single `<div className="mx-auto max-w-7xl px-4 py-6">`. We need the hero (breadcrumb + gallery + price + CTA) inside that wrapper, `<ProductStory>` **outside** the wrapper for full-width, and then the rest (specs + reviews + related) back inside a wrapper.
+
+Replace the return expression with this structure (all other imports/vars/state remain unchanged):
+
+```tsx
+  return (
+    <>
+      <JsonLd data={productSchema} />
+      <BreadcrumbSchema items={breadcrumbItems} />
+
+      <div className="mx-auto max-w-7xl px-4 py-6">
+        {/* Breadcrumb */}
+        <nav className="mb-4 text-sm text-muted-foreground">
+          <Link href="/" className="hover:text-foreground">
+            Accueil
+          </Link>
+          <span className="mx-1.5">/</span>
+          {product.category_slug ? (
+            <>
+              <Link
+                href={`/c/${product.category_slug}`}
+                className="hover:text-foreground"
+              >
+                {product.category_name}
+              </Link>
+              <span className="mx-1.5">/</span>
+            </>
+          ) : null}
+          <span className="text-foreground">{product.name}</span>
+        </nav>
+
+        {product.variants.length > 0 ? (
+          <ProductGalleryWithVariants
+            images={product.images}
+            variants={product.variants}
+            basePrice={product.base_price}
+            product={{
+              id: product.id,
+              name: product.name,
+              slug: product.slug,
+              imageUrl: product.image_url ?? product.images[0]?.url ?? null,
+            }}
+          >
+            <div className="flex items-start justify-between gap-2">
+              <div>
+                {product.brand ? (
+                  <span className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+                    {product.brand}
+                  </span>
+                ) : null}
+                <h1 className="text-2xl font-bold sm:text-3xl">{product.name}</h1>
+              </div>
+              <WishlistButtonDynamic productId={product.id} />
+            </div>
+          </ProductGalleryWithVariants>
+        ) : (
+          <div className="grid gap-8 md:grid-cols-2">
+            <ImageGallery images={product.images}>
+              <Image
+                src={getImageUrl(product.images[0]?.url)}
+                alt={product.images[0]?.alt || product.name}
+                fill
+                priority
+                fetchPriority="high"
+                sizes="(max-width: 768px) 100vw, 50vw"
+                className="object-contain p-6"
+              />
+            </ImageGallery>
+
+            <div className="space-y-4">
+              <div className="flex items-start justify-between gap-2">
+                <div>
+                  {product.brand ? (
+                    <span className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+                      {product.brand}
+                    </span>
+                  ) : null}
+                  <h1 className="text-2xl font-bold sm:text-3xl">{product.name}</h1>
+                </div>
+                <WishlistButtonDynamic productId={product.id} />
+              </div>
+
+              <div className="space-y-4">
+                <div>
+                  <div className="flex items-center gap-3">
+                    <p className="text-2xl font-bold">
+                      {formatPrice(product.base_price)}
+                    </p>
+                    {hasDiscount && (
+                      <span className="rounded-md bg-destructive px-2 py-0.5 text-xs font-bold text-white">
+                        -{discountPercent}%
+                      </span>
+                    )}
+                  </div>
+                  {hasDiscount && (
+                    <p className="text-sm text-muted-foreground line-through">
+                      {formatPrice(comparePrice)}
+                    </p>
+                  )}
+                </div>
+                {isOutOfStock && (
+                  <p className="text-sm font-medium text-destructive">Rupture de stock</p>
+                )}
+                <AddToCartButton
+                  disabled={isOutOfStock}
+                  item={{
+                    productId: product.id,
+                    variantId: null,
+                    name: product.name,
+                    variantName: null,
+                    price: product.base_price,
+                    imageUrl: product.image_url ?? product.images[0]?.url ?? null,
+                    slug: product.slug,
+                  }}
+                />
+                <WhatsAppProductButton
+                  productName={product.name}
+                  price={product.base_price}
+                  slug={product.slug}
+                  variant="full"
+                />
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Full-width Product Story (outside max-w-7xl) */}
+      <ProductStory
+        tagline={product.tagline}
+        highlights={product.highlights}
+        featureBlocks={product.feature_blocks}
+        faq={product.faq}
+        description={product.description}
+        descriptionType={product.description_type}
+        productId={product.id}
+      />
+
+      <div className="mx-auto max-w-7xl px-4 py-6">
+        <ProductSpecs attributes={product.attributes} />
+
+        <Suspense fallback={null}>
+          <ProductReviews productId={product.id} />
+        </Suspense>
+
+        <Suspense fallback={<RelatedProductsSkeleton />}>
+          <RelatedProducts
+            productId={product.id}
+            categoryId={product.category_id ?? ""}
+            categorySlug={product.category_slug}
+          />
+        </Suspense>
+      </div>
+    </>
+  );
+```
+
+- [ ] **Step 14.3: Verify build + visual check**
+
+```bash
+npx tsc --noEmit
+npm run test -- --run __tests__/unit/product-story
+```
+
+Expected: tsc clean, tests pass.
+
+- [ ] **Step 14.4: Start the dev server and visually verify a legacy product still renders**
+
+```bash
+npm run dev
+```
+
+Open http://localhost:3000 and pick any existing product (one that has a legacy Lexical description). Verify:
+- The hero (gallery + price + CTAs) looks the same as before.
+- The old description now appears **in the new full-width free-content block** with the larger `prose-lg` size.
+- The Caractéristiques section renders below.
+- No layout break on mobile.
+
+Stop the dev server with Ctrl+C.
+
+- [ ] **Step 14.5: Commit Tasks 13 + 14 together**
+
+```bash
+git add components/storefront/product-details.tsx app/\(storefront\)/p/\[slug\]/page.tsx
+git commit -m "feat(storefront): render product story as full-width section on product page"
+```
+
+---
+
+## Task 15 — Admin: uploadStoryImage action
+
+**Files:**
+- Create: `actions/admin/story.ts`
+
+- [ ] **Step 15.1: Create the server action**
+
+```ts
+"use server";
+
+import { nanoid } from "nanoid";
+import { z } from "zod";
+import { requireAdmin } from "@/lib/auth/guards";
+import { queryFirst } from "@/lib/db";
+import { uploadToR2 } from "@/lib/storage/images";
+import type { ActionResult } from "@/lib/utils";
+
+const idSchema = z.string().min(1, "ID requis");
+
+/**
+ * Upload a feature-block image to R2 under `products/{productId}/story/`.
+ * Returns { success: true, url } where `url` is the R2 key (same convention as
+ * product_images.url). The admin form stores this key in the feature_blocks JSON.
+ *
+ * Deletion is NOT handled here — orphaned story images are cleaned up by the
+ * Story section editor when the admin removes a feature block (best-effort;
+ * left in R2 if the admin navigates away without saving).
+ */
+export async function uploadStoryImage(
+  productId: string,
+  formData: FormData,
+): Promise<ActionResult & { url?: string }> {
+  await requireAdmin();
+
+  const idResult = idSchema.safeParse(productId);
+  if (!idResult.success) return { success: false, error: "ID produit invalide" };
+
+  const product = await queryFirst<{ id: string }>(
+    "SELECT id FROM products WHERE id = ?",
+    [productId],
+  );
+  if (!product) return { success: false, error: "Produit introuvable" };
+
+  const file = formData.get("file") as File | null;
+  if (!file || file.size === 0) {
+    return { success: false, error: "Aucun fichier sélectionné" };
+  }
+  if (!file.type.startsWith("image/")) {
+    return { success: false, error: "Le fichier doit être une image" };
+  }
+  if (file.size > 5 * 1024 * 1024) {
+    return { success: false, error: "L'image ne doit pas dépasser 5 Mo" };
+  }
+
+  const id = nanoid();
+  const ext = file.name.split(".").pop() || "jpg";
+  const key = `products/${productId}/story/${id}.${ext}`;
+
+  try {
+    await uploadToR2(file, key);
+  } catch (err) {
+    console.error("[admin/story] uploadStoryImage failed", err);
+    return { success: false, error: "Erreur lors de l'upload de l'image" };
+  }
+
+  return { success: true, url: key };
+}
+```
+
+- [ ] **Step 15.2: Verify tsc + commit**
+
+```bash
+npx tsc --noEmit
+git add actions/admin/story.ts
+git commit -m "feat(admin): add uploadStoryImage action for feature block images"
+```
+
+---
+
+## Task 16 — Admin: extend productSchema and updateProduct with story fields
+
+**Files:**
+- Modify: `actions/admin/products.ts` (productSchema around lines 18-33, updateProduct around lines 100-241)
+
+- [ ] **Step 16.1: Import story validations at the top of `actions/admin/products.ts`**
+
+Add after the existing imports:
+
+```ts
+import {
+  taglineSchema,
+  highlightsSchema,
+  featureBlocksSchema,
+  faqSchema,
+} from "@/lib/validations/product-story";
+```
+
+- [ ] **Step 16.2: Extend `productSchema` (around line 18)**
+
+Add the four new fields to the `productSchema` object. Because form data carries them as JSON strings, we preprocess:
+
+Replace the end of `productSchema` (just before the closing `})`) with:
+
+```ts
+  is_active: z.coerce.number().int().min(0).max(1).default(1),
+  is_featured: z.coerce.number().int().min(0).max(1).default(0),
+  tagline: z.preprocess(
+    (v) => (typeof v === "string" && v.trim() === "" ? null : v),
+    taglineSchema,
+  ),
+  highlights: z.preprocess((v) => {
+    if (typeof v !== "string" || v.trim() === "") return null;
+    try { return JSON.parse(v); } catch { return "__invalid__"; }
+  }, highlightsSchema),
+  feature_blocks: z.preprocess((v) => {
+    if (typeof v !== "string" || v.trim() === "") return null;
+    try { return JSON.parse(v); } catch { return "__invalid__"; }
+  }, featureBlocksSchema),
+  faq: z.preprocess((v) => {
+    if (typeof v !== "string" || v.trim() === "") return null;
+    try { return JSON.parse(v); } catch { return "__invalid__"; }
+  }, faqSchema),
+});
+```
+
+(The `"__invalid__"` sentinel forces a Zod failure on malformed JSON so the admin sees a validation error rather than a silent null.)
+
+- [ ] **Step 16.3: Extend the `updateProduct` SQL UPDATE statement**
+
+Locate the `updateSql` template literal inside `updateProduct` (around line 163). Replace it with:
+
+```ts
+  const updateSql = `UPDATE products SET
+     category_id = ?, name = ?, slug = ?, description = ?, description_type = ?, short_description = ?,
+     base_price = ?, compare_price = ?, sku = ?, brand = ?,
+     is_active = ?, is_featured = ?, stock_quantity = ?,
+     low_stock_threshold = ?, weight_grams = ?, meta_title = ?, meta_description = ?,
+     tagline = ?, highlights = ?, feature_blocks = ?, faq = ?,
+     is_draft = 0,
+     updated_at = datetime('now')
+   WHERE id = ?`;
+```
+
+- [ ] **Step 16.4: Update `buildParams` to include the 4 new fields**
+
+Just before the `id,` line at the end of `buildParams`, insert the 4 new bind values (right after `data.meta_description || null,`):
+
+```ts
+    data.tagline ?? null,
+    data.highlights == null ? null : JSON.stringify(data.highlights),
+    data.feature_blocks == null ? null : JSON.stringify(data.feature_blocks),
+    data.faq == null ? null : JSON.stringify(data.faq),
+    id,
+```
+
+- [ ] **Step 16.5: Verify tsc**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 16.6: Commit**
+
+```bash
+git add actions/admin/products.ts
+git commit -m "feat(admin): extend updateProduct to persist product story fields"
+```
+
+---
+
+## Task 17 — Admin: StoryIconPicker component
+
+**Files:**
+- Create: `components/admin/story-icon-picker.tsx`
+
+- [ ] **Step 17.1: Create the picker**
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { HIGHLIGHT_ICON_NAMES } from "@/lib/validations/product-story";
+import { HIGHLIGHT_ICON_MAP } from "@/components/storefront/product-story/icons";
+
+interface StoryIconPickerProps {
+  value: string;
+  onChange: (name: string) => void;
+  className?: string;
+}
+
+export function StoryIconPicker({ value, onChange, className }: StoryIconPickerProps) {
+  const [open, setOpen] = useState(false);
+  const icon = HIGHLIGHT_ICON_MAP[value as keyof typeof HIGHLIGHT_ICON_MAP]
+    ?? HIGHLIGHT_ICON_MAP["star"];
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className={cn("h-10 w-10 shrink-0", className)}
+          aria-label="Choisir une icône"
+        >
+          <HugeiconsIcon icon={icon} size={20} strokeWidth={1.5} />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-80 p-2">
+        <div className="grid grid-cols-6 gap-1">
+          {HIGHLIGHT_ICON_NAMES.map((name) => {
+            const isSelected = name === value;
+            return (
+              <button
+                key={name}
+                type="button"
+                title={name}
+                aria-label={name}
+                aria-pressed={isSelected}
+                className={cn(
+                  "flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground transition hover:bg-accent hover:text-foreground",
+                  isSelected && "bg-accent text-foreground ring-2 ring-primary",
+                )}
+                onClick={() => {
+                  onChange(name);
+                  setOpen(false);
+                }}
+              >
+                <HugeiconsIcon
+                  icon={HIGHLIGHT_ICON_MAP[name]}
+                  size={20}
+                  strokeWidth={1.5}
+                />
+              </button>
+            );
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+```
+
+- [ ] **Step 17.2: Verify tsc + commit**
+
+```bash
+npx tsc --noEmit
+git add components/admin/story-icon-picker.tsx
+git commit -m "feat(admin): add StoryIconPicker popover component"
+```
+
+---
+
+## Task 18 — Admin: StoryFeatureBlockEditor component
+
+**Files:**
+- Create: `components/admin/story-feature-block-editor.tsx`
+
+- [ ] **Step 18.1: Create the editor**
+
+```tsx
+"use client";
+
+import { useState, useTransition } from "react";
+import Image from "next/image";
+import { toast } from "sonner";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Delete02Icon, Upload04Icon } from "@hugeicons/core-free-icons";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { getImageUrl } from "@/lib/utils/images";
+import { uploadStoryImage } from "@/actions/admin/story";
+import type { ProductFeatureBlock } from "@/lib/db/types";
+
+interface StoryFeatureBlockEditorProps {
+  productId: string;
+  block: ProductFeatureBlock;
+  index: number;
+  onChange: (next: ProductFeatureBlock) => void;
+  onRemove: () => void;
+  canRemove: boolean;
+}
+
+export function StoryFeatureBlockEditor({
+  productId,
+  block,
+  index,
+  onChange,
+  onRemove,
+  canRemove,
+}: StoryFeatureBlockEditorProps) {
+  const [isUploading, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function handleFile(file: File) {
+    setError(null);
+    const fd = new FormData();
+    fd.set("file", file);
+    startTransition(async () => {
+      try {
+        const result = await uploadStoryImage(productId, fd);
+        if (result.success && result.url) {
+          onChange({ ...block, image_url: result.url });
+          toast.success("Image téléchargée");
+        } else {
+          setError(result.error || "Erreur lors de l'upload");
+          toast.error(result.error || "Erreur lors de l'upload");
+        }
+      } catch (err) {
+        console.error("[StoryFeatureBlockEditor] upload failed", err);
+        toast.error("Erreur inattendue");
+      }
+    });
+  }
+
+  return (
+    <div className="space-y-3 rounded-lg border bg-muted/30 p-4">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-semibold text-muted-foreground">
+          Bloc {index + 1}
+        </span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          disabled={!canRemove}
+          onClick={onRemove}
+          aria-label="Supprimer le bloc"
+        >
+          <HugeiconsIcon icon={Delete02Icon} size={16} />
+        </Button>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor={`block-${index}-title`}>Titre</Label>
+        <Input
+          id={`block-${index}-title`}
+          value={block.title}
+          maxLength={120}
+          onChange={(e) => onChange({ ...block, title: e.target.value })}
+          placeholder="Un argument, une phrase"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label htmlFor={`block-${index}-body`}>Texte</Label>
+          <span className="text-xs text-muted-foreground">
+            {block.body.length}/600
+          </span>
+        </div>
+        <Textarea
+          id={`block-${index}-body`}
+          value={block.body}
+          maxLength={600}
+          rows={4}
+          onChange={(e) => onChange({ ...block, body: e.target.value })}
+          placeholder="Décris l'argument en 2–4 phrases"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label>Image (optionnelle)</Label>
+        {block.image_url ? (
+          <div className="relative h-40 w-full overflow-hidden rounded-md border">
+            <Image
+              src={getImageUrl(block.image_url)}
+              alt={block.image_alt ?? ""}
+              fill
+              sizes="(max-width: 768px) 100vw, 50vw"
+              className="object-cover"
+            />
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              className="absolute right-2 top-2"
+              onClick={() => onChange({ ...block, image_url: undefined, image_alt: undefined })}
+            >
+              Retirer
+            </Button>
+          </div>
+        ) : (
+          <label className="flex h-24 cursor-pointer items-center justify-center gap-2 rounded-md border border-dashed border-border text-sm text-muted-foreground hover:bg-accent/50">
+            <HugeiconsIcon icon={Upload04Icon} size={18} />
+            {isUploading ? "Téléchargement..." : "Télécharger une image"}
+            <input
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file) handleFile(file);
+                e.target.value = ""; // allow re-selecting same file
+              }}
+            />
+          </label>
+        )}
+        {error && <p className="text-sm text-destructive">{error}</p>}
+      </div>
+
+      {block.image_url && (
+        <div className="space-y-2">
+          <Label htmlFor={`block-${index}-alt`}>Texte alternatif</Label>
+          <Input
+            id={`block-${index}-alt`}
+            value={block.image_alt ?? ""}
+            maxLength={200}
+            onChange={(e) => onChange({ ...block, image_alt: e.target.value })}
+            placeholder="Description de l'image pour l'accessibilité"
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 18.2: Verify tsc + commit**
+
+```bash
+npx tsc --noEmit
+git add components/admin/story-feature-block-editor.tsx
+git commit -m "feat(admin): add StoryFeatureBlockEditor with R2 image upload"
+```
+
+---
+
+## Task 19 — Admin: ProductStorySection (aggregates everything)
+
+**Files:**
+- Create: `components/admin/product-story-section.tsx`
+
+- [ ] **Step 19.1: Create the section component**
+
+```tsx
+"use client";
+
+import { useMemo, useState } from "react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Add01Icon, Delete02Icon } from "@hugeicons/core-free-icons";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { StoryIconPicker } from "./story-icon-picker";
+import { StoryFeatureBlockEditor } from "./story-feature-block-editor";
+import type {
+  ProductHighlight,
+  ProductFeatureBlock,
+  ProductFaqItem,
+} from "@/lib/db/types";
+import { HIGHLIGHT_ICON_NAMES } from "@/lib/validations/product-story";
+
+interface ProductStorySectionProps {
+  productId: string;
+  tagline: string | null;
+  highlights: ProductHighlight[] | null;
+  featureBlocks: ProductFeatureBlock[] | null;
+  faq: ProductFaqItem[] | null;
+}
+
+const MIN_HL = 3;
+const MAX_HL = 6;
+const MIN_FB = 2;
+const MAX_FB = 4;
+const MAX_FAQ = 5;
+const DEFAULT_ICON = HIGHLIGHT_ICON_NAMES[0];
+
+export function ProductStorySection({
+  productId,
+  tagline: initialTagline,
+  highlights: initialHighlights,
+  featureBlocks: initialFeatureBlocks,
+  faq: initialFaq,
+}: ProductStorySectionProps) {
+  const [tagline, setTagline] = useState<string>(initialTagline ?? "");
+  const [highlights, setHighlights] = useState<ProductHighlight[]>(
+    () => initialHighlights ?? [],
+  );
+  const [featureBlocks, setFeatureBlocks] = useState<ProductFeatureBlock[]>(
+    () => initialFeatureBlocks ?? [],
+  );
+  const [faq, setFaq] = useState<ProductFaqItem[]>(() => initialFaq ?? []);
+
+  // Serialized hidden-input values sent with the main form submit.
+  const hiddenValues = useMemo(
+    () => ({
+      tagline: tagline.trim(),
+      highlights_json:
+        highlights.length === 0 ? "" : JSON.stringify(highlights),
+      feature_blocks_json:
+        featureBlocks.length === 0 ? "" : JSON.stringify(featureBlocks),
+      faq_json: faq.length === 0 ? "" : JSON.stringify(faq),
+    }),
+    [tagline, highlights, featureBlocks, faq],
+  );
+
+  return (
+    <div className="space-y-8">
+      <input type="hidden" name="tagline" value={hiddenValues.tagline} />
+      <input type="hidden" name="highlights" value={hiddenValues.highlights_json} />
+      <input type="hidden" name="feature_blocks" value={hiddenValues.feature_blocks_json} />
+      <input type="hidden" name="faq" value={hiddenValues.faq_json} />
+
+      {/* Tagline */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label htmlFor="story-tagline">Accroche</Label>
+          <span className="text-xs text-muted-foreground">{tagline.length}/200</span>
+        </div>
+        <Textarea
+          id="story-tagline"
+          rows={2}
+          value={tagline}
+          maxLength={200}
+          onChange={(e) => setTagline(e.target.value)}
+          placeholder="Ex. Un écran plus grand, une autonomie qui dure."
+        />
+      </div>
+
+      {/* Highlights */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label>Points forts</Label>
+          <p className="text-xs text-muted-foreground">
+            Entre {MIN_HL} et {MAX_HL} — ou laisse vide pour masquer ce bloc
+          </p>
+        </div>
+        <div className="space-y-2">
+          {highlights.map((h, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <StoryIconPicker
+                value={h.icon}
+                onChange={(icon) => {
+                  setHighlights((prev) =>
+                    prev.map((x, idx) => (idx === i ? { ...x, icon } : x)),
+                  );
+                }}
+              />
+              <Input
+                value={h.label}
+                maxLength={80}
+                placeholder="Ex. Charge rapide 33 W"
+                onChange={(e) => {
+                  const label = e.target.value;
+                  setHighlights((prev) =>
+                    prev.map((x, idx) => (idx === i ? { ...x, label } : x)),
+                  );
+                }}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Supprimer le point fort"
+                onClick={() => setHighlights((prev) => prev.filter((_, idx) => idx !== i))}
+              >
+                <HugeiconsIcon icon={Delete02Icon} size={16} />
+              </Button>
+            </div>
+          ))}
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={highlights.length >= MAX_HL}
+          onClick={() => setHighlights((prev) => [...prev, { icon: DEFAULT_ICON, label: "" }])}
+        >
+          <HugeiconsIcon icon={Add01Icon} size={14} className="mr-1.5" />
+          Ajouter un point fort
+        </Button>
+        {highlights.length > 0 && highlights.length < MIN_HL && (
+          <p className="text-xs text-destructive">
+            Ajoute au moins {MIN_HL} points forts ou supprime-les tous pour masquer le bloc.
+          </p>
+        )}
+      </div>
+
+      {/* Feature blocks */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label>Feature blocks</Label>
+          <p className="text-xs text-muted-foreground">
+            Entre {MIN_FB} et {MAX_FB} — ou laisse vide pour masquer ce bloc
+          </p>
+        </div>
+        <div className="space-y-3">
+          {featureBlocks.map((block, i) => (
+            <StoryFeatureBlockEditor
+              key={i}
+              productId={productId}
+              block={block}
+              index={i}
+              canRemove={featureBlocks.length > 0}
+              onChange={(next) =>
+                setFeatureBlocks((prev) => prev.map((x, idx) => (idx === i ? next : x)))
+              }
+              onRemove={() =>
+                setFeatureBlocks((prev) => prev.filter((_, idx) => idx !== i))
+              }
+            />
+          ))}
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={featureBlocks.length >= MAX_FB}
+          onClick={() =>
+            setFeatureBlocks((prev) => [...prev, { title: "", body: "" }])
+          }
+        >
+          <HugeiconsIcon icon={Add01Icon} size={14} className="mr-1.5" />
+          Ajouter un bloc
+        </Button>
+        {featureBlocks.length > 0 && featureBlocks.length < MIN_FB && (
+          <p className="text-xs text-destructive">
+            Ajoute au moins {MIN_FB} blocs ou supprime-les tous pour masquer le bloc.
+          </p>
+        )}
+      </div>
+
+      {/* FAQ */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label>FAQ</Label>
+          <p className="text-xs text-muted-foreground">Jusqu'à {MAX_FAQ} questions</p>
+        </div>
+        <div className="space-y-3">
+          {faq.map((item, i) => (
+            <div key={i} className="space-y-2 rounded-lg border bg-muted/30 p-4">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-semibold text-muted-foreground">
+                  Question {i + 1}
+                </span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label="Supprimer la question"
+                  onClick={() => setFaq((prev) => prev.filter((_, idx) => idx !== i))}
+                >
+                  <HugeiconsIcon icon={Delete02Icon} size={16} />
+                </Button>
+              </div>
+              <Input
+                value={item.question}
+                maxLength={160}
+                placeholder="La question"
+                onChange={(e) => {
+                  const question = e.target.value;
+                  setFaq((prev) => prev.map((x, idx) => (idx === i ? { ...x, question } : x)));
+                }}
+              />
+              <Textarea
+                value={item.answer}
+                rows={3}
+                maxLength={600}
+                placeholder="La réponse"
+                onChange={(e) => {
+                  const answer = e.target.value;
+                  setFaq((prev) => prev.map((x, idx) => (idx === i ? { ...x, answer } : x)));
+                }}
+              />
+            </div>
+          ))}
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={faq.length >= MAX_FAQ}
+          onClick={() => setFaq((prev) => [...prev, { question: "", answer: "" }])}
+        >
+          <HugeiconsIcon icon={Add01Icon} size={14} className="mr-1.5" />
+          Ajouter une question
+        </Button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 19.2: Verify tsc + commit**
+
+```bash
+npx tsc --noEmit
+git add components/admin/product-story-section.tsx
+git commit -m "feat(admin): add ProductStorySection form component"
+```
+
+---
+
+## Task 20 — Wire the Story section into `product-form-sections.tsx`
+
+**Files:**
+- Modify: `components/admin/product-form-sections.tsx:42-53`, `:167-218`, `:264+`
+
+- [ ] **Step 20.1: Import the new section component at the top**
+
+After the existing imports (around line 42), add:
+
+```ts
+import { ProductStorySection } from "./product-story-section";
+```
+
+- [ ] **Step 20.2: Add the Story entry to the `SECTIONS` array**
+
+Change (around line 45–53):
+
+```ts
+const SECTIONS: SectionDef[] = [
+  { id: "section-general", label: "Informations" },
+  { id: "section-category", label: "Catégorie" },
+  { id: "section-specs", label: "Caractéristiques" },
+  { id: "section-pricing", label: "Tarification" },
+  { id: "section-images", label: "Images" },
+  { id: "section-seo", label: "SEO" },
+  { id: "section-visibility", label: "Visibilité" },
+];
+```
+
+to:
+
+```ts
+const SECTIONS: SectionDef[] = [
+  { id: "section-general", label: "Informations" },
+  { id: "section-category", label: "Catégorie" },
+  { id: "section-specs", label: "Caractéristiques" },
+  { id: "section-story", label: "Story" },
+  { id: "section-pricing", label: "Tarification" },
+  { id: "section-images", label: "Images" },
+  { id: "section-seo", label: "SEO" },
+  { id: "section-visibility", label: "Visibilité" },
+];
+```
+
+- [ ] **Step 20.3: Relabel the Description field in "Informations générales" to clarify its new role**
+
+Around line 209–216, change:
+
+```tsx
+<div className="space-y-2">
+  <Label>Description</Label>
+  <DescriptionEditor
+    name="description"
+    descriptionType={product.description_type}
+    defaultValue={product.description}
+  />
+</div>
+```
+
+to:
+
+```tsx
+<div className="space-y-2">
+  <Label>Contenu complémentaire</Label>
+  <p className="text-xs text-muted-foreground">
+    S'affiche dans le bloc « zone libre » de la Story, sous les blocs structurés.
+  </p>
+  <DescriptionEditor
+    name="description"
+    descriptionType={product.description_type}
+    defaultValue={product.description}
+  />
+</div>
+```
+
+- [ ] **Step 20.4: Insert a new `<Card id="section-story">` between Caractéristiques and Tarification**
+
+After the closing `</Card>` of the `section-specs` card (around line 241, just before `{/* Section: Tarification & Stock */}`), insert:
+
+```tsx
+          {/* Section: Story */}
+          <Card id="section-story">
+            <CardHeader>
+              <div className="flex items-start justify-between gap-3">
+                <div className="space-y-1">
+                  <CardTitle>Story produit</CardTitle>
+                  <p className="text-sm text-muted-foreground">
+                    Blocs éditoriaux rendus en pleine largeur sur la fiche produit.
+                    Tous les blocs sont optionnels.
+                  </p>
+                </div>
+                {!isNew && product.slug && (
+                  <Button variant="outline" size="sm" asChild className="shrink-0">
+                    <a href={`/p/${product.slug}`} target="_blank" rel="noopener noreferrer">
+                      Aperçu
+                    </a>
+                  </Button>
+                )}
+              </div>
+            </CardHeader>
+            <CardContent>
+              <ProductStorySection
+                productId={product.id}
+                tagline={product.tagline}
+                highlights={product.highlights}
+                featureBlocks={product.feature_blocks}
+                faq={product.faq}
+              />
+            </CardContent>
+          </Card>
+```
+
+The preview button only appears on non-draft products (a draft has no slug yet) and links to the published storefront page. Since the button text is plain French, it renders the currently **saved** version — editing the form won't update the preview until the admin clicks "Mettre à jour".
+
+- [ ] **Step 20.5: Verify tsc + test**
+
+```bash
+npx tsc --noEmit
+npm run lint -- --max-warnings 0 2>&1 | tail -20
+```
+
+Expected: no TS errors, no new lint errors.
+
+- [ ] **Step 20.6: Visual check: full round-trip in admin + storefront**
+
+```bash
+npm run dev
+```
+
+In a browser:
+
+1. Go to http://localhost:3000/admin/login and sign in as an admin (or use the existing dev credentials).
+2. Open any existing product in the admin: `/products/<id>/edit`.
+3. Scroll to the new **Story produit** section.
+4. Fill in:
+   - A tagline (≤ 200 chars)
+   - 3 highlights with different icons
+   - 2 feature blocks — one with an uploaded image, one without
+   - 2 FAQ items
+5. Click "Mettre à jour" — expect a success toast.
+6. Open the product page on the storefront (`/p/<slug>`). Verify:
+   - Hero renders as before.
+   - Below the hero, the full-width Story section shows tagline → highlights → feature blocks (zig-zag) → FAQ accordion → (if the product had a legacy description) free content.
+   - The Caractéristiques grid appears below the Story.
+   - Mobile (< 640px): all blocks stack vertically, feature block images appear above their text.
+
+Stop the dev server with Ctrl+C.
+
+- [ ] **Step 20.7: Commit**
+
+```bash
+git add components/admin/product-form-sections.tsx
+git commit -m "feat(admin): add Story section to product form"
+```
+
+---
+
+## Deferred: React component snapshot tests
+
+The spec mentions snapshot tests for `components/storefront/product-story/*`. The project's Vitest config is currently `environment: "node"` with only `.test.ts` (not `.tsx`) includes, and has no Testing Library / jsdom setup. Adding that infrastructure is out of scope for this PR.
+
+The risks covered by the missing snapshot tests are mitigated by:
+
+- **Empty-state logic** — trivially 5 lines of `!!` checks in `ProductStory` (no extraction into a helper needed; violates YAGNI for a 5-line check).
+- **Per-block rendering** — each block is read-only presentational; a visual smoke test in Task 14.4 / 20.6 catches issues.
+- **Props shape** — `tsc --noEmit` catches every signature mismatch at build time.
+
+A follow-up PR can add `@testing-library/react` + jsdom if the team wants snapshot tests for all storefront components, not just the story blocks.
+
+---
+
+## Task 21 — Final verification + PR
+
+- [ ] **Step 21.1: Run the full pre-commit suite locally**
+
+```bash
+npx tsc --noEmit && npm run lint && npm run test
+```
+
+Expected: all three succeed.
+
+- [ ] **Step 21.2: Inspect git history**
+
+```bash
+git log --oneline main..feat/product-story-template
+```
+
+Expected: one commit per Task 1–20 plus the existing Task 0 spec commit (~18 commits).
+
+- [ ] **Step 21.3: Push the branch**
+
+```bash
+git push -u origin feat/product-story-template
+```
+
+- [ ] **Step 21.4: Open a PR — report URL, do NOT merge**
+
+```bash
+gh pr create --title "feat(storefront): Apple-like Product Story template" --body "$(cat <<'EOF'
+## Summary
+
+- Add four nullable columns to `products` (`tagline`, `highlights`, `feature_blocks`, `faq`) via an expand-only migration.
+- Render a new full-width `<ProductStory>` section on the product page with five optional blocks (tagline, highlights grid, zig-zag feature blocks, FAQ accordion, free content fallback).
+- Add a "Story" section in the admin product editor with per-block validation, icon picker (50 curated Hugeicons), and R2 image upload for feature blocks.
+- Preserve backward compatibility: every existing product keeps its current description, now surfaced in the free-content block with `prose-lg` sizing.
+
+Spec: [`docs/superpowers/specs/2026-04-16-product-story-template-design.md`](docs/superpowers/specs/2026-04-16-product-story-template-design.md)
+Plan: [`docs/superpowers/plans/2026-04-16-product-story-template.md`](docs/superpowers/plans/2026-04-16-product-story-template.md)
+
+## Test plan
+
+- [x] Unit: zod validation edge cases (3 files)
+- [x] Unit: JSON parse / hydrate fallback on malformed data
+- [x] Unit: icon shortlist 1:1 coverage
+- [x] Manual: legacy product still renders (description surfaces in free-content block)
+- [x] Manual: new product with all 5 blocks renders correctly on desktop + mobile
+- [x] Manual: admin round-trip (edit → save → reflected on storefront)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Report the PR URL back to the user. Do **not** merge without explicit approval.
+
+---
+
+## Self-review checklist (for the engineer implementing)
+
+Before marking the plan done:
+
+- [ ] Every `tsc` check passed at the end of its task.
+- [ ] Every new test file passed (not skipped).
+- [ ] Every commit message starts with a conventional-commits type + scope from the approved enum (`storefront`, `admin`, `db`).
+- [ ] No `git add -A` used — all `git add` commands are targeted to specific paths (avoids bundling `.claude/settings.local.json` and untracked AI tool folders).
+- [ ] Branch is `feat/product-story-template` (unchanged since creation).
+- [ ] PR body references spec + plan.
+- [ ] PR is **not merged** until the user says so.

--- a/docs/superpowers/plans/2026-04-16-product-story-template.md
+++ b/docs/superpowers/plans/2026-04-16-product-story-template.md
@@ -18,7 +18,7 @@
 
 ### New files
 
-```
+```text
 drizzle/
 └── 0010_product_story.sql                               # schema migration
 
@@ -57,7 +57,7 @@ __tests__/unit/
 
 ### Modified files
 
-```
+```text
 lib/db/schema.ts                                         # add 4 columns
 lib/db/types.ts                                          # add types + extend Product
 lib/db/products.ts                                       # deserialize JSON in getProductBySlug

--- a/docs/superpowers/specs/2026-04-16-product-story-template-design.md
+++ b/docs/superpowers/specs/2026-04-16-product-story-template-design.md
@@ -1,0 +1,310 @@
+# Product Story — Template de description produit Apple-like
+
+**Date** : 2026-04-16
+**Statut** : Approuvé (brainstorming)
+**Auteur** : Claude + @kkzakaria
+
+## Contexte
+
+Actuellement, la description produit est un unique champ rich text (`products.description`, Lexical JSON) rendu via `ProductDetails` (`components/storefront/product-details.tsx`). Selon que des caractéristiques (attributs) existent ou non, le bloc est :
+
+- une section plate avec un `<div className="prose prose-sm max-w-prose dark:prose-invert">`,
+- ou le contenu d'un onglet `Description` aux côtés d'un onglet `Caractéristiques`.
+
+Conséquences :
+
+- Le rendu dépend entièrement de ce que l'admin saisit dans l'éditeur Lexical : aucune garantie de cohérence visuelle d'un produit à l'autre.
+- Aucun storytelling structuré (accroche, points forts, feature blocks, FAQ), ce qui pénalise la perception de qualité et la conversion sur un marché où la fiche produit est souvent le principal argument de vente.
+- La zone description est enfouie sous la galerie, dans un onglet, ce qui écrase toute volonté éditoriale.
+
+## Objectif
+
+Fournir un **template structuré et stylisé** qui s'applique à **toute description produit**, produit un rendu soigné / élégant / moderne de type *Apple product page*, et garantit la cohérence visuelle entre produits — tout en restant facile à remplir côté admin et en ne cassant aucune description existante.
+
+## Décisions structurantes
+
+| Dimension | Choix | Raison |
+|---|---|---|
+| Approche | Template **structuré** (schéma imposé, pas simple stylisation) | Garantit cohérence visuelle et storytelling quel que soit l'admin qui saisit |
+| Direction visuelle | **Apple-like** (éditorial premium) | Silencieux, luxueux, typographie généreuse, pas de cards ni bordures |
+| Placement sur la page | **Section pleine largeur** sous la galerie (sortie du `max-w-7xl`) | Le storytelling devient un scroll dédié, pas un onglet enfoui |
+| Blocs retenus | Tagline (A), Highlights (B), Feature blocks (C), FAQ optionnel (F), Zone libre (I) | Menu validé au brainstorming ; A+B+C portent le style éditorial, F = contenu produit spécifique, I = fallback legacy + contenu additionnel |
+| Blocs écartés | Dans la boîte (D), Garantie/support (E), Comparaison (G), Vidéo (H) | Out of scope MVP ; peuvent être ajoutés plus tard comme blocs supplémentaires sans casser le schéma |
+| Disposition feature blocks | **Zig-zag** (alternance image gauche/droite) | Pattern Apple signature, rythme visuel |
+| Image feature block | **Optionnelle** | Si absente, texte centré pleine largeur |
+| Grille highlights | **3 colonnes** (wrap 2 puis 1 sur mobile), icône au-dessus / label en dessous, centré | Style éditorial Apple-like |
+| FAQ | **Accordéon** shadcn (tout replié par défaut) | Évite d'alourdir la page avec 5 questions déployées |
+| Stratégie de migration | **Bascule progressive, aucune migration de données** | L'ancienne `description` reste en place et nourrit le bloc *Zone libre* ; l'admin enrichit produit par produit |
+| Icon picker | Shortlist curatée de ~50 icônes Hugeicons | Rapidité de sélection + cohérence visuelle (vs 8 000 icônes) |
+| Onglets Description/Caractéristiques | **Supprimés** | La Story occupe sa propre section pleine largeur ; les attributs deviennent une section séparée en dessous |
+
+## Architecture cible de la page produit
+
+Ordre vertical final :
+
+```
+[ Fil d'Ariane ]
+[ Galerie image  |  Nom + Prix + Add to cart + Wishlist + WhatsApp ]
+[ SECTION PRODUCT STORY (pleine largeur) ]
+    [ Tagline ]            ← optionnel
+    [ Highlights ]         ← optionnel
+    [ Feature block 1 ]    ← optionnel
+    [ Feature block 2 ]
+    [ … ]
+    [ FAQ ]                ← optionnel
+    [ Zone libre ]         ← prose Lexical, affiche aussi la description legacy
+[ Section Caractéristiques (grille clé/valeur actuelle) ]  ← contraint au max-w-7xl
+[ Avis clients ]
+[ Produits similaires ]
+```
+
+La section *Product Story* **ne rend rien** si tous les blocs sont vides (pas de section fantôme). Idem pour chaque sous-bloc individuellement.
+
+## Modèle de données
+
+Nouvelles colonnes sur `products` (migration Drizzle, 100% backward compatible, expand-only) :
+
+| Colonne | Type | Nullable | Contenu |
+|---|---|---|---|
+| `tagline` | `text` | oui | Phrase d'accroche éditoriale |
+| `highlights` | `text` (JSON) | oui | `Array<{ icon: string, label: string }>` |
+| `feature_blocks` | `text` (JSON) | oui | `Array<{ title: string, body: string, image_url?: string, image_alt?: string }>` |
+| `faq` | `text` (JSON) | oui | `Array<{ question: string, answer: string }>` |
+
+**Colonnes existantes conservées inchangées** :
+
+- `description` + `description_type` → désormais considérés comme la source du **bloc Zone libre**. Aucune migration de données n'est nécessaire : toute description legacy continue à s'afficher (mais au sein de la nouvelle section Story).
+- `short_description` → continue à alimenter le SEO / meta description, pas affiché dans la Story.
+
+**TypeScript** (`lib/db/types.ts`) :
+
+```ts
+export interface ProductHighlight {
+  icon: string;     // nom d'une icône Hugeicons de la shortlist
+  label: string;    // ≤ 80 car.
+}
+
+export interface ProductFeatureBlock {
+  title: string;    // ≤ 120 car.
+  body: string;     // ≤ 600 car.
+  image_url?: string | null;
+  image_alt?: string | null;
+}
+
+export interface ProductFaqItem {
+  question: string; // ≤ 160 car.
+  answer: string;   // ≤ 600 car.
+}
+
+// Ajouts à l'interface Product :
+export interface Product {
+  // … champs existants …
+  tagline: string | null;
+  highlights: ProductHighlight[] | null;
+  feature_blocks: ProductFeatureBlock[] | null;
+  faq: ProductFaqItem[] | null;
+}
+```
+
+Les champs JSON sont désérialisés côté query helpers (`lib/db/products.ts`). En cas de JSON malformé en base (ne devrait jamais arriver, la saisie passe par le form admin) : log + traité comme `null`.
+
+### Limites de saisie
+
+Validées avec Zod dans `lib/validations/product-story.ts` et appliquées à la fois côté admin (form) et côté Server Action.
+
+| Champ | Limite |
+|---|---|
+| `tagline` | ≤ 200 caractères |
+| `highlights` | 3 à 6 items ; `label` ≤ 80 car. |
+| `feature_blocks` | 2 à 4 items ; `title` ≤ 120 car. ; `body` ≤ 600 car. |
+| `faq` | 0 à 5 items ; `question` ≤ 160 car. ; `answer` ≤ 600 car. |
+| Icônes highlights | Doivent appartenir à la shortlist curatée |
+
+Ces mins/max s'appliquent **quand le bloc est activé**. Un admin peut laisser le bloc `highlights` à `null` (donc non affiché) ; il ne peut pas saisir 1 ou 2 highlights (on refuse) — c'est 3 min ou 0 (= bloc désactivé). Même logique pour feature blocks (0 ou 2–4).
+
+## Rendu storefront
+
+Nouveau répertoire `components/storefront/product-story/` :
+
+```
+product-story/
+├── index.tsx                    # composant racine, gère le "rien à afficher"
+├── story-tagline.tsx
+├── story-highlights.tsx
+├── story-feature-block.tsx
+├── story-faq.tsx
+├── story-free-content.tsx       # wrap le rendu Lexical existant
+└── icons.ts                     # shortlist Hugeicons + mapping string → composant
+```
+
+### `<ProductStory>` (racine)
+
+- `<section>` **sortie du `max-w-7xl`** pour occuper toute la largeur viewport. Techniquement : le `ProductStory` est rendu **hors** du conteneur `<div className="mx-auto max-w-7xl px-4 py-6">` de `app/(storefront)/p/[slug]/page.tsx`. La page produit est donc réorganisée pour séparer (a) l'encart hero contraint à `max-w-7xl`, (b) `ProductStory` pleine largeur, (c) les caractéristiques / reviews / related reprenant le `max-w-7xl`.
+- Si tous les blocs (tagline, highlights, feature_blocks, faq, free content) sont vides → retourne `null`.
+- Backgrounds alternés : bloc impair `bg-background`, bloc pair `bg-muted/30`. Les blocs en transparence (tagline + highlights) peuvent partager le même fond ; on alterne **entre feature blocks** pour créer le rythme visuel.
+- Padding vertical par bloc : `py-16 sm:py-24`.
+
+### `<StoryTagline>`
+
+```tsx
+<div className="mx-auto max-w-[800px] px-6 text-center">
+  <p className="text-4xl font-light leading-tight tracking-tight sm:text-5xl lg:text-6xl">
+    {tagline}
+  </p>
+</div>
+```
+
+### `<StoryHighlights>`
+
+```tsx
+<div className="mx-auto max-w-6xl px-6">
+  <div className="grid grid-cols-1 gap-10 sm:grid-cols-2 md:grid-cols-3">
+    {highlights.map((h) => (
+      <div key={h.label} className="flex flex-col items-center text-center">
+        <HugeiconsIcon icon={resolveIcon(h.icon)} size={40} strokeWidth={1.5} />
+        <p className="mt-4 text-base font-medium">{h.label}</p>
+      </div>
+    ))}
+  </div>
+</div>
+```
+
+Couleur icône : `text-foreground` par défaut (noble, cohérent avec le mood Apple-like). La mint green (`#00FF9C`) n'est pas utilisée ici — elle reste réservée aux CTA d'achat (préserve sa force).
+
+### `<StoryFeatureBlock>`
+
+```tsx
+<div className="mx-auto max-w-6xl px-6">
+  <div
+    className={cn(
+      "grid gap-8 md:grid-cols-2 md:gap-12 lg:gap-16 items-center",
+      // zig-zag : l'index pair garde image à gauche, l'index impair inverse
+      indexIsOdd && "md:[&>*:first-child]:order-2",
+    )}
+  >
+    {image_url && (
+      <div className="relative aspect-[4/3] w-full overflow-hidden rounded-xl">
+        <Image src={image_url} alt={image_alt ?? ""} fill sizes="(max-width: 768px) 100vw, 50vw" className="object-cover" />
+      </div>
+    )}
+    <div className={cn("space-y-4", !image_url && "mx-auto max-w-2xl text-center")}>
+      <h3 className="text-2xl font-semibold tracking-tight sm:text-3xl lg:text-4xl">
+        {title}
+      </h3>
+      <p className="text-lg leading-relaxed text-muted-foreground">
+        {body}
+      </p>
+    </div>
+  </div>
+</div>
+```
+
+- Mobile (< `md`) : grid s'effondre en une colonne, image toujours au-dessus du texte.
+- Si `image_url` est absent : le texte prend toute la largeur centrée (max-w-2xl).
+
+### `<StoryFaq>`
+
+S'appuie sur `Accordion` de shadcn (`components/ui/accordion.tsx`, à ajouter via `npx shadcn add accordion` si absent).
+
+```tsx
+<div className="mx-auto max-w-3xl px-6">
+  <h2 className="mb-8 text-3xl font-semibold tracking-tight">Questions fréquentes</h2>
+  <Accordion type="single" collapsible>
+    {faq.map((item, i) => (
+      <AccordionItem key={i} value={`item-${i}`}>
+        <AccordionTrigger className="text-left text-lg">{item.question}</AccordionTrigger>
+        <AccordionContent className="text-base leading-relaxed">{item.answer}</AccordionContent>
+      </AccordionItem>
+    ))}
+  </Accordion>
+</div>
+```
+
+### `<StoryFreeContent>`
+
+Wrap minimal autour du rendu prose existant pour le resituer dans le rythme de la section :
+
+```tsx
+<div className="mx-auto max-w-3xl px-6">
+  <div
+    className="prose prose-lg max-w-none dark:prose-invert"
+    dangerouslySetInnerHTML={{ __html: descriptionToHtml(description, descriptionType) }}
+  />
+</div>
+```
+
+Passage de `prose-sm` à `prose-lg` pour rester cohérent avec la typographie généreuse de la section. Aucun changement à `descriptionToHtml` ni à `lexical-to-html` : toutes les descriptions existantes s'affichent telles quelles.
+
+### Shortlist Hugeicons (~50 icônes)
+
+Dans `components/storefront/product-story/icons.ts` : un objet `HIGHLIGHT_ICONS: Record<string, IconSvgElement>` qui map un nom canonique (ex. `"battery"`, `"camera"`, `"wifi"`, `"shield"`, `"flash"`, `"cpu"`, `"display"`, `"bluetooth"`, `"volume"`, `"sd-card"`, `"weight"`, `"ruler"`, `"water-resistant"`, `"charge-fast"`, `"star"`, `"gift"`, `"truck"`, `"package"`, …) vers un composant Hugeicons.
+
+La fonction `resolveIcon(name)` retourne l'icône demandée ou une icône de fallback (`Star01Icon`) si le nom ne fait pas partie de la shortlist. Côté admin, le picker ne permet de sélectionner que des noms de la shortlist, donc ce fallback ne devrait jamais être atteint en prod — mais il nous protège si on dépublie une icône sans purger les produits.
+
+Liste complète des 50 icônes fournie en annexe du plan d'implémentation (pour éviter de polluer ce spec).
+
+## Admin editor UX
+
+Nouvel **onglet "Story"** dans la page admin produit (`app/(admin)/admin/products/[id]/page.tsx`), à côté de l'onglet "Informations" déjà présent.
+
+### Structure du form
+
+- **Tagline** : `<Textarea>` + compteur `{count}/200`
+- **Points forts (Highlights)** :
+  - Liste éditable (ajouter, supprimer, réordonner par drag-and-drop — utiliser `@dnd-kit` si pas déjà présent, sinon une réorganisation par boutons ↑/↓ suffit)
+  - Chaque item : popover picker d'icône (grille visuelle des 50 icônes) + input label
+  - Contrainte 3 à 6 items, message d'erreur clair si < 3 (« Ajoute au moins 3 points forts ou laisse le bloc vide »)
+- **Feature blocks** :
+  - Liste éditable, 2 à 4 blocs
+  - Chaque bloc : input `title`, `<Textarea>` `body` (avec compteur), zone upload image (drop-zone + bouton, upload direct R2 via `lib/storage/images.ts`, avec preview), input `image_alt`
+- **FAQ** :
+  - Liste éditable, 0 à 5 items (entièrement optionnel)
+  - Chaque item : input `question`, `<Textarea>` `answer`
+- **Description libre** : l'éditeur Lexical existant (`components/admin/rich-text-editor.tsx`), inchangé, avec juste un label clarifié (« Contenu complémentaire »).
+- **Bouton "Aperçu"** en haut de l'onglet : ouvre `/p/{slug}` dans un nouvel onglet (le contenu publié, donc non-previsualisation de la saisie en cours — voir *Open questions*).
+
+### Server Action
+
+`actions/admin/products.ts` :
+
+- La Server Action `updateProduct` accepte les nouveaux champs `tagline`, `highlights`, `feature_blocks`, `faq`.
+- Validation Zod via `product-story.ts`.
+- Sérialisation JSON des champs `highlights` / `feature_blocks` / `faq` avant INSERT/UPDATE.
+- En cas de `fieldErrors` retournés, le form affiche les erreurs par champ comme les autres formulaires admin.
+
+## Migration & rollout
+
+1. **Migration Drizzle** `drizzle/XXXX_product_story_blocks.sql` : `ALTER TABLE products ADD COLUMN tagline TEXT; ADD COLUMN highlights TEXT; ADD COLUMN feature_blocks TEXT; ADD COLUMN faq TEXT;` — toutes nullables.
+2. **Expand-only** → compatible avec le contrôle de sécurité `scripts/check-migration-safety.mjs`. Aucun marker d'acknowledge nécessaire.
+3. Déploiement : PR → merge → canary 10% → promote (pipeline standard).
+4. **Aucune migration de données** : les produits existants rendent leur ancienne `description` via le bloc *Zone libre*, exactement comme avant (à la classe `prose-sm` → `prose-lg` près).
+5. **Plan de curation** : l'équipe enrichit les top-ventes en priorité, produit par produit, après le déploiement. Hors scope de cette PR.
+
+## Stratégie de test
+
+- **Unit tests** (Vitest) :
+  - `lib/validations/product-story.ts` : validation Zod (limites min/max, icônes valides, JSON bien typé).
+  - `lib/db/products.ts` : désérialisation JSON (cas normal + JSON malformé → `null` + log).
+  - `components/storefront/product-story/*` : snapshot + rendu conditionnel (tous vides → `null`, chaque bloc seul → rendu, combinaisons).
+- **Tests d'intégration** de la page produit : au moins un produit legacy (pas de champs Story) et un produit enrichi (tous les blocs) doivent render sans erreur.
+- **Visual check** manuel : poste un produit de test sur preview Cloudflare avec tous les blocs remplis + image, vérifier rendu mobile + desktop.
+
+## Impact & risques
+
+- **Backward compatibility** : ✅ les descriptions existantes continuent à s'afficher sans aucune intervention.
+- **SEO** : ✅ `short_description` et `description` restent utilisés pour la meta et le schema.org ; pas de changement côté indexation. Le schema.org Product peut ensuite (phase 2) être enrichi avec les `faq` en `FAQPage` pour Rich Results → hors scope MVP.
+- **Perf** : +4 colonnes nullables sur `products`, impact négligeable. Les JSON sont petits (quelques centaines d'octets par produit max). Les images feature block utilisent déjà `next/image` + R2.
+- **Risque 1 — Friction admin** : le form devient plus riche. Mitigation : tous les blocs sont optionnels, l'admin peut publier un produit avec zéro bloc Story et conserver l'ancienne description.
+- **Risque 2 — Icônes manquantes** : si on supprime une icône de la shortlist sans purger les produits, le fallback affiche une étoile. Mitigation : code-review de toute modification de `icons.ts`.
+
+## Questions ouvertes (à trancher dans le plan d'implémentation)
+
+1. **Preview admin live** : pour le MVP, le bouton "Aperçu" ouvre la page publique (= dernière version publiée). Une vraie preview WYSIWYG de la saisie en cours est coûteuse et peut être une itération future.
+2. **Drag-and-drop vs flèches ↑/↓** : si `@dnd-kit` n'est pas déjà installé, on commence par des flèches. La réorganisation est rarement utilisée et l'expérience flèches reste correcte.
+3. **FAQ en JSON-LD `FAQPage`** : hors scope MVP, à traiter dans une PR SEO dédiée après la sortie du template.
+
+## Annexes (dans le plan d'implémentation)
+
+- Liste complète des 50 icônes Hugeicons retenues
+- Mapping exact des noms canoniques vers les composants Hugeicons
+- Exemples de saisie pour 2–3 catégories (smartphone, TV, accessoire)

--- a/docs/superpowers/specs/2026-04-16-product-story-template-design.md
+++ b/docs/superpowers/specs/2026-04-16-product-story-template-design.md
@@ -42,7 +42,7 @@ Fournir un **template structuré et stylisé** qui s'applique à **toute descrip
 
 Ordre vertical final :
 
-```
+```text
 [ Fil d'Ariane ]
 [ Galerie image  |  Nom + Prix + Add to cart + Wishlist + WhatsApp ]
 [ SECTION PRODUCT STORY (pleine largeur) ]
@@ -126,7 +126,7 @@ Ces mins/max s'appliquent **quand le bloc est activé**. Un admin peut laisser l
 
 Nouveau répertoire `components/storefront/product-story/` :
 
-```
+```text
 product-story/
 ├── index.tsx                    # composant racine, gère le "rien à afficher"
 ├── story-tagline.tsx

--- a/drizzle/0010_nasty_rafael_vega.sql
+++ b/drizzle/0010_nasty_rafael_vega.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `products` ADD `tagline` text;--> statement-breakpoint
+ALTER TABLE `products` ADD `highlights` text;--> statement-breakpoint
+ALTER TABLE `products` ADD `feature_blocks` text;--> statement-breakpoint
+ALTER TABLE `products` ADD `faq` text;

--- a/drizzle/meta/0010_snapshot.json
+++ b/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,2957 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "74499940-bff5-45c1-b0c6-4e95db48be84",
+  "prevId": "ebbe5154-a5f4-452a-bc1f-450c48842165",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_account_userId": {
+          "name": "idx_account_userId",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "idx_account_provider": {
+          "name": "idx_account_provider",
+          "columns": [
+            "providerId",
+            "accountId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "addresses": {
+      "name": "addresses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Domicile'"
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "street": {
+          "name": "street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commune": {
+          "name": "commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Abidjan'"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_addresses_user": {
+          "name": "idx_addresses_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "addresses_user_id_user_id_fk": {
+          "name": "addresses_user_id_user_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "addresses_zone_id_delivery_zones_id_fk": {
+          "name": "addresses_zone_id_delivery_zones_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "delivery_zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_audit_log_actor": {
+          "name": "idx_audit_log_actor",
+          "columns": [
+            "actor_id"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_log_action": {
+          "name": "idx_audit_log_action",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_log_created": {
+          "name": "idx_audit_log_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "banner_gradients": {
+      "name": "banner_gradients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_from": {
+          "name": "color_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_to": {
+          "name": "color_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "banners": {
+      "name": "banners",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "badge_text": {
+          "name": "badge_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "badge_color": {
+          "name": "badge_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'mint'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cta_text": {
+          "name": "cta_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Découvrir'"
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bg_gradient_from": {
+          "name": "bg_gradient_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#183C78'"
+        },
+        "bg_gradient_to": {
+          "name": "bg_gradient_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#1E4A8F'"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_banners_active_order": {
+          "name": "idx_banners_active_order",
+          "columns": [
+            "is_active",
+            "display_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "idx_categories_slug": {
+          "name": "idx_categories_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "idx_categories_parent": {
+          "name": "idx_categories_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "categories_parent_id_categories_id_fk": {
+          "name": "categories_parent_id_categories_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "delivery_zones": {
+      "name": "delivery_zones",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commune": {
+          "name": "commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fee": {
+          "name": "fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimated_hours": {
+          "name": "estimated_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 24
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "order_items": {
+      "name": "order_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_name": {
+          "name": "variant_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_order_items_order": {
+          "name": "idx_order_items_order",
+          "columns": [
+            "order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "order_items_order_id_orders_id_fk": {
+          "name": "order_items_order_id_orders_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_items_product_id_products_id_fk": {
+          "name": "order_items_product_id_products_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_items_variant_id_product_variants_id_fk": {
+          "name": "order_items_variant_id_product_variants_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "order_status_history": {
+      "name": "order_status_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_order_status_history_order": {
+          "name": "idx_order_status_history_order",
+          "columns": [
+            "order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "order_status_history_order_id_orders_id_fk": {
+          "name": "order_status_history_order_id_orders_id_fk",
+          "tableFrom": "order_status_history",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "orders": {
+      "name": "orders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_number": {
+          "name": "order_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_fee": {
+          "name": "delivery_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "promo_code_id": {
+          "name": "promo_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'web'"
+        },
+        "delivery_address": {
+          "name": "delivery_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_commune": {
+          "name": "delivery_commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_phone": {
+          "name": "delivery_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_instructions": {
+          "name": "delivery_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "estimated_delivery": {
+          "name": "estimated_delivery",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "internal_notes": {
+          "name": "internal_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivery_person_id": {
+          "name": "delivery_person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivery_person_name": {
+          "name": "delivery_person_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preparing_at": {
+          "name": "preparing_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_at": {
+          "name": "shipping_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "returned_at": {
+          "name": "returned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "return_reason": {
+          "name": "return_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "orders_order_number_unique": {
+          "name": "orders_order_number_unique",
+          "columns": [
+            "order_number"
+          ],
+          "isUnique": true
+        },
+        "idx_orders_user": {
+          "name": "idx_orders_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_orders_status": {
+          "name": "idx_orders_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_orders_number": {
+          "name": "idx_orders_number",
+          "columns": [
+            "order_number"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "orders_user_id_user_id_fk": {
+          "name": "orders_user_id_user_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "orders_promo_code_id_promo_codes_id_fk": {
+          "name": "orders_promo_code_id_promo_codes_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "promo_codes",
+          "columnsFrom": [
+            "promo_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product_attributes": {
+      "name": "product_attributes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_product_attributes_product": {
+          "name": "idx_product_attributes_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "product_attributes_product_id_products_id_fk": {
+          "name": "product_attributes_product_id_products_id_fk",
+          "tableFrom": "product_attributes",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product_images": {
+      "name": "product_images",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_product_images_product": {
+          "name": "idx_product_images_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "product_images_product_id_products_id_fk": {
+          "name": "product_images_product_id_products_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_images_variant_id_product_variants_id_fk": {
+          "name": "product_images_variant_id_product_variants_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product_variants": {
+      "name": "product_variants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compare_price": {
+          "name": "compare_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "product_variants_sku_unique": {
+          "name": "product_variants_sku_unique",
+          "columns": [
+            "sku"
+          ],
+          "isUnique": true
+        },
+        "idx_product_variants_product": {
+          "name": "idx_product_variants_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "product_variants_product_id_products_id_fk": {
+          "name": "product_variants_product_id_products_id_fk",
+          "tableFrom": "product_variants",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "products": {
+      "name": "products",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description_type": {
+          "name": "description_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'richtext'"
+        },
+        "short_description": {
+          "name": "short_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_price": {
+          "name": "base_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compare_price": {
+          "name": "compare_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "low_stock_threshold": {
+          "name": "low_stock_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        },
+        "weight_grams": {
+          "name": "weight_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta_title": {
+          "name": "meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "highlights": {
+          "name": "highlights",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feature_blocks": {
+          "name": "feature_blocks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "faq": {
+          "name": "faq",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "products_slug_unique": {
+          "name": "products_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "products_sku_unique": {
+          "name": "products_sku_unique",
+          "columns": [
+            "sku"
+          ],
+          "isUnique": true
+        },
+        "idx_products_slug": {
+          "name": "idx_products_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "idx_products_category": {
+          "name": "idx_products_category",
+          "columns": [
+            "category_id"
+          ],
+          "isUnique": false
+        },
+        "idx_products_active": {
+          "name": "idx_products_active",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        },
+        "idx_products_featured": {
+          "name": "idx_products_featured",
+          "columns": [
+            "is_featured"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "products_category_id_categories_id_fk": {
+          "name": "products_category_id_categories_id_fk",
+          "tableFrom": "products",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "promo_codes": {
+      "name": "promo_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discount_value": {
+          "name": "discount_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "min_order_amount": {
+          "name": "min_order_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "promo_codes_code_unique": {
+          "name": "promo_codes_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reviews": {
+      "name": "reviews",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_verified_purchase": {
+          "name": "is_verified_purchase",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_reviews_product": {
+          "name": "idx_reviews_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        },
+        "idx_reviews_user": {
+          "name": "idx_reviews_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reviews_product_id_products_id_fk": {
+          "name": "reviews_product_id_products_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_user_id_user_id_fk": {
+          "name": "reviews_user_id_user_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "rating_range": {
+          "name": "rating_range",
+          "value": "\"reviews\".\"rating\" BETWEEN 1 AND 5"
+        }
+      }
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_session_userId": {
+          "name": "idx_session_userId",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stores": {
+      "name": "stores",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "google_maps_url": {
+          "name": "google_maps_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "opening_hours": {
+          "name": "opening_hours",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_stores_active_order": {
+          "name": "idx_stores_active_order",
+          "columns": [
+            "is_active",
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'customer'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "banReason": {
+          "name": "banReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banExpires": {
+          "name": "banExpires",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'customer'"
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'email'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_phone_unique": {
+          "name": "users_phone_unique",
+          "columns": [
+            "phone"
+          ],
+          "isUnique": true
+        },
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "idx_users_phone": {
+          "name": "idx_users_phone",
+          "columns": [
+            "phone"
+          ],
+          "isUnique": false
+        },
+        "idx_users_is_active": {
+          "name": "idx_users_is_active",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "whatsapp_carts": {
+      "name": "whatsapp_carts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_wa_carts_session": {
+          "name": "idx_wa_carts_session",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "whatsapp_carts_session_id_whatsapp_sessions_id_fk": {
+          "name": "whatsapp_carts_session_id_whatsapp_sessions_id_fk",
+          "tableFrom": "whatsapp_carts",
+          "tableTo": "whatsapp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "whatsapp_carts_product_id_products_id_fk": {
+          "name": "whatsapp_carts_product_id_products_id_fk",
+          "tableFrom": "whatsapp_carts",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "whatsapp_carts_variant_id_product_variants_id_fk": {
+          "name": "whatsapp_carts_variant_id_product_variants_id_fk",
+          "tableFrom": "whatsapp_carts",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "whatsapp_config": {
+      "name": "whatsapp_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_number_id": {
+          "name": "phone_number_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_phone_number": {
+          "name": "display_phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verify_token": {
+          "name": "verify_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "business_account_id": {
+          "name": "business_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "admin_phones": {
+          "name": "admin_phones",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "whatsapp_messages": {
+      "name": "whatsapp_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "wa_message_id": {
+          "name": "wa_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_wa_messages_session": {
+          "name": "idx_wa_messages_session",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_wa_messages_created": {
+          "name": "idx_wa_messages_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_wa_messages_wa_id": {
+          "name": "idx_wa_messages_wa_id",
+          "columns": [
+            "wa_message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "whatsapp_messages_session_id_whatsapp_sessions_id_fk": {
+          "name": "whatsapp_messages_session_id_whatsapp_sessions_id_fk",
+          "tableFrom": "whatsapp_messages",
+          "tableTo": "whatsapp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "whatsapp_sessions": {
+      "name": "whatsapp_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "wa_phone": {
+          "name": "wa_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "otp_code": {
+          "name": "otp_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "otp_expires_at": {
+          "name": "otp_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "whatsapp_sessions_wa_phone_unique": {
+          "name": "whatsapp_sessions_wa_phone_unique",
+          "columns": [
+            "wa_phone"
+          ],
+          "isUnique": true
+        },
+        "idx_wa_sessions_phone": {
+          "name": "idx_wa_sessions_phone",
+          "columns": [
+            "wa_phone"
+          ],
+          "isUnique": false
+        },
+        "idx_wa_sessions_user": {
+          "name": "idx_wa_sessions_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "whatsapp_sessions_user_id_user_id_fk": {
+          "name": "whatsapp_sessions_user_id_user_id_fk",
+          "tableFrom": "whatsapp_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wishlist": {
+      "name": "wishlist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "wishlist_user_product_unique": {
+          "name": "wishlist_user_product_unique",
+          "columns": [
+            "user_id",
+            "product_id"
+          ],
+          "isUnique": true
+        },
+        "idx_wishlist_user": {
+          "name": "idx_wishlist_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_wishlist_product": {
+          "name": "idx_wishlist_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wishlist_user_id_user_id_fk": {
+          "name": "wishlist_user_id_user_id_fk",
+          "tableFrom": "wishlist",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wishlist_product_id_products_id_fk": {
+          "name": "wishlist_product_id_products_id_fk",
+          "tableFrom": "wishlist",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1776157513310,
       "tag": "0009_fast_karnak",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1776358177965,
+      "tag": "0010_nasty_rafael_vega",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/admin/products.ts
+++ b/lib/db/admin/products.ts
@@ -6,7 +6,7 @@ import type {
   ProductImage,
   ProductVariant,
 } from "@/lib/db/types";
-import { hydrateProductStoryFields } from "@/lib/utils/product-story";
+import { hydrateProductStoryFields, type ProductWithRawStory } from "@/lib/utils/product-story";
 
 export interface AdminProductFilters {
   search?: string;
@@ -102,11 +102,7 @@ export async function getAdminProductCount(
 export async function getAdminProductById(
   id: string
 ): Promise<ProductDetail | null> {
-  const product = await queryFirst<Omit<Product, "highlights" | "feature_blocks" | "faq"> & {
-    highlights: string | null;
-    feature_blocks: string | null;
-    faq: string | null;
-  }>(
+  const product = await queryFirst<ProductWithRawStory>(
     `SELECT p.*, c.name as category_name, c.slug as category_slug
      FROM products p
      LEFT JOIN categories c ON c.id = p.category_id

--- a/lib/db/admin/products.ts
+++ b/lib/db/admin/products.ts
@@ -6,6 +6,7 @@ import type {
   ProductImage,
   ProductVariant,
 } from "@/lib/db/types";
+import { hydrateProductStoryFields } from "@/lib/utils/product-story";
 
 export interface AdminProductFilters {
   search?: string;
@@ -101,7 +102,11 @@ export async function getAdminProductCount(
 export async function getAdminProductById(
   id: string
 ): Promise<ProductDetail | null> {
-  const product = await queryFirst<Product>(
+  const product = await queryFirst<Omit<Product, "highlights" | "feature_blocks" | "faq"> & {
+    highlights: string | null;
+    feature_blocks: string | null;
+    faq: string | null;
+  }>(
     `SELECT p.*, c.name as category_name, c.slug as category_slug
      FROM products p
      LEFT JOIN categories c ON c.id = p.category_id
@@ -125,5 +130,5 @@ export async function getAdminProductById(
     ),
   ]);
 
-  return { ...product, images, variants, attributes };
+  return { ...hydrateProductStoryFields(product), images, variants, attributes };
 }

--- a/lib/db/products.ts
+++ b/lib/db/products.ts
@@ -1,5 +1,6 @@
 import { query, queryFirst } from "@/lib/db";
 import type { Product, ProductCardData, ProductAttribute, ProductDetail, ProductImage, ProductVariant } from "@/lib/db/types";
+import { hydrateProductStoryFields } from "@/lib/utils/product-story";
 
 export async function getProductsByCategory(
   categoryId: string,
@@ -30,7 +31,11 @@ export async function getProductCountByCategory(categoryId: string): Promise<num
 }
 
 export async function getProductBySlug(slug: string): Promise<ProductDetail | null> {
-  const product = await queryFirst<Product>(
+  const product = await queryFirst<Omit<Product, "highlights" | "feature_blocks" | "faq"> & {
+    highlights: string | null;
+    feature_blocks: string | null;
+    faq: string | null;
+  }>(
     `SELECT p.*, c.name as category_name, c.slug as category_slug
      FROM products p
      JOIN categories c ON c.id = p.category_id
@@ -54,7 +59,7 @@ export async function getProductBySlug(slug: string): Promise<ProductDetail | nu
     ),
   ]);
 
-  return { ...product, images, variants, attributes };
+  return { ...hydrateProductStoryFields(product), images, variants, attributes };
 }
 
 export async function getFeaturedProducts(limit = 10): Promise<Product[]> {

--- a/lib/db/products.ts
+++ b/lib/db/products.ts
@@ -1,6 +1,6 @@
 import { query, queryFirst } from "@/lib/db";
 import type { Product, ProductCardData, ProductAttribute, ProductDetail, ProductImage, ProductVariant } from "@/lib/db/types";
-import { hydrateProductStoryFields } from "@/lib/utils/product-story";
+import { hydrateProductStoryFields, type ProductWithRawStory } from "@/lib/utils/product-story";
 
 export async function getProductsByCategory(
   categoryId: string,
@@ -31,11 +31,7 @@ export async function getProductCountByCategory(categoryId: string): Promise<num
 }
 
 export async function getProductBySlug(slug: string): Promise<ProductDetail | null> {
-  const product = await queryFirst<Omit<Product, "highlights" | "feature_blocks" | "faq"> & {
-    highlights: string | null;
-    feature_blocks: string | null;
-    faq: string | null;
-  }>(
+  const product = await queryFirst<ProductWithRawStory>(
     `SELECT p.*, c.name as category_name, c.slug as category_slug
      FROM products p
      JOIN categories c ON c.id = p.category_id

--- a/lib/db/products.ts
+++ b/lib/db/products.ts
@@ -8,7 +8,7 @@ export async function getProductsByCategory(
 ): Promise<Product[]> {
   const limit = opts.limit ?? 20;
   const offset = opts.offset ?? 0;
-  return query<Product>(
+  const rows = await query<ProductWithRawStory>(
     `SELECT p.*,
        (SELECT pi.url FROM product_images pi WHERE pi.product_id = p.id AND pi.is_primary = 1 LIMIT 1) as image_url,
        (SELECT COUNT(*) FROM product_variants pv WHERE pv.product_id = p.id AND pv.is_active = 1) as variant_count,
@@ -20,6 +20,7 @@ export async function getProductsByCategory(
      LIMIT ? OFFSET ?`,
     [categoryId, limit, offset]
   );
+  return rows.map(hydrateProductStoryFields);
 }
 
 export async function getProductCountByCategory(categoryId: string): Promise<number> {
@@ -59,7 +60,7 @@ export async function getProductBySlug(slug: string): Promise<ProductDetail | nu
 }
 
 export async function getFeaturedProducts(limit = 10): Promise<Product[]> {
-  return query<Product>(
+  const rows = await query<ProductWithRawStory>(
     `SELECT p.*,
        (SELECT pi.url FROM product_images pi WHERE pi.product_id = p.id AND pi.is_primary = 1 LIMIT 1) as image_url,
        (SELECT COUNT(*) FROM product_variants pv WHERE pv.product_id = p.id AND pv.is_active = 1) as variant_count,
@@ -71,11 +72,12 @@ export async function getFeaturedProducts(limit = 10): Promise<Product[]> {
      LIMIT ?`,
     [limit]
   );
+  return rows.map(hydrateProductStoryFields);
 }
 
 export async function getLatestProducts(limit = 10, excludeFeatured = false): Promise<Product[]> {
   const featuredFilter = excludeFeatured ? "AND p.is_featured = 0" : "";
-  return query<Product>(
+  const rows = await query<ProductWithRawStory>(
     `SELECT p.*,
        (SELECT pi.url FROM product_images pi WHERE pi.product_id = p.id AND pi.is_primary = 1 LIMIT 1) as image_url,
        (SELECT COUNT(*) FROM product_variants pv WHERE pv.product_id = p.id AND pv.is_active = 1) as variant_count,
@@ -87,13 +89,14 @@ export async function getLatestProducts(limit = 10, excludeFeatured = false): Pr
      LIMIT ?`,
     [limit]
   );
+  return rows.map(hydrateProductStoryFields);
 }
 
 export async function getProductsByCategorySlug(
   categorySlug: string,
   limit = 10
 ): Promise<Product[]> {
-  return query<Product>(
+  const rows = await query<ProductWithRawStory>(
     `SELECT p.*,
        (SELECT pi.url FROM product_images pi WHERE pi.product_id = p.id AND pi.is_primary = 1 LIMIT 1) as image_url,
        (SELECT COUNT(*) FROM product_variants pv WHERE pv.product_id = p.id AND pv.is_active = 1) as variant_count,
@@ -105,6 +108,7 @@ export async function getProductsByCategorySlug(
      LIMIT ?`,
     [categorySlug, limit]
   );
+  return rows.map(hydrateProductStoryFields);
 }
 
 /** Strip a Product to only the fields needed by client-side cards. */
@@ -129,7 +133,7 @@ export async function getRelatedProducts(
   categoryId: string,
   limit = 8
 ): Promise<Product[]> {
-  return query<Product>(
+  const rows = await query<ProductWithRawStory>(
     `SELECT p.*,
        (SELECT pi.url FROM product_images pi WHERE pi.product_id = p.id AND pi.is_primary = 1 LIMIT 1) as image_url,
        (SELECT COUNT(*) FROM product_variants pv WHERE pv.product_id = p.id AND pv.is_active = 1) as variant_count,
@@ -141,4 +145,5 @@ export async function getRelatedProducts(
      LIMIT ?`,
     [categoryId, productId, limit]
   );
+  return rows.map(hydrateProductStoryFields);
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -156,6 +156,10 @@ export const products = sqliteTable("products", {
   weight_grams: integer("weight_grams"),
   meta_title: text("meta_title"),
   meta_description: text("meta_description"),
+  tagline: text("tagline"),
+  highlights: text("highlights"),
+  feature_blocks: text("feature_blocks"),
+  faq: text("faq"),
   created_at: text("created_at").notNull().default(sql`(datetime('now'))`),
   updated_at: text("updated_at").notNull().default(sql`(datetime('now'))`),
 }, (table) => [

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -10,6 +10,23 @@ export interface Category {
   created_at: string;
 }
 
+export interface ProductHighlight {
+  icon: string;
+  label: string;
+}
+
+export interface ProductFeatureBlock {
+  title: string;
+  body: string;
+  image_url?: string | null;
+  image_alt?: string | null;
+}
+
+export interface ProductFaqItem {
+  question: string;
+  answer: string;
+}
+
 export interface Product {
   id: string;
   category_id: string | null;
@@ -29,6 +46,10 @@ export interface Product {
   weight_grams: number | null;
   meta_title: string | null;
   meta_description: string | null;
+  tagline: string | null;
+  highlights: ProductHighlight[] | null;
+  feature_blocks: ProductFeatureBlock[] | null;
+  faq: ProductFaqItem[] | null;
   is_draft: number;
   created_at: string;
   updated_at: string;

--- a/lib/utils/product-story.ts
+++ b/lib/utils/product-story.ts
@@ -4,6 +4,7 @@ import {
   faqSchema,
 } from "@/lib/validations/product-story";
 import type {
+  Product,
   ProductHighlight,
   ProductFeatureBlock,
   ProductFaqItem,
@@ -20,6 +21,8 @@ export interface StoryRawFields {
   faq: string | null;
 }
 
+export type ProductWithRawStory = Omit<Product, keyof StoryRawFields> & StoryRawFields;
+
 export interface StoryHydratedFields {
   tagline: string | null;
   highlights: ProductHighlight[] | null;
@@ -29,7 +32,7 @@ export interface StoryHydratedFields {
 
 function parseWith<T>(
   raw: string | null,
-  schema: { safeParse: (input: unknown) => { success: boolean; data?: T } },
+  schema: { safeParse: (input: unknown) => { success: boolean; data?: T; error?: { issues: unknown[] } } },
   label: string,
 ): T | null {
   if (raw == null || raw === "") return null;
@@ -44,6 +47,7 @@ function parseWith<T>(
   if (!result.success) {
     console.error(`[product-story] JSON failed ${label} schema validation — falling back to null`, {
       raw: raw.slice(0, 120),
+      issues: result.error?.issues,
     });
     return null;
   }

--- a/lib/utils/product-story.ts
+++ b/lib/utils/product-story.ts
@@ -1,0 +1,80 @@
+import {
+  highlightsSchema,
+  featureBlocksSchema,
+  faqSchema,
+} from "@/lib/validations/product-story";
+import type {
+  ProductHighlight,
+  ProductFeatureBlock,
+  ProductFaqItem,
+} from "@/lib/db/types";
+
+/**
+ * Row shape as returned by raw D1 queries: JSON columns are strings.
+ * After hydration, they become typed arrays (or null on absence / malformed JSON).
+ */
+export interface StoryRawFields {
+  tagline: string | null;
+  highlights: string | null;
+  feature_blocks: string | null;
+  faq: string | null;
+}
+
+export interface StoryHydratedFields {
+  tagline: string | null;
+  highlights: ProductHighlight[] | null;
+  feature_blocks: ProductFeatureBlock[] | null;
+  faq: ProductFaqItem[] | null;
+}
+
+function parseWith<T>(
+  raw: string | null,
+  schema: { safeParse: (input: unknown) => { success: boolean; data?: T } },
+  label: string,
+): T | null {
+  if (raw == null || raw === "") return null;
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch (err) {
+    console.error(`[product-story] malformed JSON in column ${label} — falling back to null`, err);
+    return null;
+  }
+  const result = schema.safeParse(json);
+  if (!result.success) {
+    console.error(`[product-story] JSON failed ${label} schema validation — falling back to null`, {
+      raw: raw.slice(0, 120),
+    });
+    return null;
+  }
+  return result.data ?? null;
+}
+
+export function parseHighlights(raw: string | null): ProductHighlight[] | null {
+  return parseWith(raw, highlightsSchema, "highlights");
+}
+
+export function parseFeatureBlocks(raw: string | null): ProductFeatureBlock[] | null {
+  return parseWith(raw, featureBlocksSchema, "feature_blocks");
+}
+
+export function parseFaq(raw: string | null): ProductFaqItem[] | null {
+  return parseWith(raw, faqSchema, "faq");
+}
+
+/**
+ * Takes a DB row that still has JSON strings in the story columns and returns
+ * the same object with those columns hydrated to typed arrays (or null).
+ * Used by `getProductBySlug` and `getAdminProductById`.
+ */
+export function hydrateProductStoryFields<T extends StoryRawFields>(
+  row: T,
+): Omit<T, keyof StoryRawFields> & StoryHydratedFields {
+  return {
+    ...row,
+    tagline: row.tagline ?? null,
+    highlights: parseHighlights(row.highlights),
+    feature_blocks: parseFeatureBlocks(row.feature_blocks),
+    faq: parseFaq(row.faq),
+  };
+}

--- a/lib/validations/product-story.ts
+++ b/lib/validations/product-story.ts
@@ -73,7 +73,7 @@ export const taglineSchema = z
 
 export const highlightSchema = z.object({
   icon: iconSchema,
-  label: z.string().min(1, "Libellé requis").max(80, "Max 80 caractères"),
+  label: z.string().trim().min(1, "Libellé requis").max(80, "Max 80 caractères"),
 });
 
 /** highlights → null (disabled) OR 3–6 items */
@@ -84,10 +84,10 @@ export const highlightsSchema = z
   .nullable();
 
 export const featureBlockSchema = z.object({
-  title: z.string().min(1, "Titre requis").max(120, "Max 120 caractères"),
-  body: z.string().min(1, "Texte requis").max(600, "Max 600 caractères"),
-  image_url: z.string().min(1).max(500).optional(),
-  image_alt: z.string().max(200).optional(),
+  title: z.string().trim().min(1, "Titre requis").max(120, "Max 120 caractères"),
+  body: z.string().trim().min(1, "Texte requis").max(600, "Max 600 caractères"),
+  image_url: z.string().min(1).max(500).nullable().optional(),
+  image_alt: z.string().trim().max(200).nullable().optional(),
 });
 
 /** feature_blocks → null (disabled) OR 2–4 items */
@@ -98,8 +98,8 @@ export const featureBlocksSchema = z
   .nullable();
 
 export const faqItemSchema = z.object({
-  question: z.string().min(1, "Question requise").max(160, "Max 160 caractères"),
-  answer: z.string().min(1, "Réponse requise").max(600, "Max 600 caractères"),
+  question: z.string().trim().min(1, "Question requise").max(160, "Max 160 caractères"),
+  answer: z.string().trim().min(1, "Réponse requise").max(600, "Max 600 caractères"),
 });
 
 /** faq → null OR 0–5 items (empty array treated as "no faq") */

--- a/lib/validations/product-story.ts
+++ b/lib/validations/product-story.ts
@@ -1,0 +1,119 @@
+import { z } from "zod";
+
+/**
+ * Curated shortlist of Hugeicons names used in product highlights.
+ * Storefront icons module (`components/storefront/product-story/icons.ts`) must
+ * expose a component for every name in this list. Removing a name here must
+ * be coordinated with a DB cleanup of any product still referencing it.
+ */
+export const HIGHLIGHT_ICON_NAMES = [
+  "battery",
+  "battery-charging",
+  "bluetooth",
+  "bolt",
+  "camera",
+  "charge-fast",
+  "cloud",
+  "compass",
+  "cpu",
+  "dashboard",
+  "display",
+  "eye",
+  "fingerprint",
+  "flash",
+  "gaming-pad",
+  "gift",
+  "globe",
+  "gps",
+  "headphones",
+  "heart",
+  "hourglass",
+  "key",
+  "leaf",
+  "lock",
+  "medal",
+  "microphone",
+  "moon",
+  "music-note",
+  "notification",
+  "package",
+  "palette",
+  "printer",
+  "ruler",
+  "sd-card",
+  "shield",
+  "shield-check",
+  "shopping-bag",
+  "smart-phone",
+  "sparkle",
+  "speaker",
+  "star",
+  "sun",
+  "tools",
+  "truck",
+  "tv",
+  "usb",
+  "video",
+  "volume",
+  "water-resistant",
+  "wifi",
+  "zap",
+] as const;
+
+export type HighlightIconName = (typeof HIGHLIGHT_ICON_NAMES)[number];
+
+const iconSchema = z.enum(HIGHLIGHT_ICON_NAMES);
+
+/** tagline → trimmed, empty → null, max 200 chars */
+export const taglineSchema = z
+  .union([z.string(), z.null()])
+  .transform((v) => (v == null ? null : v.trim()))
+  .transform((v) => (v === "" ? null : v))
+  .pipe(z.string().max(200, "La tagline doit faire moins de 200 caractères").nullable());
+
+export const highlightSchema = z.object({
+  icon: iconSchema,
+  label: z.string().min(1, "Libellé requis").max(80, "Max 80 caractères"),
+});
+
+/** highlights → null (disabled) OR 3–6 items */
+export const highlightsSchema = z
+  .array(highlightSchema)
+  .min(3, "Au moins 3 points forts")
+  .max(6, "Au plus 6 points forts")
+  .nullable();
+
+export const featureBlockSchema = z.object({
+  title: z.string().min(1, "Titre requis").max(120, "Max 120 caractères"),
+  body: z.string().min(1, "Texte requis").max(600, "Max 600 caractères"),
+  image_url: z.string().min(1).max(500).optional(),
+  image_alt: z.string().max(200).optional(),
+});
+
+/** feature_blocks → null (disabled) OR 2–4 items */
+export const featureBlocksSchema = z
+  .array(featureBlockSchema)
+  .min(2, "Au moins 2 blocs")
+  .max(4, "Au plus 4 blocs")
+  .nullable();
+
+export const faqItemSchema = z.object({
+  question: z.string().min(1, "Question requise").max(160, "Max 160 caractères"),
+  answer: z.string().min(1, "Réponse requise").max(600, "Max 600 caractères"),
+});
+
+/** faq → null OR 0–5 items (empty array treated as "no faq") */
+export const faqSchema = z
+  .array(faqItemSchema)
+  .max(5, "Au plus 5 questions")
+  .nullable();
+
+/** Aggregate shape sent from the admin form */
+export const productStorySchema = z.object({
+  tagline: taglineSchema,
+  highlights: highlightsSchema,
+  feature_blocks: featureBlocksSchema,
+  faq: faqSchema,
+});
+
+export type ProductStoryInput = z.infer<typeof productStorySchema>;


### PR DESCRIPTION
## Summary

- Add four nullable columns to `products` (`tagline`, `highlights`, `feature_blocks`, `faq`) via an expand-only migration.
- Render a new full-width `<ProductStory>` section on the product page with five optional blocks (tagline, highlights grid, zig-zag feature blocks, FAQ accordion, free content fallback).
- Add a "Story" section in the admin product editor with per-block validation, icon picker (51 curated Hugeicons), and R2 image upload for feature blocks.
- Preserve backward compatibility: every existing product keeps its current description, now surfaced in the free-content block with `prose-lg` sizing.

Spec: [`docs/superpowers/specs/2026-04-16-product-story-template-design.md`](docs/superpowers/specs/2026-04-16-product-story-template-design.md)
Plan: [`docs/superpowers/plans/2026-04-16-product-story-template.md`](docs/superpowers/plans/2026-04-16-product-story-template.md)

## Test plan

- [x] Unit: Zod validation edge cases (21 tests)
- [x] Unit: JSON parse / hydrate fallback on malformed data (9 tests)
- [x] Unit: icon shortlist 1:1 coverage (3 tests)
- [x] tsc --noEmit clean (zero errors)
- [x] ESLint clean
- [x] Full vitest suite (743 tests / 55 files)
- [ ] Manual: legacy product still renders (description surfaces in free-content block)
- [ ] Manual: new product with all 5 blocks renders correctly on desktop + mobile
- [ ] Manual: admin round-trip (edit → save → reflected on storefront)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Product Story: full-width story section (tagline, highlights with icon shortlist + fallback, zig‑zag feature blocks with optional images, FAQ accordion, legacy free-content)

* **DB**
  * Added four nullable product fields for story content (migration included)

* **Admin**
  * Story editor with icon picker, feature-block image uploads, serialized hidden inputs, and preview link

* **Storefront**
  * ProductSpecs replaces prior details view; ProductStory rendered outside main content width; new FAQ accordion UI

* **Tests**
  * Unit tests for validation, parsing/hydration, and icon resolution

* **Docs**
  * Design/spec and migration/implementation plan added
<!-- end of auto-generated comment: release notes by coderabbit.ai -->