### PR TITLE
fix(admin): constrain AI product output via strict JSON Schema

### DIFF
--- a/__tests__/unit/ai/submit-tool-schema.test.ts
+++ b/__tests__/unit/ai/submit-tool-schema.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import Ajv from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+import { SUBMIT_PRODUCT_TOOL_SCHEMA } from "@/lib/ai/submit-tool-schema";
+
+/**
+ * The JSON Schema we hand to Anthropic constrains Claude's tool-call output.
+ * These tests pin the schema's behavior on the two payloads that motivated
+ * its existence:
+ *   - the canonical fixture from `product-research.test.ts` MUST pass
+ *   - the MacBook payload that triggered the production bug MUST fail
+ *     (top-level `category` instead of `category_suggestion`, top-level
+ *     `tagline`/`highlights`/`feature_blocks` instead of nested under `story`,
+ *     `image_candidates` as strings instead of objects).
+ */
+
+const ajv = new Ajv({ allErrors: true, strict: false });
+addFormats(ajv);
+const validate = ajv.compile(SUBMIT_PRODUCT_TOOL_SCHEMA);
+
+const validOutput = {
+  name: "Galaxy A55",
+  category_suggestion: "smartphones",
+  attributes: { colors: [], dimensions: {}, specs: [] },
+  story: {},
+  seo: {},
+  image_candidates: [{ url: "https://x.test/a.jpg", source_domain: "x.test" }],
+};
+
+// Reduced reproduction of the MacBook payload that hit prod (truncated body
+// fields — the schema violations we test for don't depend on length).
+const macbookPayload = {
+  brand: "Apple",
+  name: "MacBook Pro M5",
+  category: "Ordinateur portable",
+  tagline: "La puissance Pro. Décuplée par l'IA.",
+  short_description:
+    "Le MacBook Pro animé par la nouvelle puce Apple M5 propulse vos workflows créatifs et IA grâce à un GPU de nouvelle génération doté d'un Neural Accelerator dans chaque cœur, jusqu'à 24 heures d'autonomie.",
+  long_description: "Apple repousse une nouvelle fois les limites…",
+  highlights: [
+    { icon: "cpu", title: "Puce Apple M5", text: "CPU 10 cœurs." },
+    { icon: "sparkle", title: "IA jusqu'à 3,5× plus rapide", text: "Neural Accelerator." },
+    { icon: "display", title: "Liquid Retina XDR", text: "3024 × 1964 px." },
+  ],
+  feature_blocks: [
+    { title: "Conçu pour l'IA", body: "M5 + Neural Accelerator." },
+    { title: "Endurance pro", body: "24 h d'autonomie." },
+  ],
+  image_candidates: [
+    "https://www.apple.com/m5.jpg",
+    "https://www.apple.com/m5-side.jpg",
+    "https://www.apple.com/m5-back.jpg",
+  ],
+};
+
+describe("SUBMIT_PRODUCT_TOOL_SCHEMA", () => {
+  it("accepte le fixture canonique validOutput", () => {
+    const ok = validate(validOutput);
+    expect(validate.errors ?? []).toEqual([]);
+    expect(ok).toBe(true);
+  });
+
+  it("accepte un payload not_found", () => {
+    const ok = validate({ not_found: true, reason: "produit ambigu" });
+    expect(validate.errors ?? []).toEqual([]);
+    expect(ok).toBe(true);
+  });
+
+  it("rejette le payload MacBook (champs au mauvais niveau, strings au lieu d'objets pour image_candidates)", () => {
+    const ok = validate(macbookPayload);
+    expect(ok).toBe(false);
+    const errors = validate.errors ?? [];
+
+    // image_candidates: chaque string échoue avec instancePath /image_candidates/N et keyword "type" (object)
+    const stringImageErrors = errors.filter(
+      (e) => /^\/image_candidates\/\d+$/.test(e.instancePath) && e.keyword === "type",
+    );
+    expect(stringImageErrors.length).toBeGreaterThanOrEqual(3);
+
+    // category_suggestion manquant ou propriété "category" non autorisée — au moins un de ces signaux
+    // doit ressortir d'au moins une branche de oneOf.
+    const flagsCategoryIssue = errors.some(
+      (e) =>
+        (e.keyword === "required" && (e.params as { missingProperty?: string }).missingProperty === "category_suggestion") ||
+        (e.keyword === "additionalProperties" && (e.params as { additionalProperty?: string }).additionalProperty === "category"),
+    );
+    expect(flagsCategoryIssue).toBe(true);
+
+    // additionalProperties: tagline / highlights / feature_blocks / long_description au top-level ne sont pas autorisés
+    const flagsTopLevelLeak = errors.some(
+      (e) =>
+        e.keyword === "additionalProperties" &&
+        ["tagline", "highlights", "feature_blocks", "long_description"].includes(
+          (e.params as { additionalProperty?: string }).additionalProperty ?? "",
+        ),
+    );
+    expect(flagsTopLevelLeak).toBe(true);
+  });
+
+  it("rejette short_description > 120 caractères", () => {
+    const ok = validate({
+      ...validOutput,
+      short_description: "x".repeat(121),
+    });
+    expect(ok).toBe(false);
+    expect(
+      (validate.errors ?? []).some(
+        (e) => e.instancePath === "/short_description" && e.keyword === "maxLength",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejette image_candidates avec une URL non valide", () => {
+    const ok = validate({
+      ...validOutput,
+      image_candidates: [{ url: "pas-une-url", source_domain: "x.test" }],
+    });
+    expect(ok).toBe(false);
+    expect(
+      (validate.errors ?? []).some(
+        (e) => e.instancePath === "/image_candidates/0/url" && e.keyword === "format",
+      ),
+    ).toBe(true);
+  });
+});

--- a/__tests__/unit/ai/submit-tool-schema.test.ts
+++ b/__tests__/unit/ai/submit-tool-schema.test.ts
@@ -5,13 +5,12 @@ import { SUBMIT_PRODUCT_TOOL_SCHEMA } from "@/lib/ai/submit-tool-schema";
 
 /**
  * The JSON Schema we hand to Anthropic constrains Claude's tool-call output.
- * These tests pin the schema's behavior on the two payloads that motivated
- * its existence:
- *   - the canonical fixture from `product-research.test.ts` MUST pass
- *   - the MacBook payload that triggered the production bug MUST fail
- *     (top-level `category` instead of `category_suggestion`, top-level
- *     `tagline`/`highlights`/`feature_blocks` instead of nested under `story`,
- *     `image_candidates` as strings instead of objects).
+ * These tests pin the schema's behavior on:
+ *   - the canonical fixture from `product-research.test.ts` (MUST pass)
+ *   - the MacBook-style payload (top-level `category` / `tagline` / `highlights`,
+ *     string-only `image_candidates`) MUST fail
+ *   - oneOf disambiguation between the success and not_found branches
+ *   - bounded length, URL format, and enum membership backstops
  */
 
 const ajv = new Ajv({ allErrors: true, strict: false });
@@ -119,6 +118,57 @@ describe("SUBMIT_PRODUCT_TOOL_SCHEMA", () => {
     expect(
       (validate.errors ?? []).some(
         (e) => e.instancePath === "/image_candidates/0/url" && e.keyword === "format",
+      ),
+    ).toBe(true);
+  });
+
+  // oneOf disambiguation — the whole PR strategy rests on these branches being
+  // mutually exclusive. Pin so an accidental swap to anyOf or a loosened
+  // additionalProperties doesn't silently neutralize the schema.
+  describe("oneOf disambiguation", () => {
+    it.each([
+      ["empty payload", {}],
+      ["not_found:true without reason", { not_found: true }],
+      ["not_found:false alone", { not_found: false }],
+      ["hybrid (not_found:true mixed with success fields)", {
+        not_found: true,
+        reason: "ambigu",
+        name: "X",
+        category_suggestion: "smartphones",
+        image_candidates: [{ url: "https://x.test/a.jpg", source_domain: "x.test" }],
+      }],
+    ])("rejette %s", (_label, payload) => {
+      expect(validate(payload)).toBe(false);
+    });
+  });
+
+  it("rejette une propriété inconnue au top-level (additionalProperties:false sur ProductSubmission)", () => {
+    const ok = validate({ ...validOutput, mystery_field: "x" });
+    expect(ok).toBe(false);
+    expect(
+      (validate.errors ?? []).some(
+        (e) =>
+          e.keyword === "additionalProperties" &&
+          (e.params as { additionalProperty?: string }).additionalProperty === "mystery_field",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejette un highlight avec un icône hors de HIGHLIGHT_ICON_NAMES", () => {
+    const ok = validate({
+      ...validOutput,
+      story: {
+        highlights: [
+          { icon: "laser-cannon", label: "x" },
+          { icon: "battery", label: "y" },
+          { icon: "wifi", label: "z" },
+        ],
+      },
+    });
+    expect(ok).toBe(false);
+    expect(
+      (validate.errors ?? []).some(
+        (e) => /\/story\/highlights\/0\/icon$/.test(e.instancePath) && e.keyword === "enum",
       ),
     ).toBe(true);
   });

--- a/lib/ai/product-research.ts
+++ b/lib/ai/product-research.ts
@@ -47,7 +47,7 @@ export function buildSystemPrompt(): string {
     "- Ne génère PAS de prix ni de stock (ne sont pas dans le schéma).",
     "- short_description est un RÉSUMÉ court (≤120 caractères), pas une description complète. La description longue va dans description_html.",
     "- tagline, highlights, feature_blocks, faq sont nestés sous story (ex : { story: { tagline, highlights: [...] } }).",
-    "- Pour chaque highlight, choisis un icône parmi cette liste exacte : " + icons + ".",
+    "- Pour chaque highlight, choisis une icône parmi cette liste exacte : " + icons + ".",
     "- image_candidates est un tableau d'OBJETS de la forme { url, source_domain, alt? } — JAMAIS un tableau de strings. 6 à 10 entrées, images directes (jpg/png/webp), sites constructeurs/presse, évite les watermarks.",
     "- Les descriptions suivent un style Apple : tagline courte et percutante, highlights concis, feature_blocks éditoriaux avec un titre et un corps de 1-2 paragraphes.",
   ].join("\n");

--- a/lib/ai/product-research.ts
+++ b/lib/ai/product-research.ts
@@ -1,6 +1,7 @@
 import type Anthropic from "@anthropic-ai/sdk";
 import { parseAiToolInput, type AiProductOutput } from "@/lib/validations/product-ai";
 import { HIGHLIGHT_ICON_NAMES } from "@/lib/validations/product-story";
+import { SUBMIT_PRODUCT_TOOL_SCHEMA } from "@/lib/ai/submit-tool-schema";
 
 export type ResearchErrorCode =
   | "invalid_ai_output"       // Claude returned a submit_product payload we couldn't parse
@@ -41,10 +42,13 @@ export function buildSystemPrompt(): string {
     "2. Si le produit est introuvable ou trop ambigu, appelle submit_product avec { \"not_found\": true, \"reason\": \"…\" }.",
     "3. Sinon, appelle submit_product avec une fiche complète.",
     "Règles :",
+    "- Respecte STRICTEMENT le schéma JSON du tool submit_product (champs, nesting, types). En cas de doute, omets le champ.",
     "- N'invente aucune caractéristique. Omets plutôt.",
     "- Ne génère PAS de prix ni de stock (ne sont pas dans le schéma).",
+    "- short_description est un RÉSUMÉ court (≤120 caractères), pas une description complète. La description longue va dans description_html.",
+    "- tagline, highlights, feature_blocks, faq sont nestés sous story (ex : { story: { tagline, highlights: [...] } }).",
     "- Pour chaque highlight, choisis un icône parmi cette liste exacte : " + icons + ".",
-    "- image_candidates : 6 à 10 URLs d'images directes (jpg/png/webp), privilégie les sites constructeurs et la presse ; évite les watermarks.",
+    "- image_candidates est un tableau d'OBJETS de la forme { url, source_domain, alt? } — JAMAIS un tableau de strings. 6 à 10 entrées, images directes (jpg/png/webp), sites constructeurs/presse, évite les watermarks.",
     "- Les descriptions suivent un style Apple : tagline courte et percutante, highlights concis, feature_blocks éditoriaux avec un titre et un corps de 1-2 paragraphes.",
   ].join("\n");
 }
@@ -59,10 +63,7 @@ export function buildTools(): Anthropic.ToolUnion[] {
     {
       name: SUBMIT_TOOL_NAME,
       description: "Soumet la fiche produit complète (ou signale que le produit est introuvable).",
-      input_schema: {
-        type: "object",
-        additionalProperties: true,
-      },
+      input_schema: SUBMIT_PRODUCT_TOOL_SCHEMA,
     },
   ];
 }

--- a/lib/ai/submit-tool-schema.ts
+++ b/lib/ai/submit-tool-schema.ts
@@ -1,0 +1,186 @@
+import { HIGHLIGHT_ICON_NAMES } from "@/lib/validations/product-story";
+
+/**
+ * JSON Schema for the `submit_product` tool input.
+ *
+ * Mirrors `aiProductOutputSchema` (success) and `aiNotFoundSchema` (not_found)
+ * from `lib/validations/product-ai.ts`. Anthropic uses this to constrain the
+ * model's tool-call output, which dramatically reduces shape drift (e.g. the
+ * model emitting `image_candidates` as strings instead of objects, or putting
+ * `tagline`/`highlights` at the top level instead of nested under `story`).
+ *
+ * Two variants via `oneOf`:
+ *  - `not_found: true` + `reason` only — when the product can't be identified.
+ *  - Full product fiche with required `name`, `category_suggestion`, `image_candidates`.
+ *
+ * The Zod parser in `parseAiToolInput()` is the runtime safety net; this schema
+ * is the upstream constraint. They MUST stay in sync — if you change one,
+ * change the other and update the matching test.
+ */
+export const SUBMIT_PRODUCT_TOOL_SCHEMA = {
+  type: "object" as const,
+  oneOf: [
+    {
+      title: "ProductNotFound",
+      type: "object",
+      required: ["not_found", "reason"],
+      additionalProperties: false,
+      properties: {
+        not_found: { type: "boolean", const: true },
+        reason: {
+          type: "string",
+          maxLength: 300,
+          description: "Pourquoi le produit est introuvable ou ambigu.",
+        },
+      },
+    },
+    {
+      title: "ProductSubmission",
+      type: "object",
+      required: ["name", "category_suggestion", "image_candidates"],
+      additionalProperties: false,
+      properties: {
+        name: { type: "string", minLength: 1, maxLength: 150 },
+        brand: { type: "string", maxLength: 80 },
+        category_suggestion: {
+          type: "string",
+          minLength: 1,
+          description: "Catégorie suggérée (ex: smartphones, ordinateurs portables, audio).",
+        },
+        short_description: {
+          type: "string",
+          maxLength: 120,
+          description: "Résumé court (≤120 caractères). Pas une description complète.",
+        },
+        description_html: {
+          type: "string",
+          description: "Description longue en HTML simple (<p>, <ul>, <li>).",
+        },
+        attributes: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            colors: {
+              type: "array",
+              maxItems: 12,
+              items: {
+                type: "object",
+                required: ["name", "hex"],
+                additionalProperties: false,
+                properties: {
+                  name: { type: "string", minLength: 1, maxLength: 40 },
+                  hex: { type: "string", pattern: "^#[0-9a-fA-F]{6}$" },
+                },
+              },
+            },
+            dimensions: {
+              type: "object",
+              additionalProperties: false,
+              properties: {
+                length_mm: { type: "integer", exclusiveMinimum: 0 },
+                height_mm: { type: "integer", exclusiveMinimum: 0 },
+                width_mm: { type: "integer", exclusiveMinimum: 0 },
+                weight_g: { type: "integer", exclusiveMinimum: 0 },
+              },
+            },
+            specs: {
+              type: "array",
+              maxItems: 20,
+              items: {
+                type: "object",
+                required: ["name", "value"],
+                additionalProperties: false,
+                properties: {
+                  name: { type: "string", minLength: 1, maxLength: 60 },
+                  value: { type: "string", minLength: 1, maxLength: 200 },
+                },
+              },
+            },
+          },
+        },
+        story: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            tagline: { type: "string", maxLength: 200 },
+            highlights: {
+              type: "array",
+              minItems: 3,
+              maxItems: 6,
+              items: {
+                type: "object",
+                required: ["icon", "label"],
+                additionalProperties: false,
+                properties: {
+                  icon: { type: "string", enum: [...HIGHLIGHT_ICON_NAMES] },
+                  label: { type: "string", minLength: 1, maxLength: 80 },
+                },
+              },
+            },
+            feature_blocks: {
+              type: "array",
+              minItems: 2,
+              maxItems: 4,
+              items: {
+                type: "object",
+                required: ["title", "body"],
+                additionalProperties: false,
+                properties: {
+                  title: { type: "string", minLength: 1, maxLength: 120 },
+                  body: { type: "string", minLength: 1, maxLength: 600 },
+                },
+              },
+            },
+            faq: {
+              type: "array",
+              maxItems: 5,
+              items: {
+                type: "object",
+                required: ["question", "answer"],
+                additionalProperties: false,
+                properties: {
+                  question: { type: "string", minLength: 1, maxLength: 160 },
+                  answer: { type: "string", minLength: 1, maxLength: 600 },
+                },
+              },
+            },
+          },
+        },
+        seo: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            meta_title: { type: "string", maxLength: 60 },
+            meta_description: { type: "string", maxLength: 160 },
+          },
+        },
+        image_candidates: {
+          type: "array",
+          minItems: 1,
+          maxItems: 12,
+          description:
+            "Tableau d'OBJETS — chaque image est { url, source_domain, alt? }. Pas de strings nues.",
+          items: {
+            type: "object",
+            required: ["url", "source_domain"],
+            additionalProperties: false,
+            properties: {
+              url: {
+                type: "string",
+                format: "uri",
+                description: "URL absolue d'image directe (jpg/png/webp).",
+              },
+              source_domain: { type: "string", minLength: 1 },
+              alt: { type: "string", maxLength: 200 },
+            },
+          },
+        },
+        not_found: {
+          type: "boolean",
+          const: false,
+          description: "Omettre, ou false, pour soumettre une fiche.",
+        },
+      },
+    },
+  ],
+};

