### PR TITLE
feat(storefront): restore Description + Caractéristiques tabs

### DIFF
--- a/app/(storefront)/p/[slug]/page.tsx
+++ b/app/(storefront)/p/[slug]/page.tsx
@@ -11,8 +11,7 @@ import { AddToCartButton } from "@/components/storefront/add-to-cart-button";
 import { WhatsAppProductButton } from "@/components/storefront/whatsapp-product-button";
 import { HorizontalSection } from "@/components/storefront/horizontal-section";
 import { WishlistButtonDynamic } from "@/components/storefront/wishlist-button-dynamic";
-import { ProductSpecs } from "@/components/storefront/product-details";
-import { ProductStory } from "@/components/storefront/product-story";
+import { ProductDetails } from "@/components/storefront/product-details";
 import { StarRating } from "@/components/storefront/star-rating";
 import { JsonLd } from "@/components/seo/json-ld";
 import { BreadcrumbSchema } from "@/components/seo/breadcrumb-schema";
@@ -341,19 +340,17 @@ export default async function ProductPage({ params }: Props) {
         )}
       </div>
 
-      {/* Full-width Product Story (OUTSIDE max-w-7xl) */}
-      <ProductStory
-        tagline={product.tagline}
-        highlights={product.highlights}
-        featureBlocks={product.feature_blocks}
-        faq={product.faq}
-        description={product.description}
-        descriptionType={product.description_type}
-        productId={product.id}
-      />
-
       <div className="mx-auto max-w-7xl px-4 py-6">
-        <ProductSpecs attributes={product.attributes} />
+        <ProductDetails
+          tagline={product.tagline}
+          highlights={product.highlights}
+          featureBlocks={product.feature_blocks}
+          faq={product.faq}
+          description={product.description}
+          descriptionType={product.description_type}
+          productId={product.id}
+          attributes={product.attributes}
+        />
 
         {/* Reviews */}
         <Suspense fallback={null}>

--- a/components/storefront/product-details.tsx
+++ b/components/storefront/product-details.tsx
@@ -1,34 +1,130 @@
-import type { ProductAttribute } from "@/lib/db/types";
+import type {
+  ProductAttribute,
+  ProductFaqItem,
+  ProductFeatureBlock,
+  ProductHighlight,
+} from "@/lib/db/types";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { descriptionToHtml } from "@/lib/utils/description-to-html";
+import { ProductStory } from "./product-story";
 
