### PR TITLE
feat(admin): AI-powered product creation

### DIFF
--- a/__tests__/unit/actions/products-ai.test.ts
+++ b/__tests__/unit/actions/products-ai.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { mockAdminSession } from "../../helpers/mocks";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  redirect: vi.fn((url: string): never => {
+    const err = new Error(`NEXT_REDIRECT: ${url}`) as Error & { digest: string };
+    err.digest = `NEXT_REDIRECT;${url}`;
+    throw err;
+  }),
+  execute: vi.fn(),
+  queryFirst: vi.fn(),
+  query: vi.fn(),
+  fetchAndUploadImage: vi.fn(),
+  revalidatePath: vi.fn(),
+  dbBatch: vi.fn(),
+  prepare: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({ redirect: mocks.redirect }));
+vi.mock("next/headers", () => ({ headers: vi.fn().mockResolvedValue(new Headers()) }));
+vi.mock("next/cache", () => ({ revalidatePath: mocks.revalidatePath }));
+vi.mock("@/lib/auth", () => ({ initAuth: vi.fn().mockResolvedValue({ api: { getSession: mocks.getSession } }) }));
+vi.mock("@/lib/db", () => ({
+  execute: mocks.execute,
+  queryFirst: mocks.queryFirst,
+  query: mocks.query,
+}));
+vi.mock("@/lib/cloudflare/context", () => ({
+  getDB: async () => ({
+    prepare: (sql: string) => { mocks.prepare(sql); return { bind: (..._args: unknown[]) => ({ sql, args: _args }) }; },
+    batch: (stmts: unknown[]) => mocks.dbBatch(stmts),
+  }),
+}));
+vi.mock("@/lib/ai/image-fetch", () => ({ fetchAndUploadImage: mocks.fetchAndUploadImage }));
+
+import { importCandidateImages } from "@/actions/admin/products-ai";
+
+import type { AiProductOutput } from "@/lib/validations/product-ai";
+
+const OUTPUT: AiProductOutput = {
+  name: "Galaxy A55",
+  brand: "Samsung",
+  category_suggestion: "smartphones",
+  description_html: "<p>Hi</p>",
+  short_description: "short",
+  attributes: {
+    colors: [{ name: "Noir", hex: "#111111" }],
+    dimensions: { length_mm: 160 },
+    specs: [{ name: "Écran", value: '6.6" AMOLED' }],
+  },
+  story: {
+    tagline: "tag",
+    highlights: [
+      { icon: "camera", label: "l1" },
+      { icon: "battery", label: "l2" },
+      { icon: "display", label: "l3" },
+    ],
+    feature_blocks: [
+      { title: "t1", body: "b1" },
+      { title: "t2", body: "b2" },
+    ],
+    faq: [{ question: "q", answer: "a" }],
+  },
+  seo: { meta_title: "Galaxy A55", meta_description: "d" },
+  image_candidates: [
+    { url: "https://x.test/a.jpg", source_domain: "x.test" },
+    { url: "https://x.test/b.jpg", source_domain: "x.test" },
+  ],
+};
+
+describe("importCandidateImages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue(mockAdminSession);
+    mocks.execute.mockResolvedValue({ meta: { changes: 1 } });
+    mocks.queryFirst.mockResolvedValue(null);
+    mocks.query.mockResolvedValue([]);
+    mocks.dbBatch.mockResolvedValue([]);
+    mocks.fetchAndUploadImage.mockImplementation(async (_: string, url: string) =>
+      ({ ok: true, key: `products/d1/${url.split("/").pop()}`, contentType: "image/jpeg", size: 10 }));
+  });
+
+  it("refuse un admin non authentifié", async () => {
+    mocks.getSession.mockResolvedValue(null);
+    await expect(importCandidateImages(OUTPUT, ["https://x.test/a.jpg"])).rejects.toThrow("NEXT_REDIRECT");
+  });
+
+  it("refuse une URL hors image_candidates", async () => {
+    const r = await importCandidateImages(OUTPUT, ["https://evil.test/x.jpg"]);
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error).toMatch(/invalide/i);
+  });
+
+  it("crée le draft + applique les champs + télécharge les images (happy path)", async () => {
+    const r = await importCandidateImages(OUTPUT, [
+      "https://x.test/a.jpg",
+      "https://x.test/b.jpg",
+    ]);
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.id).toBeTruthy();
+      expect(r.warnings).toEqual([]);
+    }
+    expect(mocks.fetchAndUploadImage).toHaveBeenCalledTimes(2);
+    expect(mocks.dbBatch).toHaveBeenCalled();
+  });
+
+  it("renvoie warnings pour les images échouées mais crée quand même le draft", async () => {
+    mocks.fetchAndUploadImage.mockImplementationOnce(async () => ({ ok: false, reason: "too_large" }));
+    mocks.fetchAndUploadImage.mockImplementationOnce(async (_: string, url: string) =>
+      ({ ok: true, key: `products/d1/${url.split("/").pop()}`, contentType: "image/jpeg", size: 10 }));
+
+    const r = await importCandidateImages(OUTPUT, [
+      "https://x.test/a.jpg",
+      "https://x.test/b.jpg",
+    ]);
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.warnings).toEqual(["https://x.test/a.jpg"]);
+  });
+});

--- a/__tests__/unit/actions/products-ai.test.ts
+++ b/__tests__/unit/actions/products-ai.test.ts
@@ -178,4 +178,26 @@ describe("importCandidateImages", () => {
     expect(r.success).toBe(false);
     expect(deleteFromR2Mock).toHaveBeenCalledTimes(2);
   });
+
+  it("supprime la ligne draft orpheline si le batch échoue", async () => {
+    mocks.dbBatch.mockRejectedValueOnce(new Error("batch failed"));
+    mocks.fetchAndUploadImage.mockImplementation(async (_: string, url: string) => ({
+      ok: true,
+      key: `products/d1/${url.split("/").pop()}`,
+      contentType: "image/jpeg",
+      size: 10,
+    }));
+
+    const r = await importCandidateImages(OUTPUT, ["https://x.test/a.jpg"]);
+    expect(r.success).toBe(false);
+
+    // The compensating DELETE should have been issued with the draft id.
+    const deleteCalls = mocks.execute.mock.calls.filter(
+      (call: unknown[]) => typeof call[0] === "string" && call[0].startsWith("DELETE FROM products"),
+    );
+    expect(deleteCalls).toHaveLength(1);
+    // The draft id is the one passed to fetchAndUploadImage as the first arg.
+    const fetchCall = mocks.fetchAndUploadImage.mock.calls[0] as [string, string];
+    expect((deleteCalls[0] as unknown[])[1]).toEqual([fetchCall[0]]);
+  });
 });

--- a/__tests__/unit/actions/products-ai.test.ts
+++ b/__tests__/unit/actions/products-ai.test.ts
@@ -33,6 +33,10 @@ vi.mock("@/lib/cloudflare/context", () => ({
   }),
 }));
 vi.mock("@/lib/ai/image-fetch", () => ({ fetchAndUploadImage: mocks.fetchAndUploadImage }));
+vi.mock("@/lib/storage/images", () => ({
+  deleteFromR2: vi.fn().mockResolvedValue(undefined),
+  uploadToR2: vi.fn().mockResolvedValue(undefined),
+}));
 
 import { importCandidateImages } from "@/actions/admin/products-ai";
 
@@ -117,5 +121,61 @@ describe("importCandidateImages", () => {
     ]);
     expect(r.success).toBe(true);
     if (r.success) expect(r.warnings).toEqual(["https://x.test/a.jpg"]);
+  });
+
+  it("écrit la clé R2 brute (sans prefixe /images/) et propage alt", async () => {
+    const outputWithAlt = {
+      ...OUTPUT,
+      image_candidates: [
+        { url: "https://x.test/a.jpg", source_domain: "x.test", alt: "Face avant" },
+        { url: "https://x.test/b.jpg", source_domain: "x.test", alt: "Profil" },
+      ],
+    };
+    mocks.fetchAndUploadImage.mockImplementation(async (_: string, url: string) => ({
+      ok: true,
+      key: `products/d1/${url.split("/").pop()}`,
+      contentType: "image/jpeg",
+      size: 10,
+    }));
+
+    const r = await importCandidateImages(outputWithAlt, [
+      "https://x.test/a.jpg",
+      "https://x.test/b.jpg",
+    ]);
+    expect(r.success).toBe(true);
+
+    const imageInserts = mocks.prepare.mock.calls
+      .map((call) => call[0] as string)
+      .filter((sql) => sql.includes("INSERT INTO product_images"));
+    expect(imageInserts.length).toBe(2); // one prepare() call per image row
+    expect(imageInserts[0]).toContain("(id, product_id, url, alt, is_primary, sort_order, created_at)");
+
+    // Also verify the bind args carry the bare key and alt
+    const batchCall = mocks.dbBatch.mock.calls[0][0] as Array<{ sql: string; args: unknown[] }>;
+    const imageBinds = batchCall.filter((s) => s.sql.includes("INSERT INTO product_images"));
+    expect(imageBinds).toHaveLength(2);
+    expect(imageBinds[0].args[2]).toBe("products/d1/a.jpg"); // url = bare key, no "/images/" prefix
+    expect(imageBinds[0].args[3]).toBe("Face avant");        // alt
+    expect(imageBinds[1].args[2]).toBe("products/d1/b.jpg");
+    expect(imageBinds[1].args[3]).toBe("Profil");
+  });
+
+  it("nettoie les images R2 orphelines si le batch échoue", async () => {
+    const { deleteFromR2: deleteFromR2Mock } = await import("@/lib/storage/images");
+    // deleteFromR2 was auto-mocked via vi.mock below — set up the mock.
+    mocks.dbBatch.mockRejectedValueOnce(new Error("batch failed"));
+    mocks.fetchAndUploadImage.mockImplementation(async (_: string, url: string) => ({
+      ok: true,
+      key: `products/d1/${url.split("/").pop()}`,
+      contentType: "image/jpeg",
+      size: 10,
+    }));
+
+    const r = await importCandidateImages(OUTPUT, [
+      "https://x.test/a.jpg",
+      "https://x.test/b.jpg",
+    ]);
+    expect(r.success).toBe(false);
+    expect(deleteFromR2Mock).toHaveBeenCalledTimes(2);
   });
 });

--- a/__tests__/unit/ai/image-fetch.test.ts
+++ b/__tests__/unit/ai/image-fetch.test.ts
@@ -67,4 +67,14 @@ describe("fetchAndUploadImage", () => {
     if (r.ok) expect(r.key).toMatch(/^products\/draft-1\/[A-Za-z0-9_-]+\.png$/);
     expect(uploadToR2Mock).toHaveBeenCalledOnce();
   });
+
+  it("renvoie upload_failed si uploadToR2 throw", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeImageResponse()));
+    uploadToR2Mock.mockRejectedValueOnce(new Error("R2 bucket non disponible"));
+
+    const r = await fetchAndUploadImage("draft-1", "https://example.test/a.png");
+
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("upload_failed");
+  });
 });

--- a/__tests__/unit/ai/image-fetch.test.ts
+++ b/__tests__/unit/ai/image-fetch.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const { uploadToR2Mock } = vi.hoisted(() => ({ uploadToR2Mock: vi.fn() }));
+vi.mock("@/lib/storage/images", () => ({ uploadToR2: uploadToR2Mock }));
+
+import { fetchAndUploadImage, IMAGE_MAX_BYTES } from "@/lib/ai/image-fetch";
+
+function makeImageResponse(opts: {
+  ok?: boolean;
+  status?: number;
+  contentType?: string;
+  body?: Uint8Array;
+} = {}) {
+  const body = opts.body ?? new Uint8Array([0x89, 0x50, 0x4e, 0x47]); // PNG header-ish
+  return new Response(body as BodyInit, {
+    status: opts.status ?? 200,
+    headers: { "content-type": opts.contentType ?? "image/png" },
+  });
+}
+
+describe("fetchAndUploadImage", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("rejette URL localhost (SSRF)", async () => {
+    const r = await fetchAndUploadImage("draft-1", "http://127.0.0.1/x.png");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("ssrf");
+  });
+
+  it("rejette les IPs privées RFC1918", async () => {
+    const r = await fetchAndUploadImage("draft-1", "http://10.0.0.1/x.png");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("ssrf");
+  });
+
+  it("rejette les schemas non-http", async () => {
+    const r = await fetchAndUploadImage("draft-1", "file:///etc/passwd");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("ssrf");
+  });
+
+  it("rejette les content-types non-image", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      makeImageResponse({ contentType: "text/html" }),
+    ));
+    const r = await fetchAndUploadImage("draft-1", "https://example.test/x.png");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("bad_content_type");
+  });
+
+  it("rejette si body > 5 MB", async () => {
+    const big = new Uint8Array(IMAGE_MAX_BYTES + 1);
+    big[0] = 0x89;
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeImageResponse({ body: big })));
+    const r = await fetchAndUploadImage("draft-1", "https://example.test/big.png");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("too_large");
+  });
+
+  it("upload vers R2 pour une image valide", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeImageResponse()));
+    uploadToR2Mock.mockResolvedValue("products/draft-1/abc.png");
+
+    const r = await fetchAndUploadImage("draft-1", "https://example.test/a.png");
+
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.key).toMatch(/^products\/draft-1\/[A-Za-z0-9_-]+\.png$/);
+    expect(uploadToR2Mock).toHaveBeenCalledOnce();
+  });
+});

--- a/__tests__/unit/ai/image-fetch.test.ts
+++ b/__tests__/unit/ai/image-fetch.test.ts
@@ -77,4 +77,71 @@ describe("fetchAndUploadImage", () => {
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toBe("upload_failed");
   });
+
+  it("rejette un redirect vers une IP privée (SSRF via Location header)", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(null, {
+        status: 302,
+        headers: { location: "http://10.0.0.1/evil.png" },
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const r = await fetchAndUploadImage("draft-1", "https://public.test/a.png");
+
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("ssrf");
+    expect(fetchMock).toHaveBeenCalledTimes(1); // second hop never issued
+  });
+
+  it("suit un redirect vers une URL publique", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(null, {
+        status: 301,
+        headers: { location: "https://cdn.public.test/a.png" },
+      }))
+      .mockResolvedValueOnce(makeImageResponse());
+    vi.stubGlobal("fetch", fetchMock);
+    uploadToR2Mock.mockResolvedValue("products/draft-1/abc.png");
+
+    const r = await fetchAndUploadImage("draft-1", "https://origin.test/a.png");
+    expect(r.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("abandonne au-delà du cap de redirects", async () => {
+    const loopingResp = () => new Response(null, {
+      status: 302,
+      headers: { location: "https://public.test/next" },
+    });
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(loopingResp())
+      .mockResolvedValueOnce(loopingResp())
+      .mockResolvedValueOnce(loopingResp())
+      .mockResolvedValueOnce(loopingResp());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const r = await fetchAndUploadImage("draft-1", "https://public.test/a");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("fetch_failed");
+  });
+
+  it("normalise un AbortError pendant le streaming du body en reason=timeout", async () => {
+    // Simulate fetch resolving OK, but reader.read() throwing AbortError mid-stream
+    const aborted = Object.assign(new Error("aborted"), { name: "AbortError" });
+    const bodyStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([0x89]));
+        controller.error(aborted);
+      },
+    });
+    const resp = new Response(bodyStream, {
+      status: 200,
+      headers: { "content-type": "image/png" },
+    });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(resp));
+
+    const r = await fetchAndUploadImage("draft-1", "https://public.test/a.png");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("timeout");
+  });
 });

--- a/__tests__/unit/ai/product-research.test.ts
+++ b/__tests__/unit/ai/product-research.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { researchProduct, type ResearchProgress } from "@/lib/ai/product-research";
+import type Anthropic from "@anthropic-ai/sdk";
+
+function makeAnthropicStub(content: unknown[]): Anthropic {
+  return {
+    messages: {
+      create: async () => ({ content, stop_reason: "end_turn" }),
+    },
+  } as unknown as Anthropic;
+}
+
+async function drain(iter: AsyncGenerator<ResearchProgress>): Promise<ResearchProgress[]> {
+  const out: ResearchProgress[] = [];
+  for await (const ev of iter) out.push(ev);
+  return out;
+}
+
+const validOutput = {
+  name: "Galaxy A55",
+  category_suggestion: "smartphones",
+  attributes: { colors: [], dimensions: {}, specs: [] },
+  story: {},
+  seo: {},
+  image_candidates: [{ url: "https://x.test/a.jpg", source_domain: "x.test" }],
+};
+
+describe("researchProduct", () => {
+  it("émet progress puis done pour une sortie valide", async () => {
+    const anthropic = makeAnthropicStub([
+      { type: "tool_use", name: "web_search", id: "1", input: { query: "Galaxy A55" } },
+      { type: "tool_use", name: "web_search", id: "2", input: { query: "Galaxy A55 images" } },
+      { type: "tool_use", name: "submit_product", id: "3", input: validOutput },
+    ]);
+
+    const events = await drain(researchProduct("Galaxy A55", anthropic));
+
+    expect(events.map((e) => e.type)).toEqual(["progress", "progress", "progress", "done"]);
+    expect((events.at(-1) as { type: "done"; output: typeof validOutput }).output.name).toBe("Galaxy A55");
+  });
+
+  it("émet not_found", async () => {
+    const anthropic = makeAnthropicStub([
+      { type: "tool_use", name: "submit_product", id: "x", input: { not_found: true, reason: "unknown" } },
+    ]);
+    const events = await drain(researchProduct("zxzx", anthropic));
+    expect(events[0]).toEqual({ type: "progress", step: "finalize" });
+    expect(events.at(-1)).toEqual({ type: "not_found", reason: "unknown" });
+  });
+
+  it("émet error pour une sortie invalide", async () => {
+    const anthropic = makeAnthropicStub([
+      { type: "tool_use", name: "submit_product", id: "x", input: { garbage: true } },
+    ]);
+    const events = await drain(researchProduct("x", anthropic));
+    expect(events.find((e) => e.type === "error")).toEqual({ type: "error", code: "invalid_ai_output" });
+  });
+
+  it("émet error si submit_product jamais appelé", async () => {
+    const anthropic = makeAnthropicStub([
+      { type: "text", text: "hmm" },
+    ]);
+    const events = await drain(researchProduct("x", anthropic));
+    expect(events.at(-1)).toEqual({ type: "error", code: "api_error" });
+  });
+});

--- a/__tests__/unit/ai/product-research.test.ts
+++ b/__tests__/unit/ai/product-research.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { researchProduct, type ResearchProgress } from "@/lib/ai/product-research";
+import { classifyError, researchProduct, type ResearchProgress } from "@/lib/ai/product-research";
 import type Anthropic from "@anthropic-ai/sdk";
 
 /**
@@ -102,5 +102,46 @@ describe("researchProduct", () => {
     ]);
     const events = await drain(researchProduct("x", anthropic));
     expect(events.at(-1)).toEqual({ type: "error", code: "api_error" });
+  });
+});
+
+describe("classifyError", () => {
+  it("retourne timeout si aborted", () => {
+    expect(classifyError(new Error("any"), true)).toBe("timeout");
+  });
+
+  it("retourne timeout pour AbortError", () => {
+    const err = Object.assign(new Error("aborted"), { name: "AbortError" });
+    expect(classifyError(err, false)).toBe("timeout");
+  });
+
+  it("retourne auth_failed pour 401/403", () => {
+    expect(classifyError({ status: 401 }, false)).toBe("auth_failed");
+    expect(classifyError({ status: 403 }, false)).toBe("auth_failed");
+  });
+
+  it("retourne upstream_rate_limited pour 429", () => {
+    expect(classifyError({ status: 429 }, false)).toBe("upstream_rate_limited");
+  });
+
+  it("retourne no_credits pour 400 avec message de solde", () => {
+    const err = { status: 400, error: { error: { message: "Your credit balance is too low" } } };
+    expect(classifyError(err, false)).toBe("no_credits");
+  });
+
+  it("retourne no_credits aussi pour 'billing' dans le message", () => {
+    const err = { status: 400, error: { error: { message: "billing issue" } } };
+    expect(classifyError(err, false)).toBe("no_credits");
+  });
+
+  it("retourne upstream_unavailable pour 5xx", () => {
+    expect(classifyError({ status: 500 }, false)).toBe("upstream_unavailable");
+    expect(classifyError({ status: 503 }, false)).toBe("upstream_unavailable");
+  });
+
+  it("retourne api_error pour un 400 non-billing ou erreur inconnue", () => {
+    expect(classifyError({ status: 400, error: { error: { message: "bad request" } } }, false)).toBe("api_error");
+    expect(classifyError(new Error("random"), false)).toBe("api_error");
+    expect(classifyError(undefined, false)).toBe("api_error");
   });
 });

--- a/__tests__/unit/ai/product-research.test.ts
+++ b/__tests__/unit/ai/product-research.test.ts
@@ -2,10 +2,36 @@ import { describe, expect, it } from "vitest";
 import { researchProduct, type ResearchProgress } from "@/lib/ai/product-research";
 import type Anthropic from "@anthropic-ai/sdk";
 
-function makeAnthropicStub(content: unknown[]): Anthropic {
+/**
+ * Build a minimal Anthropic stub where `messages.stream(...)` returns an object
+ * that (a) yields the provided events as an async iterable, and (b) exposes a
+ * `finalMessage()` method returning a message whose `content` is derived from
+ * the `tool_use` events we recorded.
+ */
+function makeAnthropicStub(events: Array<{ type: string; content_block?: { type: string; name?: string; input?: unknown } }>): Anthropic {
   return {
     messages: {
-      create: async () => ({ content, stop_reason: "end_turn" }),
+      stream: () => {
+        const toolUses = events
+          .filter((e) => e.type === "content_block_start" && e.content_block?.type === "tool_use")
+          .map((e) => ({
+            type: "tool_use" as const,
+            name: e.content_block!.name,
+            input: e.content_block!.input,
+          }));
+
+        const iterable = (async function* () {
+          for (const ev of events) yield ev;
+        })();
+
+        return {
+          [Symbol.asyncIterator]() { return iterable; },
+          finalMessage: async () => ({
+            content: toolUses,
+            stop_reason: "end_turn",
+          }),
+        };
+      },
     },
   } as unknown as Anthropic;
 }
