### PR TITLE
fix(admin): stop AI from hallucinating image URLs

### DIFF
--- a/__tests__/unit/ai/image-fetch.test.ts
+++ b/__tests__/unit/ai/image-fetch.test.ts
@@ -39,6 +39,18 @@ describe("fetchAndUploadImage", () => {
     if (!r.ok) expect(r.reason).toBe("ssrf");
   });
 
+  it("inclut le status HTTP dans bad_status (404 vs 403)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      new Response("not found", { status: 404, headers: { "content-type": "image/png" } }),
+    ));
+    const r = await fetchAndUploadImage("draft-1", "https://example.test/x.png");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe("bad_status");
+      expect(r.status).toBe(404);
+    }
+  });
+
   it("rejette les content-types non-image", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
       makeImageResponse({ contentType: "text/html" }),

--- a/__tests__/unit/ai/prompt-validation.test.ts
+++ b/__tests__/unit/ai/prompt-validation.test.ts
@@ -87,6 +87,11 @@ describe("aiProductOutputSchema", () => {
     };
     expect(aiProductOutputSchema.safeParse(bad).success).toBe(false);
   });
+
+  it("accepte image_candidates vide (Claude doit pouvoir admettre l'absence d'URLs sûres)", () => {
+    const out = { name: "X", category_suggestion: "y", image_candidates: [] };
+    expect(aiProductOutputSchema.safeParse(out).success).toBe(true);
+  });
 });
 
 describe("parseAiToolInput", () => {

--- a/__tests__/unit/ai/submit-tool-schema.test.ts
+++ b/__tests__/unit/ai/submit-tool-schema.test.ts
@@ -113,6 +113,12 @@ describe("SUBMIT_PRODUCT_TOOL_SCHEMA", () => {
     ).toBe(true);
   });
 
+  it("accepte image_candidates vide", () => {
+    const ok = validate({ ...validOutput, image_candidates: [] });
+    expect(validate.errors ?? []).toEqual([]);
+    expect(ok).toBe(true);
+  });
+
   it("rejette image_candidates avec une URL non valide", () => {
     const ok = validate({
       ...validOutput,

--- a/actions/admin/products-ai.ts
+++ b/actions/admin/products-ai.ts
@@ -38,8 +38,8 @@ export async function importCandidateImages(
   const output = outputParsed.data;
 
   const candidateSet = new Set(output.image_candidates.map((c) => c.url));
-  if (selectedUrls.length < 1 || selectedUrls.length > 8) {
-    return { success: false, error: "Sélectionnez entre 1 et 8 images" };
+  if (selectedUrls.length > 8) {
+    return { success: false, error: "Sélectionnez au plus 8 images" };
   }
   for (const u of selectedUrls) {
     if (!candidateSet.has(u)) return { success: false, error: "Sélection d'images invalide" };

--- a/components/admin/ai-product/ai-image-selector.tsx
+++ b/components/admin/ai-product/ai-image-selector.tsx
@@ -11,7 +11,10 @@ interface AiImageSelectorProps {
   busy: boolean;
 }
 
-const MIN = 1;
+// MIN = 0 — Claude is allowed to return image_candidates: [] when web_search
+// didn't surface any URL it can copy verbatim; admin then proceeds without
+// images and adds them manually after the draft is created.
+const MIN = 0;
 const MAX = 8;
 
 export function AiImageSelector({ output, onConfirm, onCancel, busy }: AiImageSelectorProps) {
@@ -28,6 +31,7 @@ export function AiImageSelector({ output, onConfirm, onCancel, busy }: AiImageSe
   }
 
   const canConfirm = selected.length >= MIN && !busy;
+  const noCandidates = output.image_candidates.length === 0;
 
   return (
     <div className="space-y-6">
@@ -38,7 +42,9 @@ export function AiImageSelector({ output, onConfirm, onCancel, busy }: AiImageSe
           {output.attributes.colors.length > 0 && ` · ${output.attributes.colors.length} couleurs détectées`}
         </p>
         <p className="mt-1 text-xs text-muted-foreground">
-          Choisissez {MIN} à {MAX} images. La 1re cochée sera l&apos;image principale.
+          {noCandidates
+            ? "L'IA n'a pas trouvé d'images fiables. Continuez sans images puis ajoutez-les manuellement après création."
+            : `Choisissez jusqu'à ${MAX} images. La 1re cochée sera l'image principale.`}
         </p>
       </div>
 
@@ -87,7 +93,11 @@ export function AiImageSelector({ output, onConfirm, onCancel, busy }: AiImageSe
           Annuler
         </Button>
         <Button type="button" disabled={!canConfirm} onClick={() => onConfirm(selected)}>
-          {busy ? "Importation…" : `Importer et continuer (${selected.length})`}
+          {busy
+            ? "Importation…"
+            : selected.length === 0
+              ? "Continuer sans images"
+              : `Importer et continuer (${selected.length})`}
         </Button>
       </div>
     </div>

--- a/lib/ai/image-fetch.ts
+++ b/lib/ai/image-fetch.ts
@@ -22,7 +22,14 @@ const EXT_BY_TYPE: Record<string, string> = {
 
 export type FetchImageResult =
   | { ok: true; key: string; contentType: string; size: number }
-  | { ok: false; reason: "ssrf" | "bad_status" | "bad_content_type" | "too_large" | "timeout" | "fetch_failed" | "upload_failed" };
+  | {
+      ok: false;
+      reason: "ssrf" | "bad_status" | "bad_content_type" | "too_large" | "timeout" | "fetch_failed" | "upload_failed";
+      // HTTP status surfaced for `bad_status` so the diagnostic log can
+      // distinguish 403 (anti-bot, may need more headers) from 404 (URL
+      // hallucinated by the model, fix is upstream in the prompt).
+      status?: number;
+    };
 
 /**
  * Rejects URLs that could hit internal networks. DNS lookup is not available
@@ -118,7 +125,7 @@ export async function fetchAndUploadImage(
       return { ok: false, reason: "fetch_failed" };
     }
 
-    if (!resp.ok) return { ok: false, reason: "bad_status" };
+    if (!resp.ok) return { ok: false, reason: "bad_status", status: resp.status };
 
     const ct = (resp.headers.get("content-type") ?? "").split(";")[0].trim().toLowerCase();
     if (!ALLOWED_TYPES.has(ct)) return { ok: false, reason: "bad_content_type" };

--- a/lib/ai/product-research.ts
+++ b/lib/ai/product-research.ts
@@ -48,7 +48,7 @@ export function buildSystemPrompt(): string {
     "- short_description est un RÉSUMÉ court (≤120 caractères), pas une description complète. La description longue va dans description_html.",
     "- tagline, highlights, feature_blocks, faq sont nestés sous story (ex : { story: { tagline, highlights: [...] } }).",
     "- Pour chaque highlight, choisis une icône parmi cette liste exacte : " + icons + ".",
-    "- image_candidates est un tableau d'OBJETS de la forme { url, source_domain, alt? } — JAMAIS un tableau de strings. 6 à 10 entrées, images directes (jpg/png/webp), sites constructeurs/presse, évite les watermarks.",
+    "- image_candidates : N'INVENTE JAMAIS d'URLs. Inclus UNIQUEMENT des URLs présentes telles quelles dans les résultats web_search (copier-coller exact, jamais reconstruire un pattern type `/imgroot/.../001.jpg` ni deviner un nom de fichier). Si web_search n'a renvoyé aucune URL d'image directement utilisable, retourne `image_candidates: []` — l'admin ajoutera les images après. Format des entrées : { url, source_domain, alt? } — JAMAIS un tableau de strings. Privilégie images directes (jpg/png/webp).",
     "- Les descriptions suivent un style Apple : tagline courte et percutante, highlights concis, feature_blocks éditoriaux avec un titre et un corps de 1-2 paragraphes.",
   ].join("\n");
 }

--- a/lib/ai/submit-tool-schema.ts
+++ b/lib/ai/submit-tool-schema.ts
@@ -154,10 +154,9 @@ export const SUBMIT_PRODUCT_TOOL_SCHEMA = {
     },
     image_candidates: {
       type: "array",
-      minItems: 1,
       maxItems: 12,
       description:
-        "Tableau d'OBJETS — chaque image est { url, source_domain, alt? }. Pas de strings nues.",
+        "Tableau d'OBJETS — chaque image est { url, source_domain, alt? }. Pas de strings nues. Inclus UNIQUEMENT des URLs trouvées telles quelles dans les résultats web_search ; tableau vide si aucune URL n'est sûre.",
       items: {
         type: "object",
         required: ["url", "source_domain"],

--- a/lib/validations/product-ai.ts
+++ b/lib/validations/product-ai.ts
@@ -71,11 +71,15 @@ export const aiProductOutputSchema = z.object({
     meta_title: z.string().trim().max(60).optional(),
     meta_description: z.string().trim().max(160).optional(),
   }).default({}),
+  // min:0 — Claude must be allowed to honestly return [] when web_search
+  // didn't surface any image URL it can copy verbatim. Forcing min:1 made it
+  // hallucinate URL patterns (e.g. cdn.gsmarena.com/vv/pics/{model}-{N}.jpg)
+  // that 404'd at display and import time. Admin fills images manually if 0.
   image_candidates: z.array(z.object({
     url: z.string().url(),
     source_domain: z.string().min(1),
     alt: z.string().max(200).optional(),
-  })).min(1).max(12),
+  })).max(12).default([]),
 });
 
 export const aiNotFoundSchema = z.object({


### PR DESCRIPTION
## Summary
- System prompt explicitly forbids URL construction. Claude must copy URLs verbatim from web_search results or return `[]` honestly.
- `image_candidates` min: 1 → 0 (Zod + JSON Schema). The previous floor forced fabrication when web_search yielded no usable image URLs.
- Selector + import action accept 0 images. Button label flips to "Continuer sans images"; admin uploads them via the regular product edit form afterwards.
- `bad_status` now carries the HTTP status code so future logs distinguish 403 (anti-bot, fix headers) from 404 (model hallucination, fix prompt).
- 3 new tests pin the new behavior (empty `image_candidates` accepted at Zod and JSON Schema layers, status code surfaced in `bad_status`).

## Diagnostic
Two consecutive `wrangler tail` runs after the #205 deploy showed every selected URL returning HTTP 404. Examples:
- `cdn.gsmarena.com/vv/pics/honor/honor-magic8-pro-5g-{1..6}.jpg`
- `fdn.gsmarena.com/imgroot/news/25/10/honor-magic8-pro-official/-1220x526/gsmarena_{001,002}.jpg`

Pattern: Claude memorized real URL structures (gsmarena's CDN paths exist) but is inventing the slugs/filenames. The Anthropic `web_search` tool returns page text, not embedded image URLs, so the model has no live URLs to cite verbatim — and was forced to fabricate by the `min: 1` floor.

## Test plan
- [x] `npm run test -- __tests__/unit/ai/` — 65/65 (3 new)
- [x] `tsc --noEmit` clean
- [ ] After deploy, generate a product. Expected outcome: `image_candidates: []` most of the time, occasional 1-2 real URLs from sources Claude is highly confident about (Wikipedia, archive.org). Selector shows "Continuer sans images" → admin proceeds → uploads images manually in the product edit page.
- [ ] If a URL fails import, `wrangler tail` will show its HTTP status (e.g. `status: 403` → still a Referer/UA issue to fix; `status: 404` → still hallucinating, prompt may need more reinforcement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now import AI products without selecting images when reliable candidates aren't available.
  * Error responses now include HTTP status codes for better diagnostics.

* **Bug Fixes**
  * AI will no longer hallucinate invalid image URLs when no safe images are found.

* **Tests**
  * Added validation tests for empty image candidate handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->