### PR TITLE
chore: align Worker observability with Cloudflare dashboard

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -35,4 +35,10 @@
       "bucket_name": "netereka-opennext-cache"
     }
   ],
+  "observability": {
+    "logs": {
+      "enabled": false,
+      "invocation_logs": true
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Sync wrangler.jsonc with the observability settings proposed by the Cloudflare dashboard
- Disables full log ingestion, keeps invocation logs on

## Test plan
- [ ] Next deploy picks up the new observability block without errors
- [ ] Invocation logs still appear in the Cloudflare dashboard
- [ ] Full logs no longer accrue cost

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated observability and logging configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->