### PR TITLE
fix(admin): log Zod issues for invalid AI product output

### DIFF
--- a/lib/ai/product-research.ts
+++ b/lib/ai/product-research.ts
@@ -141,6 +141,12 @@ export async function* researchProduct(
     const parsed = parseAiToolInput(submitInput);
     if (parsed.kind === "ok") { yield { type: "done", output: parsed.output }; return; }
     if (parsed.kind === "not_found") { yield { type: "not_found", reason: parsed.reason }; return; }
+    // Diagnostic: surface why submit_product input failed validation. Without this,
+    // operators see "invalid_ai_output" with no way to tell which fields are wrong.
+    console.error("[ai-product] invalid_ai_output", {
+      issues: parsed.issues,
+      submitInput: JSON.stringify(submitInput).slice(0, 4000),
+    });
     yield { type: "error", code: "invalid_ai_output" };
   } catch (err) {
     console.error("[ai-product] researchProduct failed:", err);


### PR DESCRIPTION
## Summary
- Adds `console.error` with the Zod issues + a 4 KB excerpt of the raw `submit_product` payload right before yielding `error: invalid_ai_output`.
- Pure observability change — no behavior change in the success path, no schema or prompt changes.

## Why
Admins hit *« Le modèle n'a pas produit une fiche exploitable. Réessayez. »* repeatedly without any way to tell which fields the model produced incorrectly. The Zod issues were computed but discarded. With this log, the next failed generation in production will reveal the exact validation failures (likely shape mismatch on `image_candidates`) so we can target the right fix (prompt vs JSON Schema in the tool definition) instead of guessing.

## Test plan
- [x] Existing test `émet error:invalid_ai_output pour une sortie cassée` still passes; verified the new log fires with the expected `issues` + `submitInput` payload.
- [ ] After deploy, trigger one AI product generation, then check Cloudflare Worker logs (`wrangler tail`) for `[ai-product] invalid_ai_output` to identify the failing fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error diagnostics for AI tool input validation failures, adding detailed logging with validation details and input previews to support better troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->