### PR TITLE
fix(admin): unblock AI image preview + import (Referer / UA / diagnostics)

### DIFF
--- a/__tests__/unit/ai/image-fetch.test.ts
+++ b/__tests__/unit/ai/image-fetch.test.ts
@@ -125,6 +125,19 @@ describe("fetchAndUploadImage", () => {
     if (!r.ok) expect(r.reason).toBe("fetch_failed");
   });
 
+  it("envoie un User-Agent navigateur et un Accept image (anti-403)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeImageResponse());
+    vi.stubGlobal("fetch", fetchMock);
+    uploadToR2Mock.mockResolvedValue("products/draft-1/abc.png");
+
+    await fetchAndUploadImage("draft-1", "https://example.test/a.png");
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers["user-agent"]).toMatch(/Mozilla\/5\.0/);
+    expect(headers["accept"]).toContain("image/");
+  });
+
   it("normalise un AbortError pendant le streaming du body en reason=timeout", async () => {
     // Simulate fetch resolving OK, but reader.read() throwing AbortError mid-stream
     const aborted = Object.assign(new Error("aborted"), { name: "AbortError" });

--- a/actions/admin/products-ai.ts
+++ b/actions/admin/products-ai.ts
@@ -104,7 +104,16 @@ export async function importCandidateImages(
   const succeeded: Array<{ url: string; r: FetchSuccess }> = fetchResults.filter(
     (x): x is { url: string; r: FetchSuccess } => x.r.ok,
   );
-  const failed = fetchResults.filter((x) => !x.r.ok).map((x) => x.url);
+  const failedDetails = fetchResults
+    .filter((x): x is { url: string; r: Exclude<FetchImageResult, { ok: true }> } => !x.r.ok)
+    .map((x) => ({ url: x.url, reason: x.r.reason }));
+  const failed = failedDetails.map((x) => x.url);
+  if (failedDetails.length > 0) {
+    // Diagnostic: surface per-URL failure reasons so we can tell whether
+    // images bounced on Referer/UA blocks (bad_status/bad_content_type) vs
+    // hallucinated URLs (fetch_failed) vs size limits (too_large).
+    console.error("[admin/products-ai] image fetch failures", failedDetails);
+  }
 
   const descriptionHtml = output.description_html
     ? sanitizeDescriptionHtml(output.description_html, draftId)

--- a/components/admin/ai-product/ai-image-selector.tsx
+++ b/components/admin/ai-product/ai-image-selector.tsx
@@ -60,7 +60,16 @@ export function AiImageSelector({ output, onConfirm, onCancel, busy }: AiImageSe
             >
               <div className="relative aspect-square bg-muted">
                 {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img src={c.url} alt={c.alt ?? ""} className="h-full w-full object-contain" />
+                <img
+                  src={c.url}
+                  alt={c.alt ?? ""}
+                  className="h-full w-full object-contain"
+                  // Many manufacturer/news sites block hotlinks based on the
+                  // Referer header; stripping it makes the cross-origin preview
+                  // succeed on more sources.
+                  referrerPolicy="no-referrer"
+                  loading="lazy"
+                />
                 {isSelected && (
                   <span className="absolute left-2 top-2 flex size-6 items-center justify-center rounded-full bg-primary text-xs font-bold text-primary-foreground">
                     {index + 1}

--- a/lib/ai/image-fetch.ts
+++ b/lib/ai/image-fetch.ts
@@ -54,6 +54,18 @@ function isBlockedHost(hostname: string): boolean {
 const MAX_REDIRECTS = 3;
 
 /**
+ * Browser-like request headers. Many image CDNs (Apple, Samsung, news sites
+ * Claude cites) gate on User-Agent and 403 Cloudflare Workers' default UA.
+ * A realistic Chrome UA + standard image Accept dramatically improves the
+ * fetch success rate without changing semantics for hosts that don't care.
+ */
+const FETCH_HEADERS: Record<string, string> = {
+  "user-agent":
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+  accept: "image/avif,image/webp,image/apng,image/*,*/*;q=0.8",
+};
+
+/**
  * Follow HTTP redirects manually so each Location target passes the SSRF host check
  * before we issue the next request. `redirect: "follow"` would let a public URL
  * bounce to a private IP and bypass the initial hostname validation.
@@ -64,7 +76,11 @@ async function fetchWithSsrfSafeRedirects(
 ): Promise<{ ok: true; resp: Response } | { ok: false; reason: "ssrf" | "fetch_failed" }> {
   let current = initialUrl;
   for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
-    const resp = await fetch(current.toString(), { signal, redirect: "manual" });
+    const resp = await fetch(current.toString(), {
+      signal,
+      redirect: "manual",
+      headers: FETCH_HEADERS,
+    });
     const status = resp.status;
     if (status < 300 || status >= 400) return { ok: true, resp };
 


### PR DESCRIPTION
## Summary
- Strip Referer on the preview `<img>` in `ai-image-selector.tsx` via `referrerPolicy=\"no-referrer\"`. Many sites only block when they see `netereka.ci` as the referrer; an origin-less request usually succeeds.
- Send a realistic Chrome `User-Agent` + image `Accept` header from the Worker fetch in `lib/ai/image-fetch.ts` so we don't get 403'd as the default `Cloudflare-Workers/1.0` UA.
- Log per-URL fetch failures with their `reason` in `importCandidateImages`. Without the reason, diagnosing whether it's a Referer/UA block vs a hallucinated URL vs a too-large body required guessing.
- Add a unit test pinning the UA + Accept headers so a regression doesn't silently turn the Worker back into a CF default UA.

## Why
The AI generation now succeeds (post #201/#203) but the user reports preview thumbnails don't render and the import marks every URL as failed. The image_candidates Claude returns mostly point at manufacturer (Apple, Samsung) and press domains that gate on Referer + User-Agent. Empirically these two headers fix the bulk of cases — and for whatever residual failures remain, the new server log surfaces the exact `reason` so we can target the next iteration.

## Test plan
- [x] `npm run test -- __tests__/unit/ai/image-fetch.test.ts` — 12/12 (1 new)
- [x] `tsc --noEmit` clean
- [ ] After deploy, generate a product, check the selector grid actually renders thumbnails, click Import, and verify in `wrangler tail` that any remaining failures show their reason — adjust headers / add Referer-rewriting if a specific class of failure remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Image previews now include lazy loading and improved referrer policy handling for enhanced performance and security.

* **Bug Fixes**
  * Enhanced error logging and reporting for failed image imports during admin product import operations.

* **Tests**
  * Added comprehensive unit tests for image fetching and validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->