--- a/lib/ai/submit-tool-schema.ts
+++ b/lib/ai/submit-tool-schema.ts
@@ -14,8 +14,10 @@ import { HIGHLIGHT_ICON_NAMES } from "@/lib/validations/product-story";
  *  - Full product fiche with required `name`, `category_suggestion`, `image_candidates`.
  *
  * The Zod parser in `parseAiToolInput()` is the runtime safety net; this schema
- * is the upstream constraint. They MUST stay in sync — if you change one,
- * change the other and update the matching test.
+ * is the upstream constraint. They MUST stay in sync — there is no automated
+ * equivalence check between the two. When changing one, change the other and
+ * update `__tests__/unit/ai/submit-tool-schema.test.ts` (verify the canonical
+ * `validOutput` fixture still passes both).
  */
 export const SUBMIT_PRODUCT_TOOL_SCHEMA = {
   type: "object" as const,
@@ -175,6 +177,8 @@ export const SUBMIT_PRODUCT_TOOL_SCHEMA = {
             },
           },
         },
+        // Discriminator: keeps the two oneOf branches mutually exclusive even if
+        // `name`/`category_suggestion`/`image_candidates` are ever made optional.
         not_found: {
           type: "boolean",
           const: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,8 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
         "better-sqlite3": "^12.6.2",
         "drizzle-kit": "^0.31.8",
         "eslint": "^9",
@@ -2287,30 +2289,6 @@
         "node": ">=v18"
       }
     },