@@ -26,39 +52,53 @@ const validOutput = {
 };
 
 describe("researchProduct", () => {
-  it("émet progress puis done pour une sortie valide", async () => {
+  it("émet progress (search) pour un server_tool_use web_search puis done", async () => {
     const anthropic = makeAnthropicStub([
-      { type: "tool_use", name: "web_search", id: "1", input: { query: "Galaxy A55" } },
-      { type: "tool_use", name: "web_search", id: "2", input: { query: "Galaxy A55 images" } },
-      { type: "tool_use", name: "submit_product", id: "3", input: validOutput },
+      { type: "content_block_start", content_block: { type: "server_tool_use", name: "web_search", input: { query: "Galaxy A55" } } },
+      { type: "content_block_start", content_block: { type: "tool_use", name: "submit_product", input: validOutput } },
     ]);
 
     const events = await drain(researchProduct("Galaxy A55", anthropic));
 
-    expect(events.map((e) => e.type)).toEqual(["progress", "progress", "progress", "done"]);
-    expect((events.at(-1) as { type: "done"; output: typeof validOutput }).output.name).toBe("Galaxy A55");
+    expect(events.map((e) => e.type)).toEqual(["progress", "progress", "done"]);
+    const terminal = events.at(-1) as { type: "done"; output: typeof validOutput };
+    expect(terminal.output.name).toBe("Galaxy A55");
   });
 
-  it("émet not_found", async () => {
+  it("émet search → specs → images pour 3 recherches consécutives", async () => {
     const anthropic = makeAnthropicStub([
-      { type: "tool_use", name: "submit_product", id: "x", input: { not_found: true, reason: "unknown" } },
+      { type: "content_block_start", content_block: { type: "server_tool_use", name: "web_search", input: { query: "a" } } },
+      { type: "content_block_start", content_block: { type: "server_tool_use", name: "web_search", input: { query: "b" } } },
+      { type: "content_block_start", content_block: { type: "server_tool_use", name: "web_search", input: { query: "c" } } },
+      { type: "content_block_start", content_block: { type: "tool_use", name: "submit_product", input: validOutput } },
+    ]);
+
+    const events = await drain(researchProduct("x", anthropic));
+    const progressSteps = events
+      .filter((e) => e.type === "progress")
+      .map((e) => (e as { type: "progress"; step: string }).step);
+    expect(progressSteps).toEqual(["search", "specs", "images", "finalize"]);
+  });
+
+  it("émet not_found quand submit_product signale introuvable", async () => {
+    const anthropic = makeAnthropicStub([
+      { type: "content_block_start", content_block: { type: "tool_use", name: "submit_product", input: { not_found: true, reason: "unknown" } } },
     ]);
     const events = await drain(researchProduct("zxzx", anthropic));
-    expect(events[0]).toEqual({ type: "progress", step: "finalize" });
     expect(events.at(-1)).toEqual({ type: "not_found", reason: "unknown" });
   });
 
-  it("émet error pour une sortie invalide", async () => {
+  it("émet error:invalid_ai_output pour une sortie cassée", async () => {
     const anthropic = makeAnthropicStub([
-      { type: "tool_use", name: "submit_product", id: "x", input: { garbage: true } },
+      { type: "content_block_start", content_block: { type: "tool_use", name: "submit_product", input: { garbage: true } } },
     ]);
     const events = await drain(researchProduct("x", anthropic));
-    expect(events.find((e) => e.type === "error")).toEqual({ type: "error", code: "invalid_ai_output" });
+    expect(events.at(-1)).toEqual({ type: "error", code: "invalid_ai_output" });
   });
 
-  it("émet error si submit_product jamais appelé", async () => {
+  it("émet error:api_error si submit_product jamais appelé", async () => {
     const anthropic = makeAnthropicStub([
-      { type: "text", text: "hmm" },
+      { type: "content_block_start", content_block: { type: "text", name: undefined } },
     ]);
     const events = await drain(researchProduct("x", anthropic));
     expect(events.at(-1)).toEqual({ type: "error", code: "api_error" });

--- a/__tests__/unit/ai/prompt-validation.test.ts
+++ b/__tests__/unit/ai/prompt-validation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { aiPromptSchema } from "@/lib/validations/product-ai";
+
+describe("aiPromptSchema", () => {
+  it("accepte un prompt normal", () => {
+    expect(aiPromptSchema.safeParse("Samsung Galaxy A55").success).toBe(true);
+  });
+
+  it("trim les espaces", () => {
+    const r = aiPromptSchema.safeParse("  iPhone 15 Pro  ");
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toBe("iPhone 15 Pro");
+  });
+
+  it("rejette trop court (< 3 chars après trim)", () => {
+    expect(aiPromptSchema.safeParse("  a ").success).toBe(false);
+  });
+
+  it("rejette trop long (> 200 chars)", () => {
+    expect(aiPromptSchema.safeParse("x".repeat(201)).success).toBe(false);
+  });
+
+  it("rejette les caractères de contrôle", () => {
+    expect(aiPromptSchema.safeParse("Galaxy\x00A55").success).toBe(false);
+    expect(aiPromptSchema.safeParse("Galaxy\nA55").success).toBe(false);
+  });
+});

--- a/__tests__/unit/ai/prompt-validation.test.ts
+++ b/__tests__/unit/ai/prompt-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { aiPromptSchema } from "@/lib/validations/product-ai";
+import { aiPromptSchema, aiProductOutputSchema, aiNotFoundSchema, parseAiToolInput } from "@/lib/validations/product-ai";
 
 describe("aiPromptSchema", () => {
   it("accepte un prompt normal", () => {
@@ -23,5 +23,92 @@ describe("aiPromptSchema", () => {
   it("rejette les caractères de contrôle", () => {
     expect(aiPromptSchema.safeParse("Galaxy\x00A55").success).toBe(false);
     expect(aiPromptSchema.safeParse("Galaxy\nA55").success).toBe(false);
+  });
+});
+
+describe("aiProductOutputSchema", () => {
+  const valid = {
+    name: "Samsung Galaxy A55",
+    brand: "Samsung",
+    category_suggestion: "smartphones",
+    short_description: "Smartphone 128Go",
+    description_html: "<p>Super téléphone.</p>",
+    attributes: {
+      colors: [{ name: "Noir", hex: "#1a1a1a" }],
+      dimensions: { length_mm: 161, height_mm: 77, width_mm: 8, weight_g: 213 },
+      specs: [{ name: "Écran", value: "6.6\" AMOLED 120Hz" }],
+    },
+    story: {
+      tagline: "Le nouveau standard du milieu de gamme",
+      highlights: [
+        { icon: "camera", label: "Triple capteur 50MP" },
+        { icon: "battery", label: "Autonomie 2 jours" },
+        { icon: "display", label: "Écran 120Hz" },
+      ],
+      feature_blocks: [
+        { title: "Un écran qui impressionne", body: "AMOLED 120Hz, 6.6 pouces." },
+        { title: "Une autonomie tenace", body: "Batterie 5000 mAh, charge rapide 25W." },
+      ],
+      faq: [
+        { question: "Est-il compatible 5G ?", answer: "Oui, pleinement compatible." },
+      ],
+    },
+    seo: {
+      meta_title: "Samsung Galaxy A55 5G 128Go | Netereka",
+      meta_description: "Achetez le Galaxy A55 5G 128Go avec livraison à domicile.",
+    },
+    image_candidates: [
+      { url: "https://images.samsung.com/a.jpg", source_domain: "samsung.com", alt: "Face avant" },
+    ],
+  };
+
+  it("accepte une sortie complète valide", () => {
+    expect(aiProductOutputSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it("rejette un hex invalide", () => {
+    const bad = { ...valid, attributes: { ...valid.attributes, colors: [{ name: "Noir", hex: "black" }] } };
+    expect(aiProductOutputSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it("rejette une URL d'image invalide", () => {
+    const bad = { ...valid, image_candidates: [{ url: "not-a-url", source_domain: "x", alt: "" }] };
+    expect(aiProductOutputSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it("rejette un icône de highlight hors liste curée", () => {
+    const bad = {
+      ...valid,
+      story: { ...valid.story, highlights: [
+        { icon: "invalid-icon", label: "x" },
+        { icon: "camera", label: "y" },
+        { icon: "battery", label: "z" },
+      ] },
+    };
+    expect(aiProductOutputSchema.safeParse(bad).success).toBe(false);
+  });
+});
+
+describe("parseAiToolInput", () => {
+  it("retourne une erreur when not_found flag true", () => {
+    const r = parseAiToolInput({ not_found: true, reason: "Produit inconnu" });
+    expect(r.kind).toBe("not_found");
+  });
+
+  it("retourne ok pour une sortie complète", () => {
+    const out = {
+      name: "X", category_suggestion: "y",
+      attributes: { colors: [], dimensions: {}, specs: [] },
+      story: {},
+      seo: {},
+      image_candidates: [{ url: "https://x.test/a.jpg", source_domain: "x.test" }],
+    };
+    const r = parseAiToolInput(out);
+    expect(r.kind).toBe("ok");
+  });
+
+  it("retourne invalid pour un payload cassé", () => {
+    const r = parseAiToolInput({ oops: true });
+    expect(r.kind).toBe("invalid");
   });
 });

--- a/__tests__/unit/ai/prompt-validation.test.ts
+++ b/__tests__/unit/ai/prompt-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { aiPromptSchema, aiProductOutputSchema, aiNotFoundSchema, parseAiToolInput } from "@/lib/validations/product-ai";
+import { aiPromptSchema, aiProductOutputSchema, parseAiToolInput } from "@/lib/validations/product-ai";
 
 describe("aiPromptSchema", () => {
   it("accepte un prompt normal", () => {

--- a/__tests__/unit/ai/rate-limit.test.ts
+++ b/__tests__/unit/ai/rate-limit.test.ts
@@ -5,6 +5,9 @@ vi.mock("@/lib/cloudflare/context", () => ({ getKV: () => getKVMock() }));
 
 import { checkRateLimit, AI_GEN_MAX_PER_HOUR } from "@/lib/ai/rate-limit";
 
+const NOW = 1_000_000_000_000; // fixed epoch for deterministic resetAt
+const WINDOW_MS = 3_600_000;
+
 function makeKV(initial: Map<string, string> = new Map()) {
   const store = new Map(initial);
   return {
@@ -14,41 +17,86 @@ function makeKV(initial: Map<string, string> = new Map()) {
   };
 }
 
+function bucket(count: number, resetAt: number): string {
+  return JSON.stringify({ count, resetAt });
+}
+
 describe("checkRateLimit", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("autorise la première génération", async () => {
+  it("autorise la première génération (pas de bucket)", async () => {
     const kv = makeKV();
     getKVMock.mockResolvedValue(kv);
 
-    const r = await checkRateLimit("admin-1");
+    const r = await checkRateLimit("admin-1", NOW);
 
     expect(r.ok).toBe(true);
-    expect(kv.put).toHaveBeenCalledWith("ai_gen:admin-1", "1", expect.objectContaining({ expirationTtl: 3600 }));
+    expect(kv.put).toHaveBeenCalledWith(
+      "ai_gen:admin-1",
+      bucket(1, NOW + WINDOW_MS),
+      expect.objectContaining({ expirationTtl: 3600 }),
+    );
+  });
+
+  it("démarre un nouveau bucket si l'ancien a expiré", async () => {
+    const kv = makeKV(new Map([["ai_gen:admin-1", bucket(AI_GEN_MAX_PER_HOUR, NOW - 1)]]));
+    getKVMock.mockResolvedValue(kv);
+
+    const r = await checkRateLimit("admin-1", NOW);
+    expect(r.ok).toBe(true);
+    expect(kv.put).toHaveBeenCalledWith(
+      "ai_gen:admin-1",
+      bucket(1, NOW + WINDOW_MS),
+      expect.objectContaining({ expirationTtl: 3600 }),
+    );
+  });
+
+  it("n'étend pas le resetAt sur un incrément (fenêtre vraiment fixe)", async () => {
+    const originalReset = NOW + 1_800_000; // 30 min left
+    const kv = makeKV(new Map([["ai_gen:admin-1", bucket(3, originalReset)]]));
+    getKVMock.mockResolvedValue(kv);
+
+    const r = await checkRateLimit("admin-1", NOW);
+    expect(r.ok).toBe(true);
+    // resetAt preserved; ttl reflects remaining window, not full 3600
+    expect(kv.put).toHaveBeenCalledWith(
+      "ai_gen:admin-1",
+      bucket(4, originalReset),
+      expect.objectContaining({ expirationTtl: 1800 }),
+    );
   });
 
   it(`autorise jusqu'à ${AI_GEN_MAX_PER_HOUR} générations`, async () => {
-    const kv = makeKV(new Map([["ai_gen:admin-1", String(AI_GEN_MAX_PER_HOUR - 1)]]));
+    const kv = makeKV(new Map([["ai_gen:admin-1", bucket(AI_GEN_MAX_PER_HOUR - 1, NOW + WINDOW_MS)]]));
     getKVMock.mockResolvedValue(kv);
 
-    const r = await checkRateLimit("admin-1");
+    const r = await checkRateLimit("admin-1", NOW);
     expect(r.ok).toBe(true);
   });
 
-  it(`rejette la ${AI_GEN_MAX_PER_HOUR + 1}ème génération`, async () => {
-    const kv = makeKV(new Map([["ai_gen:admin-1", String(AI_GEN_MAX_PER_HOUR)]]));
+  it(`rejette la ${AI_GEN_MAX_PER_HOUR + 1}ème génération avec retryAfterSec précis`, async () => {
+    const resetAt = NOW + 1_500_000; // 25 min = 1500s remaining
+    const kv = makeKV(new Map([["ai_gen:admin-1", bucket(AI_GEN_MAX_PER_HOUR, resetAt)]]));
     getKVMock.mockResolvedValue(kv);
 
-    const r = await checkRateLimit("admin-1");
+    const r = await checkRateLimit("admin-1", NOW);
     expect(r.ok).toBe(false);
-    if (!r.ok) expect(r.retryAfterSec).toBeGreaterThan(0);
+    if (!r.ok) expect(r.retryAfterSec).toBe(1500);
   });
 
   it("isole les buckets par admin", async () => {
-    const kv = makeKV(new Map([["ai_gen:admin-1", String(AI_GEN_MAX_PER_HOUR)]]));
+    const kv = makeKV(new Map([["ai_gen:admin-1", bucket(AI_GEN_MAX_PER_HOUR, NOW + WINDOW_MS)]]));
     getKVMock.mockResolvedValue(kv);
 
-    const r = await checkRateLimit("admin-2");
+    const r = await checkRateLimit("admin-2", NOW);
+    expect(r.ok).toBe(true);
+  });
+
+  it("tolère une valeur KV malformée (repart à zéro)", async () => {
+    const kv = makeKV(new Map([["ai_gen:admin-1", "not-json"]]));
+    getKVMock.mockResolvedValue(kv);
+
+    const r = await checkRateLimit("admin-1", NOW);
     expect(r.ok).toBe(true);
   });
 });

--- a/__tests__/unit/ai/rate-limit.test.ts
+++ b/__tests__/unit/ai/rate-limit.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const getKVMock = vi.fn();
+vi.mock("@/lib/cloudflare/context", () => ({ getKV: () => getKVMock() }));
+
+import { checkRateLimit, AI_GEN_MAX_PER_HOUR } from "@/lib/ai/rate-limit";
+
+function makeKV(initial: Map<string, string> = new Map()) {
+  const store = new Map(initial);
+  return {
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    put: vi.fn(async (key: string, value: string) => { store.set(key, value); }),
+    _store: store,
+  };
+}
+
+describe("checkRateLimit", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("autorise la première génération", async () => {
+    const kv = makeKV();
+    getKVMock.mockResolvedValue(kv);
+
+    const r = await checkRateLimit("admin-1");
+
+    expect(r.ok).toBe(true);
+    expect(kv.put).toHaveBeenCalledWith("ai_gen:admin-1", "1", expect.objectContaining({ expirationTtl: 3600 }));
+  });
+
+  it(`autorise jusqu'à ${AI_GEN_MAX_PER_HOUR} générations`, async () => {
+    const kv = makeKV(new Map([["ai_gen:admin-1", String(AI_GEN_MAX_PER_HOUR - 1)]]));
+    getKVMock.mockResolvedValue(kv);
+
+    const r = await checkRateLimit("admin-1");
+    expect(r.ok).toBe(true);
+  });
+
+  it(`rejette la ${AI_GEN_MAX_PER_HOUR + 1}ème génération`, async () => {
+    const kv = makeKV(new Map([["ai_gen:admin-1", String(AI_GEN_MAX_PER_HOUR)]]));
+    getKVMock.mockResolvedValue(kv);
+
+    const r = await checkRateLimit("admin-1");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.retryAfterSec).toBeGreaterThan(0);
+  });
+
+  it("isole les buckets par admin", async () => {
+    const kv = makeKV(new Map([["ai_gen:admin-1", String(AI_GEN_MAX_PER_HOUR)]]));
+    getKVMock.mockResolvedValue(kv);
+
+    const r = await checkRateLimit("admin-2");
+    expect(r.ok).toBe(true);
+  });
+});

--- a/actions/admin/products-ai.ts
+++ b/actions/admin/products-ai.ts
@@ -45,10 +45,23 @@ export async function importCandidateImages(
     if (!candidateSet.has(u)) return { success: false, error: "Sélection d'images invalide" };
   }
 
-  const tagline        = taglineSchema.parse(output.story.tagline ?? null);
-  const highlights     = output.story.highlights        ? highlightsSchema.parse(output.story.highlights)        : null;
-  const featureBlocks  = output.story.feature_blocks    ? featureBlocksSchema.parse(output.story.feature_blocks) : null;
-  const faq            = output.story.faq               ? faqSchema.parse(output.story.faq)                      : null;
+  const storyTagline      = taglineSchema.safeParse(output.story.tagline ?? null);
+  const storyHighlights   = output.story.highlights     ? highlightsSchema.safeParse(output.story.highlights)    : { success: true as const, data: null };
+  const storyFeatureBlocks = output.story.feature_blocks ? featureBlocksSchema.safeParse(output.story.feature_blocks) : { success: true as const, data: null };
+  const storyFaq          = output.story.faq           ? faqSchema.safeParse(output.story.faq)                 : { success: true as const, data: null };
+  if (!storyTagline.success || !storyHighlights.success || !storyFeatureBlocks.success || !storyFaq.success) {
+    console.error("[admin/products-ai] story validation drift", {
+      tagline: storyTagline.success ? null : storyTagline.error.issues,
+      highlights: storyHighlights.success ? null : storyHighlights.error.issues,
+      feature_blocks: storyFeatureBlocks.success ? null : storyFeatureBlocks.error.issues,
+      faq: storyFaq.success ? null : storyFaq.error.issues,
+    });
+    return { success: false, error: "La story produit générée est invalide" };
+  }
+  const tagline = storyTagline.data;
+  const highlights = storyHighlights.data;
+  const featureBlocks = storyFeatureBlocks.data;
+  const faq = storyFaq.data;
 
   const draftId = nanoid();
   const placeholderSlug = `draft-${draftId}`;

--- a/actions/admin/products-ai.ts
+++ b/actions/admin/products-ai.ts
@@ -83,18 +83,18 @@ export async function importCandidateImages(
   const categoryId = category?.id ?? null;
 
   const baseSlug = slugify(output.name);
-  let finalSlug = baseSlug || placeholderSlug;
+  // Keep the placeholder slug if slugify produced nothing OR every candidate in 20 tries collided.
+  // The placeholder is guaranteed unique (nanoid-based) so the batch UPDATE below won't throw on slug.
+  let finalSlug = placeholderSlug;
   if (baseSlug) {
-    let suffix = 1;
     let candidate = baseSlug;
-    while (suffix <= 20) {
+    for (let suffix = 1; suffix <= 20; suffix++) {
       const taken = await queryFirst<{ id: string }>(
         "SELECT id FROM products WHERE slug = ? AND id != ? LIMIT 1",
         [candidate, draftId],
       );
       if (!taken) { finalSlug = candidate; break; }
-      suffix++;
-      candidate = `${baseSlug}-${suffix}`;
+      candidate = `${baseSlug}-${suffix + 1}`;
     }
   }
 

--- a/actions/admin/products-ai.ts
+++ b/actions/admin/products-ai.ts
@@ -182,13 +182,18 @@ export async function importCandidateImages(
     await db.batch(stmts);
   } catch (err) {
     console.error("[admin/products-ai] batch write failed", err);
-    // Orphan R2 hygiene: the batch failed but we already uploaded to R2.
-    // Best-effort cleanup — failures here should not mask the original error.
-    await Promise.allSettled(
-      succeeded.map(({ r }) => deleteFromR2(r.key).catch((e) => {
-        console.warn("[admin/products-ai] orphan cleanup failed for key", r.key, e);
+    // Compensating cleanup — the draft row, any pending attribute/image inserts,
+    // and the R2 objects we uploaded must all be undone so retries stay idempotent
+    // and no orphans survive. All failures here are logged but swallowed so the
+    // original error reaches the caller.
+    await Promise.allSettled([
+      ...succeeded.map(({ r }) => deleteFromR2(r.key).catch((e) => {
+        console.warn("[admin/products-ai] orphan R2 cleanup failed for key", r.key, e);
       })),
-    );
+      execute("DELETE FROM products WHERE id = ?", [draftId]).catch((e) => {
+        console.warn("[admin/products-ai] orphan draft cleanup failed for id", draftId, e);
+      }),
+    ]);
     return { success: false, error: "Erreur lors de l'enregistrement de la fiche IA" };
   }
 

--- a/actions/admin/products-ai.ts
+++ b/actions/admin/products-ai.ts
@@ -1,0 +1,176 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { nanoid } from "nanoid";
+import { requireAdmin } from "@/lib/auth/guards";
+import { execute, queryFirst } from "@/lib/db";
+import { getDB } from "@/lib/cloudflare/context";
+import { slugify, type ActionResult } from "@/lib/utils";
+import { sanitizeDescriptionHtml } from "@/lib/utils/sanitize-html";
+import { fetchAndUploadImage, type FetchImageResult } from "@/lib/ai/image-fetch";
+import type { AiProductOutput } from "@/lib/validations/product-ai";
+import { aiProductOutputSchema } from "@/lib/validations/product-ai";
+import {
+  taglineSchema,
+  highlightsSchema,
+  featureBlocksSchema,
+  faqSchema,
+} from "@/lib/validations/product-story";
+
+type ImportResult = ActionResult & { id?: string; warnings?: string[] };
+
+type FetchSuccess = Extract<FetchImageResult, { ok: true }>;
+
+/** Create a draft + populate every AI-sourced field + attach selected images.
+ *  Price, stock, SKU, visibility flags remain at their draft defaults; the admin
+ *  fills them in the existing 5-step wizard on /products/{id}/edit. */
+export async function importCandidateImages(
+  aiOutput: AiProductOutput,
+  selectedUrls: string[],
+): Promise<ImportResult> {
+  await requireAdmin();
+
+  const outputParsed = aiProductOutputSchema.safeParse(aiOutput);
+  if (!outputParsed.success) {
+    return { success: false, error: "Fiche IA invalide" };
+  }
+  const output = outputParsed.data;
+
+  const candidateSet = new Set(output.image_candidates.map((c) => c.url));
+  if (selectedUrls.length < 1 || selectedUrls.length > 8) {
+    return { success: false, error: "Sélectionnez entre 1 et 8 images" };
+  }
+  for (const u of selectedUrls) {
+    if (!candidateSet.has(u)) return { success: false, error: "Sélection d'images invalide" };
+  }
+
+  const tagline        = taglineSchema.parse(output.story.tagline ?? null);
+  const highlights     = output.story.highlights        ? highlightsSchema.parse(output.story.highlights)        : null;
+  const featureBlocks  = output.story.feature_blocks    ? featureBlocksSchema.parse(output.story.feature_blocks) : null;
+  const faq            = output.story.faq               ? faqSchema.parse(output.story.faq)                      : null;
+
+  const draftId = nanoid();
+  const placeholderSlug = `draft-${draftId}`;
+  try {
+    await execute(
+      `INSERT INTO products (id, category_id, name, slug, base_price, is_active, is_draft, created_at, updated_at)
+       VALUES (?, NULL, '', ?, 0, 0, 1, datetime('now'), datetime('now'))`,
+      [draftId, placeholderSlug],
+    );
+  } catch (err) {
+    console.error("[admin/products-ai] draft insert failed", err);
+    return { success: false, error: "Erreur lors de la création du brouillon" };
+  }
+
+  const category = await queryFirst<{ id: string }>(
+    "SELECT id FROM categories WHERE LOWER(slug) = LOWER(?) LIMIT 1",
+    [output.category_suggestion],
+  );
+  const categoryId = category?.id ?? null;
+
+  const baseSlug = slugify(output.name);
+  let finalSlug = baseSlug || placeholderSlug;
+  if (baseSlug) {
+    let suffix = 1;
+    let candidate = baseSlug;
+    while (suffix <= 20) {
+      const taken = await queryFirst<{ id: string }>(
+        "SELECT id FROM products WHERE slug = ? AND id != ? LIMIT 1",
+        [candidate, draftId],
+      );
+      if (!taken) { finalSlug = candidate; break; }
+      suffix++;
+      candidate = `${baseSlug}-${suffix}`;
+    }
+  }
+
+  const fetchResults = await Promise.all(
+    selectedUrls.map((url) => fetchAndUploadImage(draftId, url).then((r) => ({ url, r }))),
+  );
+  const succeeded: Array<{ url: string; r: FetchSuccess }> = fetchResults.filter(
+    (x): x is { url: string; r: FetchSuccess } => x.r.ok,
+  );
+  const failed = fetchResults.filter((x) => !x.r.ok).map((x) => x.url);
+
+  const descriptionHtml = output.description_html
+    ? sanitizeDescriptionHtml(output.description_html, draftId)
+    : null;
+
+  const db = await getDB();
+  const stmts: ReturnType<typeof db.prepare>[] = [];
+
+  stmts.push(
+    db.prepare(
+      `UPDATE products SET
+         category_id = ?, name = ?, slug = ?, brand = ?,
+         description = ?, description_type = 'html', short_description = ?,
+         meta_title = ?, meta_description = ?,
+         tagline = ?, highlights = ?, feature_blocks = ?, faq = ?,
+         updated_at = datetime('now')
+       WHERE id = ? AND is_draft = 1`,
+    ).bind(
+      categoryId,
+      output.name,
+      finalSlug,
+      output.brand ?? null,
+      descriptionHtml,
+      output.short_description ?? null,
+      output.seo.meta_title ?? null,
+      output.seo.meta_description ?? null,
+      tagline,
+      highlights ? JSON.stringify(highlights) : null,
+      featureBlocks ? JSON.stringify(featureBlocks) : null,
+      faq ? JSON.stringify(faq) : null,
+      draftId,
+    ),
+  );
+
+  for (const c of output.attributes.colors) {
+    stmts.push(
+      db.prepare(
+        `INSERT INTO product_attributes (id, product_id, name, value) VALUES (?, ?, 'Couleur', ?)`,
+      ).bind(nanoid(), draftId, `${c.name}|${c.hex}`),
+    );
+  }
+  const dims = output.attributes.dimensions;
+  const dimFields: Array<[string, number | undefined]> = [
+    ["Longueur", dims.length_mm],
+    ["Hauteur",  dims.height_mm],
+    ["Largeur",  dims.width_mm],
+    ["Poids",    dims.weight_g],
+  ];
+  for (const [label, val] of dimFields) {
+    if (val != null) {
+      stmts.push(
+        db.prepare(`INSERT INTO product_attributes (id, product_id, name, value) VALUES (?, ?, ?, ?)`)
+          .bind(nanoid(), draftId, label, String(val)),
+      );
+    }
+  }
+  for (const s of output.attributes.specs) {
+    stmts.push(
+      db.prepare(`INSERT INTO product_attributes (id, product_id, name, value) VALUES (?, ?, ?, ?)`)
+        .bind(nanoid(), draftId, s.name, s.value),
+    );
+  }
+
+  succeeded.forEach(({ r }, idx) => {
+    stmts.push(
+      db.prepare(
+        `INSERT INTO product_images (id, product_id, url, is_primary, sort_order, created_at)
+         VALUES (?, ?, ?, ?, ?, datetime('now'))`,
+      ).bind(nanoid(), draftId, `/images/${r.key}`, idx === 0 ? 1 : 0, idx),
+    );
+  });
+
+  try {
+    await db.batch(stmts);
+  } catch (err) {
+    console.error("[admin/products-ai] batch write failed", err);
+    return { success: false, error: "Erreur lors de l'enregistrement de la fiche IA" };
+  }
+
+  revalidatePath("/products");
+  revalidatePath(`/products/${draftId}/edit`);
+  return { success: true, id: draftId, warnings: failed };
+}

--- a/actions/admin/products-ai.ts
+++ b/actions/admin/products-ai.ts
@@ -8,6 +8,7 @@ import { getDB } from "@/lib/cloudflare/context";
 import { slugify, type ActionResult } from "@/lib/utils";
 import { sanitizeDescriptionHtml } from "@/lib/utils/sanitize-html";
 import { fetchAndUploadImage, type FetchImageResult } from "@/lib/ai/image-fetch";
+import { deleteFromR2 } from "@/lib/storage/images";
 import type { AiProductOutput } from "@/lib/validations/product-ai";
 import { aiProductOutputSchema } from "@/lib/validations/product-ai";
 import {
@@ -154,12 +155,13 @@ export async function importCandidateImages(
     );
   }
 
-  succeeded.forEach(({ r }, idx) => {
+  succeeded.forEach(({ url, r }, idx) => {
+    const alt = output.image_candidates.find((c) => c.url === url)?.alt ?? null;
     stmts.push(
       db.prepare(
-        `INSERT INTO product_images (id, product_id, url, is_primary, sort_order, created_at)
-         VALUES (?, ?, ?, ?, ?, datetime('now'))`,
-      ).bind(nanoid(), draftId, `/images/${r.key}`, idx === 0 ? 1 : 0, idx),
+        `INSERT INTO product_images (id, product_id, url, alt, is_primary, sort_order, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, datetime('now'))`,
+      ).bind(nanoid(), draftId, r.key, alt, idx === 0 ? 1 : 0, idx),
     );
   });
 
@@ -167,6 +169,13 @@ export async function importCandidateImages(
     await db.batch(stmts);
   } catch (err) {
     console.error("[admin/products-ai] batch write failed", err);
+    // Orphan R2 hygiene: the batch failed but we already uploaded to R2.
+    // Best-effort cleanup — failures here should not mask the original error.
+    await Promise.allSettled(
+      succeeded.map(({ r }) => deleteFromR2(r.key).catch((e) => {
+        console.warn("[admin/products-ai] orphan cleanup failed for key", r.key, e);
+      })),
+    );
     return { success: false, error: "Erreur lors de l'enregistrement de la fiche IA" };
   }
 

--- a/app/(admin)/products/ai-new/ai-new-client.tsx
+++ b/app/(admin)/products/ai-new/ai-new-client.tsx
@@ -26,6 +26,10 @@ export function AiNewClient() {
 
   const generate = useCallback(async () => {
     const trimmed = prompt.trim();
+    if (trimmed.length < 3) {
+      setUi({ kind: "prompt", error: "Prompt trop court (min 3 caractères)" });
+      return;
+    }
     setUi({ kind: "generating", completed: new Set(), active: "search" });
 
     let resp: Response;
@@ -83,6 +87,8 @@ export function AiNewClient() {
         }
       }
     }
+    // Stream ended without a terminal event — network drop, Worker timeout, etc.
+    setUi({ kind: "prompt", error: "La génération a été interrompue. Réessayez." });
   }, [prompt]);
 
   const confirmImport = useCallback((selectedUrls: string[]) => {

--- a/app/(admin)/products/ai-new/ai-new-client.tsx
+++ b/app/(admin)/products/ai-new/ai-new-client.tsx
@@ -18,6 +18,21 @@ type UiState =
   | { kind: "generating"; completed: Set<ProgressStep>; active: ProgressStep | null }
   | { kind: "selecting"; output: AiProductOutput };
 
+const ERROR_MESSAGES: Record<string, string> = {
+  no_credits: "Crédit Anthropic épuisé. Rechargez le compte pour continuer.",
+  auth_failed: "Clé API Anthropic invalide. Vérifiez la configuration.",
+  upstream_rate_limited: "Anthropic a temporairement limité nos requêtes. Réessayez dans quelques minutes.",
+  upstream_unavailable: "Service IA momentanément indisponible. Réessayez.",
+  timeout: "La génération a dépassé le délai maximum. Réessayez avec un prompt plus précis.",
+  invalid_ai_output: "Le modèle n'a pas produit une fiche exploitable. Réessayez.",
+  feature_disabled: "La génération IA est désactivée. Contactez un administrateur.",
+};
+
+function errorMessageFor(code: string | undefined): string {
+  if (code && ERROR_MESSAGES[code]) return ERROR_MESSAGES[code];
+  return "Une erreur est survenue. Réessayez.";
+}
+
 export function AiNewClient() {
   const router = useRouter();
   const [prompt, setPrompt] = useState("");
@@ -45,9 +60,12 @@ export function AiNewClient() {
     }
 
     if (!resp.ok || !resp.body) {
-      const msg = resp.status === 429
-        ? "Limite de générations atteinte. Réessayez plus tard."
-        : "Une erreur est survenue. Réessayez.";
+      let msg: string;
+      if (resp.status === 429) msg = "Limite de générations atteinte (10/h). Réessayez plus tard.";
+      else if (resp.status === 403) msg = "Accès refusé. Reconnectez-vous avec un compte administrateur.";
+      else if (resp.status === 404) msg = "La génération IA est désactivée. Contactez un administrateur.";
+      else if (resp.status === 400) msg = "Prompt invalide. Vérifiez la saisie.";
+      else msg = "Une erreur est survenue. Réessayez.";
       setUi({ kind: "prompt", error: msg });
       return;
     }
@@ -82,7 +100,7 @@ export function AiNewClient() {
           setUi({ kind: "prompt", error: "Produit introuvable. Précisez marque + modèle." });
           return;
         } else if (event.type === "error") {
-          setUi({ kind: "prompt", error: "Le modèle n'a pas pu produire une fiche valide. Réessayez." });
+          setUi({ kind: "prompt", error: errorMessageFor(event.code) });
           return;
         }
       }

--- a/app/(admin)/products/ai-new/ai-new-client.tsx
+++ b/app/(admin)/products/ai-new/ai-new-client.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ArrowLeft02Icon } from "@hugeicons/core-free-icons";
+import { Button } from "@/components/ui/button";
+import { AiPromptForm } from "@/components/admin/ai-product/ai-prompt-form";
+import { AiProgressPanel, type ProgressStep } from "@/components/admin/ai-product/ai-progress-panel";
+import { AiImageSelector } from "@/components/admin/ai-product/ai-image-selector";
+import { importCandidateImages } from "@/actions/admin/products-ai";
+import type { AiProductOutput } from "@/lib/validations/product-ai";
+
+type UiState =
+  | { kind: "prompt"; error?: string | null }
+  | { kind: "generating"; completed: Set<ProgressStep>; active: ProgressStep | null }
+  | { kind: "selecting"; output: AiProductOutput };
+
+export function AiNewClient() {
+  const router = useRouter();
+  const [prompt, setPrompt] = useState("");
+  const [ui, setUi] = useState<UiState>({ kind: "prompt", error: null });
+  const [importing, startImporting] = useTransition();
+
+  const generate = useCallback(async () => {
+    const trimmed = prompt.trim();
+    setUi({ kind: "generating", completed: new Set(), active: "search" });
+
+    let resp: Response;
+    try {
+      resp = await fetch("/api/admin/products-ai/generate", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ prompt: trimmed }),
+      });
+    } catch {
+      setUi({ kind: "prompt", error: "Impossible de contacter le service. Réessayez." });
+      return;
+    }
+
+    if (!resp.ok || !resp.body) {
+      const msg = resp.status === 429
+        ? "Limite de générations atteinte. Réessayez plus tard."
+        : "Une erreur est survenue. Réessayez.";
+      setUi({ kind: "prompt", error: msg });
+      return;
+    }
+
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    const completed = new Set<ProgressStep>();
+    let active: ProgressStep | null = "search";
+
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        let event: { type: string; step?: ProgressStep; output?: AiProductOutput; reason?: string; code?: string };
+        try { event = JSON.parse(line); } catch { continue; }
+
+        if (event.type === "progress" && event.step) {
+          if (active && active !== event.step) completed.add(active);
+          active = event.step;
+          setUi({ kind: "generating", completed: new Set(completed), active });
+        } else if (event.type === "done" && event.output) {
+          setUi({ kind: "selecting", output: event.output });
+          return;
+        } else if (event.type === "not_found") {
+          setUi({ kind: "prompt", error: "Produit introuvable. Précisez marque + modèle." });
+          return;
+        } else if (event.type === "error") {
+          setUi({ kind: "prompt", error: "Le modèle n'a pas pu produire une fiche valide. Réessayez." });
+          return;
+        }
+      }
+    }
+  }, [prompt]);
+
+  const confirmImport = useCallback((selectedUrls: string[]) => {
+    if (ui.kind !== "selecting") return;
+    startImporting(async () => {
+      const r = await importCandidateImages(ui.output, selectedUrls);
+      if (!r.success) { toast.error(r.error ?? "Erreur d'import"); return; }
+      if (r.warnings && r.warnings.length > 0) {
+        toast.warning(`${r.warnings.length} image(s) n'ont pas pu être importées.`);
+      }
+      router.push(`/products/${r.id}/edit`);
+    });
+  }, [ui, router]);
+
+  return (
+    <div className="mx-auto w-full max-w-2xl px-4 py-8">
+      <div className="mb-6 flex items-center gap-2">
+        <Button variant="ghost" size="icon" asChild>
+          <Link href="/products" aria-label="Retour">
+            <HugeiconsIcon icon={ArrowLeft02Icon} size={20} />
+          </Link>
+        </Button>
+        <h1 className="text-xl font-semibold">Créer un produit avec l&apos;IA</h1>
+      </div>
+
+      {ui.kind === "prompt" && (
+        <AiPromptForm
+          prompt={prompt}
+          onPromptChange={setPrompt}
+          onSubmit={generate}
+          disabled={false}
+          error={ui.error}
+        />
+      )}
+      {ui.kind === "generating" && (
+        <AiProgressPanel completed={ui.completed} active={ui.active} />
+      )}
+      {ui.kind === "selecting" && (
+        <AiImageSelector
+          output={ui.output}
+          onConfirm={confirmImport}
+          onCancel={() => setUi({ kind: "prompt", error: null })}
+          busy={importing}
+        />
+      )}
+    </div>
+  );
+}

--- a/app/(admin)/products/ai-new/page.tsx
+++ b/app/(admin)/products/ai-new/page.tsx
@@ -1,0 +1,13 @@
+import { notFound } from "next/navigation";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { requireAdmin } from "@/lib/auth/guards";
+import { isAiFeatureEnabled } from "@/lib/ai/client";
+import { AiNewClient } from "./ai-new-client";
+
+export default async function AiNewProductPage() {
+  await requireAdmin();
+  const { env } = await getCloudflareContext({ async: true });
+  if (!isAiFeatureEnabled(env)) notFound();
+
+  return <AiNewClient />;
+}

--- a/app/(admin)/products/page.tsx
+++ b/app/(admin)/products/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { requireAdmin } from "@/lib/auth/guards";
 import { AdminHeader } from "@/components/admin/admin-header";
 import { AdminPageHeader } from "@/components/admin/admin-page-header";
@@ -9,6 +10,7 @@ import { ProductFilters } from "@/components/admin/product-filters";
 import { getAdminProducts, getAdminProductCount } from "@/lib/db/admin/products";
 import { getAllCategories } from "@/lib/db/admin/categories";
 import { cleanupDraftProducts } from "@/actions/admin/products";
+import { isAiFeatureEnabled } from "@/lib/ai/client";
 import { ProductsPageClient, ProductsPageActions } from "./products-page-client";
 
 interface Props {
@@ -24,6 +26,9 @@ const PAGE_SIZE = 20;
 
 export default async function ProductsPage({ searchParams }: Props) {
   await requireAdmin();
+
+  const { env } = await getCloudflareContext({ async: true });
+  const aiEnabled = isAiFeatureEnabled(env);
 
   // Remove draft products abandoned for 24+ hours after response is sent
   after(() =>
@@ -79,7 +84,7 @@ export default async function ProductsPage({ searchParams }: Props) {
             categories={categoryOptions}
             className="flex-1"
           />
-          <ProductsPageActions />
+          <ProductsPageActions aiEnabled={aiEnabled} />
         </div>
       </AdminPageHeader>
 
@@ -88,6 +93,7 @@ export default async function ProductsPage({ searchParams }: Props) {
         products={productData}
         categories={categoryOptions}
         totalCount={totalCount}
+        aiEnabled={aiEnabled}
       />
 
       {/* Active filter chips (mobile) */}

--- a/app/(admin)/products/products-page-client.tsx
+++ b/app/(admin)/products/products-page-client.tsx
@@ -25,12 +25,14 @@ interface ProductsPageClientProps {
   products: ProductData[];
   categories: { id: string; name: string }[];
   totalCount: number;
+  aiEnabled: boolean;
 }
 
 export function ProductsPageClient({
   products,
   categories,
   totalCount,
+  aiEnabled,
 }: ProductsPageClientProps) {
   return (
     <>
@@ -41,6 +43,11 @@ export function ProductsPageClient({
           <ViewSwitcher />
         </div>
         <div className="flex items-center gap-2">
+          {aiEnabled && (
+            <Button asChild size="sm" variant="outline">
+              <Link href="/products/ai-new">✨ Avec l&apos;IA</Link>
+            </Button>
+          )}
           <Button asChild size="sm">
             <Link href="/products/new">Nouveau</Link>
           </Button>
@@ -63,9 +70,14 @@ export function ProductsPageClient({
   );
 }
 
-export function ProductsPageActions() {
+export function ProductsPageActions({ aiEnabled }: { aiEnabled: boolean }) {
   return (
     <div className="flex items-center gap-2">
+      {aiEnabled && (
+        <Button asChild variant="outline">
+          <Link href="/products/ai-new">✨ Créer avec l&apos;IA</Link>
+        </Button>
+      )}
       <Button asChild>
         <Link href="/products/new">Nouveau produit</Link>
       </Button>

--- a/app/api/admin/products-ai/generate/route.ts
+++ b/app/api/admin/products-ai/generate/route.ts
@@ -6,8 +6,6 @@ import { checkRateLimit } from "@/lib/ai/rate-limit";
 import { getAnthropicClient, isAiFeatureEnabled } from "@/lib/ai/client";
 import { researchProduct } from "@/lib/ai/product-research";
 
-export const runtime = "edge";
-
 export async function POST(req: Request) {
   const { env } = await getCloudflareContext({ async: true });
   if (!isAiFeatureEnabled(env)) {

--- a/app/api/admin/products-ai/generate/route.ts
+++ b/app/api/admin/products-ai/generate/route.ts
@@ -32,12 +32,13 @@ export async function POST(req: Request) {
 
   const anthropic = await getAnthropicClient();
   const encoder = new TextEncoder();
+  const model = env.AI_MODEL || undefined;
 
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
       const write = (obj: unknown) => controller.enqueue(encoder.encode(JSON.stringify(obj) + "\n"));
       try {
-        for await (const ev of researchProduct(parsed.data, anthropic)) {
+        for await (const ev of researchProduct(parsed.data, anthropic, { model })) {
           write(ev);
         }
       } catch (err) {

--- a/app/api/admin/products-ai/generate/route.ts
+++ b/app/api/admin/products-ai/generate/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { requireAdmin } from "@/lib/auth/guards";
+import { aiPromptSchema } from "@/lib/validations/product-ai";
+import { checkRateLimit } from "@/lib/ai/rate-limit";
+import { getAnthropicClient, isAiFeatureEnabled } from "@/lib/ai/client";
+import { researchProduct } from "@/lib/ai/product-research";
+
+export const runtime = "edge";
+
+export async function POST(req: Request) {
+  const { env } = await getCloudflareContext({ async: true });
+  if (!isAiFeatureEnabled(env)) {
+    return new NextResponse("Not found", { status: 404 });
+  }
+
+  let session;
+  try { session = await requireAdmin(); }
+  catch { return new NextResponse("Forbidden", { status: 403 }); }
+
+  const body = await req.json().catch(() => null) as { prompt?: unknown } | null;
+  const parsed = aiPromptSchema.safeParse(body?.prompt);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "invalid_prompt", issues: parsed.error.issues }, { status: 400 });
+  }
+
+  const rl = await checkRateLimit(session.user.id);
+  if (!rl.ok) {
+    return new NextResponse(JSON.stringify({ error: "rate_limited", retryAfterSec: rl.retryAfterSec }), {
+      status: 429,
+      headers: { "content-type": "application/json", "retry-after": String(rl.retryAfterSec) },
+    });
+  }
+
+  const anthropic = await getAnthropicClient();
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const write = (obj: unknown) => controller.enqueue(encoder.encode(JSON.stringify(obj) + "\n"));
+      try {
+        for await (const ev of researchProduct(parsed.data, anthropic)) {
+          write(ev);
+        }
+      } catch (err) {
+        console.error("[ai-product] route stream error:", err);
+        write({ type: "error", code: "api_error" });
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new NextResponse(stream, {
+    headers: {
+      "content-type": "application/x-ndjson; charset=utf-8",
+      "cache-control": "no-store",
+    },
+  });
+}

--- a/components/admin/ai-product/ai-image-selector.tsx
+++ b/components/admin/ai-product/ai-image-selector.tsx
@@ -52,7 +52,9 @@ export function AiImageSelector({ output, onConfirm, onCancel, busy }: AiImageSe
               type="button"
               disabled={busy}
               onClick={() => toggle(c.url)}
-              className={`group relative overflow-hidden rounded-lg border text-left transition ${
+              aria-pressed={isSelected}
+              aria-label={`${isSelected ? "Désélectionner" : "Sélectionner"} l'image ${c.alt ? `« ${c.alt} »` : ""} de ${c.source_domain}`.trim()}
+              className={`group relative overflow-hidden rounded-lg border text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${
                 isSelected ? "border-primary ring-2 ring-primary/40" : "border-border hover:border-foreground"
               }`}
             >

--- a/components/admin/ai-product/ai-image-selector.tsx
+++ b/components/admin/ai-product/ai-image-selector.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import type { AiProductOutput } from "@/lib/validations/product-ai";
+
+interface AiImageSelectorProps {
+  output: AiProductOutput;
+  onConfirm: (selectedUrls: string[]) => void;
+  onCancel: () => void;
+  busy: boolean;
+}
+
+const MIN = 1;
+const MAX = 8;
+
+export function AiImageSelector({ output, onConfirm, onCancel, busy }: AiImageSelectorProps) {
+  const [selected, setSelected] = useState<string[]>(() =>
+    output.image_candidates.slice(0, Math.min(4, output.image_candidates.length)).map((c) => c.url),
+  );
+
+  function toggle(url: string) {
+    setSelected((prev) => {
+      if (prev.includes(url)) return prev.filter((u) => u !== url);
+      if (prev.length >= MAX) return prev;
+      return [...prev, url];
+    });
+  }
+
+  const canConfirm = selected.length >= MIN && !busy;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold">Fiche prête · sélectionnez les images</h2>
+        <p className="text-sm text-muted-foreground">
+          <strong>{output.name}</strong>
+          {output.attributes.colors.length > 0 && ` · ${output.attributes.colors.length} couleurs détectées`}
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Choisissez {MIN} à {MAX} images. La 1re cochée sera l&apos;image principale.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
+        {output.image_candidates.map((c) => {
+          const isSelected = selected.includes(c.url);
+          const index = selected.indexOf(c.url);
+          return (
+            <button
+              key={c.url}
+              type="button"
+              disabled={busy}
+              onClick={() => toggle(c.url)}
+              className={`group relative overflow-hidden rounded-lg border text-left transition ${
+                isSelected ? "border-primary ring-2 ring-primary/40" : "border-border hover:border-foreground"
+              }`}
+            >
+              <div className="relative aspect-square bg-muted">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img src={c.url} alt={c.alt ?? ""} className="h-full w-full object-contain" />
+                {isSelected && (
+                  <span className="absolute left-2 top-2 flex size-6 items-center justify-center rounded-full bg-primary text-xs font-bold text-primary-foreground">
+                    {index + 1}
+                  </span>
+                )}
+              </div>
+              <p className="truncate px-2 py-1 text-xs text-muted-foreground">{c.source_domain}</p>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex items-center justify-between pt-4">
+        <Button type="button" variant="outline" onClick={onCancel} disabled={busy}>
+          Annuler
+        </Button>
+        <Button type="button" disabled={!canConfirm} onClick={() => onConfirm(selected)}>
+          {busy ? "Importation…" : `Importer et continuer (${selected.length})`}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/ai-product/ai-progress-panel.tsx
+++ b/components/admin/ai-product/ai-progress-panel.tsx
@@ -43,7 +43,7 @@ export function AiProgressPanel({ completed, active }: AiProgressPanelProps) {
           );
         })}
       </ul>
-      <p className="pt-2 text-xs text-muted-foreground">Peut prendre jusqu&apos;à 30 secondes.</p>
+      <p className="pt-2 text-xs text-muted-foreground">Peut prendre jusqu&apos;à 90 secondes.</p>
     </div>
   );
 }

--- a/components/admin/ai-product/ai-progress-panel.tsx
+++ b/components/admin/ai-product/ai-progress-panel.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+export type ProgressStep = "search" | "specs" | "images" | "finalize";
+
+const LABELS: Record<ProgressStep, string> = {
+  search:   "Recherche du produit",
+  specs:    "Récupération des spécifications",
+  images:   "Recherche d'images",
+  finalize: "Génération de la fiche",
+};
+
+const ORDER: ProgressStep[] = ["search", "specs", "images", "finalize"];
+
+interface AiProgressPanelProps {
+  completed: Set<ProgressStep>;
+  active: ProgressStep | null;
+}
+
+export function AiProgressPanel({ completed, active }: AiProgressPanelProps) {
+  return (
+    <div className="space-y-3">
+      <h2 className="text-lg font-semibold">Génération en cours</h2>
+      <ul className="space-y-2">
+        {ORDER.map((step) => {
+          const isDone = completed.has(step);
+          const isActive = active === step;
+          return (
+            <li key={step} className="flex items-center gap-3 text-sm">
+              <span
+                aria-hidden
+                className={
+                  isDone ? "text-emerald-600" :
+                  isActive ? "text-amber-500 animate-pulse" :
+                  "text-muted-foreground"
+                }
+              >
+                {isDone ? "✓" : isActive ? "⏳" : "○"}
+              </span>
+              <span className={isDone || isActive ? "text-foreground" : "text-muted-foreground"}>
+                {LABELS[step]}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+      <p className="pt-2 text-xs text-muted-foreground">Peut prendre jusqu&apos;à 30 secondes.</p>
+    </div>
+  );
+}

--- a/components/admin/ai-product/ai-prompt-form.tsx
+++ b/components/admin/ai-product/ai-prompt-form.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+const EXAMPLES = ["iPhone 15 Pro", "Samsung Galaxy A55", "MacBook Air M3", "AirPods Pro 2"];
+
+interface AiPromptFormProps {
+  prompt: string;
+  onPromptChange: (v: string) => void;
+  onSubmit: () => void;
+  disabled: boolean;
+  error?: string | null;
+}
+
+export function AiPromptForm({ prompt, onPromptChange, onSubmit, disabled, error }: AiPromptFormProps) {
+  return (
+    <form
+      className="space-y-6"
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (!disabled && prompt.trim().length >= 3) onSubmit();
+      }}
+    >
+      <div className="space-y-2">
+        <Label htmlFor="ai-prompt">Décrivez le produit</Label>
+        <Input
+          id="ai-prompt"
+          value={prompt}
+          onChange={(e) => onPromptChange(e.target.value)}
+          placeholder="ex: Samsung Galaxy A55"
+          disabled={disabled}
+          autoFocus
+          maxLength={200}
+        />
+        <p className="text-xs text-muted-foreground">
+          Marque + modèle suffit. Ajoutez la capacité (ex: 128Go) pour un modèle précis.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {EXAMPLES.map((ex) => (
+          <button
+            key={ex}
+            type="button"
+            disabled={disabled}
+            onClick={() => onPromptChange(ex)}
+            className="rounded-full border bg-background px-3 py-1 text-xs text-muted-foreground hover:border-foreground hover:text-foreground disabled:opacity-50"
+          >
+            {ex}
+          </button>
+        ))}
+      </div>
+
+      {error && (
+        <p role="alert" className="text-sm text-destructive">{error}</p>
+      )}
+
+      <Button type="submit" disabled={disabled || prompt.trim().length < 3} className="w-full">
+        ✨ Générer la fiche
+      </Button>
+    </form>
+  );
+}

--- a/components/admin/ai-product/ai-prompt-form.tsx
+++ b/components/admin/ai-product/ai-prompt-form.tsx
@@ -46,7 +46,7 @@ export function AiPromptForm({ prompt, onPromptChange, onSubmit, disabled, error
             type="button"
             disabled={disabled}
             onClick={() => onPromptChange(ex)}
-            className="rounded-full border bg-background px-3 py-1 text-xs text-muted-foreground hover:border-foreground hover:text-foreground disabled:opacity-50"
+            className="inline-flex min-h-11 items-center rounded-full border bg-background px-4 py-2 text-xs text-muted-foreground transition-colors hover:border-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:opacity-50"
           >
             {ex}
           </button>

--- a/docs/superpowers/plans/2026-04-18-ai-product-creation.md
+++ b/docs/superpowers/plans/2026-04-18-ai-product-creation.md
@@ -1,0 +1,2132 @@
+# AI-Powered Product Creation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an AI-assisted path for creating products from a short text prompt. Claude researches the product online, suggests images, and pre-fills the existing 5-step wizard so the admin only has to validate and set the local XOF price.
+
+**Architecture:**
+- A new Route Handler streams progress events while Claude runs web search + a custom `submit_product` tool to produce a strictly-validated JSON payload.
+- A dedicated `/products/ai-new` client page walks through three states (prompt → progress → image selection) then calls a Server Action that downloads the selected images to R2 and hydrates a draft product.
+- The existing 5-step `ProductWizard` at `/products/{id}/edit` opens pre-filled; the admin fills price + stock there.
+
+**Tech Stack:** Next.js 16 App Router, TypeScript, `@anthropic-ai/sdk` (new), Cloudflare Workers (D1, KV, R2) via OpenNext, Vitest, Zod, React Hook Form patterns already in use, shadcn/ui.
+
+**Spec:** [docs/superpowers/specs/2026-04-18-ai-product-creation-design.md](../specs/2026-04-18-ai-product-creation-design.md)
+
+---
+
+## File Structure
+
+### Created
+
+| Path | Responsibility |
+| --- | --- |
+| `lib/ai/client.ts` | Anthropic SDK singleton. Reads `ANTHROPIC_API_KEY` from `getCloudflareContext().env`. Exposes `getAnthropicClient()`. Nothing else. |
+| `lib/ai/rate-limit.ts` | KV-backed fixed-window counter (1h, 10 calls) keyed by `ai_gen:{adminId}`. Exposes `checkRateLimit(adminId)` returning `{ ok: true } \| { ok: false, retryAfterSec }`. |
+| `lib/ai/product-research.ts` | Pure function `researchProduct(prompt, anthropic)`. Wraps `anthropic.messages.stream(...)` with `web_search_20250305` + custom `submit_product` tool; returns an async iterator of progress events then a terminal `done`/`not_found`/`error` event. Knows nothing about DB/R2. |
+| `lib/ai/image-fetch.ts` | Given a URL + `draftId`, resolves host (rejects SSRF ranges), fetches with 10s timeout, enforces content-type whitelist + 5MB max, uploads to R2 via existing `uploadToR2()`. Returns `{ ok, key } \| { ok: false, reason }`. |
+| `lib/validations/product-ai.ts` | Zod schemas: `aiPromptSchema`, `aiProductOutputSchema`, `aiNotFoundSchema`, helper `parseAiToolInput(raw)` returning a discriminated union. Re-uses `HIGHLIGHT_ICON_NAMES` from `product-story.ts`. |
+| `app/api/admin/products-ai/generate/route.ts` | `POST` Route Handler. Auth + rate-limit + feature flag + prompt validation, then streams NDJSON events from `researchProduct`. |
+| `actions/admin/products-ai.ts` | Server action `importCandidateImages(aiOutput, selectedUrls[])`. Validates selection is a subset of `aiOutput.image_candidates`, creates draft, downloads images in parallel, writes attributes + products update in a single D1 batch. Returns `{ success, id, warnings }`. |
+| `app/(admin)/products/ai-new/page.tsx` | Server component. `requireAdmin()` + feature-flag gate (404 when disabled). Renders `<AiNewClient />`. |
+| `app/(admin)/products/ai-new/ai-new-client.tsx` | Client component: state machine (`prompt \| generating \| selecting \| importing`), calls the Route Handler, consumes the NDJSON stream, calls the import server action on confirm. |
+| `components/admin/ai-product/ai-prompt-form.tsx` | Prompt input + example chips. Disabled state during generation. |
+| `components/admin/ai-product/ai-progress-panel.tsx` | Status-line checklist driven by received progress events. |
+| `components/admin/ai-product/ai-image-selector.tsx` | Grid of candidate thumbnails, checkboxes, min/max selection enforced, source-domain caption. |
+| `__tests__/unit/ai/rate-limit.test.ts` | Fixed-window logic, per-admin bucket isolation. |
+| `__tests__/unit/ai/product-research.test.ts` | Streaming → progress event mapping, schema validation, retries, not-found. |
+| `__tests__/unit/ai/image-fetch.test.ts` | SSRF, size, content-type, timeout, happy path. |
+| `__tests__/unit/ai/prompt-validation.test.ts` | Zod: length bounds, control-char rejection. |
+| `__tests__/unit/actions/products-ai.test.ts` | Server action: guard, selection whitelisting, happy path, partial image failure. |
+
+### Modified
+
+| Path | Reason |
+| --- | --- |
+| `env.d.ts` | Add `ANTHROPIC_API_KEY: string;` and `AI_PRODUCT_CREATION_ENABLED?: string;` to `CloudflareEnv`. |
+| `app/(admin)/products/products-page-client.tsx` | Add a `"✨ Créer avec l'IA"` `<Link>` next to the existing `"Nouveau"` button (mobile). |
+| `app/(admin)/products/products-page-client.tsx` (or wherever `ProductsPageActions` lives — look in the same file; if it's defined in `app/(admin)/products/page.tsx` as a barrel export, modify there) | Add the same button to the desktop actions. Fine-grained path resolved in Task 9. |
+| `package.json` | Add `@anthropic-ai/sdk` dependency. |
+
+No migration required. Existing `createDraftProduct()`, `applyDraftUpdate()`, `product_attributes`, and `product_images` are sufficient.
+
+---
+
+## Task 1 — Add environment types and dependency
+
+**Files:**
+- Modify: `env.d.ts`
+- Modify: `package.json` (add `@anthropic-ai/sdk`)
+
+- [ ] **Step 1: Update `env.d.ts`**
+
+Replace the closing brace of `CloudflareEnv` with:
+
+```ts
+  // Email (Resend)
+  RESEND_API_KEY?: string;
+  RESEND_FROM_EMAIL?: string; // defaults to "NETEREKA <commandes@netereka.ci>"
+
+  // AI-powered product creation
+  ANTHROPIC_API_KEY: string;
+  // "0" disables the feature (button hidden, /products/ai-new returns 404). Any other value or unset = enabled.
+  AI_PRODUCT_CREATION_ENABLED?: string;
+}
+```
+
+- [ ] **Step 2: Install the Anthropic SDK**
+
+Run:
+
+```bash
+npm install @anthropic-ai/sdk@^0.33.0
+```
+
+Expected: `package.json` and `package-lock.json` updated, `node_modules/@anthropic-ai/sdk` present.
+
+- [ ] **Step 3: Verify TypeScript still compiles**
+
+Run:
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: exits with code 0 and prints nothing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add env.d.ts package.json package-lock.json
+git commit -m "chore(admin): add @anthropic-ai/sdk and AI env vars"
+```
+
+---
+
+## Task 2 — Anthropic client singleton
+
+**Files:**
+- Create: `lib/ai/client.ts`
+- Test: (none — thin wrapper; covered transitively by product-research tests)
+
+- [ ] **Step 1: Create the singleton**
+
+Write:
+
+```ts
+// lib/ai/client.ts
+import Anthropic from "@anthropic-ai/sdk";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+
+let cached: Anthropic | null = null;
+
+export async function getAnthropicClient(): Promise<Anthropic> {
+  if (cached) return cached;
+  const { env } = await getCloudflareContext({ async: true });
+  if (!env.ANTHROPIC_API_KEY) {
+    throw new Error("ANTHROPIC_API_KEY is not configured");
+  }
+  cached = new Anthropic({ apiKey: env.ANTHROPIC_API_KEY });
+  return cached;
+}
+
+export function isAiFeatureEnabled(env: CloudflareEnv): boolean {
+  return env.AI_PRODUCT_CREATION_ENABLED !== "0";
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run:
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/ai/client.ts
+git commit -m "feat(admin): add Anthropic client singleton and feature flag helper"
+```
+
+---
+
+## Task 3 — Prompt validation (Zod)
+
+**Files:**
+- Create: `lib/validations/product-ai.ts` (minimal version — prompt only; expanded in Task 5)
+- Test: `__tests__/unit/ai/prompt-validation.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `__tests__/unit/ai/prompt-validation.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { aiPromptSchema } from "@/lib/validations/product-ai";
+
+describe("aiPromptSchema", () => {
+  it("accepte un prompt normal", () => {
+    expect(aiPromptSchema.safeParse("Samsung Galaxy A55").success).toBe(true);
+  });
+
+  it("trim les espaces", () => {
+    const r = aiPromptSchema.safeParse("  iPhone 15 Pro  ");
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toBe("iPhone 15 Pro");
+  });
+
+  it("rejette trop court (< 3 chars après trim)", () => {
+    expect(aiPromptSchema.safeParse("  a ").success).toBe(false);
+  });
+
+  it("rejette trop long (> 200 chars)", () => {
+    expect(aiPromptSchema.safeParse("x".repeat(201)).success).toBe(false);
+  });
+
+  it("rejette les caractères de contrôle", () => {
+    expect(aiPromptSchema.safeParse("Galaxy\x00A55").success).toBe(false);
+    expect(aiPromptSchema.safeParse("Galaxy\nA55").success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run:
+
+```bash
+npx vitest run __tests__/unit/ai/prompt-validation.test.ts
+```
+
+Expected: FAIL — module `@/lib/validations/product-ai` not found.
+
+- [ ] **Step 3: Implement the schema**
+
+Create `lib/validations/product-ai.ts`:
+
+```ts
+import { z } from "zod";
+
+/**
+ * Admin-typed prompt for AI product generation.
+ * Trim → reject control chars → length bounds. 3–200 chars feels natural
+ * for product names (brand + model + capacity).
+ */
+export const aiPromptSchema = z
+  .string()
+  .transform((v) => v.trim())
+  .refine((v) => !/[\u0000-\u001F\u007F]/.test(v), {
+    message: "Caractères de contrôle interdits",
+  })
+  .refine((v) => v.length >= 3, { message: "Prompt trop court (min 3 caractères)" })
+  .refine((v) => v.length <= 200, { message: "Prompt trop long (max 200 caractères)" });
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+npx vitest run __tests__/unit/ai/prompt-validation.test.ts
+```
+
+Expected: PASS × 5.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/validations/product-ai.ts __tests__/unit/ai/prompt-validation.test.ts
+git commit -m "feat(admin): add AI prompt Zod schema with tests"
+```
+
+---
+
+## Task 4 — Rate limit (KV-backed, per-admin)
+
+**Files:**
+- Create: `lib/ai/rate-limit.ts`
+- Test: `__tests__/unit/ai/rate-limit.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `__tests__/unit/ai/rate-limit.test.ts`:
+
+```ts
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const getKVMock = vi.fn();
+vi.mock("@/lib/cloudflare/context", () => ({ getKV: () => getKVMock() }));
+
+import { checkRateLimit, AI_GEN_MAX_PER_HOUR } from "@/lib/ai/rate-limit";
+
+function makeKV(initial: Map<string, string> = new Map()) {
+  const store = new Map(initial);
+  return {
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    put: vi.fn(async (key: string, value: string) => { store.set(key, value); }),
+    _store: store,
+  };
+}
+
+describe("checkRateLimit", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("autorise la première génération", async () => {
+    const kv = makeKV();
+    getKVMock.mockResolvedValue(kv);
+
+    const r = await checkRateLimit("admin-1");
+
+    expect(r.ok).toBe(true);
+    expect(kv.put).toHaveBeenCalledWith("ai_gen:admin-1", "1", expect.objectContaining({ expirationTtl: 3600 }));
+  });
+
+  it(`autorise jusqu'à ${AI_GEN_MAX_PER_HOUR} générations`, async () => {
+    const kv = makeKV(new Map([["ai_gen:admin-1", String(AI_GEN_MAX_PER_HOUR - 1)]]));
+    getKVMock.mockResolvedValue(kv);
+
+    const r = await checkRateLimit("admin-1");
+    expect(r.ok).toBe(true);
+  });
+
+  it(`rejette la ${AI_GEN_MAX_PER_HOUR + 1}ème génération`, async () => {
+    const kv = makeKV(new Map([["ai_gen:admin-1", String(AI_GEN_MAX_PER_HOUR)]]));
+    getKVMock.mockResolvedValue(kv);
+
+    const r = await checkRateLimit("admin-1");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.retryAfterSec).toBeGreaterThan(0);
+  });
+
+  it("isole les buckets par admin", async () => {
+    const kv = makeKV(new Map([["ai_gen:admin-1", String(AI_GEN_MAX_PER_HOUR)]]));
+    getKVMock.mockResolvedValue(kv);
+
+    const r = await checkRateLimit("admin-2");
+    expect(r.ok).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run:
+
+```bash
+npx vitest run __tests__/unit/ai/rate-limit.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the rate limit**
+
+Create `lib/ai/rate-limit.ts`:
+
+```ts
+import { getKV } from "@/lib/cloudflare/context";
+
+export const AI_GEN_MAX_PER_HOUR = 10;
+const WINDOW_SEC = 3600;
+
+export type RateLimitResult = { ok: true } | { ok: false; retryAfterSec: number };
+
+/**
+ * Fixed 1-hour window, per-admin. Not exactly fair (bursts at window edges)
+ * but trivial to implement on KV and sufficient as a cost ceiling.
+ */
+export async function checkRateLimit(adminId: string): Promise<RateLimitResult> {
+  const kv = await getKV();
+  if (!kv) throw new Error("KV namespace unavailable");
+
+  const key = `ai_gen:${adminId}`;
+  const current = await kv.get(key);
+  const count = current ? Number(current) : 0;
+
+  if (count >= AI_GEN_MAX_PER_HOUR) {
+    return { ok: false, retryAfterSec: WINDOW_SEC };
+  }
+
+  await kv.put(key, String(count + 1), { expirationTtl: WINDOW_SEC });
+  return { ok: true };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+npx vitest run __tests__/unit/ai/rate-limit.test.ts
+```
+
+Expected: PASS × 4.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/ai/rate-limit.ts __tests__/unit/ai/rate-limit.test.ts
+git commit -m "feat(admin): add per-admin KV rate limit for AI generation"
+```
+
+---
+
+## Task 5 — AI output Zod schema (full)
+
+**Files:**
+- Modify: `lib/validations/product-ai.ts` (append output schemas)
+- Test: `__tests__/unit/ai/prompt-validation.test.ts` (extend; rename not needed)
+
+- [ ] **Step 1: Write the failing test (add `describe` block for output schema)**
+
+Append to `__tests__/unit/ai/prompt-validation.test.ts`:
+
+```ts
+import { aiProductOutputSchema, aiNotFoundSchema, parseAiToolInput } from "@/lib/validations/product-ai";
+
+describe("aiProductOutputSchema", () => {
+  const valid = {
+    name: "Samsung Galaxy A55",
+    brand: "Samsung",
+    category_suggestion: "smartphones",
+    short_description: "Smartphone 128Go",
+    description_html: "<p>Super téléphone.</p>",
+    attributes: {
+      colors: [{ name: "Noir", hex: "#1a1a1a" }],
+      dimensions: { length_mm: 161, height_mm: 77, width_mm: 8, weight_g: 213 },
+      specs: [{ name: "Écran", value: "6.6\" AMOLED 120Hz" }],
+    },
+    story: {
+      tagline: "Le nouveau standard du milieu de gamme",
+      highlights: [
+        { icon: "camera", label: "Triple capteur 50MP" },
+        { icon: "battery", label: "Autonomie 2 jours" },
+        { icon: "display", label: "Écran 120Hz" },
+      ],
+      feature_blocks: [
+        { title: "Un écran qui impressionne", body: "AMOLED 120Hz, 6.6 pouces." },
+        { title: "Une autonomie tenace", body: "Batterie 5000 mAh, charge rapide 25W." },
+      ],
+      faq: [
+        { question: "Est-il compatible 5G ?", answer: "Oui, pleinement compatible." },
+      ],
+    },
+    seo: {
+      meta_title: "Samsung Galaxy A55 5G 128Go | Netereka",
+      meta_description: "Achetez le Galaxy A55 5G 128Go avec livraison à domicile.",
+    },
+    image_candidates: [
+      { url: "https://images.samsung.com/a.jpg", source_domain: "samsung.com", alt: "Face avant" },
+    ],
+  };
+
+  it("accepte une sortie complète valide", () => {
+    expect(aiProductOutputSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it("rejette un hex invalide", () => {
+    const bad = { ...valid, attributes: { ...valid.attributes, colors: [{ name: "Noir", hex: "black" }] } };
+    expect(aiProductOutputSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it("rejette une URL d'image invalide", () => {
+    const bad = { ...valid, image_candidates: [{ url: "not-a-url", source_domain: "x", alt: "" }] };
+    expect(aiProductOutputSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it("rejette un icône de highlight hors liste curée", () => {
+    const bad = {
+      ...valid,
+      story: { ...valid.story, highlights: [
+        { icon: "invalid-icon", label: "x" },
+        { icon: "camera", label: "y" },
+        { icon: "battery", label: "z" },
+      ] },
+    };
+    expect(aiProductOutputSchema.safeParse(bad).success).toBe(false);
+  });
+});
+
+describe("parseAiToolInput", () => {
+  it("retourne une erreur when not_found flag true", () => {
+    const r = parseAiToolInput({ not_found: true, reason: "Produit inconnu" });
+    expect(r.kind).toBe("not_found");
+  });
+
+  it("retourne ok pour une sortie complète", () => {
+    const out = {
+      name: "X", category_suggestion: "y",
+      attributes: { colors: [], dimensions: {}, specs: [] },
+      story: {},
+      seo: {},
+      image_candidates: [{ url: "https://x.test/a.jpg", source_domain: "x.test" }],
+    };
+    const r = parseAiToolInput(out);
+    expect(r.kind).toBe("ok");
+  });
+
+  it("retourne invalid pour un payload cassé", () => {
+    const r = parseAiToolInput({ oops: true });
+    expect(r.kind).toBe("invalid");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests and confirm they fail**
+
+Run:
+
+```bash
+npx vitest run __tests__/unit/ai/prompt-validation.test.ts
+```
+
+Expected: FAIL on the new describe blocks — symbols not exported.
+
+- [ ] **Step 3: Extend `lib/validations/product-ai.ts`**
+
+Append to `lib/validations/product-ai.ts`:
+
+```ts
+import { HIGHLIGHT_ICON_NAMES } from "@/lib/validations/product-story";
+
+const hexColor = z.string().regex(/^#[0-9a-fA-F]{6}$/, "Couleur hex invalide (format #rrggbb)");
+
+const colorSchema = z.object({
+  name: z.string().trim().min(1).max(40),
+  hex: hexColor,
+});
+
+const dimensionsSchema = z.object({
+  length_mm: z.number().int().positive().optional(),
+  height_mm: z.number().int().positive().optional(),
+  width_mm:  z.number().int().positive().optional(),
+  weight_g:  z.number().int().positive().optional(),
+});
+
+const specSchema = z.object({
+  name:  z.string().trim().min(1).max(60),
+  value: z.string().trim().min(1).max(200),
+});
+
+// Icon list reused from product-story — keeps the UI and AI in lockstep.
+const highlightSchema = z.object({
+  icon: z.enum(HIGHLIGHT_ICON_NAMES),
+  label: z.string().trim().min(1).max(80),
+});
+
+const featureBlockSchema = z.object({
+  title: z.string().trim().min(1).max(120),
+  body:  z.string().trim().min(1).max(600),
+});
+
+const faqSchema = z.object({
+  question: z.string().trim().min(1).max(160),
+  answer:   z.string().trim().min(1).max(600),
+});
+
+export const aiProductOutputSchema = z.object({
+  name: z.string().trim().min(1).max(150),
+  brand: z.string().trim().max(80).optional(),
+  category_suggestion: z.string().trim().min(1),
+  short_description: z.string().trim().max(120).optional(),
+  description_html: z.string().optional(),
+  attributes: z.object({
+    colors: z.array(colorSchema).max(12).default([]),
+    dimensions: dimensionsSchema.default({}),
+    specs: z.array(specSchema).max(20).default([]),
+  }).default({ colors: [], dimensions: {}, specs: [] }),
+  story: z.object({
+    tagline: z.string().trim().max(200).optional(),
+    highlights: z.array(highlightSchema).min(3).max(6).optional(),
+    feature_blocks: z.array(featureBlockSchema).min(2).max(4).optional(),
+    faq: z.array(faqSchema).max(5).optional(),
+  }).default({}),
+  seo: z.object({
+    meta_title: z.string().trim().max(60).optional(),
+    meta_description: z.string().trim().max(160).optional(),
+  }).default({}),
+  image_candidates: z.array(z.object({
+    url: z.string().url(),
+    source_domain: z.string().min(1),
+    alt: z.string().max(200).optional(),
+  })).min(1).max(12),
+});
+
+export const aiNotFoundSchema = z.object({
+  not_found: z.literal(true),
+  reason: z.string().max(300),
+});
+
+export type AiProductOutput = z.infer<typeof aiProductOutputSchema>;
+
+export type AiToolInputResult =
+  | { kind: "ok"; output: AiProductOutput }
+  | { kind: "not_found"; reason: string }
+  | { kind: "invalid"; issues: z.ZodIssue[] };
+
+/** Try not-found first — it has a discriminating literal — then the full schema. */
+export function parseAiToolInput(raw: unknown): AiToolInputResult {
+  const nf = aiNotFoundSchema.safeParse(raw);
+  if (nf.success) return { kind: "not_found", reason: nf.data.reason };
+
+  const ok = aiProductOutputSchema.safeParse(raw);
+  if (ok.success) return { kind: "ok", output: ok.data };
+  return { kind: "invalid", issues: ok.error.issues };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+npx vitest run __tests__/unit/ai/prompt-validation.test.ts
+```
+
+Expected: PASS — all (5 prompt tests + new output tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/validations/product-ai.ts __tests__/unit/ai/prompt-validation.test.ts
+git commit -m "feat(admin): add AI product output Zod schema (reuses story icons)"
+```
+
+---
+
+## Task 6 — Image fetch with SSRF / size / content-type guards
+
+**Files:**
+- Create: `lib/ai/image-fetch.ts`
+- Test: `__tests__/unit/ai/image-fetch.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `__tests__/unit/ai/image-fetch.test.ts`:
+
+```ts
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const uploadToR2Mock = vi.fn();
+vi.mock("@/lib/storage/images", () => ({ uploadToR2: uploadToR2Mock }));
+
+import { fetchAndUploadImage, IMAGE_MAX_BYTES } from "@/lib/ai/image-fetch";
+
+function makeImageResponse(opts: {
+  ok?: boolean;
+  status?: number;
+  contentType?: string;
+  body?: Uint8Array;
+} = {}) {
+  const body = opts.body ?? new Uint8Array([0x89, 0x50, 0x4e, 0x47]); // PNG header-ish
+  return new Response(body, {
+    status: opts.status ?? 200,
+    headers: { "content-type": opts.contentType ?? "image/png" },
+  });
+}
+
+describe("fetchAndUploadImage", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("rejette URL localhost (SSRF)", async () => {
+    const r = await fetchAndUploadImage("draft-1", "http://127.0.0.1/x.png");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("ssrf");
+  });
+
+  it("rejette les IPs privées RFC1918", async () => {
+    const r = await fetchAndUploadImage("draft-1", "http://10.0.0.1/x.png");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("ssrf");
+  });
+
+  it("rejette les schemas non-http", async () => {
+    const r = await fetchAndUploadImage("draft-1", "file:///etc/passwd");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("ssrf");
+  });
+
+  it("rejette les content-types non-image", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      makeImageResponse({ contentType: "text/html" }),
+    ));
+    const r = await fetchAndUploadImage("draft-1", "https://example.test/x.png");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("bad_content_type");
+  });
+
+  it("rejette si body > 5 MB", async () => {
+    const big = new Uint8Array(IMAGE_MAX_BYTES + 1);
+    big[0] = 0x89; // dummy PNG-ish first byte
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeImageResponse({ body: big })));
+    const r = await fetchAndUploadImage("draft-1", "https://example.test/big.png");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("too_large");
+  });
+
+  it("upload vers R2 pour une image valide", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeImageResponse()));
+    uploadToR2Mock.mockResolvedValue("products/draft-1/abc.png");
+
+    const r = await fetchAndUploadImage("draft-1", "https://example.test/a.png");
+
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.key).toMatch(/^products\/draft-1\/[A-Za-z0-9_-]+\.png$/);
+    expect(uploadToR2Mock).toHaveBeenCalledOnce();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run:
+
+```bash
+npx vitest run __tests__/unit/ai/image-fetch.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `lib/ai/image-fetch.ts`**
+
+Create:
+
+```ts
+import { nanoid } from "nanoid";
+import { uploadToR2 } from "@/lib/storage/images";
+
+export const IMAGE_MAX_BYTES = 5 * 1024 * 1024;
+export const IMAGE_FETCH_TIMEOUT_MS = 10_000;
+
+const ALLOWED_TYPES = new Set([
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+  "image/webp",
+  "image/avif",
+]);
+
+const EXT_BY_TYPE: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/jpg":  "jpg",
+  "image/png":  "png",
+  "image/webp": "webp",
+  "image/avif": "avif",
+};
+
+export type FetchImageResult =
+  | { ok: true; key: string; contentType: string; size: number }
+  | { ok: false; reason: "ssrf" | "bad_status" | "bad_content_type" | "too_large" | "timeout" | "fetch_failed" };
+
+/**
+ * Rejects URLs that could hit internal networks. DNS lookup is not available
+ * inside Workers, so we rely on host-based heuristics: literal IP in private
+ * ranges, or common internal hostnames. Any DNS name resolves to whatever the
+ * Cloudflare edge resolves it to — this is a best-effort guard, not absolute.
+ */
+function isBlockedHost(hostname: string): boolean {
+  const h = hostname.toLowerCase();
+  if (h === "localhost" || h.endsWith(".localhost") || h === "metadata.google.internal") return true;
+
+  // IPv4 literal ranges
+  const v4 = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (v4) {
+    const [a, b] = [Number(v4[1]), Number(v4[2])];
+    if (a === 10) return true;
+    if (a === 127) return true;
+    if (a === 169 && b === 254) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 0) return true;
+  }
+  // IPv6 literal (fast-path for the most common internal ranges)
+  if (h.startsWith("[") && h.endsWith("]")) {
+    const inner = h.slice(1, -1);
+    if (inner === "::1" || inner.startsWith("fc") || inner.startsWith("fd") || inner.startsWith("fe80:")) return true;
+  }
+  return false;
+}
+
+export async function fetchAndUploadImage(
+  draftId: string,
+  url: string,
+): Promise<FetchImageResult> {
+  let parsed: URL;
+  try { parsed = new URL(url); } catch { return { ok: false, reason: "ssrf" }; }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return { ok: false, reason: "ssrf" };
+  if (isBlockedHost(parsed.hostname)) return { ok: false, reason: "ssrf" };
+
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), IMAGE_FETCH_TIMEOUT_MS);
+
+  let resp: Response;
+  try {
+    resp = await fetch(parsed.toString(), { signal: ac.signal, redirect: "follow" });
+  } catch (err) {
+    clearTimeout(timer);
+    if (err instanceof Error && err.name === "AbortError") return { ok: false, reason: "timeout" };
+    return { ok: false, reason: "fetch_failed" };
+  }
+  clearTimeout(timer);
+
+  if (!resp.ok) return { ok: false, reason: "bad_status" };
+
+  const ct = (resp.headers.get("content-type") ?? "").split(";")[0].trim().toLowerCase();
+  if (!ALLOWED_TYPES.has(ct)) return { ok: false, reason: "bad_content_type" };
+
+  // Bounded read — stream into a single buffer, abort when exceeding the cap.
+  const reader = resp.body?.getReader();
+  if (!reader) return { ok: false, reason: "fetch_failed" };
+
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > IMAGE_MAX_BYTES) {
+      try { await reader.cancel(); } catch { /* ignore */ }
+      return { ok: false, reason: "too_large" };
+    }
+    chunks.push(value);
+  }
+
+  const buffer = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) { buffer.set(c, offset); offset += c.byteLength; }
+
+  const ext = EXT_BY_TYPE[ct] ?? "jpg";
+  const key = `products/${draftId}/${nanoid(10)}.${ext}`;
+  const file = new File([buffer], key, { type: ct });
+  await uploadToR2(file, key);
+
+  return { ok: true, key, contentType: ct, size: total };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+npx vitest run __tests__/unit/ai/image-fetch.test.ts
+```
+
+Expected: PASS × 6.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/ai/image-fetch.ts __tests__/unit/ai/image-fetch.test.ts
+git commit -m "feat(admin): add image-fetch helper with SSRF/size/type guards"
+```
+
+---
+
+## Task 7 — Product research (Claude streaming)
+
+**Files:**
+- Create: `lib/ai/product-research.ts`
+- Test: `__tests__/unit/ai/product-research.test.ts`
+
+This task replaces the Anthropic SDK's streaming call with a pure generator over mocked events. The real SDK is only called in production; tests feed synthetic stream events to the parser.
+
+- [ ] **Step 1: Define the public interface first (no test yet; just the types and dispatch shape so the test has types to target)**
+
+Create `lib/ai/product-research.ts` with the interface only:
+
+```ts
+import type Anthropic from "@anthropic-ai/sdk";
+import { parseAiToolInput, type AiProductOutput } from "@/lib/validations/product-ai";
+import { HIGHLIGHT_ICON_NAMES } from "@/lib/validations/product-story";
+
+export type ResearchProgress =
+  | { type: "progress"; step: "search" | "specs" | "images" | "finalize" }
+  | { type: "done"; output: AiProductOutput }
+  | { type: "not_found"; reason: string }
+  | { type: "error"; code: "invalid_ai_output" | "api_error" | "feature_disabled" };
+
+export const MODEL = "claude-sonnet-4-6";
+
+// Custom "submit" tool; Claude calls it exactly once to end the generation.
+export const SUBMIT_TOOL_NAME = "submit_product";
+
+export function buildSystemPrompt(): string {
+  // Lists every allowed icon name inline so Claude can pick matching ones.
+  const icons = HIGHLIGHT_ICON_NAMES.join(", ");
+  return [
+    "Tu es rédacteur catalogue pour une boutique d'électronique en Côte d'Ivoire.",
+    "Réponds TOUJOURS en français. Ne parle jamais à l'utilisateur : tes seules sorties doivent être l'utilisation des outils.",
+    "Étapes :",
+    "1. Utilise web_search pour vérifier l'existence du produit, ses spécifications officielles et trouver des images.",
+    "2. Si le produit est introuvable ou trop ambigu, appelle submit_product avec { \"not_found\": true, \"reason\": \"…\" }.",
+    "3. Sinon, appelle submit_product avec une fiche complète.",
+    "Règles :",
+    "- N'invente aucune caractéristique. Omets plutôt.",
+    "- Ne génère PAS de prix ni de stock (ne sont pas dans le schéma).",
+    "- Pour chaque highlight, choisis un icône parmi cette liste exacte : " + icons + ".",
+    "- image_candidates : 6 à 10 URLs d'images directes (jpg/png/webp), privilégie les sites constructeurs et la presse ; évite les watermarks.",
+    "- Les descriptions suivent un style Apple : tagline courte et percutante, highlights concis, feature_blocks éditoriaux avec un titre et un corps de 1-2 paragraphes.",
+  ].join("\n");
+}
+
+export function buildTools(): Anthropic.Tool[] {
+  return [
+    {
+      // Native Anthropic web search. Counts as a paid usage.
+      type: "web_search_20250305",
+      name: "web_search",
+      max_uses: 5,
+    } as unknown as Anthropic.Tool,
+    {
+      name: SUBMIT_TOOL_NAME,
+      description: "Soumet la fiche produit complète (ou signale que le produit est introuvable).",
+      input_schema: {
+        type: "object",
+        additionalProperties: true, // validated strictly by Zod after; keep loose here
+      },
+    },
+  ];
+}
+
+/** Drives the Anthropic stream and yields typed events. */
+export async function* researchProduct(
+  prompt: string,
+  anthropic: Anthropic,
+): AsyncGenerator<ResearchProgress> {
+  let emittedSearch = false;
+  let emittedImages = false;
+  let emittedSpecs = false;
+
+  const response = await anthropic.messages.create({
+    model: MODEL,
+    max_tokens: 8000,
+    system: buildSystemPrompt(),
+    tools: buildTools(),
+    messages: [{ role: "user", content: prompt }],
+  });
+
+  for (const block of response.content) {
+    if (block.type === "tool_use" && block.name === "web_search") {
+      const q = (block.input as { query?: string } | undefined)?.query ?? "";
+      if (!emittedSearch) { yield { type: "progress", step: "search" }; emittedSearch = true; }
+      if (!emittedSpecs && /spec|caract/i.test(q)) { yield { type: "progress", step: "specs" }; emittedSpecs = true; }
+      if (!emittedImages && /image|photo/i.test(q)) { yield { type: "progress", step: "images" }; emittedImages = true; }
+    }
+    if (block.type === "tool_use" && block.name === SUBMIT_TOOL_NAME) {
+      yield { type: "progress", step: "finalize" };
+      const parsed = parseAiToolInput(block.input);
+      if (parsed.kind === "ok") { yield { type: "done", output: parsed.output }; return; }
+      if (parsed.kind === "not_found") { yield { type: "not_found", reason: parsed.reason }; return; }
+      yield { type: "error", code: "invalid_ai_output" };
+      return;
+    }
+  }
+
+  // Stream ended without submit_product — treat as API error
+  yield { type: "error", code: "api_error" };
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `__tests__/unit/ai/product-research.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { researchProduct, type ResearchProgress } from "@/lib/ai/product-research";
+import type Anthropic from "@anthropic-ai/sdk";
+
+function makeAnthropicStub(content: unknown[]): Anthropic {
+  return {
+    messages: {
+      create: async () => ({ content, stop_reason: "end_turn" }),
+    },
+  } as unknown as Anthropic;
+}
+
+async function drain(iter: AsyncGenerator<ResearchProgress>): Promise<ResearchProgress[]> {
+  const out: ResearchProgress[] = [];
+  for await (const ev of iter) out.push(ev);
+  return out;
+}
+
+const validOutput = {
+  name: "Galaxy A55",
+  category_suggestion: "smartphones",
+  attributes: { colors: [], dimensions: {}, specs: [] },
+  story: {},
+  seo: {},
+  image_candidates: [{ url: "https://x.test/a.jpg", source_domain: "x.test" }],
+};
+
+describe("researchProduct", () => {
+  it("émet progress puis done pour une sortie valide", async () => {
+    const anthropic = makeAnthropicStub([
+      { type: "tool_use", name: "web_search", id: "1", input: { query: "Galaxy A55" } },
+      { type: "tool_use", name: "web_search", id: "2", input: { query: "Galaxy A55 images" } },
+      { type: "tool_use", name: "submit_product", id: "3", input: validOutput },
+    ]);
+
+    const events = await drain(researchProduct("Galaxy A55", anthropic));
+
+    expect(events.map((e) => e.type)).toEqual(["progress", "progress", "progress", "done"]);
+    expect((events.at(-1) as { type: "done"; output: typeof validOutput }).output.name).toBe("Galaxy A55");
+  });
+
+  it("émet not_found", async () => {
+    const anthropic = makeAnthropicStub([
+      { type: "tool_use", name: "submit_product", id: "x", input: { not_found: true, reason: "unknown" } },
+    ]);
+    const events = await drain(researchProduct("zxzx", anthropic));
+    expect(events.at(-1)).toEqual({ type: "not_found", reason: "unknown" });
+  });
+
+  it("émet error pour une sortie invalide", async () => {
+    const anthropic = makeAnthropicStub([
+      { type: "tool_use", name: "submit_product", id: "x", input: { garbage: true } },
+    ]);
+    const events = await drain(researchProduct("x", anthropic));
+    expect(events.at(-1)).toEqual({ type: "error", code: "invalid_ai_output" });
+  });
+
+  it("émet error si submit_product jamais appelé", async () => {
+    const anthropic = makeAnthropicStub([
+      { type: "text", text: "hmm" },
+    ]);
+    const events = await drain(researchProduct("x", anthropic));
+    expect(events.at(-1)).toEqual({ type: "error", code: "api_error" });
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests**
+
+Run:
+
+```bash
+npx vitest run __tests__/unit/ai/product-research.test.ts
+```
+
+Expected: PASS × 4 (the implementation was written in Step 1 before the test per the "interface first" convention here — reviewing the output now locks in the contract).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/ai/product-research.ts __tests__/unit/ai/product-research.test.ts
+git commit -m "feat(admin): add Claude-backed product research generator"
+```
+
+---
+
+## Task 8 — Route Handler (streaming NDJSON)
+
+**Files:**
+- Create: `app/api/admin/products-ai/generate/route.ts`
+
+Route Handler-based so the client can consume a stream. No dedicated test: the handler mostly wires together already-tested pieces; tests would mostly assert glue.
+
+- [ ] **Step 1: Create the handler**
+
+Create `app/api/admin/products-ai/generate/route.ts`:
+
+```ts
+import { NextResponse } from "next/server";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { requireAdmin } from "@/lib/auth/guards";
+import { aiPromptSchema } from "@/lib/validations/product-ai";
+import { checkRateLimit } from "@/lib/ai/rate-limit";
+import { getAnthropicClient, isAiFeatureEnabled } from "@/lib/ai/client";
+import { researchProduct } from "@/lib/ai/product-research";
+
+export const runtime = "edge"; // runs inside the OpenNext worker like the rest of the app
+
+export async function POST(req: Request) {
+  const { env } = await getCloudflareContext({ async: true });
+  if (!isAiFeatureEnabled(env)) {
+    return new NextResponse("Not found", { status: 404 });
+  }
+
+  let session;
+  try { session = await requireAdmin(); }
+  catch { return new NextResponse("Forbidden", { status: 403 }); }
+
+  const body = await req.json().catch(() => null) as { prompt?: unknown } | null;
+  const parsed = aiPromptSchema.safeParse(body?.prompt);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "invalid_prompt", issues: parsed.error.issues }, { status: 400 });
+  }
+
+  const rl = await checkRateLimit(session.user.id);
+  if (!rl.ok) {
+    return new NextResponse(JSON.stringify({ error: "rate_limited", retryAfterSec: rl.retryAfterSec }), {
+      status: 429,
+      headers: { "content-type": "application/json", "retry-after": String(rl.retryAfterSec) },
+    });
+  }
+
+  const anthropic = await getAnthropicClient();
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const write = (obj: unknown) => controller.enqueue(encoder.encode(JSON.stringify(obj) + "\n"));
+      try {
+        for await (const ev of researchProduct(parsed.data, anthropic)) {
+          write(ev);
+        }
+      } catch (err) {
+        console.error("[ai-product] route stream error:", err);
+        write({ type: "error", code: "api_error" });
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new NextResponse(stream, {
+    headers: {
+      "content-type": "application/x-ndjson; charset=utf-8",
+      "cache-control": "no-store",
+    },
+  });
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run:
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "app/api/admin/products-ai/generate/route.ts"
+git commit -m "feat(admin): add AI product generation streaming route"
+```
+
+---
+
+## Task 9 — Server action: importCandidateImages
+
+**Files:**
+- Create: `actions/admin/products-ai.ts`
+- Test: `__tests__/unit/actions/products-ai.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `__tests__/unit/actions/products-ai.test.ts`:
+
+```ts
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { mockAdminSession } from "../../helpers/mocks";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  redirect: vi.fn((url: string): never => {
+    const err = new Error(`NEXT_REDIRECT: ${url}`) as Error & { digest: string };
+    err.digest = `NEXT_REDIRECT;${url}`;
+    throw err;
+  }),
+  execute: vi.fn(),
+  queryFirst: vi.fn(),
+  query: vi.fn(),
+  fetchAndUploadImage: vi.fn(),
+  revalidatePath: vi.fn(),
+  dbBatch: vi.fn(),
+  prepare: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({ redirect: mocks.redirect }));
+vi.mock("next/headers", () => ({ headers: vi.fn().mockResolvedValue(new Headers()) }));
+vi.mock("next/cache", () => ({ revalidatePath: mocks.revalidatePath }));
+vi.mock("@/lib/auth", () => ({ initAuth: vi.fn().mockResolvedValue({ api: { getSession: mocks.getSession } }) }));
+vi.mock("@/lib/db", () => ({
+  execute: mocks.execute,
+  queryFirst: mocks.queryFirst,
+  query: mocks.query,
+}));
+vi.mock("@/lib/cloudflare/context", () => ({
+  getDB: async () => ({
+    prepare: (sql: string) => { mocks.prepare(sql); return { bind: (..._args: unknown[]) => ({ sql, args: _args }) }; },
+    batch: (stmts: unknown[]) => mocks.dbBatch(stmts),
+  }),
+}));
+vi.mock("@/lib/ai/image-fetch", () => ({ fetchAndUploadImage: mocks.fetchAndUploadImage }));
+
+import { importCandidateImages } from "@/actions/admin/products-ai";
+
+const OUTPUT = {
+  name: "Galaxy A55",
+  brand: "Samsung",
+  category_suggestion: "smartphones",
+  description_html: "<p>Hi</p>",
+  short_description: "short",
+  attributes: {
+    colors: [{ name: "Noir", hex: "#111111" }],
+    dimensions: { length_mm: 160 },
+    specs: [{ name: "Écran", value: '6.6" AMOLED' }],
+  },
+  story: {
+    tagline: "tag",
+    highlights: [
+      { icon: "camera", label: "l1" },
+      { icon: "battery", label: "l2" },
+      { icon: "display", label: "l3" },
+    ],
+    feature_blocks: [
+      { title: "t1", body: "b1" },
+      { title: "t2", body: "b2" },
+    ],
+    faq: [{ question: "q", answer: "a" }],
+  },
+  seo: { meta_title: "Galaxy A55", meta_description: "d" },
+  image_candidates: [
+    { url: "https://x.test/a.jpg", source_domain: "x.test" },
+    { url: "https://x.test/b.jpg", source_domain: "x.test" },
+  ],
+};
+
+describe("importCandidateImages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue(mockAdminSession);
+    mocks.execute.mockResolvedValue({ meta: { changes: 1 } });
+    mocks.queryFirst.mockResolvedValue(null);
+    mocks.query.mockResolvedValue([]);
+    mocks.dbBatch.mockResolvedValue([]);
+    mocks.fetchAndUploadImage.mockImplementation(async (_: string, url: string) =>
+      ({ ok: true, key: `products/d1/${url.split("/").pop()}`, contentType: "image/jpeg", size: 10 }));
+  });
+
+  it("refuse un admin non authentifié", async () => {
+    mocks.getSession.mockResolvedValue(null);
+    await expect(importCandidateImages(OUTPUT, ["https://x.test/a.jpg"])).rejects.toThrow("NEXT_REDIRECT");
+  });
+
+  it("refuse une URL hors image_candidates", async () => {
+    const r = await importCandidateImages(OUTPUT, ["https://evil.test/x.jpg"]);
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error).toMatch(/invalide/i);
+  });
+
+  it("crée le draft + applique les champs + télécharge les images (happy path)", async () => {
+    const r = await importCandidateImages(OUTPUT, [
+      "https://x.test/a.jpg",
+      "https://x.test/b.jpg",
+    ]);
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.id).toBeTruthy();
+      expect(r.warnings).toEqual([]);
+    }
+    expect(mocks.fetchAndUploadImage).toHaveBeenCalledTimes(2);
+    expect(mocks.dbBatch).toHaveBeenCalled();
+  });
+
+  it("renvoie warnings pour les images échouées mais crée quand même le draft", async () => {
+    mocks.fetchAndUploadImage.mockImplementationOnce(async () => ({ ok: false, reason: "too_large" }));
+    mocks.fetchAndUploadImage.mockImplementationOnce(async (_: string, url: string) =>
+      ({ ok: true, key: `products/d1/${url.split("/").pop()}`, contentType: "image/jpeg", size: 10 }));
+
+    const r = await importCandidateImages(OUTPUT, [
+      "https://x.test/a.jpg",
+      "https://x.test/b.jpg",
+    ]);
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.warnings).toEqual(["https://x.test/a.jpg"]);
+  });
+});
+```
+
+Ensure `__tests__/helpers/mocks.ts` exposes `mockAdminSession` (it does — used by auth-guards.test.ts).
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run:
+
+```bash
+npx vitest run __tests__/unit/actions/products-ai.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the server action**
+
+Create `actions/admin/products-ai.ts`:
+
+```ts
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { nanoid } from "nanoid";
+import { requireAdmin } from "@/lib/auth/guards";
+import { execute, queryFirst } from "@/lib/db";
+import { getDB } from "@/lib/cloudflare/context";
+import { slugify, type ActionResult } from "@/lib/utils";
+import { sanitizeDescriptionHtml } from "@/lib/utils/sanitize-html";
+import { fetchAndUploadImage } from "@/lib/ai/image-fetch";
+import type { AiProductOutput } from "@/lib/validations/product-ai";
+import { aiProductOutputSchema } from "@/lib/validations/product-ai";
+import {
+  taglineSchema,
+  highlightsSchema,
+  featureBlocksSchema,
+  faqSchema,
+} from "@/lib/validations/product-story";
+
+type ImportResult = ActionResult & { id?: string; warnings?: string[] };
+
+/** Create a draft + populate every AI-sourced field + attach selected images.
+ *  Price, stock, SKU, visibility flags remain at their draft defaults; the admin
+ *  fills them in the existing 5-step wizard on /products/{id}/edit. */
+export async function importCandidateImages(
+  aiOutput: AiProductOutput,
+  selectedUrls: string[],
+): Promise<ImportResult> {
+  await requireAdmin();
+
+  // Re-validate the AI payload server-side (don't trust the client).
+  const outputParsed = aiProductOutputSchema.safeParse(aiOutput);
+  if (!outputParsed.success) {
+    return { success: false, error: "Fiche IA invalide" };
+  }
+  const output = outputParsed.data;
+
+  const candidateSet = new Set(output.image_candidates.map((c) => c.url));
+  if (selectedUrls.length < 1 || selectedUrls.length > 8) {
+    return { success: false, error: "Sélectionnez entre 1 et 8 images" };
+  }
+  for (const u of selectedUrls) {
+    if (!candidateSet.has(u)) return { success: false, error: "Sélection d'images invalide" };
+  }
+
+  // Validate story sub-sections against the canonical schemas to catch drift.
+  const tagline        = taglineSchema.parse(output.story.tagline ?? null);
+  const highlights     = output.story.highlights        ? highlightsSchema.parse(output.story.highlights)        : null;
+  const featureBlocks  = output.story.feature_blocks    ? featureBlocksSchema.parse(output.story.feature_blocks) : null;
+  const faq            = output.story.faq               ? faqSchema.parse(output.story.faq)                      : null;
+
+  // 1) Create the draft row (same idiom as createDraftProduct, inlined to get the id).
+  const draftId = nanoid();
+  const placeholderSlug = `draft-${draftId}`;
+  try {
+    await execute(
+      `INSERT INTO products (id, category_id, name, slug, base_price, is_active, is_draft, created_at, updated_at)
+       VALUES (?, NULL, '', ?, 0, 0, 1, datetime('now'), datetime('now'))`,
+      [draftId, placeholderSlug],
+    );
+  } catch (err) {
+    console.error("[admin/products-ai] draft insert failed", err);
+    return { success: false, error: "Erreur lors de la création du brouillon" };
+  }
+
+  // 2) Resolve category suggestion → category_id (or null).
+  const category = await queryFirst<{ id: string }>(
+    "SELECT id FROM categories WHERE LOWER(slug) = LOWER(?) LIMIT 1",
+    [output.category_suggestion],
+  );
+  const categoryId = category?.id ?? null;
+
+  // 3) Resolve a unique non-colliding slug from the name.
+  const baseSlug = slugify(output.name);
+  let finalSlug = baseSlug || placeholderSlug;
+  if (baseSlug) {
+    let suffix = 1;
+    let candidate = baseSlug;
+    while (suffix <= 20) {
+      const taken = await queryFirst<{ id: string }>(
+        "SELECT id FROM products WHERE slug = ? AND id != ? LIMIT 1",
+        [candidate, draftId],
+      );
+      if (!taken) { finalSlug = candidate; break; }
+      suffix++;
+      candidate = `${baseSlug}-${suffix}`;
+    }
+  }
+
+  // 4) Download images in parallel. Selection order determines primary.
+  const fetchResults = await Promise.all(
+    selectedUrls.map((url) => fetchAndUploadImage(draftId, url).then((r) => ({ url, r }))),
+  );
+  const succeeded = fetchResults.filter((x) => x.r.ok) as Array<{ url: string; r: Extract<typeof fetchResults[number]["r"], { ok: true }> }>;
+  const failed = fetchResults.filter((x) => !x.r.ok).map((x) => x.url);
+
+  // 5) Sanitize description HTML.
+  const descriptionHtml = output.description_html
+    ? sanitizeDescriptionHtml(output.description_html, draftId)
+    : null;
+
+  // 6) Write everything in a single D1 batch.
+  const db = await getDB();
+  const stmts: ReturnType<typeof db.prepare>[] = [];
+
+  stmts.push(
+    db.prepare(
+      `UPDATE products SET
+         category_id = ?, name = ?, slug = ?, brand = ?,
+         description = ?, description_type = 'html', short_description = ?,
+         meta_title = ?, meta_description = ?,
+         tagline = ?, highlights = ?, feature_blocks = ?, faq = ?,
+         updated_at = datetime('now')
+       WHERE id = ? AND is_draft = 1`,
+    ).bind(
+      categoryId,
+      output.name,
+      finalSlug,
+      output.brand ?? null,
+      descriptionHtml,
+      output.short_description ?? null,
+      output.seo.meta_title ?? null,
+      output.seo.meta_description ?? null,
+      tagline,
+      highlights ? JSON.stringify(highlights) : null,
+      featureBlocks ? JSON.stringify(featureBlocks) : null,
+      faq ? JSON.stringify(faq) : null,
+      draftId,
+    ),
+  );
+
+  // Attributes: colors (stored as "Name|#hex" under name="Couleur", matching the UI convention),
+  // fixed dimensions (Longueur/Hauteur/Largeur/Poids), and free-form specs.
+  for (const c of output.attributes.colors) {
+    stmts.push(
+      db.prepare(
+        `INSERT INTO product_attributes (id, product_id, name, value) VALUES (?, ?, 'Couleur', ?)`,
+      ).bind(nanoid(), draftId, `${c.name}|${c.hex}`),
+    );
+  }
+  const dims = output.attributes.dimensions;
+  const dimFields: Array<[string, number | undefined]> = [
+    ["Longueur", dims.length_mm],
+    ["Hauteur",  dims.height_mm],
+    ["Largeur",  dims.width_mm],
+    ["Poids",    dims.weight_g],
+  ];
+  for (const [label, val] of dimFields) {
+    if (val != null) {
+      stmts.push(
+        db.prepare(`INSERT INTO product_attributes (id, product_id, name, value) VALUES (?, ?, ?, ?)`)
+          .bind(nanoid(), draftId, label, String(val)),
+      );
+    }
+  }
+  for (const s of output.attributes.specs) {
+    stmts.push(
+      db.prepare(`INSERT INTO product_attributes (id, product_id, name, value) VALUES (?, ?, ?, ?)`)
+        .bind(nanoid(), draftId, s.name, s.value),
+    );
+  }
+
+  // Images — first successful = primary.
+  succeeded.forEach(({ r }, idx) => {
+    stmts.push(
+      db.prepare(
+        `INSERT INTO product_images (id, product_id, url, is_primary, sort_order, created_at)
+         VALUES (?, ?, ?, ?, ?, datetime('now'))`,
+      ).bind(nanoid(), draftId, `/images/${r.key}`, idx === 0 ? 1 : 0, idx),
+    );
+  });
+
+  try {
+    await db.batch(stmts);
+  } catch (err) {
+    console.error("[admin/products-ai] batch write failed", err);
+    return { success: false, error: "Erreur lors de l'enregistrement de la fiche IA" };
+  }
+
+  revalidatePath("/products");
+  revalidatePath(`/products/${draftId}/edit`);
+  return { success: true, id: draftId, warnings: failed };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+npx vitest run __tests__/unit/actions/products-ai.test.ts
+```
+
+Expected: PASS × 4.
+
+- [ ] **Step 5: Type-check the whole project**
+
+Run:
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add actions/admin/products-ai.ts __tests__/unit/actions/products-ai.test.ts
+git commit -m "feat(admin): add importCandidateImages server action"
+```
+
+---
+
+## Task 10 — Client UI: prompt form
+
+**Files:**
+- Create: `components/admin/ai-product/ai-prompt-form.tsx`
+
+- [ ] **Step 1: Implement the prompt form**
+
+Create `components/admin/ai-product/ai-prompt-form.tsx`:
+
+```tsx
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+const EXAMPLES = ["iPhone 15 Pro", "Samsung Galaxy A55", "MacBook Air M3", "AirPods Pro 2"];
+
+interface AiPromptFormProps {
+  prompt: string;
+  onPromptChange: (v: string) => void;
+  onSubmit: () => void;
+  disabled: boolean;
+  error?: string | null;
+}
+
+export function AiPromptForm({ prompt, onPromptChange, onSubmit, disabled, error }: AiPromptFormProps) {
+  return (
+    <form
+      className="space-y-6"
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (!disabled && prompt.trim().length >= 3) onSubmit();
+      }}
+    >
+      <div className="space-y-2">
+        <Label htmlFor="ai-prompt">Décrivez le produit</Label>
+        <Input
+          id="ai-prompt"
+          value={prompt}
+          onChange={(e) => onPromptChange(e.target.value)}
+          placeholder="ex: Samsung Galaxy A55"
+          disabled={disabled}
+          autoFocus
+          maxLength={200}
+        />
+        <p className="text-xs text-muted-foreground">
+          Marque + modèle suffit. Ajoutez la capacité (ex: 128Go) pour un modèle précis.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {EXAMPLES.map((ex) => (
+          <button
+            key={ex}
+            type="button"
+            disabled={disabled}
+            onClick={() => onPromptChange(ex)}
+            className="rounded-full border bg-background px-3 py-1 text-xs text-muted-foreground hover:border-foreground hover:text-foreground disabled:opacity-50"
+          >
+            {ex}
+          </button>
+        ))}
+      </div>
+
+      {error && (
+        <p role="alert" className="text-sm text-destructive">{error}</p>
+      )}
+
+      <Button type="submit" disabled={disabled || prompt.trim().length < 3} className="w-full">
+        ✨ Générer la fiche
+      </Button>
+    </form>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run:
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "components/admin/ai-product/ai-prompt-form.tsx"
+git commit -m "feat(admin): add AI prompt form component"
+```
+
+---
+
+## Task 11 — Client UI: progress panel
+
+**Files:**
+- Create: `components/admin/ai-product/ai-progress-panel.tsx`
+
+- [ ] **Step 1: Implement the progress panel**
+
+Create `components/admin/ai-product/ai-progress-panel.tsx`:
+
+```tsx
+"use client";
+
+export type ProgressStep = "search" | "specs" | "images" | "finalize";
+
+const LABELS: Record<ProgressStep, string> = {
+  search:   "Recherche du produit",
+  specs:    "Récupération des spécifications",
+  images:   "Recherche d'images",
+  finalize: "Génération de la fiche",
+};
+
+const ORDER: ProgressStep[] = ["search", "specs", "images", "finalize"];
+
+interface AiProgressPanelProps {
+  completed: Set<ProgressStep>;
+  active: ProgressStep | null;
+}
+
+export function AiProgressPanel({ completed, active }: AiProgressPanelProps) {
+  return (
+    <div className="space-y-3">
+      <h2 className="text-lg font-semibold">Génération en cours</h2>
+      <ul className="space-y-2">
+        {ORDER.map((step) => {
+          const isDone = completed.has(step);
+          const isActive = active === step;
+          return (
+            <li key={step} className="flex items-center gap-3 text-sm">
+              <span
+                aria-hidden
+                className={
+                  isDone ? "text-emerald-600" :
+                  isActive ? "text-amber-500 animate-pulse" :
+                  "text-muted-foreground"
+                }
+              >
+                {isDone ? "✓" : isActive ? "⏳" : "○"}
+              </span>
+              <span className={isDone || isActive ? "text-foreground" : "text-muted-foreground"}>
+                {LABELS[step]}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+      <p className="pt-2 text-xs text-muted-foreground">Peut prendre jusqu'à 30 secondes.</p>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check and commit**
+
+Run:
+
+```bash
+npx tsc --noEmit
+git add "components/admin/ai-product/ai-progress-panel.tsx"
+git commit -m "feat(admin): add AI progress panel component"
+```
+
+---
+
+## Task 12 — Client UI: image selector
+
+**Files:**
+- Create: `components/admin/ai-product/ai-image-selector.tsx`
+
+- [ ] **Step 1: Implement the selector**
+
+Create `components/admin/ai-product/ai-image-selector.tsx`:
+
+```tsx
+"use client";
+
+import Image from "next/image";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import type { AiProductOutput } from "@/lib/validations/product-ai";
+
+interface AiImageSelectorProps {
+  output: AiProductOutput;
+  onConfirm: (selectedUrls: string[]) => void;
+  onCancel: () => void;
+  busy: boolean;
+}
+
+const MIN = 1;
+const MAX = 8;
+
+export function AiImageSelector({ output, onConfirm, onCancel, busy }: AiImageSelectorProps) {
+  const [selected, setSelected] = useState<string[]>(() =>
+    output.image_candidates.slice(0, Math.min(4, output.image_candidates.length)).map((c) => c.url),
+  );
+
+  function toggle(url: string) {
+    setSelected((prev) => {
+      if (prev.includes(url)) return prev.filter((u) => u !== url);
+      if (prev.length >= MAX) return prev;
+      return [...prev, url];
+    });
+  }
+
+  const canConfirm = selected.length >= MIN && !busy;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold">Fiche prête · sélectionnez les images</h2>
+        <p className="text-sm text-muted-foreground">
+          <strong>{output.name}</strong>
+          {output.attributes.colors.length > 0 && ` · ${output.attributes.colors.length} couleurs détectées`}
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Choisissez {MIN} à {MAX} images. La 1re cochée sera l'image principale.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
+        {output.image_candidates.map((c) => {
+          const isSelected = selected.includes(c.url);
+          const index = selected.indexOf(c.url);
+          return (
+            <button
+              key={c.url}
+              type="button"
+              disabled={busy}
+              onClick={() => toggle(c.url)}
+              className={`group relative overflow-hidden rounded-lg border text-left transition ${
+                isSelected ? "border-primary ring-2 ring-primary/40" : "border-border hover:border-foreground"
+              }`}
+            >
+              <div className="relative aspect-square bg-muted">
+                {/* External host — use plain <img> to avoid next/image remote patterns config. */}
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img src={c.url} alt={c.alt ?? ""} className="h-full w-full object-contain" />
+                {isSelected && (
+                  <span className="absolute left-2 top-2 flex size-6 items-center justify-center rounded-full bg-primary text-xs font-bold text-primary-foreground">
+                    {index + 1}
+                  </span>
+                )}
+              </div>
+              <p className="truncate px-2 py-1 text-xs text-muted-foreground">{c.source_domain}</p>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex items-center justify-between pt-4">
+        <Button type="button" variant="outline" onClick={onCancel} disabled={busy}>
+          Annuler
+        </Button>
+        <Button type="button" disabled={!canConfirm} onClick={() => onConfirm(selected)}>
+          {busy ? "Importation…" : `Importer et continuer (${selected.length})`}
+        </Button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check and commit**
+
+```bash
+npx tsc --noEmit
+git add "components/admin/ai-product/ai-image-selector.tsx"
+git commit -m "feat(admin): add AI image selector component"
+```
+
+---
+
+## Task 13 — Main client page
+
+**Files:**
+- Create: `app/(admin)/products/ai-new/ai-new-client.tsx`
+- Create: `app/(admin)/products/ai-new/page.tsx`
+
+- [ ] **Step 1: Implement the state-machine client**
+
+Create `app/(admin)/products/ai-new/ai-new-client.tsx`:
+
+```tsx
+"use client";
+
+import Link from "next/link";
+import { useCallback, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { ArrowLeft02Icon } from "@hugeicons/core-free-icons";
+import { Button } from "@/components/ui/button";
+import { AiPromptForm } from "@/components/admin/ai-product/ai-prompt-form";
+import { AiProgressPanel, type ProgressStep } from "@/components/admin/ai-product/ai-progress-panel";
+import { AiImageSelector } from "@/components/admin/ai-product/ai-image-selector";
+import { importCandidateImages } from "@/actions/admin/products-ai";
+import type { AiProductOutput } from "@/lib/validations/product-ai";
+
+type UiState =
+  | { kind: "prompt"; error?: string | null }
+  | { kind: "generating"; completed: Set<ProgressStep>; active: ProgressStep | null }
+  | { kind: "selecting"; output: AiProductOutput };
+
+export function AiNewClient() {
+  const router = useRouter();
+  const [prompt, setPrompt] = useState("");
+  const [ui, setUi] = useState<UiState>({ kind: "prompt", error: null });
+  const [importing, startImporting] = useTransition();
+
+  const generate = useCallback(async () => {
+    const trimmed = prompt.trim();
+    setUi({ kind: "generating", completed: new Set(), active: "search" });
+
+    let resp: Response;
+    try {
+      resp = await fetch("/api/admin/products-ai/generate", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ prompt: trimmed }),
+      });
+    } catch {
+      setUi({ kind: "prompt", error: "Impossible de contacter le service. Réessayez." });
+      return;
+    }
+
+    if (!resp.ok || !resp.body) {
+      const msg = resp.status === 429
+        ? "Limite de générations atteinte. Réessayez plus tard."
+        : "Une erreur est survenue. Réessayez.";
+      setUi({ kind: "prompt", error: msg });
+      return;
+    }
+
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    const completed = new Set<ProgressStep>();
+    let active: ProgressStep | null = "search";
+
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        let event: { type: string; step?: ProgressStep; output?: AiProductOutput; reason?: string; code?: string };
+        try { event = JSON.parse(line); } catch { continue; }
+
+        if (event.type === "progress" && event.step) {
+          if (active && active !== event.step) completed.add(active);
+          active = event.step;
+          setUi({ kind: "generating", completed: new Set(completed), active });
+        } else if (event.type === "done" && event.output) {
+          setUi({ kind: "selecting", output: event.output });
+          return;
+        } else if (event.type === "not_found") {
+          setUi({ kind: "prompt", error: "Produit introuvable. Précisez marque + modèle." });
+          return;
+        } else if (event.type === "error") {
+          setUi({ kind: "prompt", error: "Le modèle n'a pas pu produire une fiche valide. Réessayez." });
+          return;
+        }
+      }
+    }
+  }, [prompt]);
+
+  const confirmImport = useCallback((selectedUrls: string[]) => {
+    if (ui.kind !== "selecting") return;
+    startImporting(async () => {
+      const r = await importCandidateImages(ui.output, selectedUrls);
+      if (!r.success) { toast.error(r.error ?? "Erreur d'import"); return; }
+      if (r.warnings && r.warnings.length > 0) {
+        toast.warning(`${r.warnings.length} image(s) n'ont pas pu être importées.`);
+      }
+      router.push(`/products/${r.id}/edit`);
+    });
+  }, [ui, router]);
+
+  return (
+    <div className="mx-auto w-full max-w-2xl px-4 py-8">
+      <div className="mb-6 flex items-center gap-2">
+        <Button variant="ghost" size="icon" asChild>
+          <Link href="/products" aria-label="Retour">
+            <HugeiconsIcon icon={ArrowLeft02Icon} size={20} />
+          </Link>
+        </Button>
+        <h1 className="text-xl font-semibold">Créer un produit avec l'IA</h1>
+      </div>
+
+      {ui.kind === "prompt" && (
+        <AiPromptForm
+          prompt={prompt}
+          onPromptChange={setPrompt}
+          onSubmit={generate}
+          disabled={false}
+          error={ui.error}
+        />
+      )}
+      {ui.kind === "generating" && (
+        <AiProgressPanel completed={ui.completed} active={ui.active} />
+      )}
+      {ui.kind === "selecting" && (
+        <AiImageSelector
+          output={ui.output}
+          onConfirm={confirmImport}
+          onCancel={() => setUi({ kind: "prompt", error: null })}
+          busy={importing}
+        />
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Implement the server page**
+
+Create `app/(admin)/products/ai-new/page.tsx`:
+
+```tsx
+import { notFound } from "next/navigation";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { requireAdmin } from "@/lib/auth/guards";
+import { isAiFeatureEnabled } from "@/lib/ai/client";
+import { AiNewClient } from "./ai-new-client";
+
+export default async function AiNewProductPage() {
+  await requireAdmin();
+  const { env } = await getCloudflareContext({ async: true });
+  if (!isAiFeatureEnabled(env)) notFound();
+
+  return <AiNewClient />;
+}
+```
+
+- [ ] **Step 3: Type-check and commit**
+
+Run:
+
+```bash
+npx tsc --noEmit
+git add "app/(admin)/products/ai-new"
+git commit -m "feat(admin): add AI product creation page and client state machine"
+```
+
+---
+
+## Task 14 — Entry button on `/products`
+
+**Files:**
+- Modify: `app/(admin)/products/products-page-client.tsx` (mobile toolbar)
+- Modify: the file exporting `ProductsPageActions` (desktop header). That export is imported in `app/(admin)/products/page.tsx:12` — open `products-page-client.tsx` and locate `export function ProductsPageActions`.
+
+- [ ] **Step 1: Check whether the feature flag needs to be passed down**
+
+Read `app/(admin)/products/products-page-client.tsx` and locate `ProductsPageActions`. The button should appear whenever the flag is enabled. Since the flag is server-side, pass a boolean prop from the server page down to both mobile and desktop action slots.
+
+- [ ] **Step 2: Modify `app/(admin)/products/page.tsx`**
+
+Compute the flag once and pass to the client:
+
+```tsx
+// near the top imports:
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { isAiFeatureEnabled } from "@/lib/ai/client";
+
+// inside the component, after requireAdmin():
+const { env } = await getCloudflareContext({ async: true });
+const aiEnabled = isAiFeatureEnabled(env);
+
+// then pass to the two client components:
+//   <ProductFilters categories={categoryOptions} className="flex-1" />
+//   <ProductsPageActions aiEnabled={aiEnabled} />          // updated
+// ...
+//   <ProductsPageClient
+//     products={productData}
+//     categories={categoryOptions}
+//     totalCount={totalCount}
+//     aiEnabled={aiEnabled}                                // new prop
+//   />
+```
+
+- [ ] **Step 3: Modify `app/(admin)/products/products-page-client.tsx`**
+
+Add the `aiEnabled` prop to both the mobile client and `ProductsPageActions`. Insert a `<Link href="/products/ai-new">` button next to the existing "Nouveau" / "Nouveau produit" button, shown only when `aiEnabled`. Use a distinctive visual: keep `variant="outline"` and prepend the sparkle emoji.
+
+Mobile toolbar (around line 44):
+
+```tsx
+<div className="flex items-center gap-2">
+  {aiEnabled && (
+    <Button asChild size="sm" variant="outline">
+      <Link href="/products/ai-new">✨ Avec l'IA</Link>
+    </Button>
+  )}
+  <Button asChild size="sm">
+    <Link href="/products/new">Nouveau</Link>
+  </Button>
+</div>
+```
+
+For `ProductsPageActions`, mirror the same two buttons. The desktop label can be the longer `"✨ Créer avec l'IA"`.
+
+Update the `ProductsPageClientProps` interface to add `aiEnabled: boolean` and the `ProductsPageActions` signature similarly.
+
+- [ ] **Step 4: Type-check and lint**
+
+Run:
+
+```bash
+npx tsc --noEmit
+npm run lint
+```
+
+Expected: 0 errors from both.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "app/(admin)/products/page.tsx" "app/(admin)/products/products-page-client.tsx"
+git commit -m "feat(admin): link to AI product creation from /products"
+```
+
+---
+
+## Task 15 — Smoke-test the flow locally
+
+**Files:** none (manual verification)
+
+- [ ] **Step 1: Set the Anthropic key in the local wrangler env**
+
+If an `.dev.vars` file exists at repo root, add `ANTHROPIC_API_KEY="sk-ant-..."`. Otherwise, create it:
+
+```bash
+printf 'ANTHROPIC_API_KEY="sk-ant-your-key"\n' >> .dev.vars
+```
+
+- [ ] **Step 2: Start the dev server**
+
+Run:
+
+```bash
+npm run dev
+```
+
+- [ ] **Step 3: Navigate and test**
+
+- Open `http://localhost:3000/products` after signing in as an admin.
+- Verify the `"✨ Avec l'IA"` button is present.
+- Click it → lands on `/products/ai-new`.
+- Type `Samsung Galaxy A55` → click Generate.
+- Watch progress panel tick through.
+- Confirm image selection appears with ≥3 candidate thumbnails.
+- Select 3 images → Import.
+- Verify redirect to `/products/{id}/edit`, wizard opens at step 1, name + category + attributes + story + SEO pre-filled.
+- Fill price + stock in step 3, save and publish.
+- Confirm product is visible on the storefront.
+
+- [ ] **Step 4: Test the kill-switch**
+
+- Stop the dev server.
+- Add `AI_PRODUCT_CREATION_ENABLED="0"` to `.dev.vars`.
+- Restart.
+- Verify the "Avec l'IA" button is hidden on `/products` and that `/products/ai-new` returns 404.
+- Remove the flag and restart.
+
+- [ ] **Step 5: Report any issues**
+
+If any of the steps produce unexpected behaviour, note them for the review step. Otherwise proceed to Task 16.
+
+---
+
+## Task 16 — Final verification and PR
+
+**Files:** none (housekeeping)
+
+- [ ] **Step 1: Full verification**
+
+Run:
+
+```bash
+npx tsc --noEmit && npm run lint && npm run test
+```
+
+Expected: all 3 exit 0.
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin feat/ai-product-creation
+```
+
+- [ ] **Step 3: Open the PR**
+
+Run:
+
+```bash
+gh pr create --title "feat(admin): AI-powered product creation" --body "$(cat <<'EOF'
+## Summary
+- Adds a "✨ Créer avec l'IA" entry on `/products` that opens a dedicated prompt page.
+- Claude Sonnet 4.6 with native web search researches the product; a `submit_product` tool produces a Zod-validated payload (name, attributes, story, SEO, candidate image URLs).
+- Admin picks 1–8 images → server downloads to R2 → draft created, existing 5-step wizard opens pre-filled for validation (price + stock left for the admin).
+- Kill switch via `AI_PRODUCT_CREATION_ENABLED=0`; rate limit 10 gen/h/admin.
+
+## Test plan
+- [ ] Unit tests (`npm run test`) — new suites under `__tests__/unit/ai/*` and `__tests__/unit/actions/products-ai.test.ts`
+- [ ] Manual flow on localhost: generate for `iPhone 15 Pro`, confirm pre-fill accuracy, fill price, publish
+- [ ] Kill-switch: set `AI_PRODUCT_CREATION_ENABLED=0` → button hidden, `/products/ai-new` returns 404
+- [ ] SSRF guard: try to craft a candidate URL pointing at `127.0.0.1` (client-side rejection not possible; exercised via `fetchAndUploadImage` unit tests)
+- [ ] Rate limit: run 11 generations in quick succession, verify 11th returns 429 + visible toast
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Report PR URL**
+
+Paste the PR URL in chat and wait for explicit approval before merging.
+
+---
+
+## Self-Review Notes
+
+1. **Spec coverage:**
+   - Architecture (spec §Architecture) → Tasks 2–13.
+   - AI Contract / schema (spec §AI Contract) → Tasks 5, 7.
+   - Security: `requireAdmin`, SSRF, size/content-type, sanitize, rate limit → Tasks 4, 6, 8, 9.
+   - UI placement → Tasks 13, 14.
+   - Testing (Vitest) → Tasks 3, 4, 5, 6, 7, 9.
+   - Rollout / env var gating → Tasks 1, 8, 13, 14, 15.
+   - Observability → Task 9 (`console.error/warn` in action), Task 8 (`console.error` in route).
+   - Cost estimate, dependencies, rollout → no code tasks; captured in spec and PR body.
+
+2. **Placeholder scan:** no "TBD/TODO/similar to" strings; every step contains concrete code or a concrete command with expected output.
+
+3. **Type consistency:**
+   - `ResearchProgress` events (`progress|done|not_found|error`) match between Task 7 (`product-research.ts`) and Task 8 (route handler) and Task 13 (client reader).
+   - `AiProductOutput` shape used identically in Tasks 5, 7, 9, 12, 13.
+   - `fetchAndUploadImage` signature `(draftId: string, url: string) → FetchImageResult` consistent across Tasks 6 and 9.
+   - `checkRateLimit(adminId) → { ok }|{ ok:false, retryAfterSec }` consistent across Tasks 4 and 8.
+   - Icon enum imported from `product-story.ts` in Tasks 5 and 7 (no drift).
+
+4. **Known follow-ups (intentionally out of scope):** no preview of the generated description before import (admin sees it in the wizard step 5); no retry-with-correction loop when Claude produces invalid output.

--- a/docs/superpowers/specs/2026-04-18-ai-product-creation-design.md
+++ b/docs/superpowers/specs/2026-04-18-ai-product-creation-design.md
@@ -143,12 +143,32 @@ const aiProductOutputSchema = z.object({
       value: z.string().min(1).max(200),
     })).max(20).default([]),
   }).default({ colors: [], dimensions: {}, specs: [] }),
+  // Story sub-shapes mirror lib/validations/product-story.ts — the canonical DB shape.
+  // Highlights use an *icon* enum (curated HIGHLIGHT_ICON_NAMES list) and a short *label*,
+  // not free-form title/description. Feature blocks use title/body/image_url/image_alt.
+  // The AI must pick icon names from the allowed list only.
   story: z.object({
-    tagline: z.string().max(80).optional(),
-    highlights: z.array(z.object({ title: z.string(), description: z.string() })).max(6).default([]),
-    feature_blocks: z.array(z.object({ heading: z.string(), body: z.string() })).max(6).default([]),
-    faq: z.array(z.object({ question: z.string(), answer: z.string() })).max(8).default([]),
-  }).default({ highlights: [], feature_blocks: [], faq: [] }),
+    tagline: z.string().max(200).optional(),
+    highlights: z
+      .array(z.object({
+        icon: z.enum(HIGHLIGHT_ICON_NAMES),       // imported from product-story.ts
+        label: z.string().trim().min(1).max(80),
+      }))
+      .min(3).max(6).optional(),                  // null/absent = "highlights disabled"
+    feature_blocks: z
+      .array(z.object({
+        title: z.string().trim().min(1).max(120),
+        body:  z.string().trim().min(1).max(600),
+        // image_url / image_alt omitted — AI doesn't have block-level images
+      }))
+      .min(2).max(4).optional(),                  // null/absent = "blocks disabled"
+    faq: z
+      .array(z.object({
+        question: z.string().trim().min(1).max(160),
+        answer:   z.string().trim().min(1).max(600),
+      }))
+      .max(5).optional(),                         // null/absent = "no faq"
+  }).default({}),
   seo: z.object({
     meta_title: z.string().max(60).optional(),
     meta_description: z.string().max(160).optional(),
@@ -169,8 +189,9 @@ const aiNotFoundSchema = z.object({
 
 ### Alignment with existing schemas
 
-- `story` fields map 1:1 to `taglineSchema / highlightsSchema / featureBlocksSchema / faqSchema` in `lib/validations/product-story.ts`. The AI sub-schemas above are deliberately a subset (caps on max items, max lengths). Before persisting we pass each story section through the existing schema to catch any drift.
+- `story` fields map 1:1 to `taglineSchema / highlightsSchema / featureBlocksSchema / faqSchema` in `lib/validations/product-story.ts`. The AI sub-schemas above deliberately reuse the shapes and caps from that file; importing `HIGHLIGHT_ICON_NAMES` from there keeps the icon enum in sync. Before persisting we pass each story section through the canonical schema a second time to catch any drift.
 - `description_html` is passed through `sanitizeDescriptionHtml()` (existing) before insertion; we set `description_type = "html"`.
+- The system prompt must list the allowed icon names explicitly so Claude can pick matching ones for each highlight (a phone product would pick `smart-phone`, `camera`, `battery`, etc.).
 
 ## Server-Side Flow
 

--- a/docs/superpowers/specs/2026-04-18-ai-product-creation-design.md
+++ b/docs/superpowers/specs/2026-04-18-ai-product-creation-design.md
@@ -57,7 +57,7 @@ This spec adds an AI-assisted path that takes a short text prompt (e.g. `"Samsun
 
 ### Files
 
-```
+```text
 app/(admin)/products/
   ai-new/
     page.tsx                         # Server component, gate on AI_PRODUCT_CREATION_ENABLED + requireAdmin()

--- a/docs/superpowers/specs/2026-04-18-ai-product-creation-design.md
+++ b/docs/superpowers/specs/2026-04-18-ai-product-creation-design.md
@@ -1,0 +1,316 @@
+# AI-Powered Product Creation — Design Spec
+
+**Date:** 2026-04-18
+**Status:** Approved
+**Builds on:** [2026-03-19-assisted-product-creation-design.md](./2026-03-19-assisted-product-creation-design.md) (the 5-step wizard this spec plugs into)
+
+## Context
+
+Admins currently create products by typing every field by hand — name, description, attributes, product story (tagline, highlights, feature blocks, FAQ), SEO metadata — and uploading images manually. For well-known consumer electronics (iPhone, Galaxy, MacBook…) most of this information is publicly available. Having the admin retype it is slow and produces inconsistent editorial quality.
+
+This spec adds an AI-assisted path that takes a short text prompt (e.g. `"Samsung Galaxy A55"`) and pre-fills the existing wizard, including suggested product images. The admin still walks through the 5 wizard steps and validates everything before publishing — the AI is an accelerator, not an autopilot.
+
+## Scope
+
+**In scope:**
+- New entry point on `/products`: a "✨ Créer avec l'IA" button that opens a dedicated prompt page.
+- Server-side call to Anthropic Claude with its native web search tool to research the product.
+- Structured extraction (via Claude tool use) of: name, brand, category suggestion, short description, long HTML description, attributes (colors, dimensions/weight, free-form specs), story (tagline/highlights/feature blocks/FAQ), SEO metadata, and candidate image URLs.
+- An image selection screen where the admin picks which candidate URLs to import.
+- Server-side download of selected images → upload to R2 → attach to the draft product.
+- Draft product created with all pre-filled fields, then the existing wizard opens for the admin to validate/correct step by step.
+
+**Out of scope (deferred):**
+- AI for existing products (edit flow).
+- Multiple products at once (one prompt = one product).
+- Storage/RAM variants as separate DB rows — AI targets the most common variant (e.g. 128Go). Admin can re-run with a more specific prompt for other variants.
+- Price and stock generation — the AI never fills these (no reliable XOF Côte d'Ivoire source).
+- Image generation (the AI only finds existing public image URLs, it does not generate synthetic images).
+
+## Non-Goals
+
+- Replacing the existing wizard. The manual path remains and is the fallback for products where the AI can't help (unknown/niche products, internal SKUs).
+- Real-time collaborative editing during generation.
+
+## User Flow
+
+1. Admin on `/products` clicks **"✨ Créer avec l'IA"** (new button next to "Nouveau produit").
+2. Lands on `/products/ai-new`. Sees a single prompt input with examples.
+3. Types prompt (3-200 chars) → clicks **"Générer la fiche"**.
+4. UI transitions to a progress panel. Status lines tick off as Claude emits tool_use events:
+   - `✓ Recherche du produit`
+   - `✓ Récupération des spécifications`
+   - `⏳ Recherche d'images`
+   - `○ Génération de la fiche`
+5. When generation completes, admin sees a **Selection screen**: detected product name + category + a grid of 6–10 image thumbnails (checkboxes, min 1 / max 8, source domain shown under each). First checked = primary.
+6. Admin clicks **"Importer et continuer"**. Server downloads the selected image URLs, uploads them to R2, creates the draft product with all fields pre-filled, and redirects to `/products/{id}/edit`.
+7. The existing wizard opens at step 1. All fields are populated. Admin validates/corrects each step, fills **price / stock** manually in step 3, and publishes.
+
+**Error paths:**
+- Product not found / too ambiguous → inline error under the prompt, admin retries with a more specific prompt. No DB writes.
+- Anthropic API failure after 3 retries with exponential backoff → toast + back to prompt. No DB writes.
+- Some images fail to download → draft is still created with the successful ones; admin sees a toast warning with the failed URLs.
+- Rate limit hit → explicit error with retry-after time.
+- Kill switch `AI_PRODUCT_CREATION_ENABLED=0` → the "Créer avec l'IA" button is hidden and `/products/ai-new` returns 404.
+
+## Architecture
+
+### Files
+
+```
+app/(admin)/products/
+  ai-new/
+    page.tsx                         # Server component, gate on AI_PRODUCT_CREATION_ENABLED + requireAdmin()
+    ai-new-client.tsx                # Client: prompt → progress → image selection states
+
+app/api/admin/products-ai/generate/route.ts
+                                     # Route Handler (POST, streaming): takes { prompt }, streams
+                                     # progress + final AIOutput. Route Handler (not Server Action)
+                                     # so the client can consume a ReadableStream progressively.
+
+actions/admin/products-ai.ts         # Server action:
+                                     #   - importCandidateImages(aiOutput, selectedUrls): creates draft, returns { id, warnings }
+
+lib/ai/
+  client.ts                          # Anthropic SDK singleton (reads ANTHROPIC_API_KEY from CloudflareEnv)
+  product-research.ts                # System prompt, tool definitions, orchestration of the Claude call
+  image-fetch.ts                     # Fetch URL → validate (SSRF / size / content-type) → upload R2
+  rate-limit.ts                      # KV-backed rate limit per admin
+
+lib/validations/product-ai.ts        # Zod schemas for AI output (strict) + prompt
+
+components/admin/ai-product/
+  ai-prompt-form.tsx                 # Prompt input + examples
+  ai-progress-panel.tsx              # Status-line checklist driven by stream events
+  ai-image-selector.tsx              # Candidate image grid with checkboxes
+
+env.d.ts                             # Adds ANTHROPIC_API_KEY + AI_PRODUCT_CREATION_ENABLED
+```
+
+No migration is required — the draft pattern (`createDraftProduct()` + `applyDraftUpdate()` + `product_attributes` / `product_variants` / `product_images` inserts) already covers all the fields the AI generates.
+
+### Component Boundaries
+
+- `lib/ai/product-research.ts` — **pure**: given a prompt, returns `{ output: AIProductOutput } | { error: "not_found" | "api_error" }`. Takes the Anthropic client as a dependency so tests can mock it. Knows nothing about the DB or R2.
+- `lib/ai/image-fetch.ts` — given a URL, downloads and uploads to R2. Returns `{ r2Key, width, height } | { error }`. SSRF + size + content-type guards live here.
+- `actions/admin/products-ai.ts` — composes the two: auth, rate-limit, call research, then on `importCandidateImages` call image-fetch in parallel, then write the DB.
+- Client components only call the server actions; they never see `ANTHROPIC_API_KEY` or Anthropic SDK types.
+
+## AI Contract
+
+### Model & Tools
+
+- Model: `claude-sonnet-4-6`.
+- Tools passed to Claude:
+  - `web_search_20250305` (Anthropic native) — Claude uses this ~3–5 times per generation.
+  - `submit_product` (custom tool) — defined with a JSON schema matching `AIProductOutput` below. Claude fills this tool to end the generation; its input becomes the structured output.
+
+### System Prompt (shape)
+
+- Role: "You are a product catalog writer for an electronics e-commerce in Côte d'Ivoire. Write in French."
+- Task: "Given a product prompt, research the product online and submit a complete catalog entry via the `submit_product` tool."
+- Guardrails:
+  - Do not invent specifications. If a spec is uncertain, omit it.
+  - For colors, return name + hex (hex inferred from the color name if not available).
+  - For image candidates: prefer manufacturer and press sites. Avoid marketplaces with watermarks. Return 6–10 direct image URLs, each with `source_domain` and `alt`.
+  - If the product cannot be confidently identified, call `submit_product` with `{ "not_found": true, "reason": "..." }` instead of guessing.
+  - Story output follows the existing "Apple-like product story" style used by the storefront (`ProductStorySection`): terse tagline, 3–5 highlights, 2–4 feature blocks with a heading and 1–2 paragraph body, 3–5 FAQ entries.
+  - Meta title ≤ 60 chars, meta description ≤ 160 chars, tagline ≤ 80 chars, short description ≤ 120 chars.
+
+### `AIProductOutput` Zod schema
+
+```ts
+const aiProductOutputSchema = z.object({
+  not_found: z.literal(false).default(false),
+  name: z.string().min(1).max(150),
+  brand: z.string().max(80).optional(),
+  category_suggestion: z.string().min(1),            // slug; server matches against categories table
+  short_description: z.string().max(120).optional(),
+  description_html: z.string().optional(),           // sanitized server-side before storage
+  attributes: z.object({
+    colors: z.array(z.object({
+      name: z.string().min(1).max(40),
+      hex: z.string().regex(/^#[0-9a-f]{6}$/i),
+    })).max(12).default([]),
+    dimensions: z.object({
+      length_mm: z.number().int().positive().optional(),
+      height_mm: z.number().int().positive().optional(),
+      width_mm:  z.number().int().positive().optional(),
+      weight_g:  z.number().int().positive().optional(),
+    }).default({}),
+    specs: z.array(z.object({
+      name: z.string().min(1).max(60),
+      value: z.string().min(1).max(200),
+    })).max(20).default([]),
+  }).default({ colors: [], dimensions: {}, specs: [] }),
+  story: z.object({
+    tagline: z.string().max(80).optional(),
+    highlights: z.array(z.object({ title: z.string(), description: z.string() })).max(6).default([]),
+    feature_blocks: z.array(z.object({ heading: z.string(), body: z.string() })).max(6).default([]),
+    faq: z.array(z.object({ question: z.string(), answer: z.string() })).max(8).default([]),
+  }).default({ highlights: [], feature_blocks: [], faq: [] }),
+  seo: z.object({
+    meta_title: z.string().max(60).optional(),
+    meta_description: z.string().max(160).optional(),
+  }).default({}),
+  image_candidates: z.array(z.object({
+    url: z.string().url(),
+    source_domain: z.string(),
+    alt: z.string().max(200).optional(),
+  })).min(1).max(12),
+});
+
+// Discriminated union at the top level via a second schema (not_found case):
+const aiNotFoundSchema = z.object({
+  not_found: z.literal(true),
+  reason: z.string().max(300),
+});
+```
+
+### Alignment with existing schemas
+
+- `story` fields map 1:1 to `taglineSchema / highlightsSchema / featureBlocksSchema / faqSchema` in `lib/validations/product-story.ts`. The AI sub-schemas above are deliberately a subset (caps on max items, max lengths). Before persisting we pass each story section through the existing schema to catch any drift.
+- `description_html` is passed through `sanitizeDescriptionHtml()` (existing) before insertion; we set `description_type = "html"`.
+
+## Server-Side Flow
+
+### `POST /api/admin/products-ai/generate` (Route Handler)
+
+A Route Handler rather than a Server Action because we need to stream progress events to the client as Claude emits them. Server Actions do not support streaming responses to the browser; Route Handlers return a `Response` with a `ReadableStream`, which the client consumes via `fetch()` + `response.body.getReader()`.
+
+1. `await requireAdmin()` → `session`. Not authenticated or not admin → `401` / `403`.
+2. Check `AI_PRODUCT_CREATION_ENABLED !== "0"`. Otherwise → `404` (feature hidden).
+3. Validate prompt with Zod: trimmed, 3–200 chars, no control chars. Invalid → `400`.
+4. Rate limit: KV key `ai_gen:{session.user.id}`. Window 1 hour, max 10. If exceeded → `429` with `Retry-After` header.
+5. Return a `Response` whose body is a `ReadableStream` of newline-delimited JSON events (NDJSON):
+   - `{ "type": "progress", "step": "search" | "specs" | "images" | "finalize" }` — emitted as Claude's stream surfaces matching tool_use events.
+   - `{ "type": "done", "output": AIProductOutput }` or `{ "type": "not_found", "reason": "..." }` or `{ "type": "error", "code": "invalid_ai_output" | "api_error" }` — terminal event.
+6. Internally: call `lib/ai/product-research.ts#researchProduct(prompt)` which wraps `client.messages.stream(...)` with both tools registered and yields progress events. The final `submit_product` tool input is parsed against `aiProductOutputSchema` / `aiNotFoundSchema`. Validation failure → `{ type: "error", code: "invalid_ai_output" }` + server log with the raw tool input.
+
+### `importCandidateImages(aiOutput, selectedUrls)`
+
+1. `await requireAdmin()`.
+2. Validate `selectedUrls`: array of strings, 1–8, each present in `aiOutput.image_candidates`. Reject anything else (prevents client from injecting arbitrary URLs).
+3. Call `createDraftProduct()` (existing) → `draftId`.
+4. **Map category:** look up `aiOutput.category_suggestion` against the `categories` table by slug (case-insensitive). If no match, `category_id = null`.
+5. **Download images in parallel** (`Promise.allSettled`):
+   - For each URL, call `fetchAndUploadImage(draftId, url)`. The helper enforces:
+     - `fetch` with 10s timeout.
+     - Resolved host must not be localhost / RFC1918 / link-local (SSRF protection — DNS-resolve and compare before fetching).
+     - Response `Content-Type` starts with `image/` and is one of `image/jpeg`, `image/png`, `image/webp`, `image/avif`.
+     - Response body ≤ 5 MB (enforced while reading the stream, abort on overflow).
+   - On success: upload to R2 under `products/{draftId}/{nanoid(10)}.{ext}` via existing `uploadToR2()`.
+6. Insert `product_images` rows in selection order; the first successful one is `is_primary = 1`.
+7. Write all AI fields via a single `db.batch([...])`:
+   - `UPDATE products SET name, brand, slug, category_id, description, description_type='html', short_description, meta_title, meta_description, tagline, highlights, feature_blocks, faq WHERE id = draftId AND is_draft = 1` (existing `applyDraftUpdate` helper).
+   - `INSERT INTO product_attributes (...)` — dimensions + specs + all colors as `Couleur` entries using the existing value format `"Name|#hex"`.
+   - **No `product_variants` inserts at this stage.** Variants require a price, which the admin sets in step 3 of the wizard. The wizard's step-attributes and step-pricing components already read the `Couleur` attributes and build the variant grid there. This matches how `saveDraftStep` works today (attributes in step 2, variants in step 3).
+8. `revalidatePath("/products")` + `revalidatePath("/products/{draftId}/edit")`.
+9. Return `{ success: true, id: draftId, warnings: failedUrls }`.
+
+Failure handling:
+- If `createDraftProduct()` fails → return the error, no cleanup needed (nothing else written yet).
+- If all image downloads fail → still return success with the draft id and `warnings = selectedUrls`. The admin lands on the wizard with zero images; step 4 (Médias) lets them upload manually. The AI-generated text fields are the main value and shouldn't be lost to an image fetch issue.
+- If some image downloads fail → include failed URLs in `warnings` so the client can surface a toast.
+
+## Client Flow
+
+`ai-new-client.tsx` is a single client component with a 3-state reducer:
+
+- `state = "prompt"` → renders `<AiPromptForm />`
+- `state = "generating"` → renders `<AiProgressPanel steps={...} />`, consumes the progress stream
+- `state = "selecting"` → renders `<AiImageSelector output={output} onConfirm={...} />`
+
+Transitions:
+- `prompt → generating` on submit (disables the button to prevent double-submit, also prevents prompt editing during generation)
+- `generating → selecting` on `{ type: "done" }` event
+- `generating → prompt` on `{ type: "error" }` or `not_found` result, with a toast/error banner preserving the prompt
+- `selecting → loading indicator → redirect` when admin confirms
+
+## UI Placement
+
+- **`/products` page header:** insert a new `<Button variant="outline">` labeled `"✨ Créer avec l'IA"` to the left of the existing `"Nouveau produit"` button. Button is hidden when `AI_PRODUCT_CREATION_ENABLED === "0"`.
+- **`/products/ai-new` page:** `max-w-2xl` centered layout, matches the wizard's visual style. Includes a "← Retour" link to `/products`.
+
+## Security
+
+- `ANTHROPIC_API_KEY` is only accessed server-side via `getCloudflareContext().env`. It is never in the response payload or client bundle.
+- `requireAdmin()` gates both server actions and the page.
+- SSRF protection in `image-fetch.ts`: resolve the URL's hostname and reject if it maps to `127.0.0.0/8`, `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`, `::1`, `fc00::/7`, `fe80::/10`. Reject non-`http(s)` schemes.
+- Size limit (5 MB) enforced while streaming the response body; abort on overflow so we never buffer more than the limit.
+- Content-type whitelist enforces image-only uploads.
+- `sanitizeDescriptionHtml()` applied to `description_html` before storage (reuses existing sanitizer).
+- Rate limit (10 gen/h/admin) also serves as a cost/abuse ceiling.
+
+## Observability
+
+- `console.info("[ai-product] generation start", { promptLen, adminId })`
+- `console.info("[ai-product] generation done", { adminId, durationMs, toolCalls, imageCandidates })`
+- `console.error("[ai-product] validation failed", { rawOutputSize, zodIssues })`
+- `console.warn("[ai-product] image fetch failed", { url, reason })`
+- No PII in logs beyond `adminId`.
+
+## Environment Variables
+
+Added to `env.d.ts`:
+
+```ts
+interface CloudflareEnv {
+  // existing...
+  ANTHROPIC_API_KEY: string;
+  AI_PRODUCT_CREATION_ENABLED?: string; // "0" disables the feature; any other value / unset = enabled
+}
+```
+
+Deployment: add `ANTHROPIC_API_KEY` to Cloudflare Workers secrets via `wrangler secret put ANTHROPIC_API_KEY`.
+
+## Testing Strategy
+
+Vitest-only (no e2e hitting the real Claude API — cost + flakiness).
+
+- `lib/ai/product-research.test.ts`
+  - Mocks `@anthropic-ai/sdk` stream; asserts tool-use events translate to progress events.
+  - Fixture: valid `submit_product` tool input → schema parses, `{ success: true, output }` returned.
+  - Fixture: malformed `submit_product` input → `{ success: false, error: "invalid_ai_output" }`, logs the raw input.
+  - Fixture: `not_found` tool input → `{ success: false, error: "not_found" }`.
+  - API 429 / 500 → retry 3× with exponential backoff (mock `setTimeout`), final failure returns `{ success: false, error: "api_error" }`.
+
+- `lib/ai/image-fetch.test.ts`
+  - Valid image (mocked `fetch` returning a small PNG) → uploaded to R2, returns success.
+  - URL with private IP → rejected without a network call.
+  - Non-image content-type → rejected.
+  - Body > 5 MB → abort + reject.
+  - Fetch timeout → reject.
+
+- `lib/ai/rate-limit.test.ts`
+  - 1st–10th call: allowed. 11th: rejected with `retryAfterSec`.
+  - Separate admin ids don't share the bucket.
+
+- `actions/admin/products-ai.test.ts`
+  - `requireAdmin()` enforced (mock `getSession` returning `customer` → rejected).
+  - Feature disabled env → rejected.
+  - `importCandidateImages` with a URL not in `aiOutput.image_candidates` → rejected.
+  - Happy path: draft created, attributes + variants + images inserted, correct `revalidatePath` calls.
+  - Partial image failure: still creates draft, returns `warnings`.
+
+No snapshot of the AI prompt text — asserting exact wording is brittle.
+
+## Cost Estimate
+
+- Claude Sonnet 4.6 + web search per generation: ~0.10–0.30 USD.
+- At 2 admins × 10 gen/day = ~6 USD/day ceiling (enforced by rate limit).
+- R2 storage: negligible (typical 4–6 images × ~200 KB = ~1 MB per product).
+
+## Dependencies Added
+
+- `@anthropic-ai/sdk` — only runtime dependency added.
+
+## Rollout
+
+1. Merge with `AI_PRODUCT_CREATION_ENABLED` unset (feature on by default once the secret is provisioned).
+2. If the Anthropic secret is not yet provisioned, set `AI_PRODUCT_CREATION_ENABLED=0` in the Workers env to hide the button cleanly.
+3. Monitor logs for the first week — validation failures, image-fetch failures, cost per admin — then tune rate limit / prompt if needed.
+
+## Open Questions
+
+None at time of writing. The price/stock decision is settled (never AI-generated). Variants are settled (single product per prompt, colors only; storage is part of the name).

--- a/docs/superpowers/specs/2026-04-18-ai-product-creation-design.md
+++ b/docs/superpowers/specs/2026-04-18-ai-product-creation-design.md
@@ -257,11 +257,11 @@ Transitions:
 
 - `ANTHROPIC_API_KEY` is only accessed server-side via `getCloudflareContext().env`. It is never in the response payload or client bundle.
 - `requireAdmin()` gates both server actions and the page.
-- SSRF protection in `image-fetch.ts`: resolve the URL's hostname and reject if it maps to `127.0.0.0/8`, `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`, `::1`, `fc00::/7`, `fe80::/10`. Reject non-`http(s)` schemes.
+- SSRF protection in `image-fetch.ts`: **host-literal checks only** (Cloudflare Workers do not expose DNS resolution to user code, so we cannot reject a hostname that resolves to an internal IP). We reject URL hosts that are literal private IPs (`127.0.0.0/8`, `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`, `0.0.0.0`, `::1`, `fc00::/7`, `fe80::/10`, `metadata.google.internal`, `localhost` and its subdomains) and non-`http(s)` schemes. This is defence against direct IP literals from Claude or malicious redirects; a resolver-side DNS rebinding attack is not fully mitigated. The content-type whitelist and 5 MB size cap are the other main guards.
 - Size limit (5 MB) enforced while streaming the response body; abort on overflow so we never buffer more than the limit.
 - Content-type whitelist enforces image-only uploads.
 - `sanitizeDescriptionHtml()` applied to `description_html` before storage (reuses existing sanitizer).
-- Rate limit (10 gen/h/admin) also serves as a cost/abuse ceiling.
+- Rate limit (10 gen/h/admin) — counts **attempts**, not successes. Incrementing only on success would let a misbehaving client hammer the Anthropic API (which we pay for) without tripping the limit, so the counter bumps before the API call. An admin whose generation fails still "pays" one slot; this trade favours cost control over UX.
 
 ## Observability
 
@@ -280,6 +280,7 @@ interface CloudflareEnv {
   // existing...
   ANTHROPIC_API_KEY: string;
   AI_PRODUCT_CREATION_ENABLED?: string; // "0" disables the feature; any other value / unset = enabled
+  AI_MODEL?: string;                    // override the default Anthropic model id without a code change
 }
 ```
 

--- a/env.d.ts
+++ b/env.d.ts
@@ -26,4 +26,6 @@ interface CloudflareEnv {
   ANTHROPIC_API_KEY: string;
   // "0" disables the feature (button hidden, /products/ai-new returns 404). Any other value or unset = enabled.
   AI_PRODUCT_CREATION_ENABLED?: string;
+  // Optional model override (for rolling to newer Anthropic model IDs without a code change)
+  AI_MODEL?: string;
 }

--- a/env.d.ts
+++ b/env.d.ts
@@ -22,4 +22,8 @@ interface CloudflareEnv {
   RESEND_API_KEY?: string;
   RESEND_FROM_EMAIL?: string; // defaults to "NETEREKA <commandes@netereka.ci>"
 
+  // AI-powered product creation
+  ANTHROPIC_API_KEY: string;
+  // "0" disables the feature (button hidden, /products/ai-new returns 404). Any other value or unset = enabled.
+  AI_PRODUCT_CREATION_ENABLED?: string;
 }

--- a/lib/ai/client.ts
+++ b/lib/ai/client.ts
@@ -1,0 +1,19 @@
+// lib/ai/client.ts
+import Anthropic from "@anthropic-ai/sdk";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+
+let cached: Anthropic | null = null;
+
+export async function getAnthropicClient(): Promise<Anthropic> {
+  if (cached) return cached;
+  const { env } = await getCloudflareContext({ async: true });
+  if (!env.ANTHROPIC_API_KEY) {
+    throw new Error("ANTHROPIC_API_KEY is not configured");
+  }
+  cached = new Anthropic({ apiKey: env.ANTHROPIC_API_KEY });
+  return cached;
+}
+
+export function isAiFeatureEnabled(env: CloudflareEnv): boolean {
+  return env.AI_PRODUCT_CREATION_ENABLED !== "0";
+}

--- a/lib/ai/client.ts
+++ b/lib/ai/client.ts
@@ -10,7 +10,10 @@ export async function getAnthropicClient(): Promise<Anthropic> {
   if (!env.ANTHROPIC_API_KEY) {
     throw new Error("ANTHROPIC_API_KEY is not configured");
   }
-  cached = new Anthropic({ apiKey: env.ANTHROPIC_API_KEY });
+  cached = new Anthropic({
+    apiKey: env.ANTHROPIC_API_KEY,
+    maxRetries: 3, // handles 408/409/429/5xx with exponential backoff
+  });
   return cached;
 }
 

--- a/lib/ai/image-fetch.ts
+++ b/lib/ai/image-fetch.ts
@@ -22,7 +22,7 @@ const EXT_BY_TYPE: Record<string, string> = {
 
 export type FetchImageResult =
   | { ok: true; key: string; contentType: string; size: number }
-  | { ok: false; reason: "ssrf" | "bad_status" | "bad_content_type" | "too_large" | "timeout" | "fetch_failed" };
+  | { ok: false; reason: "ssrf" | "bad_status" | "bad_content_type" | "too_large" | "timeout" | "fetch_failed" | "upload_failed" };
 
 /**
  * Rejects URLs that could hit internal networks. DNS lookup is not available
@@ -101,7 +101,12 @@ export async function fetchAndUploadImage(
   const ext = EXT_BY_TYPE[ct] ?? "jpg";
   const key = `products/${draftId}/${nanoid()}.${ext}`;
   const file = new File([buffer], key, { type: ct });
-  await uploadToR2(file, key);
+  try {
+    await uploadToR2(file, key);
+  } catch (err) {
+    console.error("[ai-product] R2 upload failed for key", key, err);
+    return { ok: false, reason: "upload_failed" };
+  }
 
   return { ok: true, key, contentType: ct, size: total };
 }

--- a/lib/ai/image-fetch.ts
+++ b/lib/ai/image-fetch.ts
@@ -99,7 +99,7 @@ export async function fetchAndUploadImage(
   for (const c of chunks) { buffer.set(c, offset); offset += c.byteLength; }
 
   const ext = EXT_BY_TYPE[ct] ?? "jpg";
-  const key = `products/${draftId}/${nanoid(10)}.${ext}`;
+  const key = `products/${draftId}/${nanoid()}.${ext}`;
   const file = new File([buffer], key, { type: ct });
   await uploadToR2(file, key);
 

--- a/lib/ai/image-fetch.ts
+++ b/lib/ai/image-fetch.ts
@@ -1,0 +1,107 @@
+import { nanoid } from "nanoid";
+import { uploadToR2 } from "@/lib/storage/images";
+
+export const IMAGE_MAX_BYTES = 5 * 1024 * 1024;
+export const IMAGE_FETCH_TIMEOUT_MS = 10_000;
+
+const ALLOWED_TYPES = new Set([
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+  "image/webp",
+  "image/avif",
+]);
+
+const EXT_BY_TYPE: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/jpg":  "jpg",
+  "image/png":  "png",
+  "image/webp": "webp",
+  "image/avif": "avif",
+};
+
+export type FetchImageResult =
+  | { ok: true; key: string; contentType: string; size: number }
+  | { ok: false; reason: "ssrf" | "bad_status" | "bad_content_type" | "too_large" | "timeout" | "fetch_failed" };
+
+/**
+ * Rejects URLs that could hit internal networks. DNS lookup is not available
+ * inside Workers, so we rely on host-based heuristics: literal IP in private
+ * ranges, or common internal hostnames. Any DNS name resolves to whatever the
+ * Cloudflare edge resolves it to — this is a best-effort guard, not absolute.
+ */
+function isBlockedHost(hostname: string): boolean {
+  const h = hostname.toLowerCase();
+  if (h === "localhost" || h.endsWith(".localhost") || h === "metadata.google.internal") return true;
+
+  const v4 = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (v4) {
+    const [a, b] = [Number(v4[1]), Number(v4[2])];
+    if (a === 10) return true;
+    if (a === 127) return true;
+    if (a === 169 && b === 254) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 0) return true;
+  }
+  if (h.startsWith("[") && h.endsWith("]")) {
+    const inner = h.slice(1, -1);
+    if (inner === "::1" || inner.startsWith("fc") || inner.startsWith("fd") || inner.startsWith("fe80:")) return true;
+  }
+  return false;
+}
+
+export async function fetchAndUploadImage(
+  draftId: string,
+  url: string,
+): Promise<FetchImageResult> {
+  let parsed: URL;
+  try { parsed = new URL(url); } catch { return { ok: false, reason: "ssrf" }; }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return { ok: false, reason: "ssrf" };
+  if (isBlockedHost(parsed.hostname)) return { ok: false, reason: "ssrf" };
+
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), IMAGE_FETCH_TIMEOUT_MS);
+
+  let resp: Response;
+  try {
+    resp = await fetch(parsed.toString(), { signal: ac.signal, redirect: "follow" });
+  } catch (err) {
+    clearTimeout(timer);
+    if (err instanceof Error && err.name === "AbortError") return { ok: false, reason: "timeout" };
+    return { ok: false, reason: "fetch_failed" };
+  }
+  clearTimeout(timer);
+
+  if (!resp.ok) return { ok: false, reason: "bad_status" };
+
+  const ct = (resp.headers.get("content-type") ?? "").split(";")[0].trim().toLowerCase();
+  if (!ALLOWED_TYPES.has(ct)) return { ok: false, reason: "bad_content_type" };
+
+  const reader = resp.body?.getReader();
+  if (!reader) return { ok: false, reason: "fetch_failed" };
+
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > IMAGE_MAX_BYTES) {
+      try { await reader.cancel(); } catch { /* ignore */ }
+      return { ok: false, reason: "too_large" };
+    }
+    chunks.push(value);
+  }
+
+  const buffer = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) { buffer.set(c, offset); offset += c.byteLength; }
+
+  const ext = EXT_BY_TYPE[ct] ?? "jpg";
+  const key = `products/${draftId}/${nanoid(10)}.${ext}`;
+  const file = new File([buffer], key, { type: ct });
+  await uploadToR2(file, key);
+
+  return { ok: true, key, contentType: ct, size: total };
+}

--- a/lib/ai/image-fetch.ts
+++ b/lib/ai/image-fetch.ts
@@ -51,6 +51,34 @@ function isBlockedHost(hostname: string): boolean {
   return false;
 }
 
+const MAX_REDIRECTS = 3;
+
+/**
+ * Follow HTTP redirects manually so each Location target passes the SSRF host check
+ * before we issue the next request. `redirect: "follow"` would let a public URL
+ * bounce to a private IP and bypass the initial hostname validation.
+ */
+async function fetchWithSsrfSafeRedirects(
+  initialUrl: URL,
+  signal: AbortSignal,
+): Promise<{ ok: true; resp: Response } | { ok: false; reason: "ssrf" | "fetch_failed" }> {
+  let current = initialUrl;
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    const resp = await fetch(current.toString(), { signal, redirect: "manual" });
+    const status = resp.status;
+    if (status < 300 || status >= 400) return { ok: true, resp };
+
+    const location = resp.headers.get("location");
+    if (!location) return { ok: true, resp }; // 3xx without Location — treat as-is (caller will see bad_status)
+    let next: URL;
+    try { next = new URL(location, current); } catch { return { ok: false, reason: "fetch_failed" }; }
+    if (next.protocol !== "http:" && next.protocol !== "https:") return { ok: false, reason: "ssrf" };
+    if (isBlockedHost(next.hostname)) return { ok: false, reason: "ssrf" };
+    current = next;
+  }
+  return { ok: false, reason: "fetch_failed" }; // redirect loop / cap exceeded
+}
+
 export async function fetchAndUploadImage(
   draftId: string,
   url: string,
@@ -63,50 +91,62 @@ export async function fetchAndUploadImage(
   const ac = new AbortController();
   const timer = setTimeout(() => ac.abort(), IMAGE_FETCH_TIMEOUT_MS);
 
-  let resp: Response;
   try {
-    resp = await fetch(parsed.toString(), { signal: ac.signal, redirect: "follow" });
-  } catch (err) {
-    clearTimeout(timer);
-    if (err instanceof Error && err.name === "AbortError") return { ok: false, reason: "timeout" };
-    return { ok: false, reason: "fetch_failed" };
-  }
-  clearTimeout(timer);
-
-  if (!resp.ok) return { ok: false, reason: "bad_status" };
-
-  const ct = (resp.headers.get("content-type") ?? "").split(";")[0].trim().toLowerCase();
-  if (!ALLOWED_TYPES.has(ct)) return { ok: false, reason: "bad_content_type" };
-
-  const reader = resp.body?.getReader();
-  if (!reader) return { ok: false, reason: "fetch_failed" };
-
-  const chunks: Uint8Array[] = [];
-  let total = 0;
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    total += value.byteLength;
-    if (total > IMAGE_MAX_BYTES) {
-      try { await reader.cancel(); } catch { /* ignore */ }
-      return { ok: false, reason: "too_large" };
+    let resp: Response;
+    try {
+      const r = await fetchWithSsrfSafeRedirects(parsed, ac.signal);
+      if (!r.ok) return { ok: false, reason: r.reason };
+      resp = r.resp;
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return { ok: false, reason: "timeout" };
+      return { ok: false, reason: "fetch_failed" };
     }
-    chunks.push(value);
+
+    if (!resp.ok) return { ok: false, reason: "bad_status" };
+
+    const ct = (resp.headers.get("content-type") ?? "").split(";")[0].trim().toLowerCase();
+    if (!ALLOWED_TYPES.has(ct)) return { ok: false, reason: "bad_content_type" };
+
+    const reader = resp.body?.getReader();
+    if (!reader) return { ok: false, reason: "fetch_failed" };
+
+    // Keep the timeout active during body streaming — an oversized or slow image
+    // can legitimately trip the abort mid-stream; reader.read() will reject with
+    // AbortError, caught below and normalized to a structured result.
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        total += value.byteLength;
+        if (total > IMAGE_MAX_BYTES) {
+          try { await reader.cancel(); } catch { /* ignore */ }
+          return { ok: false, reason: "too_large" };
+        }
+        chunks.push(value);
+      }
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return { ok: false, reason: "timeout" };
+      return { ok: false, reason: "fetch_failed" };
+    }
+
+    const buffer = new Uint8Array(total);
+    let offset = 0;
+    for (const c of chunks) { buffer.set(c, offset); offset += c.byteLength; }
+
+    const ext = EXT_BY_TYPE[ct] ?? "jpg";
+    const key = `products/${draftId}/${nanoid()}.${ext}`;
+    const file = new File([buffer], key, { type: ct });
+    try {
+      await uploadToR2(file, key);
+    } catch (err) {
+      console.error("[ai-product] R2 upload failed for key", key, err);
+      return { ok: false, reason: "upload_failed" };
+    }
+
+    return { ok: true, key, contentType: ct, size: total };
+  } finally {
+    clearTimeout(timer);
   }
-
-  const buffer = new Uint8Array(total);
-  let offset = 0;
-  for (const c of chunks) { buffer.set(c, offset); offset += c.byteLength; }
-
-  const ext = EXT_BY_TYPE[ct] ?? "jpg";
-  const key = `products/${draftId}/${nanoid()}.${ext}`;
-  const file = new File([buffer], key, { type: ct });
-  try {
-    await uploadToR2(file, key);
-  } catch (err) {
-    console.error("[ai-product] R2 upload failed for key", key, err);
-    return { ok: false, reason: "upload_failed" };
-  }
-
-  return { ok: true, key, contentType: ct, size: total };
 }

--- a/lib/ai/product-research.ts
+++ b/lib/ai/product-research.ts
@@ -2,11 +2,21 @@ import type Anthropic from "@anthropic-ai/sdk";
 import { parseAiToolInput, type AiProductOutput } from "@/lib/validations/product-ai";
 import { HIGHLIGHT_ICON_NAMES } from "@/lib/validations/product-story";
 
+export type ResearchErrorCode =
+  | "invalid_ai_output"       // Claude returned a submit_product payload we couldn't parse
+  | "api_error"               // fallback: unclassified error from the SDK
+  | "feature_disabled"        // AI_PRODUCT_CREATION_ENABLED=0
+  | "no_credits"              // Anthropic billing: balance too low
+  | "auth_failed"             // Invalid or revoked API key
+  | "upstream_rate_limited"   // Anthropic 429 — distinct from our per-admin quota
+  | "upstream_unavailable"    // Anthropic 5xx / network reachability
+  | "timeout";                // our DEFAULT_TIMEOUT_MS AbortController fired
+
 export type ResearchProgress =
   | { type: "progress"; step: "search" | "specs" | "images" | "finalize" }
   | { type: "done"; output: AiProductOutput }
   | { type: "not_found"; reason: string }
-  | { type: "error"; code: "invalid_ai_output" | "api_error" | "feature_disabled" };
+  | { type: "error"; code: ResearchErrorCode };
 
 /** Default model. Override per-call via `researchProduct(..., { model })` or via the `AI_MODEL` env var at the caller. */
 export const MODEL = "claude-sonnet-4-6";
@@ -137,8 +147,25 @@ export async function* researchProduct(
     yield { type: "error", code: "invalid_ai_output" };
   } catch (err) {
     console.error("[ai-product] researchProduct failed:", err);
-    yield { type: "error", code: "api_error" };
+    yield { type: "error", code: classifyError(err, ac.signal.aborted) };
   } finally {
     clearTimeout(timer);
   }
+}
+
+/** Map an Anthropic SDK / network error to a stable code the UI can translate. */
+export function classifyError(err: unknown, aborted: boolean): ResearchErrorCode {
+  if (aborted) return "timeout";
+  const anyErr = err as { name?: string; status?: number; error?: { error?: { message?: string } } };
+  if (anyErr?.name === "AbortError" || anyErr?.name === "APIUserAbortError") return "timeout";
+
+  const status = anyErr?.status;
+  const message = anyErr?.error?.error?.message ?? "";
+
+  if (status === 401 || status === 403) return "auth_failed";
+  if (status === 429) return "upstream_rate_limited";
+  if (status === 400 && /credit|balance|billing/i.test(message)) return "no_credits";
+  if (typeof status === "number" && status >= 500) return "upstream_unavailable";
+
+  return "api_error";
 }

--- a/lib/ai/product-research.ts
+++ b/lib/ai/product-research.ts
@@ -8,9 +8,18 @@ export type ResearchProgress =
   | { type: "not_found"; reason: string }
   | { type: "error"; code: "invalid_ai_output" | "api_error" | "feature_disabled" };
 
+/** Default model. Override per-call via `researchProduct(..., { model })` or via the `AI_MODEL` env var at the caller. */
 export const MODEL = "claude-sonnet-4-6";
 
+/** Hard budget for the Anthropic call. Claude with 3-5 web_search invocations typically finishes in 15-45s; 90s is a generous ceiling that still bounds Worker CPU exposure. */
+export const DEFAULT_TIMEOUT_MS = 90_000;
+
 export const SUBMIT_TOOL_NAME = "submit_product";
+
+export interface ResearchOptions {
+  model?: string;
+  timeoutMs?: number;
+}
 
 export function buildSystemPrompt(): string {
   const icons = HIGHLIGHT_ICON_NAMES.join(", ");
@@ -33,6 +42,8 @@ export function buildSystemPrompt(): string {
 export function buildTools(): Anthropic.Tool[] {
   return [
     {
+      // Anthropic-executed web search. The SDK 0.33 does not expose this in Anthropic.Tool,
+      // hence the cast; the server happily accepts it at runtime.
       type: "web_search_20250305",
       name: "web_search",
       max_uses: 5,
@@ -48,39 +59,86 @@ export function buildTools(): Anthropic.Tool[] {
   ];
 }
 
-/** Drives the Anthropic stream and yields typed events. */
+/**
+ * Drive an Anthropic streaming call and yield typed progress events, then a terminal event.
+ *
+ * Progress mapping (best-effort, based on content_block_start events as they arrive):
+ *  - 1st `server_tool_use` (web_search) → "search"
+ *  - 2nd web_search → "specs"
+ *  - 3rd web_search → "images"
+ *  - `tool_use` for SUBMIT_TOOL_NAME start → "finalize"
+ *
+ * Terminal events:
+ *  - `done` when submit_product input parses as full AiProductOutput
+ *  - `not_found` when submit_product input is `{ not_found: true, reason }`
+ *  - `error: invalid_ai_output` when submit_product input fails validation
+ *  - `error: api_error` on network / timeout / malformed stream
+ */
 export async function* researchProduct(
   prompt: string,
   anthropic: Anthropic,
+  opts: ResearchOptions = {},
 ): AsyncGenerator<ResearchProgress> {
-  let emittedSearch = false;
-  let emittedImages = false;
-  let emittedSpecs = false;
+  const model = opts.model ?? MODEL;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
-  const response = await anthropic.messages.create({
-    model: MODEL,
-    max_tokens: 8000,
-    system: buildSystemPrompt(),
-    tools: buildTools(),
-    messages: [{ role: "user", content: prompt }],
-  });
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeoutMs);
 
-  for (const block of response.content) {
-    if (block.type === "tool_use" && block.name === "web_search") {
-      const q = (block.input as { query?: string } | undefined)?.query ?? "";
-      if (!emittedSearch) { yield { type: "progress", step: "search" }; emittedSearch = true; }
-      if (!emittedSpecs && /spec|caract/i.test(q)) { yield { type: "progress", step: "specs" }; emittedSpecs = true; }
-      if (!emittedImages && /image|photo/i.test(q)) { yield { type: "progress", step: "images" }; emittedImages = true; }
+  let searchCount = 0;
+  let finalizeEmitted = false;
+  let submitInput: unknown = null;
+
+  try {
+    const stream = anthropic.messages.stream(
+      {
+        model,
+        max_tokens: 8000,
+        system: buildSystemPrompt(),
+        tools: buildTools(),
+        messages: [{ role: "user", content: prompt }],
+      },
+      { signal: ac.signal },
+    );
+
+    for await (const event of stream) {
+      if (event.type === "content_block_start") {
+        const block = event.content_block as { type: string; name?: string };
+        if ((block.type === "server_tool_use" || block.type === "tool_use") && block.name === "web_search") {
+          searchCount++;
+          if (searchCount === 1) yield { type: "progress", step: "search" };
+          else if (searchCount === 2) yield { type: "progress", step: "specs" };
+          else if (searchCount === 3) yield { type: "progress", step: "images" };
+        }
+        if (block.type === "tool_use" && block.name === SUBMIT_TOOL_NAME && !finalizeEmitted) {
+          finalizeEmitted = true;
+          yield { type: "progress", step: "finalize" };
+        }
+      }
     }
-    if (block.type === "tool_use" && block.name === SUBMIT_TOOL_NAME) {
-      yield { type: "progress", step: "finalize" };
-      const parsed = parseAiToolInput(block.input);
-      if (parsed.kind === "ok") { yield { type: "done", output: parsed.output }; return; }
-      if (parsed.kind === "not_found") { yield { type: "not_found", reason: parsed.reason }; return; }
-      yield { type: "error", code: "invalid_ai_output" };
+
+    // After the stream completes, pull the fully-assembled message so we can read submit_product's input.
+    const final = await stream.finalMessage();
+    for (const block of final.content) {
+      if (block.type === "tool_use" && block.name === SUBMIT_TOOL_NAME) {
+        submitInput = block.input;
+        break;
+      }
+    }
+
+    if (submitInput === null) {
+      yield { type: "error", code: "api_error" };
       return;
     }
-  }
 
-  yield { type: "error", code: "api_error" };
+    const parsed = parseAiToolInput(submitInput);
+    if (parsed.kind === "ok") { yield { type: "done", output: parsed.output }; return; }
+    if (parsed.kind === "not_found") { yield { type: "not_found", reason: parsed.reason }; return; }
+    yield { type: "error", code: "invalid_ai_output" };
+  } catch (err) {
+    console.error("[ai-product] researchProduct failed:", err);
+    yield { type: "error", code: "api_error" };
+  } finally {
+    clearTimeout(timer);
+  }
 }

--- a/lib/ai/product-research.ts
+++ b/lib/ai/product-research.ts
@@ -49,15 +49,13 @@ export function buildSystemPrompt(): string {
   ].join("\n");
 }
 
-export function buildTools(): Anthropic.Tool[] {
+export function buildTools(): Anthropic.ToolUnion[] {
   return [
     {
-      // Anthropic-executed web search. The SDK 0.33 does not expose this in Anthropic.Tool,
-      // hence the cast; the server happily accepts it at runtime.
       type: "web_search_20250305",
       name: "web_search",
       max_uses: 5,
-    } as unknown as Anthropic.Tool,
+    },
     {
       name: SUBMIT_TOOL_NAME,
       description: "Soumet la fiche produit complète (ou signale que le produit est introuvable).",
@@ -112,18 +110,17 @@ export async function* researchProduct(
     );
 
     for await (const event of stream) {
-      if (event.type === "content_block_start") {
-        const block = event.content_block as { type: string; name?: string };
-        if ((block.type === "server_tool_use" || block.type === "tool_use") && block.name === "web_search") {
-          searchCount++;
-          if (searchCount === 1) yield { type: "progress", step: "search" };
-          else if (searchCount === 2) yield { type: "progress", step: "specs" };
-          else if (searchCount === 3) yield { type: "progress", step: "images" };
-        }
-        if (block.type === "tool_use" && block.name === SUBMIT_TOOL_NAME && !finalizeEmitted) {
-          finalizeEmitted = true;
-          yield { type: "progress", step: "finalize" };
-        }
+      if (event.type !== "content_block_start") continue;
+      const block = event.content_block;
+      // server_tool_use (Anthropic-executed web_search) vs tool_use (our submit_product).
+      if (block.type === "server_tool_use" && block.name === "web_search") {
+        searchCount++;
+        if (searchCount === 1) yield { type: "progress", step: "search" };
+        else if (searchCount === 2) yield { type: "progress", step: "specs" };
+        else if (searchCount === 3) yield { type: "progress", step: "images" };
+      } else if (block.type === "tool_use" && block.name === SUBMIT_TOOL_NAME && !finalizeEmitted) {
+        finalizeEmitted = true;
+        yield { type: "progress", step: "finalize" };
       }
     }
 

--- a/lib/ai/product-research.ts
+++ b/lib/ai/product-research.ts
@@ -1,0 +1,86 @@
+import type Anthropic from "@anthropic-ai/sdk";
+import { parseAiToolInput, type AiProductOutput } from "@/lib/validations/product-ai";
+import { HIGHLIGHT_ICON_NAMES } from "@/lib/validations/product-story";
+
+export type ResearchProgress =
+  | { type: "progress"; step: "search" | "specs" | "images" | "finalize" }
+  | { type: "done"; output: AiProductOutput }
+  | { type: "not_found"; reason: string }
+  | { type: "error"; code: "invalid_ai_output" | "api_error" | "feature_disabled" };
+
+export const MODEL = "claude-sonnet-4-6";
+
+export const SUBMIT_TOOL_NAME = "submit_product";
+
+export function buildSystemPrompt(): string {
+  const icons = HIGHLIGHT_ICON_NAMES.join(", ");
+  return [
+    "Tu es rédacteur catalogue pour une boutique d'électronique en Côte d'Ivoire.",
+    "Réponds TOUJOURS en français. Ne parle jamais à l'utilisateur : tes seules sorties doivent être l'utilisation des outils.",
+    "Étapes :",
+    "1. Utilise web_search pour vérifier l'existence du produit, ses spécifications officielles et trouver des images.",
+    "2. Si le produit est introuvable ou trop ambigu, appelle submit_product avec { \"not_found\": true, \"reason\": \"…\" }.",
+    "3. Sinon, appelle submit_product avec une fiche complète.",
+    "Règles :",
+    "- N'invente aucune caractéristique. Omets plutôt.",
+    "- Ne génère PAS de prix ni de stock (ne sont pas dans le schéma).",
+    "- Pour chaque highlight, choisis un icône parmi cette liste exacte : " + icons + ".",
+    "- image_candidates : 6 à 10 URLs d'images directes (jpg/png/webp), privilégie les sites constructeurs et la presse ; évite les watermarks.",
+    "- Les descriptions suivent un style Apple : tagline courte et percutante, highlights concis, feature_blocks éditoriaux avec un titre et un corps de 1-2 paragraphes.",
+  ].join("\n");
+}
+
+export function buildTools(): Anthropic.Tool[] {
+  return [
+    {
+      type: "web_search_20250305",
+      name: "web_search",
+      max_uses: 5,
+    } as unknown as Anthropic.Tool,
+    {
+      name: SUBMIT_TOOL_NAME,
+      description: "Soumet la fiche produit complète (ou signale que le produit est introuvable).",
+      input_schema: {
+        type: "object",
+        additionalProperties: true,
+      },
+    },
+  ];
+}
+
+/** Drives the Anthropic stream and yields typed events. */
+export async function* researchProduct(
+  prompt: string,
+  anthropic: Anthropic,
+): AsyncGenerator<ResearchProgress> {
+  let emittedSearch = false;
+  let emittedImages = false;
+  let emittedSpecs = false;
+
+  const response = await anthropic.messages.create({
+    model: MODEL,
+    max_tokens: 8000,
+    system: buildSystemPrompt(),
+    tools: buildTools(),
+    messages: [{ role: "user", content: prompt }],
+  });
+
+  for (const block of response.content) {
+    if (block.type === "tool_use" && block.name === "web_search") {
+      const q = (block.input as { query?: string } | undefined)?.query ?? "";
+      if (!emittedSearch) { yield { type: "progress", step: "search" }; emittedSearch = true; }
+      if (!emittedSpecs && /spec|caract/i.test(q)) { yield { type: "progress", step: "specs" }; emittedSpecs = true; }
+      if (!emittedImages && /image|photo/i.test(q)) { yield { type: "progress", step: "images" }; emittedImages = true; }
+    }
+    if (block.type === "tool_use" && block.name === SUBMIT_TOOL_NAME) {
+      yield { type: "progress", step: "finalize" };
+      const parsed = parseAiToolInput(block.input);
+      if (parsed.kind === "ok") { yield { type: "done", output: parsed.output }; return; }
+      if (parsed.kind === "not_found") { yield { type: "not_found", reason: parsed.reason }; return; }
+      yield { type: "error", code: "invalid_ai_output" };
+      return;
+    }
+  }
+
+  yield { type: "error", code: "api_error" };
+}

--- a/lib/ai/rate-limit.ts
+++ b/lib/ai/rate-limit.ts
@@ -5,22 +5,56 @@ const WINDOW_SEC = 3600;
 
 export type RateLimitResult = { ok: true } | { ok: false; retryAfterSec: number };
 
+type Bucket = { count: number; resetAt: number };
+
 /**
- * Fixed 1-hour window, per-admin. Not exactly fair (bursts at window edges)
- * but trivial to implement on KV and sufficient as a cost ceiling.
+ * Fixed 1-hour window, per-admin. Storage is `{ count, resetAt }` in KV — resetAt is captured
+ * on the first increment of each window and not extended on subsequent increments, so the
+ * window really is fixed (unlike `putting with expirationTtl` on every write, which would
+ * slide it). On window expiry a fresh bucket is started.
+ *
+ * Concurrency: KV has no atomic increment, so two parallel requests within the same tick can
+ * both pass the check and exceed the cap by 1-2. This is acceptable as a cost ceiling — the
+ * worst case is ~12 generations/hour per admin instead of 10.
  */
-export async function checkRateLimit(adminId: string): Promise<RateLimitResult> {
+export async function checkRateLimit(
+  adminId: string,
+  now: number = Date.now(),
+): Promise<RateLimitResult> {
   const kv = await getKV();
   if (!kv) throw new Error("KV namespace unavailable");
 
   const key = `ai_gen:${adminId}`;
-  const current = await kv.get(key);
-  const count = current ? Number(current) : 0;
+  const raw = await kv.get(key);
+  const bucket: Bucket | null = raw ? safeParse(raw) : null;
 
-  if (count >= AI_GEN_MAX_PER_HOUR) {
-    return { ok: false, retryAfterSec: WINDOW_SEC };
+  // No bucket, or previous window already expired → start a new one.
+  if (!bucket || bucket.resetAt <= now) {
+    const fresh: Bucket = { count: 1, resetAt: now + WINDOW_SEC * 1000 };
+    await kv.put(key, JSON.stringify(fresh), { expirationTtl: WINDOW_SEC });
+    return { ok: true };
   }
 
-  await kv.put(key, String(count + 1), { expirationTtl: WINDOW_SEC });
+  if (bucket.count >= AI_GEN_MAX_PER_HOUR) {
+    return { ok: false, retryAfterSec: Math.max(1, Math.ceil((bucket.resetAt - now) / 1000)) };
+  }
+
+  const updated: Bucket = { count: bucket.count + 1, resetAt: bucket.resetAt };
+  const remaining = Math.max(1, Math.ceil((bucket.resetAt - now) / 1000));
+  await kv.put(key, JSON.stringify(updated), { expirationTtl: remaining });
   return { ok: true };
+}
+
+function safeParse(raw: string): Bucket | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      typeof parsed === "object" && parsed !== null &&
+      typeof (parsed as Bucket).count === "number" &&
+      typeof (parsed as Bucket).resetAt === "number"
+    ) {
+      return parsed as Bucket;
+    }
+  } catch { /* fall through */ }
+  return null;
 }

--- a/lib/ai/rate-limit.ts
+++ b/lib/ai/rate-limit.ts
@@ -1,0 +1,26 @@
+import { getKV } from "@/lib/cloudflare/context";
+
+export const AI_GEN_MAX_PER_HOUR = 10;
+const WINDOW_SEC = 3600;
+
+export type RateLimitResult = { ok: true } | { ok: false; retryAfterSec: number };
+
+/**
+ * Fixed 1-hour window, per-admin. Not exactly fair (bursts at window edges)
+ * but trivial to implement on KV and sufficient as a cost ceiling.
+ */
+export async function checkRateLimit(adminId: string): Promise<RateLimitResult> {
+  const kv = await getKV();
+  if (!kv) throw new Error("KV namespace unavailable");
+
+  const key = `ai_gen:${adminId}`;
+  const current = await kv.get(key);
+  const count = current ? Number(current) : 0;
+
+  if (count >= AI_GEN_MAX_PER_HOUR) {
+    return { ok: false, retryAfterSec: WINDOW_SEC };
+  }
+
+  await kv.put(key, String(count + 1), { expirationTtl: WINDOW_SEC });
+  return { ok: true };
+}

--- a/lib/validations/product-ai.ts
+++ b/lib/validations/product-ai.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { HIGHLIGHT_ICON_NAMES } from "@/lib/validations/product-story";
 
 /**
  * Admin-typed prompt for AI product generation.
@@ -13,3 +14,88 @@ export const aiPromptSchema = z
   })
   .refine((v) => v.length >= 3, { message: "Prompt trop court (min 3 caractères)" })
   .refine((v) => v.length <= 200, { message: "Prompt trop long (max 200 caractères)" });
+
+const hexColor = z.string().regex(/^#[0-9a-fA-F]{6}$/, "Couleur hex invalide (format #rrggbb)");
+
+const colorSchema = z.object({
+  name: z.string().trim().min(1).max(40),
+  hex: hexColor,
+});
+
+const dimensionsSchema = z.object({
+  length_mm: z.number().int().positive().optional(),
+  height_mm: z.number().int().positive().optional(),
+  width_mm:  z.number().int().positive().optional(),
+  weight_g:  z.number().int().positive().optional(),
+});
+
+const specSchema = z.object({
+  name:  z.string().trim().min(1).max(60),
+  value: z.string().trim().min(1).max(200),
+});
+
+// Icon list reused from product-story — keeps the UI and AI in lockstep.
+const highlightSchema = z.object({
+  icon: z.enum(HIGHLIGHT_ICON_NAMES),
+  label: z.string().trim().min(1).max(80),
+});
+
+const featureBlockSchema = z.object({
+  title: z.string().trim().min(1).max(120),
+  body:  z.string().trim().min(1).max(600),
+});
+
+const faqSchema = z.object({
+  question: z.string().trim().min(1).max(160),
+  answer:   z.string().trim().min(1).max(600),
+});
+
+export const aiProductOutputSchema = z.object({
+  name: z.string().trim().min(1).max(150),
+  brand: z.string().trim().max(80).optional(),
+  category_suggestion: z.string().trim().min(1),
+  short_description: z.string().trim().max(120).optional(),
+  description_html: z.string().optional(),
+  attributes: z.object({
+    colors: z.array(colorSchema).max(12).default([]),
+    dimensions: dimensionsSchema.default({}),
+    specs: z.array(specSchema).max(20).default([]),
+  }).default({ colors: [], dimensions: {}, specs: [] }),
+  story: z.object({
+    tagline: z.string().trim().max(200).optional(),
+    highlights: z.array(highlightSchema).min(3).max(6).optional(),
+    feature_blocks: z.array(featureBlockSchema).min(2).max(4).optional(),
+    faq: z.array(faqSchema).max(5).optional(),
+  }).default({}),
+  seo: z.object({
+    meta_title: z.string().trim().max(60).optional(),
+    meta_description: z.string().trim().max(160).optional(),
+  }).default({}),
+  image_candidates: z.array(z.object({
+    url: z.string().url(),
+    source_domain: z.string().min(1),
+    alt: z.string().max(200).optional(),
+  })).min(1).max(12),
+});
+
+export const aiNotFoundSchema = z.object({
+  not_found: z.literal(true),
+  reason: z.string().max(300),
+});
+
+export type AiProductOutput = z.infer<typeof aiProductOutputSchema>;
+
+export type AiToolInputResult =
+  | { kind: "ok"; output: AiProductOutput }
+  | { kind: "not_found"; reason: string }
+  | { kind: "invalid"; issues: z.ZodIssue[] };
+
+/** Try not-found first — it has a discriminating literal — then the full schema. */
+export function parseAiToolInput(raw: unknown): AiToolInputResult {
+  const nf = aiNotFoundSchema.safeParse(raw);
+  if (nf.success) return { kind: "not_found", reason: nf.data.reason };
+
+  const ok = aiProductOutputSchema.safeParse(raw);
+  if (ok.success) return { kind: "ok", output: ok.data };
+  return { kind: "invalid", issues: ok.error.issues };
+}

--- a/lib/validations/product-ai.ts
+++ b/lib/validations/product-ai.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+/**
+ * Admin-typed prompt for AI product generation.
+ * Trim → reject control chars → length bounds. 3–200 chars feels natural
+ * for product names (brand + model + capacity).
+ */
+export const aiPromptSchema = z
+  .string()
+  .transform((v) => v.trim())
+  .refine((v) => !/[\u0000-\u001F\u007F]/.test(v), {
+    message: "Caractères de contrôle interdits",
+  })
+  .refine((v) => v.length >= 3, { message: "Prompt trop court (min 3 caractères)" })
+  .refine((v) => v.length <= 200, { message: "Prompt trop long (max 200 caractères)" });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.8.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.33.1",
         "@base-ui/react": "^1.1.0",
         "@codemirror/commands": "^6.10.3",
         "@codemirror/lang-css": "^6.3.1",
@@ -114,6 +115,56 @@
         "nun": "bin/nun.mjs",
         "nup": "bin/nup.mjs"
       }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.33.1.tgz",
+      "integrity": "sha512-VrlbxiAdVRGuKP2UQlCnsShDHJKWepzvfRCkZMpU+oaUdKLpOfmylLMRojGrAgebV+kDtPjewCVP0laHXg+vsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
     },
     "node_modules/@ast-grep/napi": {
       "version": "0.40.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.8.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.33.1",
+        "@anthropic-ai/sdk": "^0.90.0",
         "@base-ui/react": "^1.1.0",
         "@codemirror/commands": "^6.10.3",
         "@codemirror/lang-css": "^6.3.1",
@@ -117,54 +117,24 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.33.1.tgz",
-      "integrity": "sha512-VrlbxiAdVRGuKP2UQlCnsShDHJKWepzvfRCkZMpU+oaUdKLpOfmylLMRojGrAgebV+kDtPjewCVP0laHXg+vsA==",
+      "version": "0.90.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
+      "integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "json-schema-to-ts": "^3.1.1"
       },
-      "engines": {
-        "node": "4.x || >=6.0.0"
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
       },
       "peerDependencies": {
-        "encoding": "^0.1.0"
+        "zod": "^3.25.0 || ^4.0.0"
       },
       "peerDependenciesMeta": {
-        "encoding": {
+        "zod": {
           "optional": true
         }
       }
-    },
-    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
     },
     "node_modules/@ast-grep/napi": {
       "version": "0.40.5",
@@ -15033,6 +15003,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -18788,6 +18771,12 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "license": "MIT"
     },
     "node_modules/ts-api-utils": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "postinstall": "node scripts/patch-opennext.mjs"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.33.1",
     "@base-ui/react": "^1.1.0",
     "@codemirror/commands": "^6.10.3",
     "@codemirror/lang-css": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "postinstall": "node scripts/patch-opennext.mjs"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.33.1",
+    "@anthropic-ai/sdk": "^0.90.0",
     "@base-ui/react": "^1.1.0",
     "@codemirror/commands": "^6.10.3",
     "@codemirror/lang-css": "^6.3.1",


### PR DESCRIPTION
## Summary

Admin can now create a product from a short text prompt (e.g. \`Samsung Galaxy A55\`). Claude Sonnet with native web search researches the product and returns a structured payload via a custom \`submit_product\` tool; the admin picks images from candidate URLs; the server downloads them to R2 and hydrates a draft; the existing 5-step wizard opens pre-filled for validation. Price, stock, SKU, and visibility remain admin-controlled.

- New page \`/products/ai-new\` with a 3-state client: prompt → progress → image selection.
- Route handler \`POST /api/admin/products-ai/generate\` streams NDJSON progress events as Claude runs.
- Server action \`importCandidateImages\` creates the draft in a single D1 batch + cleans up orphan R2 objects on failure.
- Feature flag \`AI_PRODUCT_CREATION_ENABLED=0\` hides the button and 404s the page.
- Per-admin rate limit (10/h) via KV.
- Model id overridable via \`AI_MODEL\` env var (default \`claude-sonnet-4-6\`).

## Docs

- Spec: \`docs/superpowers/specs/2026-04-18-ai-product-creation-design.md\`
- Plan: \`docs/superpowers/plans/2026-04-18-ai-product-creation.md\`

## Test plan

- [ ] \`npm run test\` — 777/777 passing (adds suites under \`__tests__/unit/ai/\` and \`__tests__/unit/actions/products-ai.test.ts\`)
- [ ] \`npx tsc --noEmit\` — clean
- [ ] \`npm run lint\` — clean
- [ ] Provision \`ANTHROPIC_API_KEY\` in Workers secrets
- [ ] Manual smoke locally: \`npm run dev\`, sign in as admin, click \"✨ Créer avec l'IA\", prompt \`Samsung Galaxy A55\`, confirm progress → image selection → wizard pre-filled → fill price + stock → publish
- [ ] Kill switch: set \`AI_PRODUCT_CREATION_ENABLED=0\` → button hidden, \`/products/ai-new\` 404s
- [ ] Rate limit: 11th generation within 1h returns 429 with \`Retry-After\`
- [ ] SSRF: image-fetch unit tests cover private IP rejection

## Notes

- Depends on \`@anthropic-ai/sdk\` (new dep). SDK-level \`maxRetries: 3\` handles transient 429/5xx.
- Anthropic call bounded by a 90s \`AbortController\` to prevent runaway Worker CPU.
- Image downloads enforce 5 MB cap, content-type whitelist, and host-literal SSRF blocks.
- No DB migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI-powered product creation: prompt → streaming progress UI → select candidate images → create draft and open editor; partial image import failures surface as warnings.
  * “✨ Créer avec l’IA” added to products list, gated by a feature flag and limited to 10 generations/hour.

* **Tests**
  * New unit tests for AI research streaming, image fetching/validation, prompt/output validation, import workflow, and rate limiting.

* **Documentation**
  * Added design/spec and rollout docs for the AI product creation flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->