-interface ProductSpecsProps {
+interface ProductDetailsProps {
+  tagline: string | null;
+  highlights: ProductHighlight[] | null;
+  featureBlocks: ProductFeatureBlock[] | null;
+  faq: ProductFaqItem[] | null;
+  description: string | null;
+  descriptionType?: string;
+  productId: string;
   attributes: ProductAttribute[];
 }
 
-/**
- * Product characteristics section. Renders a 2-column key/value grid.
- * Returns null if there are no displayable attributes (the "Couleur"
- * attribute is filtered out because it's surfaced by the color variant UI).
- */
-export function ProductSpecs({ attributes }: ProductSpecsProps) {
-  const filtered = attributes.filter((a) => a.name !== "Couleur");
-  if (filtered.length === 0) return null;
+function hasStoryContent({
+  tagline,
+  highlights,
+  featureBlocks,
+  faq,
+  description,
+  descriptionType,
+}: Pick<
+  ProductDetailsProps,
+  "tagline" | "highlights" | "featureBlocks" | "faq" | "description" | "descriptionType"
+>): boolean {
+  if (tagline) return true;
+  if (highlights && highlights.length > 0) return true;
+  if (featureBlocks && featureBlocks.length > 0) return true;
+  if (faq && faq.length > 0) return true;
+  if (description && descriptionToHtml(description, descriptionType)) return true;
+  return false;
+}
+
+export function ProductDetails({
+  tagline,
+  highlights,
+  featureBlocks,
+  faq,
+  description,
+  descriptionType,
+  productId,
+  attributes,
+}: ProductDetailsProps) {
+  const hasStory = hasStoryContent({
+    tagline,
+    highlights,
+    featureBlocks,
+    faq,
+    description,
+    descriptionType,
+  });
+  const filteredAttributes = attributes.filter((a) => a.name !== "Couleur");
+  const hasAttributes = filteredAttributes.length > 0;
+
+  if (!hasStory && !hasAttributes) return null;
+
+  const story = (
+    <ProductStory
+      tagline={tagline}
+      highlights={highlights}
+      featureBlocks={featureBlocks}
+      faq={faq}
+      description={description}
+      descriptionType={descriptionType}
+      productId={productId}
+    />
+  );
+
+  if (hasStory && !hasAttributes) {
+    return (
+      <section className="mt-10 border-t pt-8">
+        <h2 className="mb-4 text-lg font-semibold">Description</h2>
+        {story}
+      </section>
+    );
+  }
+
+  if (hasAttributes && !hasStory) {
+    return (
+      <section className="mt-10 border-t pt-8">
+        <h2 className="mb-4 text-lg font-semibold">Caractéristiques</h2>
+        <AttributesTable attributes={filteredAttributes} />
+      </section>
+    );
+  }
 
   return (
-    <section className="mt-12 border-t pt-10">
-      <h2 className="mb-6 text-2xl font-semibold tracking-tight">
-        Caractéristiques
-      </h2>
-      <dl className="grid grid-cols-1 gap-px overflow-hidden rounded-lg border bg-border sm:grid-cols-2">
-        {filtered.map((attr) => (
-          <div
-            key={attr.id}
-            className="flex items-baseline gap-4 bg-background px-4 py-3"
-          >
-            <dt className="shrink-0 text-sm text-muted-foreground">{attr.name}</dt>
-            <dd className="ml-auto text-right text-sm font-medium">{attr.value}</dd>
-          </div>
-        ))}
-      </dl>
+    <section className="mt-10 border-t pt-8">
+      <Tabs defaultValue="description">
+        <TabsList variant="line" className="mb-6">
+          <TabsTrigger value="description" className="text-sm">
+            Description
+          </TabsTrigger>
+          <TabsTrigger value="characteristics" className="text-sm">
+            Caractéristiques
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="description">{story}</TabsContent>
+
+        <TabsContent value="characteristics">
+          <AttributesTable attributes={filteredAttributes} />
+        </TabsContent>
+      </Tabs>
     </section>
+  );
+}
+
+function AttributesTable({ attributes }: { attributes: ProductAttribute[] }) {
+  return (
+    <dl className="grid grid-cols-1 gap-px overflow-hidden rounded-lg border bg-border sm:grid-cols-2">
+      {attributes.map((attr) => (
+        <div
+          key={attr.id}
+          className="flex items-baseline gap-4 bg-background px-4 py-3"
+        >
+          <dt className="shrink-0 text-sm text-muted-foreground">{attr.name}</dt>
+          <dd className="ml-auto text-right text-sm font-medium">{attr.value}</dd>
+        </div>
+      ))}
+    </dl>
   );
 }

--- a/components/storefront/product-details.tsx
+++ b/components/storefront/product-details.tsx
@@ -5,7 +5,6 @@ import type {
   ProductHighlight,
 } from "@/lib/db/types";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { descriptionToHtml } from "@/lib/utils/description-to-html";
 import { ProductStory } from "./product-story";
 
 interface ProductDetailsProps {
@@ -25,16 +24,15 @@ function hasStoryContent({
   featureBlocks,
   faq,
   description,
-  descriptionType,
 }: Pick<
   ProductDetailsProps,
-  "tagline" | "highlights" | "featureBlocks" | "faq" | "description" | "descriptionType"
+  "tagline" | "highlights" | "featureBlocks" | "faq" | "description"
 >): boolean {
   if (tagline) return true;
   if (highlights && highlights.length > 0) return true;
   if (featureBlocks && featureBlocks.length > 0) return true;
   if (faq && faq.length > 0) return true;
-  if (description && descriptionToHtml(description, descriptionType)) return true;
+  if (description && description.trim()) return true;
   return false;
 }
 
@@ -54,7 +52,6 @@ export function ProductDetails({
     featureBlocks,
     faq,
     description,
-    descriptionType,
   });
   const filteredAttributes = attributes.filter((a) => a.name !== "Couleur");
   const hasAttributes = filteredAttributes.length > 0;
@@ -94,11 +91,11 @@ export function ProductDetails({
   return (
     <section className="mt-10 border-t pt-8">
       <Tabs defaultValue="description">
-        <TabsList variant="line" className="mb-6">
-          <TabsTrigger value="description" className="text-sm">
+        <TabsList variant="line" className="mb-6 min-h-11">
+          <TabsTrigger value="description" className="px-3 text-sm">
             Description
           </TabsTrigger>
-          <TabsTrigger value="characteristics" className="text-sm">
+          <TabsTrigger value="characteristics" className="px-3 text-sm">
             Caractéristiques
           </TabsTrigger>
         </TabsList>


### PR DESCRIPTION
## Summary
- Restore the tabbed `ProductDetails` component on the product page (previously replaced by a full-width `ProductStory` + attributes-only `ProductSpecs` in #177).
- The **Description** tab renders the full `ProductStory` (tagline, highlights, feature blocks, FAQ, legacy free content).
- The **Caractéristiques** tab renders the attributes grid.
- Single-section fallback when only one side has content; renders nothing when both are empty.

## Test plan
- [ ] Open a product with both story content and attributes → two tabs visible, Description active by default
- [ ] Open a product with only attributes → single "Caractéristiques" section, no tabs
- [ ] Open a product with only story content → single "Description" section, no tabs
- [ ] Open a product with neither → section not rendered
- [ ] Verify the Story no longer appears full-width above the tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Product content is consolidated into a single "Product Details" area combining description/story and specifications.
  * When both story and specs exist, a tabbed view toggles between "Description" and "Characteristics"; single-section layouts render when only one type is present.
  * Product story now renders within the page content width (no longer full‑width).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->