-    "node_modules/@commitlint/config-validator/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@commitlint/config-validator/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@commitlint/ensure": {
       "version": "20.5.0",
       "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.5.0.tgz",
@@ -3477,6 +3455,30 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/js": {
       "version": "9.39.2",
@@ -4708,30 +4710,6 @@
           "optional": false
         }
       }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@mswjs/interceptors": {
       "version": "0.40.0",
@@ -9818,16 +9796,16 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -9851,30 +9829,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
@@ -12911,6 +12865,30 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -15017,9 +14995,9 @@
       }
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -92,6 +92,8 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
     "better-sqlite3": "^12.6.2",
     "drizzle-kit": "^0.31.8",
     "eslint": "^9",


### PR DESCRIPTION
## Summary
- Replaces the empty `additionalProperties: true` input_schema on the `submit_product` tool with a strict JSON Schema mirroring `aiProductOutputSchema`.
- Tightens the system prompt to reinforce the critical points (`image_candidates` shape, `story.*` nesting, `short_description` ≤120 chars).
- Adds `__tests__/unit/ai/submit-tool-schema.test.ts` pinning the schema's behavior on the canonical fixture (must pass) and the MacBook payload that motivated the fix (must fail with the right reasons).
- Promotes `ajv@^8` + `ajv-formats@^3` from transitive to explicit devDeps so the schema test doesn't break silently.

## Why
Production `wrangler tail` (after the diagnostic logging from #198) revealed Claude was inventing the payload shape on every call — top-level `category` instead of `category_suggestion`, top-level `tagline`/`highlights`/`feature_blocks` instead of nested under `story`, `image_candidates` as URL strings instead of `{url, source_domain}` objects, `short_description` as a full paragraph instead of a ≤120-char summary. 11 Zod issues per call on the MacBook Pro M5 prompt.

Root cause: the `submit_product` tool was declared with no structural constraints, so Claude relied entirely on the system prompt — which was imprecise about field names and shapes. Anthropic uses `input_schema` to constrain tool-call output; with a real JSON Schema in place, the model is forced into the right shape upstream.

## Test plan
- [x] `npm run test` — 825/825 pass, including 5 new schema tests
- [x] `tsc --noEmit` clean
- [ ] After deploy, generate a product with a known prompt (e.g. *MacBook Pro M5*) and verify the fiche imports without `invalid_ai_output`
- [ ] Check `wrangler tail` for any lingering `[ai-product] invalid_ai_output` events; if any, the diagnostic log from #198 will show what the schema didn't catch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation tests covering valid and invalid product submission payloads and disambiguation cases.

* **Refactor**
  * Enforced stricter JSON rules for product submissions, including mutually exclusive "not found" vs submission branches and tighter field limits/formatting.

* **New Features**
  * Introduced a formal submission schema and stronger image candidate structure (objects with URL, source, optional alt and explicit size/format constraints) plus dedicated dev-time schema validation tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->