### PR TITLE
feat(admin): give Claude an image_search tool (Brave) for product creation

### DIFF
--- a/__tests__/unit/actions/admin-ai-config.test.ts
+++ b/__tests__/unit/actions/admin-ai-config.test.ts
@@ -205,6 +205,31 @@ describe("saveAiConfig", () => {
     );
   });
 
+  it("met à jour Brave seul, préserve Anthropic via masque", async () => {
+    mocks.dbGet.mockResolvedValue({
+      id: 1,
+      anthropic_api_key: "sk-ant-existing-aaaa",
+      brave_api_key: null,
+      model: null,
+      enabled: 1,
+    });
+
+    const fd = new FormData();
+    fd.set("anthropic_api_key", "••••••••aaaa");
+    fd.set("brave_api_key", "BSA-fresh-key");
+    fd.set("enabled", "on");
+
+    const result = await saveAiConfig(fd);
+
+    expect(result.success).toBe(true);
+    expect(mocks.dbValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        anthropic_api_key: "sk-ant-existing-aaaa",
+        brave_api_key: "BSA-fresh-key",
+      }),
+    );
+  });
+
   it("clé Brave vide → null (n'active pas image_search)", async () => {
     const fd = new FormData();
     fd.set("anthropic_api_key", "sk-ant-x-1234");

--- a/__tests__/unit/actions/admin-ai-config.test.ts
+++ b/__tests__/unit/actions/admin-ai-config.test.ts
@@ -205,6 +205,27 @@ describe("saveAiConfig", () => {
     );
   });
 
+  it("rejette une valeur masque-shape Brave quand aucune clé Brave existante en DB", async () => {
+    mocks.dbGet.mockResolvedValue({
+      id: 1,
+      anthropic_api_key: "sk-ant-existing-zzzz",
+      brave_api_key: null,
+      model: null,
+      enabled: 1,
+    });
+
+    const fd = new FormData();
+    fd.set("anthropic_api_key", "••••••••zzzz");
+    fd.set("brave_api_key", "••••••••1234");
+    fd.set("enabled", "on");
+
+    const result = await saveAiConfig(fd);
+
+    expect(result.success).toBe(false);
+    expect(result.fieldErrors?.brave_api_key).toBeDefined();
+    expect(mocks.dbValues).not.toHaveBeenCalled();
+  });
+
   it("met à jour Brave seul, préserve Anthropic via masque", async () => {
     mocks.dbGet.mockResolvedValue({
       id: 1,

--- a/__tests__/unit/actions/admin-ai-config.test.ts
+++ b/__tests__/unit/actions/admin-ai-config.test.ts
@@ -163,6 +163,61 @@ describe("saveAiConfig", () => {
     expect(mocks.revalidatePath).toHaveBeenCalledWith("/ai-settings");
   });
 
+  it("sauvegarde la clé Brave en plus de la clé Anthropic", async () => {
+    const fd = new FormData();
+    fd.set("anthropic_api_key", "sk-ant-x-1234");
+    fd.set("brave_api_key", "BSA-realbravekey");
+    fd.set("enabled", "on");
+
+    const result = await saveAiConfig(fd);
+
+    expect(result.success).toBe(true);
+    expect(mocks.dbValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        anthropic_api_key: "sk-ant-x-1234",
+        brave_api_key: "BSA-realbravekey",
+      }),
+    );
+  });
+
+  it("préserve la clé Brave existante quand son masque est renvoyé tel quel", async () => {
+    mocks.dbGet.mockResolvedValue({
+      id: 1,
+      anthropic_api_key: "sk-ant-existing-zzzz",
+      brave_api_key: "BSA-existing-9876",
+      model: null,
+      enabled: 1,
+    });
+
+    const fd = new FormData();
+    fd.set("anthropic_api_key", "••••••••zzzz");
+    fd.set("brave_api_key", "••••••••9876");
+    fd.set("enabled", "on");
+
+    const result = await saveAiConfig(fd);
+
+    expect(result.success).toBe(true);
+    expect(mocks.dbValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        anthropic_api_key: "sk-ant-existing-zzzz",
+        brave_api_key: "BSA-existing-9876",
+      }),
+    );
+  });
+
+  it("clé Brave vide → null (n'active pas image_search)", async () => {
+    const fd = new FormData();
+    fd.set("anthropic_api_key", "sk-ant-x-1234");
+    fd.set("brave_api_key", "");
+    fd.set("enabled", "on");
+
+    await saveAiConfig(fd);
+
+    expect(mocks.dbValues).toHaveBeenCalledWith(
+      expect.objectContaining({ brave_api_key: null }),
+    );
+  });
+
   it("préserve la clé existante quand le masque est renvoyé tel quel", async () => {
     mocks.dbGet.mockResolvedValue({
       id: 1,

--- a/__tests__/unit/ai/config.test.ts
+++ b/__tests__/unit/ai/config.test.ts
@@ -33,6 +33,7 @@ describe("getAiSettings", () => {
     mocks.dbGet.mockResolvedValue({
       id: 1,
       anthropic_api_key: "sk-ant-db-key",
+      brave_api_key: "BSA-db-brave",
       model: "claude-opus-4-7",
       enabled: 1,
     });
@@ -41,6 +42,7 @@ describe("getAiSettings", () => {
 
     expect(result).toEqual({
       apiKey: "sk-ant-db-key",
+      braveApiKey: "BSA-db-brave",
       model: "claude-opus-4-7",
       enabled: true,
     });
@@ -73,9 +75,23 @@ describe("getAiSettings", () => {
 
     expect(result).toEqual({
       apiKey: null,
+      braveApiKey: null,
       model: null,
       enabled: true, // default-on preserved
     });
+  });
+
+  it("braveApiKey: DB win, env fallback, ou null", async () => {
+    mocks.dbGet.mockResolvedValue({
+      id: 1, anthropic_api_key: null, brave_api_key: null, model: null, enabled: 1,
+    });
+    mocks.getEnv.mockResolvedValue({ BRAVE_API_KEY: "BSA-env" });
+    expect((await getAiSettings()).braveApiKey).toBe("BSA-env");
+
+    mocks.dbGet.mockResolvedValue({
+      id: 1, anthropic_api_key: null, brave_api_key: "BSA-db", model: null, enabled: 1,
+    });
+    expect((await getAiSettings()).braveApiKey).toBe("BSA-db");
   });
 
   it("enabled=0 en DB override l'env var (DB est source de vérité si row existe)", async () => {

--- a/__tests__/unit/ai/image-search.test.ts
+++ b/__tests__/unit/ai/image-search.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { searchImages } from "@/lib/ai/image-search";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("searchImages", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("retourne no_api_key quand la clé est absente", async () => {
+    const r = await searchImages({ query: "x" }, null);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("no_api_key");
+  });
+
+  it("normalise les résultats Brave (properties.url + thumbnail.src)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      jsonResponse({
+        results: [
+          {
+            title: "Galaxy A55 product photo",
+            url: "https://samsung.com/page",
+            source: "samsung.com",
+            thumbnail: { src: "https://imgs.search.brave.com/abc.jpg" },
+            properties: { url: "https://samsung.com/galaxy-a55-product.jpg" },
+          },
+          {
+            // missing properties.url falls back to top-level url
+            title: "Hands-on review",
+            url: "https://theverge.com/img.jpg",
+            source: "theverge.com",
+            thumbnail: { src: "https://imgs.search.brave.com/def.jpg" },
+          },
+          {
+            // dropped: no usable URL at all
+            title: "broken",
+          },
+        ],
+      }),
+    ));
+
+    const r = await searchImages({ query: "Galaxy A55" }, "test-key");
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.results).toHaveLength(2);
+      expect(r.results[0]).toEqual({
+        url: "https://samsung.com/galaxy-a55-product.jpg",
+        source_domain: "samsung.com",
+        title: "Galaxy A55 product photo",
+        thumbnail_url: "https://imgs.search.brave.com/abc.jpg",
+      });
+      expect(r.results[1].source_domain).toBe("theverge.com");
+    }
+  });
+
+  it("envoie le header X-Subscription-Token et la query encodée", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ results: [] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await searchImages({ query: "iPhone 15", count: 5 }, "secret-key");
+
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl).toContain("q=iPhone+15");
+    expect(calledUrl).toContain("count=5");
+    expect(calledUrl).toContain("safesearch=strict");
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers["x-subscription-token"]).toBe("secret-key");
+  });
+
+  it("clampe count entre 1 et 20", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ results: [] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await searchImages({ query: "x", count: 999 }, "k");
+    expect(fetchMock.mock.calls[0][0] as string).toContain("count=20");
+
+    await searchImages({ query: "x", count: 0 }, "k");
+    expect(fetchMock.mock.calls[1][0] as string).toContain("count=1");
+  });
+
+  it("retourne auth_failed pour 401/403", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("nope", { status: 401 })));
+    const r = await searchImages({ query: "x" }, "bad-key");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("auth_failed");
+  });
+
+  it("retourne rate_limited pour 429", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("slow down", { status: 429 })));
+    const r = await searchImages({ query: "x" }, "k");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("rate_limited");
+  });
+
+  it("retourne upstream_error pour 5xx", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("oops", { status: 503 })));
+    const r = await searchImages({ query: "x" }, "k");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("upstream_error");
+  });
+
+  it("retourne timeout quand fetch est aborted", async () => {
+    const aborted = Object.assign(new Error("aborted"), { name: "AbortError" });
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(aborted));
+    const r = await searchImages({ query: "x" }, "k", { timeoutMs: 100 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("timeout");
+  });
+});

--- a/__tests__/unit/ai/image-search.test.ts
+++ b/__tests__/unit/ai/image-search.test.ts
@@ -12,12 +12,12 @@ describe("searchImages", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("retourne no_api_key quand la clé est absente", async () => {
-    const r = await searchImages({ query: "x" }, null);
+    const r = await searchImages({ query: "xx" }, null);
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toBe("no_api_key");
   });
 
-  it("normalise les résultats Brave (properties.url + thumbnail.src)", async () => {
+  it("normalise les résultats Brave et drop les items sans properties.url", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
       jsonResponse({
         results: [
@@ -29,14 +29,15 @@ describe("searchImages", () => {
             properties: { url: "https://samsung.com/galaxy-a55-product.jpg" },
           },
           {
-            // missing properties.url falls back to top-level url
+            // DROPPED: properties.url missing — top-level url is the hosting
+            // HTML page (per Brave docs), not a direct image URL. Feeding it
+            // to image_candidates would 404 on bad_content_type.
             title: "Hands-on review",
-            url: "https://theverge.com/img.jpg",
+            url: "https://theverge.com/article",
             source: "theverge.com",
-            thumbnail: { src: "https://imgs.search.brave.com/def.jpg" },
           },
           {
-            // dropped: no usable URL at all
+            // DROPPED: no usable URL at all
             title: "broken",
           },
         ],
@@ -46,15 +47,42 @@ describe("searchImages", () => {
     const r = await searchImages({ query: "Galaxy A55" }, "test-key");
     expect(r.ok).toBe(true);
     if (r.ok) {
-      expect(r.results).toHaveLength(2);
+      expect(r.results).toHaveLength(1);
       expect(r.results[0]).toEqual({
         url: "https://samsung.com/galaxy-a55-product.jpg",
         source_domain: "samsung.com",
         title: "Galaxy A55 product photo",
         thumbnail_url: "https://imgs.search.brave.com/abc.jpg",
       });
-      expect(r.results[1].source_domain).toBe("theverge.com");
     }
+  });
+
+  it("utilise hostname extrait de l'URL quand source est absent", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      jsonResponse({
+        results: [
+          {
+            title: "Press shot",
+            properties: { url: "https://news.samsung.com/global/foo.jpg" },
+            // no `source` field
+          },
+        ],
+      }),
+    ));
+    const r = await searchImages({ query: "xx" }, "k");
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.results[0].source_domain).toBe("news.samsung.com");
+  });
+
+  it("drop l'item quand l'URL est non-parseable et source manquant", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      jsonResponse({
+        results: [{ properties: { url: "not a url" }, title: "junk" }],
+      }),
+    ));
+    const r = await searchImages({ query: "xx" }, "k");
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.results).toHaveLength(0);
   });
 
   it("envoie le header X-Subscription-Token et la query encodée", async () => {
@@ -76,38 +104,80 @@ describe("searchImages", () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ results: [] }));
     vi.stubGlobal("fetch", fetchMock);
 
-    await searchImages({ query: "x", count: 999 }, "k");
+    await searchImages({ query: "xx", count: 999 }, "k");
     expect(fetchMock.mock.calls[0][0] as string).toContain("count=20");
 
-    await searchImages({ query: "x", count: 0 }, "k");
+    await searchImages({ query: "xx", count: 0 }, "k");
     expect(fetchMock.mock.calls[1][0] as string).toContain("count=1");
   });
 
   it("retourne auth_failed pour 401/403", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("nope", { status: 401 })));
-    const r = await searchImages({ query: "x" }, "bad-key");
+    const r = await searchImages({ query: "xx" }, "bad-key");
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toBe("auth_failed");
   });
 
   it("retourne rate_limited pour 429", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("slow down", { status: 429 })));
-    const r = await searchImages({ query: "x" }, "k");
+    const r = await searchImages({ query: "xx" }, "k");
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toBe("rate_limited");
   });
 
   it("retourne upstream_error pour 5xx", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("oops", { status: 503 })));
-    const r = await searchImages({ query: "x" }, "k");
+    const r = await searchImages({ query: "xx" }, "k");
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toBe("upstream_error");
+  });
+
+  it("retourne invalid_input pour query absente ou trop courte", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    expect((await searchImages({} as never, "k")).ok).toBe(false);
+    expect((await searchImages({ query: "" }, "k")).ok).toBe(false);
+    expect((await searchImages({ query: " " }, "k")).ok).toBe(false);
+    expect((await searchImages({ query: 42 as never }, "k")).ok).toBe(false);
+    // Aucun appel réseau ne doit avoir lieu — la garde côté input court-circuite.
+    expect(fetchMock).not.toHaveBeenCalled();
+    const r = await searchImages({ query: "" }, "k");
+    if (!r.ok) expect(r.reason).toBe("invalid_input");
+  });
+
+  it("retourne parse_failed pour un body 200 non-JSON", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      new Response("<html>oops</html>", { status: 200, headers: { "content-type": "text/html" } }),
+    ));
+    const r = await searchImages({ query: "xx" }, "k");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("parse_failed");
+  });
+
+  it("warn quand Brave 200 OK mais results manquant (schema drift)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ unexpected: "shape" })));
+    const r = await searchImages({ query: "xx" }, "k");
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.results).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("schema drift"),
+      expect.objectContaining({ keys: ["unexpected"] }),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("utilise count=10 par défaut", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ results: [] }));
+    vi.stubGlobal("fetch", fetchMock);
+    await searchImages({ query: "xx" }, "k");
+    expect(fetchMock.mock.calls[0][0] as string).toContain("count=10");
   });
 
   it("retourne timeout quand fetch est aborted", async () => {
     const aborted = Object.assign(new Error("aborted"), { name: "AbortError" });
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(aborted));
-    const r = await searchImages({ query: "x" }, "k", { timeoutMs: 100 });
+    const r = await searchImages({ query: "xx" }, "k", { timeoutMs: 100 });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toBe("timeout");
   });

--- a/__tests__/unit/ai/product-research.test.ts
+++ b/__tests__/unit/ai/product-research.test.ts
@@ -1,39 +1,69 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { classifyError, researchProduct, type ResearchProgress } from "@/lib/ai/product-research";
 import type Anthropic from "@anthropic-ai/sdk";
 
+interface StubEvent {
+  type: string;
+  content_block?: { type: string; name?: string; input?: unknown };
+}
+interface StubTurn {
+  events: StubEvent[];
+  stop_reason?: "end_turn" | "tool_use" | "max_tokens";
+}
+
 /**
- * Build a minimal Anthropic stub where `messages.stream(...)` returns an object
- * that (a) yields the provided events as an async iterable, and (b) exposes a
- * `finalMessage()` method returning a message whose `content` is derived from
- * the `tool_use` events we recorded.
+ * Build a minimal Anthropic stub. `messages.stream(...)` returns a turn-aware
+ * object — each call advances to the next StubTurn so we can exercise the
+ * multi-turn tool-use loop. Each turn yields its events and exposes a
+ * `finalMessage()` matching the turn's stop_reason + derived tool_use blocks.
+ *
+ * Backwards-compat: `makeAnthropicStub(events)` (legacy single-turn shape)
+ * is treated as one turn with stop_reason="end_turn".
+ *
+ * Tracks `passedMessages` so tests can assert the conversation thread shape
+ * across turns (assistant content + tool_result echoes).
  */
-function makeAnthropicStub(events: Array<{ type: string; content_block?: { type: string; name?: string; input?: unknown } }>): Anthropic {
-  return {
+function makeAnthropicStub(turnsOrEvents: StubTurn[] | StubEvent[]): Anthropic & { calls(): unknown[] } {
+  const turns: StubTurn[] = Array.isArray(turnsOrEvents) && turnsOrEvents.length > 0 && "events" in (turnsOrEvents[0] as object)
+    ? (turnsOrEvents as StubTurn[])
+    : [{ events: turnsOrEvents as StubEvent[], stop_reason: "end_turn" }];
+  let turnIdx = 0;
+  const passedMessages: unknown[] = [];
+
+  const stub = {
     messages: {
-      stream: () => {
-        const toolUses = events
+      stream: (params: { messages: unknown[] }) => {
+        // Snapshot the array — the loop keeps pushing into the same `messages`
+        // reference, so capturing by reference would show the *final* state.
+        passedMessages.push([...params.messages]);
+        const turn = turns[turnIdx] ?? turns[turns.length - 1];
+        const turnId = turnIdx;
+        turnIdx++;
+        const toolUses = turn.events
           .filter((e) => e.type === "content_block_start" && e.content_block?.type === "tool_use")
-          .map((e) => ({
+          .map((e, idx) => ({
             type: "tool_use" as const,
+            id: `tu_${turnId}_${idx}`,
             name: e.content_block!.name,
             input: e.content_block!.input,
           }));
 
         const iterable = (async function* () {
-          for (const ev of events) yield ev;
+          for (const ev of turn.events) yield ev;
         })();
 
         return {
           [Symbol.asyncIterator]() { return iterable; },
           finalMessage: async () => ({
             content: toolUses,
-            stop_reason: "end_turn",
+            stop_reason: turn.stop_reason ?? "end_turn",
           }),
         };
       },
     },
-  } as unknown as Anthropic;
+    calls: () => passedMessages,
+  };
+  return stub as unknown as Anthropic & { calls(): unknown[] };
 }
 
 async function drain(iter: AsyncGenerator<ResearchProgress>): Promise<ResearchProgress[]> {
@@ -100,6 +130,22 @@ describe("researchProduct", () => {
     expect(events.at(-1)).toEqual({ type: "error", code: "invalid_ai_output" });
   });
 
+  it("anti-régression prompt: interdiction de fabriquer des URLs reste explicite", async () => {
+    // Load-bearing instruction — the entire image-hallucination problem comes
+    // back if this line gets accidentally removed in a future prompt rewrite.
+    const { buildSystemPrompt } = await import("@/lib/ai/product-research");
+    const prompt = buildSystemPrompt({ hasImageSearch: true });
+    expect(prompt).toMatch(/N'INVENTE JAMAIS d'URLs/);
+    expect(prompt).toMatch(/UNIQUEMENT des URLs/);
+  });
+
+  it("sans braveApiKey, le prompt instruit le modèle de retourner image_candidates: []", async () => {
+    const { buildSystemPrompt } = await import("@/lib/ai/product-research");
+    const prompt = buildSystemPrompt({ hasImageSearch: false });
+    expect(prompt).toMatch(/image_search non disponible/i);
+    expect(prompt).toMatch(/image_candidates: \[\]/);
+  });
+
   it("buildTools n'inclut pas image_search quand braveApiKey est absent", async () => {
     // Even though the stub triggers an image_search progress event, the real
     // production behavior is that without a Brave key, image_search isn't
@@ -111,12 +157,132 @@ describe("researchProduct", () => {
     expect(withImage.find((t) => "name" in t && t.name === "image_search")).toBeDefined();
   });
 
-  it("émet error:api_error si submit_product jamais appelé", async () => {
+  it("émet error:model_no_submit quand le modèle s'arrête sans submit_product", async () => {
+    // No tool_use blocks AT ALL → no submit_product, stop_reason will default
+    // to "end_turn" in the stub → triggers the model_no_submit branch.
     const anthropic = makeAnthropicStub([
       { type: "content_block_start", content_block: { type: "text", name: undefined } },
     ]);
     const events = await drain(researchProduct("x", anthropic));
-    expect(events.at(-1)).toEqual({ type: "error", code: "api_error" });
+    expect(events.at(-1)).toEqual({ type: "error", code: "model_no_submit" });
+  });
+
+  it("multi-turn happy path : image_search → tool_result → submit_product", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        results: [{ properties: { url: "https://samsung.com/a.jpg" }, source: "samsung.com", title: "x" }],
+      }), { status: 200, headers: { "content-type": "application/json" } }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const anthropic = makeAnthropicStub([
+      {
+        events: [
+          { type: "content_block_start", content_block: { type: "server_tool_use", name: "web_search", input: { query: "Galaxy A55" } } },
+          { type: "content_block_start", content_block: { type: "tool_use", name: "image_search", input: { query: "Galaxy A55 product photo" } } },
+        ],
+        stop_reason: "tool_use",
+      },
+      {
+        events: [
+          { type: "content_block_start", content_block: { type: "tool_use", name: "submit_product", input: validOutput } },
+        ],
+        stop_reason: "end_turn",
+      },
+    ]);
+
+    const events = await drain(researchProduct("Galaxy A55", anthropic, { braveApiKey: "test-key" }));
+
+    // Brave called once with the model's query
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0] as string).toContain("q=Galaxy+A55+product+photo");
+    // Conversation thread: 2nd turn's messages must include the tool_result
+    const secondTurnMessages = (anthropic as unknown as { calls: () => unknown[][] }).calls()[1];
+    expect(Array.isArray(secondTurnMessages)).toBe(true);
+    // Last message before turn 2 must be a `user` role with tool_result content
+    const last = (secondTurnMessages as { role: string; content: unknown }[]).at(-1)!;
+    expect(last.role).toBe("user");
+    expect(Array.isArray(last.content)).toBe(true);
+    const toolResult = (last.content as { type: string; tool_use_id: string }[])[0];
+    expect(toolResult.type).toBe("tool_result");
+    expect(toolResult.tool_use_id).toBe("tu_0_0");
+    // Terminal: done
+    expect(events.at(-1)?.type).toBe("done");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("recovery: Brave échoue (auth_failed) → tool_result is_error → modèle émet submit_product avec image_candidates: []", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("nope", { status: 401 })));
+
+    const outputNoImages = { ...validOutput, image_candidates: [] };
+    const anthropic = makeAnthropicStub([
+      {
+        events: [
+          { type: "content_block_start", content_block: { type: "tool_use", name: "image_search", input: { query: "xx" } } },
+        ],
+        stop_reason: "tool_use",
+      },
+      {
+        events: [
+          { type: "content_block_start", content_block: { type: "tool_use", name: "submit_product", input: outputNoImages } },
+        ],
+        stop_reason: "end_turn",
+      },
+    ]);
+
+    const events = await drain(researchProduct("x", anthropic, { braveApiKey: "bad-key" }));
+
+    // Tool result must be flagged is_error so the model recovers
+    const secondTurnMessages = (anthropic as unknown as { calls: () => unknown[][] }).calls()[1];
+    const last = (secondTurnMessages as { role: string; content: unknown }[]).at(-1)!;
+    const toolResult = (last.content as { is_error: boolean; content: string }[])[0];
+    expect(toolResult.is_error).toBe(true);
+    expect(toolResult.content).toContain("auth_failed");
+    // And the model recovered with an empty image_candidates fiche
+    const terminal = events.at(-1) as { type: "done"; output: { image_candidates: unknown[] } };
+    expect(terminal.type).toBe("done");
+    expect(terminal.output.image_candidates).toEqual([]);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("loop_exhausted quand le modèle ne fait que retry image_search", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ results: [] }), { status: 200, headers: { "content-type": "application/json" } }),
+    ));
+
+    // 9 turns of pure image_search (more than MAX_LOOP_ITERATIONS=8). Stub
+    // returns the last turn forever past its array length, so the loop will
+    // see image_search every time and never get submit_product.
+    const stuckTurn = {
+      events: [
+        { type: "content_block_start", content_block: { type: "tool_use", name: "image_search", input: { query: "stuck" } } },
+      ],
+      stop_reason: "tool_use" as const,
+    };
+    const anthropic = makeAnthropicStub(Array(9).fill(stuckTurn));
+
+    const events = await drain(researchProduct("x", anthropic, { braveApiKey: "k" }));
+
+    expect(events.at(-1)).toEqual({ type: "error", code: "loop_exhausted" });
+    vi.unstubAllGlobals();
+  });
+
+  it("internal_error quand stop_reason=tool_use mais aucun client tool", async () => {
+    // Defensive-impossible state: stop_reason="tool_use" but only
+    // server_tool_use blocks. Anthropic shouldn't ever produce this, but if
+    // it does, we surface as internal_error (code defect, not transient).
+    const anthropic = makeAnthropicStub([
+      {
+        events: [
+          { type: "content_block_start", content_block: { type: "server_tool_use", name: "web_search", input: {} } },
+        ],
+        stop_reason: "tool_use",
+      },
+    ]);
+    const events = await drain(researchProduct("x", anthropic));
+    expect(events.at(-1)).toEqual({ type: "error", code: "internal_error" });
   });
 });
 

--- a/__tests__/unit/ai/product-research.test.ts
+++ b/__tests__/unit/ai/product-research.test.ts
@@ -65,15 +65,19 @@ describe("researchProduct", () => {
     expect(terminal.output.name).toBe("Galaxy A55");
   });
 
-  it("émet search → specs → images pour 3 recherches consécutives", async () => {
+  it("émet search → specs → images → finalize avec web_search puis image_search", async () => {
     const anthropic = makeAnthropicStub([
       { type: "content_block_start", content_block: { type: "server_tool_use", name: "web_search", input: { query: "a" } } },
       { type: "content_block_start", content_block: { type: "server_tool_use", name: "web_search", input: { query: "b" } } },
-      { type: "content_block_start", content_block: { type: "server_tool_use", name: "web_search", input: { query: "c" } } },
+      { type: "content_block_start", content_block: { type: "tool_use", name: "image_search", input: { query: "x photo" } } },
       { type: "content_block_start", content_block: { type: "tool_use", name: "submit_product", input: validOutput } },
     ]);
 
-    const events = await drain(researchProduct("x", anthropic));
+    // Note: submit_product is in the same turn as image_search, so the loop
+    // breaks before executing image_search. The progress emission still fires
+    // on content_block_start. braveApiKey is what makes image_search appear in
+    // the tools list — but the stub bypasses that, so we don't need a real key.
+    const events = await drain(researchProduct("x", anthropic, { braveApiKey: "test" }));
     const progressSteps = events
       .filter((e) => e.type === "progress")
       .map((e) => (e as { type: "progress"; step: string }).step);
@@ -94,6 +98,17 @@ describe("researchProduct", () => {
     ]);
     const events = await drain(researchProduct("x", anthropic));
     expect(events.at(-1)).toEqual({ type: "error", code: "invalid_ai_output" });
+  });
+
+  it("buildTools n'inclut pas image_search quand braveApiKey est absent", async () => {
+    // Even though the stub triggers an image_search progress event, the real
+    // production behavior is that without a Brave key, image_search isn't
+    // declared and the model can't call it. Pin via buildTools directly.
+    const { buildTools } = await import("@/lib/ai/product-research");
+    const without = buildTools({ hasImageSearch: false });
+    const withImage = buildTools({ hasImageSearch: true });
+    expect(without.find((t) => "name" in t && t.name === "image_search")).toBeUndefined();
+    expect(withImage.find((t) => "name" in t && t.name === "image_search")).toBeDefined();
   });
 
   it("émet error:api_error si submit_product jamais appelé", async () => {

--- a/actions/admin/ai-config.ts
+++ b/actions/admin/ai-config.ts
@@ -12,6 +12,8 @@ import type { ActionResult } from "@/lib/utils";
 export interface AiConfigView {
   apiKeyMask: string | null;
   apiKeyFromEnv: boolean;
+  braveApiKeyMask: string | null;
+  braveApiKeyFromEnv: boolean;
   model: string | null;
   modelFromEnv: boolean;
   enabled: boolean;
@@ -41,13 +43,17 @@ export async function getAiConfig(): Promise<AiConfigView> {
   }
 
   const dbKey = row?.anthropic_api_key || null;
+  const dbBraveKey = row?.brave_api_key || null;
   const dbModel = row?.model || null;
   const envKey = env.ANTHROPIC_API_KEY || null;
+  const envBraveKey = env.BRAVE_API_KEY || null;
   const envModel = env.AI_MODEL || null;
 
   return {
     apiKeyMask: dbKey ? maskKey(dbKey) : envKey ? maskKey(envKey) : null,
     apiKeyFromEnv: !dbKey && !!envKey,
+    braveApiKeyMask: dbBraveKey ? maskKey(dbBraveKey) : envBraveKey ? maskKey(envBraveKey) : null,
+    braveApiKeyFromEnv: !dbBraveKey && !!envBraveKey,
     model: dbModel || envModel,
     modelFromEnv: !dbModel && !!envModel,
     enabled: row
@@ -61,6 +67,7 @@ export async function saveAiConfig(formData: FormData): Promise<ActionResult> {
 
   const parsed = aiConfigSchema.safeParse({
     anthropic_api_key: formData.get("anthropic_api_key"),
+    brave_api_key: formData.get("brave_api_key"),
     model: formData.get("model"),
     enabled: formData.get("enabled") === "on",
   });
@@ -72,29 +79,45 @@ export async function saveAiConfig(formData: FormData): Promise<ActionResult> {
     const db = await getDrizzle();
     const existing = await db.select().from(aiConfig).where(eq(aiConfig.id, 1)).get();
 
-    // Detect "unchanged" by EXACT mask equality — gotcha from CLAUDE.md: startsWith("••")
-    // would falsely match a legit key that happens to start with bullets.
-    const expectedMask = existing?.anthropic_api_key ? maskKey(existing.anthropic_api_key) : null;
-    const incomingKeyRaw = parsed.data.anthropic_api_key ?? "";
-
-    let incomingKey: string | null;
-    if (expectedMask !== null && incomingKeyRaw === expectedMask) {
-      // Mask returned unchanged → preserve existing stored key
-      incomingKey = existing!.anthropic_api_key;
-    } else if (/^•{8}/.test(incomingKeyRaw)) {
-      // Looks like a mask but doesn't match an existing stored key — most often the
-      // env-fallback mask submitted as-is. Refuse rather than silently persist garbage.
-      return {
-        success: false,
-        fieldErrors: {
-          anthropic_api_key: [
-            "Cette valeur ressemble à un masque (••••••••...). Saisissez une vraie clé API ou laissez vide pour la supprimer.",
-          ],
-        },
-      };
-    } else {
-      incomingKey = incomingKeyRaw.trim() || null;
+    // Resolve a key field where the user may submit:
+    //   - raw new value → store as-is
+    //   - mask matching the EXACT current stored mask → preserve existing
+    //   - mask not matching (env-fallback mask submitted blindly) → reject
+    function resolveKey(
+      raw: string,
+      stored: string | null,
+      fieldName: string,
+    ): { ok: true; key: string | null } | { ok: false; error: string; fieldName: string } {
+      const expectedMask = stored ? maskKey(stored) : null;
+      if (expectedMask !== null && raw === expectedMask) return { ok: true, key: stored };
+      if (/^•{8}/.test(raw)) {
+        return {
+          ok: false,
+          fieldName,
+          error: "Cette valeur ressemble à un masque (••••••••...). Saisissez une vraie clé API ou laissez vide pour la supprimer.",
+        };
+      }
+      return { ok: true, key: raw.trim() || null };
     }
+
+    const anthropicResolved = resolveKey(
+      parsed.data.anthropic_api_key ?? "",
+      existing?.anthropic_api_key ?? null,
+      "anthropic_api_key",
+    );
+    if (!anthropicResolved.ok) {
+      return { success: false, fieldErrors: { [anthropicResolved.fieldName]: [anthropicResolved.error] } };
+    }
+    const braveResolved = resolveKey(
+      parsed.data.brave_api_key ?? "",
+      existing?.brave_api_key ?? null,
+      "brave_api_key",
+    );
+    if (!braveResolved.ok) {
+      return { success: false, fieldErrors: { [braveResolved.fieldName]: [braveResolved.error] } };
+    }
+    const incomingKey = anthropicResolved.key;
+    const incomingBraveKey = braveResolved.key;
 
     const incomingModel = parsed.data.model?.trim() || null;
     const enabledInt = parsed.data.enabled ? 1 : 0;
@@ -105,6 +128,7 @@ export async function saveAiConfig(formData: FormData): Promise<ActionResult> {
       .values({
         id: 1,
         anthropic_api_key: incomingKey,
+        brave_api_key: incomingBraveKey,
         model: incomingModel,
         enabled: enabledInt,
         updated_at: updated,
@@ -113,6 +137,7 @@ export async function saveAiConfig(formData: FormData): Promise<ActionResult> {
         target: aiConfig.id,
         set: {
           anthropic_api_key: incomingKey,
+          brave_api_key: incomingBraveKey,
           model: incomingModel,
           enabled: enabledInt,
           updated_at: updated,

--- a/app/(admin)/products/ai-new/ai-new-client.tsx
+++ b/app/(admin)/products/ai-new/ai-new-client.tsx
@@ -26,6 +26,9 @@ const ERROR_MESSAGES: Record<string, string> = {
   timeout: "La génération a dépassé le délai maximum. Réessayez avec un prompt plus précis.",
   invalid_ai_output: "Le modèle n'a pas produit une fiche exploitable. Réessayez.",
   feature_disabled: "La génération IA est désactivée. Contactez un administrateur.",
+  model_no_submit: "L'IA s'est arrêtée sans générer de fiche. Reformulez le prompt et réessayez.",
+  loop_exhausted: "L'IA n'a pas pu générer de fiche après plusieurs tentatives. Reformulez ou ajoutez du contexte (marque + modèle complet).",
+  internal_error: "Erreur interne. Signalez-le à un administrateur si le problème persiste.",
 };
 
 function errorMessageFor(code: string | undefined): string {

--- a/app/api/admin/products-ai/generate/route.ts
+++ b/app/api/admin/products-ai/generate/route.ts
@@ -33,12 +33,13 @@ export async function POST(req: Request) {
   const anthropic = await getAnthropicClient();
   const encoder = new TextEncoder();
   const model = settings.model ?? undefined;
+  const braveApiKey = settings.braveApiKey ?? null;
 
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
       const write = (obj: unknown) => controller.enqueue(encoder.encode(JSON.stringify(obj) + "\n"));
       try {
-        for await (const ev of researchProduct(parsed.data, anthropic, { model })) {
+        for await (const ev of researchProduct(parsed.data, anthropic, { model, braveApiKey })) {
           write(ev);
         }
       } catch (err) {

--- a/components/admin/ai/ai-config-form.tsx
+++ b/components/admin/ai/ai-config-form.tsx
@@ -16,6 +16,7 @@ interface AiConfigFormProps {
 export function AiConfigForm({ config }: AiConfigFormProps) {
   const [isPending, startTransition] = useTransition();
   const [showApiKey, setShowApiKey] = useState(false);
+  const [showBraveKey, setShowBraveKey] = useState(false);
   const [enabled, setEnabled] = useState(config.enabled);
 
   function handleSubmit(formData: FormData) {
@@ -99,6 +100,61 @@ export function AiConfigForm({ config }: AiConfigFormProps) {
                 Quand une clé est enregistrée, ce champ affiche son masque
                 (8 puces + 4 derniers caractères). Laissez le masque tel quel pour
                 conserver la clé existante, ou saisissez une nouvelle valeur.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Clé API Brave Search</CardTitle>
+            <p className="text-muted-foreground text-sm">
+              Active l&apos;outil de recherche d&apos;images. Sans clé, l&apos;IA renverra
+              <code> image_candidates: []</code> et l&apos;admin ajoutera les images manuellement.
+              Récupérée depuis{" "}
+              <a
+                href="https://api-dashboard.search.brave.com/app/keys"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+              >
+                api-dashboard.search.brave.com
+              </a>
+              .
+            </p>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {config.braveApiKeyFromEnv && (
+              <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
+                Clé chargée depuis la variable d&apos;environnement (legacy):{" "}
+                <code>{config.braveApiKeyMask}</code>. Saisissez-la ici pour la gérer
+                depuis l&apos;administration. Tant que ce champ reste vide, la valeur
+                de l&apos;environnement continue d&apos;être utilisée.
+              </div>
+            )}
+            <div className="space-y-2">
+              <Label htmlFor="brave_api_key">Clé API Brave</Label>
+              <div className="flex gap-2">
+                <Input
+                  id="brave_api_key"
+                  name="brave_api_key"
+                  type={showBraveKey ? "text" : "password"}
+                  defaultValue={config.braveApiKeyFromEnv ? "" : (config.braveApiKeyMask ?? "")}
+                  placeholder="BSA..."
+                  className="flex-1"
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setShowBraveKey((v) => !v)}
+                  className="shrink-0"
+                >
+                  {showBraveKey ? "Masquer" : "Afficher"}
+                </Button>
+              </div>
+              <p className="text-muted-foreground text-xs">
+                Optionnelle. Forfait gratuit&nbsp;: 2&nbsp;000 requêtes/mois.
               </p>
             </div>
           </CardContent>

--- a/drizzle/0012_peaceful_flatman.sql
+++ b/drizzle/0012_peaceful_flatman.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `ai_config` ADD `brave_api_key` text;

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,3028 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "89d2ca9a-8842-4f63-80ad-a18164d078d5",
+  "prevId": "16ff559c-c852-408b-8f73-ac25a0bad26a",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_account_userId": {
+          "name": "idx_account_userId",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "idx_account_provider": {
+          "name": "idx_account_provider",
+          "columns": [
+            "providerId",
+            "accountId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "addresses": {
+      "name": "addresses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Domicile'"
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "street": {
+          "name": "street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commune": {
+          "name": "commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Abidjan'"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_addresses_user": {
+          "name": "idx_addresses_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "addresses_user_id_user_id_fk": {
+          "name": "addresses_user_id_user_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "addresses_zone_id_delivery_zones_id_fk": {
+          "name": "addresses_zone_id_delivery_zones_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "delivery_zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_config": {
+      "name": "ai_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anthropic_api_key": {
+          "name": "anthropic_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "brave_api_key": {
+          "name": "brave_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "ai_config_singleton_id": {
+          "name": "ai_config_singleton_id",
+          "value": "\"ai_config\".\"id\" = 1"
+        },
+        "ai_config_enabled_bool": {
+          "name": "ai_config_enabled_bool",
+          "value": "\"ai_config\".\"enabled\" in (0, 1)"
+        }
+      }
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_audit_log_actor": {
+          "name": "idx_audit_log_actor",
+          "columns": [
+            "actor_id"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_log_action": {
+          "name": "idx_audit_log_action",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_log_created": {
+          "name": "idx_audit_log_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "banner_gradients": {
+      "name": "banner_gradients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_from": {
+          "name": "color_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_to": {
+          "name": "color_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "banners": {
+      "name": "banners",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "badge_text": {
+          "name": "badge_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "badge_color": {
+          "name": "badge_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'mint'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cta_text": {
+          "name": "cta_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Découvrir'"
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bg_gradient_from": {
+          "name": "bg_gradient_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#183C78'"
+        },
+        "bg_gradient_to": {
+          "name": "bg_gradient_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#1E4A8F'"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_banners_active_order": {
+          "name": "idx_banners_active_order",
+          "columns": [
+            "is_active",
+            "display_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "idx_categories_slug": {
+          "name": "idx_categories_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "idx_categories_parent": {
+          "name": "idx_categories_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "categories_parent_id_categories_id_fk": {
+          "name": "categories_parent_id_categories_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "delivery_zones": {
+      "name": "delivery_zones",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commune": {
+          "name": "commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fee": {
+          "name": "fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimated_hours": {
+          "name": "estimated_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 24
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "order_items": {
+      "name": "order_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_name": {
+          "name": "variant_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_order_items_order": {
+          "name": "idx_order_items_order",
+          "columns": [
+            "order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "order_items_order_id_orders_id_fk": {
+          "name": "order_items_order_id_orders_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_items_product_id_products_id_fk": {
+          "name": "order_items_product_id_products_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_items_variant_id_product_variants_id_fk": {
+          "name": "order_items_variant_id_product_variants_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "order_status_history": {
+      "name": "order_status_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_order_status_history_order": {
+          "name": "idx_order_status_history_order",
+          "columns": [
+            "order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "order_status_history_order_id_orders_id_fk": {
+          "name": "order_status_history_order_id_orders_id_fk",
+          "tableFrom": "order_status_history",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "orders": {
+      "name": "orders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_number": {
+          "name": "order_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_fee": {
+          "name": "delivery_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "promo_code_id": {
+          "name": "promo_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'web'"
+        },
+        "delivery_address": {
+          "name": "delivery_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_commune": {
+          "name": "delivery_commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_phone": {
+          "name": "delivery_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_instructions": {
+          "name": "delivery_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "estimated_delivery": {
+          "name": "estimated_delivery",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "internal_notes": {
+          "name": "internal_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivery_person_id": {
+          "name": "delivery_person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivery_person_name": {
+          "name": "delivery_person_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preparing_at": {
+          "name": "preparing_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_at": {
+          "name": "shipping_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "returned_at": {
+          "name": "returned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "return_reason": {
+          "name": "return_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "orders_order_number_unique": {
+          "name": "orders_order_number_unique",
+          "columns": [
+            "order_number"
+          ],
+          "isUnique": true
+        },
+        "idx_orders_user": {
+          "name": "idx_orders_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_orders_status": {
+          "name": "idx_orders_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_orders_number": {
+          "name": "idx_orders_number",
+          "columns": [
+            "order_number"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "orders_user_id_user_id_fk": {
+          "name": "orders_user_id_user_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "orders_promo_code_id_promo_codes_id_fk": {
+          "name": "orders_promo_code_id_promo_codes_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "promo_codes",
+          "columnsFrom": [
+            "promo_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product_attributes": {
+      "name": "product_attributes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_product_attributes_product": {
+          "name": "idx_product_attributes_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "product_attributes_product_id_products_id_fk": {
+          "name": "product_attributes_product_id_products_id_fk",
+          "tableFrom": "product_attributes",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product_images": {
+      "name": "product_images",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_product_images_product": {
+          "name": "idx_product_images_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "product_images_product_id_products_id_fk": {
+          "name": "product_images_product_id_products_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_images_variant_id_product_variants_id_fk": {
+          "name": "product_images_variant_id_product_variants_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product_variants": {
+      "name": "product_variants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compare_price": {
+          "name": "compare_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "product_variants_sku_unique": {
+          "name": "product_variants_sku_unique",
+          "columns": [
+            "sku"
+          ],
+          "isUnique": true
+        },
+        "idx_product_variants_product": {
+          "name": "idx_product_variants_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "product_variants_product_id_products_id_fk": {
+          "name": "product_variants_product_id_products_id_fk",
+          "tableFrom": "product_variants",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "products": {
+      "name": "products",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description_type": {
+          "name": "description_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'richtext'"
+        },
+        "short_description": {
+          "name": "short_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_price": {
+          "name": "base_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compare_price": {
+          "name": "compare_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "low_stock_threshold": {
+          "name": "low_stock_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        },
+        "weight_grams": {
+          "name": "weight_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta_title": {
+          "name": "meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "highlights": {
+          "name": "highlights",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feature_blocks": {
+          "name": "feature_blocks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "faq": {
+          "name": "faq",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "products_slug_unique": {
+          "name": "products_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "products_sku_unique": {
+          "name": "products_sku_unique",
+          "columns": [
+            "sku"
+          ],
+          "isUnique": true
+        },
+        "idx_products_slug": {
+          "name": "idx_products_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "idx_products_category": {
+          "name": "idx_products_category",
+          "columns": [
+            "category_id"
+          ],
+          "isUnique": false
+        },
+        "idx_products_active": {
+          "name": "idx_products_active",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        },
+        "idx_products_featured": {
+          "name": "idx_products_featured",
+          "columns": [
+            "is_featured"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "products_category_id_categories_id_fk": {
+          "name": "products_category_id_categories_id_fk",
+          "tableFrom": "products",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "promo_codes": {
+      "name": "promo_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discount_value": {
+          "name": "discount_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "min_order_amount": {
+          "name": "min_order_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "promo_codes_code_unique": {
+          "name": "promo_codes_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reviews": {
+      "name": "reviews",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_verified_purchase": {
+          "name": "is_verified_purchase",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_reviews_product": {
+          "name": "idx_reviews_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        },
+        "idx_reviews_user": {
+          "name": "idx_reviews_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reviews_product_id_products_id_fk": {
+          "name": "reviews_product_id_products_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_user_id_user_id_fk": {
+          "name": "reviews_user_id_user_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "rating_range": {
+          "name": "rating_range",
+          "value": "\"reviews\".\"rating\" BETWEEN 1 AND 5"
+        }
+      }
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_session_userId": {
+          "name": "idx_session_userId",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stores": {
+      "name": "stores",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "google_maps_url": {
+          "name": "google_maps_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "opening_hours": {
+          "name": "opening_hours",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_stores_active_order": {
+          "name": "idx_stores_active_order",
+          "columns": [
+            "is_active",
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'customer'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "banReason": {
+          "name": "banReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banExpires": {
+          "name": "banExpires",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'customer'"
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'email'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_phone_unique": {
+          "name": "users_phone_unique",
+          "columns": [
+            "phone"
+          ],
+          "isUnique": true
+        },
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "idx_users_phone": {
+          "name": "idx_users_phone",
+          "columns": [
+            "phone"
+          ],
+          "isUnique": false
+        },
+        "idx_users_is_active": {
+          "name": "idx_users_is_active",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "whatsapp_carts": {
+      "name": "whatsapp_carts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_wa_carts_session": {
+          "name": "idx_wa_carts_session",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "whatsapp_carts_session_id_whatsapp_sessions_id_fk": {
+          "name": "whatsapp_carts_session_id_whatsapp_sessions_id_fk",
+          "tableFrom": "whatsapp_carts",
+          "tableTo": "whatsapp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "whatsapp_carts_product_id_products_id_fk": {
+          "name": "whatsapp_carts_product_id_products_id_fk",
+          "tableFrom": "whatsapp_carts",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "whatsapp_carts_variant_id_product_variants_id_fk": {
+          "name": "whatsapp_carts_variant_id_product_variants_id_fk",
+          "tableFrom": "whatsapp_carts",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "whatsapp_config": {
+      "name": "whatsapp_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_number_id": {
+          "name": "phone_number_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_phone_number": {
+          "name": "display_phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verify_token": {
+          "name": "verify_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "business_account_id": {
+          "name": "business_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "admin_phones": {
+          "name": "admin_phones",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "whatsapp_messages": {
+      "name": "whatsapp_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "wa_message_id": {
+          "name": "wa_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_wa_messages_session": {
+          "name": "idx_wa_messages_session",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_wa_messages_created": {
+          "name": "idx_wa_messages_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_wa_messages_wa_id": {
+          "name": "idx_wa_messages_wa_id",
+          "columns": [
+            "wa_message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "whatsapp_messages_session_id_whatsapp_sessions_id_fk": {
+          "name": "whatsapp_messages_session_id_whatsapp_sessions_id_fk",
+          "tableFrom": "whatsapp_messages",
+          "tableTo": "whatsapp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "whatsapp_sessions": {
+      "name": "whatsapp_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "wa_phone": {
+          "name": "wa_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "otp_code": {
+          "name": "otp_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "otp_expires_at": {
+          "name": "otp_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "whatsapp_sessions_wa_phone_unique": {
+          "name": "whatsapp_sessions_wa_phone_unique",
+          "columns": [
+            "wa_phone"
+          ],
+          "isUnique": true
+        },
+        "idx_wa_sessions_phone": {
+          "name": "idx_wa_sessions_phone",
+          "columns": [
+            "wa_phone"
+          ],
+          "isUnique": false
+        },
+        "idx_wa_sessions_user": {
+          "name": "idx_wa_sessions_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "whatsapp_sessions_user_id_user_id_fk": {
+          "name": "whatsapp_sessions_user_id_user_id_fk",
+          "tableFrom": "whatsapp_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wishlist": {
+      "name": "wishlist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "wishlist_user_product_unique": {
+          "name": "wishlist_user_product_unique",
+          "columns": [
+            "user_id",
+            "product_id"
+          ],
+          "isUnique": true
+        },
+        "idx_wishlist_user": {
+          "name": "idx_wishlist_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_wishlist_product": {
+          "name": "idx_wishlist_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wishlist_user_id_user_id_fk": {
+          "name": "wishlist_user_id_user_id_fk",
+          "tableFrom": "wishlist",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wishlist_product_id_products_id_fk": {
+          "name": "wishlist_product_id_products_id_fk",
+          "tableFrom": "wishlist",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1777101305148,
       "tag": "0011_lowly_silver_sable",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1777883911156,
+      "tag": "0012_peaceful_flatman",
+      "breakpoints": true
     }
   ]
 }

--- a/env.d.ts
+++ b/env.d.ts
@@ -24,6 +24,9 @@ interface CloudflareEnv {
 
   // AI-powered product creation
   ANTHROPIC_API_KEY: string;
+  // Brave Search API key for image_search tool. Optional — if absent, the AI
+  // generation falls back to image_candidates: [] and admin uploads images manually.
+  BRAVE_API_KEY?: string;
   // "0" disables the feature (button hidden, /products/ai-new returns 404). Any other value or unset = enabled.
   AI_PRODUCT_CREATION_ENABLED?: string;
   // Optional model override (for rolling to newer Anthropic model IDs without a code change)

--- a/lib/ai/config.ts
+++ b/lib/ai/config.ts
@@ -5,6 +5,7 @@ import { aiConfig } from "@/lib/db/schema";
 
 export interface AiSettings {
   apiKey: string | null;
+  braveApiKey: string | null;
   model: string | null;
   enabled: boolean;
 }
@@ -36,10 +37,12 @@ export async function getAiSettings(): Promise<AiSettings> {
   }
 
   const dbKey = row?.anthropic_api_key || null;
+  const dbBraveKey = row?.brave_api_key || null;
   const dbModel = row?.model || null;
 
   return {
     apiKey: dbKey || env.ANTHROPIC_API_KEY || null,
+    braveApiKey: dbBraveKey || env.BRAVE_API_KEY || null,
     model: dbModel || env.AI_MODEL || null,
     enabled: row
       ? row.enabled === 1

--- a/lib/ai/image-search.ts
+++ b/lib/ai/image-search.ts
@@ -1,0 +1,111 @@
+/**
+ * Brave Image Search wrapper.
+ *
+ * Used as a custom Anthropic tool — when Claude calls `image_search` during
+ * product research, the worker invokes this and returns the results back as
+ * a tool_result block. The model then filters the candidates (rejecting
+ * banner ads, listicles, watermarked promo shots, multi-product comparisons,
+ * etc.) before emitting `image_candidates` in submit_product.
+ *
+ * Free tier: 2000 queries/month, 1 query/sec. We do not enforce client-side
+ * rate-limiting — Brave returns 429 which we surface verbatim.
+ *
+ * Docs: https://api.search.brave.com/app/documentation/image-search/get-started
+ */
+
+const BRAVE_ENDPOINT = "https://api.search.brave.com/res/v1/images/search";
+const DEFAULT_TIMEOUT_MS = 8_000;
+const MAX_COUNT = 20;
+const DEFAULT_COUNT = 10;
+
+export interface ImageSearchInput {
+  query: string;
+  count?: number;
+}
+
+export interface ImageSearchResultItem {
+  url: string;
+  source_domain: string;
+  title: string;
+  thumbnail_url: string | null;
+}
+
+export type ImageSearchResult =
+  | { ok: true; results: ImageSearchResultItem[] }
+  | { ok: false; reason: "no_api_key" | "auth_failed" | "rate_limited" | "upstream_error" | "timeout" | "fetch_failed" };
+
+interface BraveItem {
+  title?: string;
+  url?: string;
+  source?: string;
+  thumbnail?: { src?: string };
+  properties?: { url?: string };
+}
+
+/**
+ * Hit Brave Image Search and normalize results into a stable shape for the
+ * model. `properties.url` is the direct image URL when Brave found one;
+ * `thumbnail.src` is Brave's CDN cache (always live, but small).
+ */
+export async function searchImages(
+  input: ImageSearchInput,
+  apiKey: string | null,
+  opts: { timeoutMs?: number } = {},
+): Promise<ImageSearchResult> {
+  if (!apiKey) return { ok: false, reason: "no_api_key" };
+
+  const count = Math.max(1, Math.min(MAX_COUNT, input.count ?? DEFAULT_COUNT));
+  const url = new URL(BRAVE_ENDPOINT);
+  url.searchParams.set("q", input.query);
+  url.searchParams.set("count", String(count));
+  url.searchParams.set("safesearch", "strict");
+
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), opts.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+
+  try {
+    const resp = await fetch(url.toString(), {
+      signal: ac.signal,
+      headers: {
+        accept: "application/json",
+        "x-subscription-token": apiKey,
+      },
+    });
+
+    if (resp.status === 401 || resp.status === 403) return { ok: false, reason: "auth_failed" };
+    if (resp.status === 429) return { ok: false, reason: "rate_limited" };
+    if (!resp.ok) return { ok: false, reason: "upstream_error" };
+
+    const json = (await resp.json()) as { results?: BraveItem[] };
+    const items = (json.results ?? [])
+      .map((item): ImageSearchResultItem | null => {
+        // properties.url is the direct image URL; fall back to top-level url
+        // (which is normally the page hosting the image, but some payloads
+        // collapse the two for direct-image hits).
+        const directUrl = item.properties?.url ?? item.url;
+        if (!directUrl) return null;
+        return {
+          url: directUrl,
+          source_domain: item.source ?? safeDomain(directUrl),
+          title: (item.title ?? "").trim(),
+          thumbnail_url: item.thumbnail?.src ?? null,
+        };
+      })
+      .filter((x): x is ImageSearchResultItem => x !== null);
+
+    return { ok: true, results: items };
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") return { ok: false, reason: "timeout" };
+    return { ok: false, reason: "fetch_failed" };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function safeDomain(rawUrl: string): string {
+  try {
+    return new URL(rawUrl).hostname;
+  } catch {
+    return "";
+  }
+}

--- a/lib/ai/image-search.ts
+++ b/lib/ai/image-search.ts
@@ -2,10 +2,11 @@
  * Brave Image Search wrapper.
  *
  * Used as a custom Anthropic tool — when Claude calls `image_search` during
- * product research, the worker invokes this and returns the results back as
- * a tool_result block. The model then filters the candidates (rejecting
- * banner ads, listicles, watermarked promo shots, multi-product comparisons,
- * etc.) before emitting `image_candidates` in submit_product.
+ * product research, the loop in `researchProduct` invokes this and returns
+ * the results back as a tool_result block. The model then filters the
+ * candidates (rejecting banner ads, listicles, watermarked promo shots,
+ * multi-product comparisons, etc.) before emitting `image_candidates` in
+ * submit_product.
  *
  * Free tier: 2000 queries/month, 1 query/sec. We do not enforce client-side
  * rate-limiting — Brave returns 429 which we surface verbatim.
@@ -32,7 +33,18 @@ export interface ImageSearchResultItem {
 
 export type ImageSearchResult =
   | { ok: true; results: ImageSearchResultItem[] }
-  | { ok: false; reason: "no_api_key" | "auth_failed" | "rate_limited" | "upstream_error" | "timeout" | "fetch_failed" };
+  | {
+      ok: false;
+      reason:
+        | "no_api_key"
+        | "invalid_input"
+        | "auth_failed"
+        | "rate_limited"
+        | "upstream_error"
+        | "parse_failed"
+        | "timeout"
+        | "fetch_failed";
+    };
 
 interface BraveItem {
   title?: string;
@@ -44,8 +56,11 @@ interface BraveItem {
 
 /**
  * Hit Brave Image Search and normalize results into a stable shape for the
- * model. `properties.url` is the direct image URL when Brave found one;
- * `thumbnail.src` is Brave's CDN cache (always live, but small).
+ * model. Per Brave's schema, `properties.url` is the direct image URL while
+ * the top-level `url` is the page hosting the image (HTML). We require
+ * `properties.url` and skip items missing it — feeding HTML page URLs into
+ * `image_candidates` reintroduces the `bad_content_type` failure mode the
+ * upstream pipeline was hardened against.
  */
 export async function searchImages(
   input: ImageSearchInput,
@@ -53,6 +68,18 @@ export async function searchImages(
   opts: { timeoutMs?: number } = {},
 ): Promise<ImageSearchResult> {
   if (!apiKey) return { ok: false, reason: "no_api_key" };
+
+  // Validate before any work — Anthropic only best-effort enforces input_schema,
+  // so a malformed model payload reaches us as untyped JSON. Without this, a
+  // null/missing `query` would either crash (TypeError on `input.count`) or
+  // build a `q=undefined` URL that Brave silently returns as 0 results.
+  if (
+    !input ||
+    typeof input.query !== "string" ||
+    input.query.trim().length < 2
+  ) {
+    return { ok: false, reason: "invalid_input" };
+  }
 
   const count = Math.max(1, Math.min(MAX_COUNT, input.count ?? DEFAULT_COUNT));
   const url = new URL(BRAVE_ENDPOINT);
@@ -76,17 +103,39 @@ export async function searchImages(
     if (resp.status === 429) return { ok: false, reason: "rate_limited" };
     if (!resp.ok) return { ok: false, reason: "upstream_error" };
 
-    const json = (await resp.json()) as { results?: BraveItem[] };
-    const items = (json.results ?? [])
+    let json: { results?: BraveItem[] };
+    try {
+      json = (await resp.json()) as { results?: BraveItem[] };
+    } catch {
+      // 200 with non-JSON body → distinct from network failure so an operator
+      // can tell "Brave is broken / proxy returned an HTML error page" apart
+      // from "DNS / TCP failed".
+      return { ok: false, reason: "parse_failed" };
+    }
+
+    if (json?.results === undefined) {
+      // 200 OK but no `results` field — likely Brave shipped a v2 schema. Log
+      // so the next deploy-tail catches the drift instead of silently returning
+      // 0 results forever.
+      console.warn("[image-search] Brave 200 OK but no `results` field — schema drift?", {
+        keys: Object.keys(json ?? {}),
+      });
+    }
+
+    const items = (json?.results ?? [])
       .map((item): ImageSearchResultItem | null => {
-        // properties.url is the direct image URL; fall back to top-level url
-        // (which is normally the page hosting the image, but some payloads
-        // collapse the two for direct-image hits).
-        const directUrl = item.properties?.url ?? item.url;
+        // Strict: only direct image URLs. Brave's top-level `url` is the
+        // hosting HTML page, which would 404 / serve text/html on our fetch.
+        const directUrl = item.properties?.url;
         if (!directUrl) return null;
+        const domain = item.source ?? safeDomain(directUrl);
+        // Drop items with unparseable URL — empty `source_domain` defeats the
+        // model's filtering pass (it can't distinguish manufacturer from
+        // listicle if both are empty).
+        if (!domain) return null;
         return {
           url: directUrl,
-          source_domain: item.source ?? safeDomain(directUrl),
+          source_domain: domain,
           title: (item.title ?? "").trim(),
           thumbnail_url: item.thumbnail?.src ?? null,
         };

--- a/lib/ai/product-research.ts
+++ b/lib/ai/product-research.ts
@@ -12,7 +12,10 @@ export type ResearchErrorCode =
   | "auth_failed"             // Invalid or revoked API key
   | "upstream_rate_limited"   // Anthropic 429 — distinct from our per-admin quota
   | "upstream_unavailable"    // Anthropic 5xx / network reachability
-  | "timeout";                // our DEFAULT_TIMEOUT_MS AbortController fired
+  | "timeout"                 // our DEFAULT_TIMEOUT_MS AbortController fired
+  | "model_no_submit"         // model stopped (end_turn / max_tokens) without calling submit_product
+  | "loop_exhausted"          // hit MAX_LOOP_ITERATIONS — model is stuck (admin should not naively retry)
+  | "internal_error";         // defensive-impossible state in the loop — code defect, not a transient issue
 
 export type ResearchProgress =
   | { type: "progress"; step: "search" | "specs" | "images" | "finalize" }
@@ -26,7 +29,13 @@ export const MODEL = "claude-sonnet-4-6";
 /** Hard budget for the Anthropic call. With the tool-use loop (web_search + image_search round-trips), end-to-end can run 30-90s; 120s is a generous ceiling. */
 export const DEFAULT_TIMEOUT_MS = 120_000;
 
-/** Cap to prevent runaway tool-use loops if the model never reaches submit_product. */
+/**
+ * Cap on conversation turns (each turn = one Anthropic stream call). web_search
+ * `max_uses: 5` is per-call (not cumulative), so a turn can fire many tool calls;
+ * 8 turns covers worst legitimate flows (turn 1: web_search × 5 + 1st image_search;
+ * turn 2: more image_search; turn 3: submit_product) with margin. Bump if either
+ * tool's per-call limit grows.
+ */
 const MAX_LOOP_ITERATIONS = 8;
 
 export const SUBMIT_TOOL_NAME = "submit_product";
@@ -35,7 +44,7 @@ export const IMAGE_SEARCH_TOOL_NAME = "image_search";
 export interface ResearchOptions {
   model?: string;
   timeoutMs?: number;
-  /** Brave Search API key. When null, image_search returns reason:"no_api_key" and the model is expected to emit image_candidates: []. */
+  /** Brave Search API key. When null, the `image_search` tool is omitted from the tool list and the system prompt tells the model to emit `image_candidates: []`. */
   braveApiKey?: string | null;
 }
 
@@ -119,9 +128,13 @@ export function buildTools(opts: { hasImageSearch: boolean } = { hasImageSearch:
  *
  * Loop:
  *  - Stream a turn. As content blocks start, yield progress events.
- *  - At end of turn, if stop_reason="tool_use", execute every client tool (image_search)
- *    and append a tool_result message. If submit_product is in the turn, capture its input
- *    and exit the loop. Repeat (up to MAX_LOOP_ITERATIONS).
+ *  - At end of turn:
+ *    - If `submit_product` is in the turn, capture its input and exit (terminal
+ *      regardless of stop_reason).
+ *    - Else if stop_reason="tool_use", execute every client tool (image_search)
+ *      and append a tool_result message; loop.
+ *    - Else surface `model_no_submit` (refusal / max_tokens).
+ *  - Repeat up to MAX_LOOP_ITERATIONS, then yield `loop_exhausted`.
  *
  * Progress mapping (best-effort):
  *  - 1st web_search → "search"
@@ -193,10 +206,12 @@ export async function* researchProduct(
       }
 
       if (final.stop_reason !== "tool_use") {
-        // Model stopped without calling submit_product — most often max_tokens or end_turn
-        // after a refusal. Surface as api_error so the UI shows a generic retry message.
+        // Model stopped without calling submit_product — usually max_tokens or
+        // end_turn after a refusal. Distinct from `loop_exhausted`: here the
+        // model voluntarily stopped, so a naive retry may help; for
+        // loop_exhausted (below) the model is stuck and retry burns more tokens.
         console.error("[ai-product] stream ended without submit_product", { stop_reason: final.stop_reason });
-        yield { type: "error", code: "api_error" };
+        yield { type: "error", code: "model_no_submit" };
         return;
       }
 
@@ -206,10 +221,12 @@ export async function* researchProduct(
         (b): b is Anthropic.ToolUseBlock => b.type === "tool_use" && b.name === IMAGE_SEARCH_TOOL_NAME,
       );
       if (clientToolUses.length === 0) {
-        // stop_reason=tool_use but no client tool to run — should be impossible (submit_product
-        // was checked above). Defensive bail-out.
+        // stop_reason=tool_use but no client tool to run — should be impossible
+        // (submit_product was checked above; server_tool_use blocks are resolved
+        // by Anthropic and never end with tool_use stop_reason). If we get here,
+        // it's a code defect, not a transient failure — admin retrying won't help.
         console.error("[ai-product] tool_use stop without client-runnable tool");
-        yield { type: "error", code: "api_error" };
+        yield { type: "error", code: "internal_error" };
         return;
       }
 
@@ -217,6 +234,11 @@ export async function* researchProduct(
         clientToolUses.map(async (tu): Promise<Anthropic.ToolResultBlockParam> => {
           try {
             const result = await searchImages(tu.input as ImageSearchInput, braveApiKey);
+            // is_error: true tells the model the tool genuinely failed (vs.
+            // returning empty results). Without this Claude may treat a
+            // 429/auth_failed as "no images found" and blindly retry, exhausting
+            // the loop. Anthropic docs: is_error makes the model "try a
+            // different approach" — typically falling back to image_candidates: [].
             return {
               type: "tool_result",
               tool_use_id: tu.id,
@@ -228,7 +250,7 @@ export async function* researchProduct(
             return {
               type: "tool_result",
               tool_use_id: tu.id,
-              content: JSON.stringify({ ok: false, reason: "fetch_failed" }),
+              content: JSON.stringify({ ok: false, reason: "internal_error" }),
               is_error: true,
             };
           }
@@ -239,8 +261,18 @@ export async function* researchProduct(
     }
 
     if (submitInput === null) {
-      console.error("[ai-product] hit MAX_LOOP_ITERATIONS without submit_product");
-      yield { type: "error", code: "api_error" };
+      // Loop exhausted — the model called tools 8 times without calling
+      // submit_product. Usually means it's stuck retrying image_search after
+      // an is_error tool_result. Distinct from model_no_submit: here a retry
+      // will likely loop again and burn another 30-60s of tokens.
+      console.error("[ai-product] loop_exhausted", {
+        iterations: MAX_LOOP_ITERATIONS,
+        webSearchCount,
+        imagesEmitted,
+        finalizeEmitted,
+        messageCount: messages.length,
+      });
+      yield { type: "error", code: "loop_exhausted" };
       return;
     }
 

--- a/lib/ai/product-research.ts
+++ b/lib/ai/product-research.ts
@@ -2,6 +2,7 @@ import type Anthropic from "@anthropic-ai/sdk";
 import { parseAiToolInput, type AiProductOutput } from "@/lib/validations/product-ai";
 import { HIGHLIGHT_ICON_NAMES } from "@/lib/validations/product-story";
 import { SUBMIT_PRODUCT_TOOL_SCHEMA } from "@/lib/ai/submit-tool-schema";
+import { searchImages, type ImageSearchInput } from "@/lib/ai/image-search";
 
 export type ResearchErrorCode =
   | "invalid_ai_output"       // Claude returned a submit_product payload we couldn't parse
@@ -22,25 +23,34 @@ export type ResearchProgress =
 /** Default model. Override per-call via `researchProduct(..., { model })` or via the `AI_MODEL` env var at the caller. */
 export const MODEL = "claude-sonnet-4-6";
 
-/** Hard budget for the Anthropic call. Claude with 3-5 web_search invocations typically finishes in 15-45s; 90s is a generous ceiling that still bounds Worker CPU exposure. */
-export const DEFAULT_TIMEOUT_MS = 90_000;
+/** Hard budget for the Anthropic call. With the tool-use loop (web_search + image_search round-trips), end-to-end can run 30-90s; 120s is a generous ceiling. */
+export const DEFAULT_TIMEOUT_MS = 120_000;
+
+/** Cap to prevent runaway tool-use loops if the model never reaches submit_product. */
+const MAX_LOOP_ITERATIONS = 8;
 
 export const SUBMIT_TOOL_NAME = "submit_product";
+export const IMAGE_SEARCH_TOOL_NAME = "image_search";
 
 export interface ResearchOptions {
   model?: string;
   timeoutMs?: number;
+  /** Brave Search API key. When null, image_search returns reason:"no_api_key" and the model is expected to emit image_candidates: []. */
+  braveApiKey?: string | null;
 }
 
-export function buildSystemPrompt(): string {
+export function buildSystemPrompt(opts: { hasImageSearch: boolean } = { hasImageSearch: true }): string {
   const icons = HIGHLIGHT_ICON_NAMES.join(", ");
-  return [
+  const lines = [
     "Tu es rédacteur catalogue pour une boutique d'électronique en Côte d'Ivoire.",
     "Réponds TOUJOURS en français. Ne parle jamais à l'utilisateur : tes seules sorties doivent être l'utilisation des outils.",
     "Étapes :",
-    "1. Utilise web_search pour vérifier l'existence du produit, ses spécifications officielles et trouver des images.",
-    "2. Si le produit est introuvable ou trop ambigu, appelle submit_product avec { \"not_found\": true, \"reason\": \"…\" }.",
-    "3. Sinon, appelle submit_product avec une fiche complète.",
+    "1. Utilise web_search pour vérifier l'existence du produit, ses spécifications officielles.",
+    opts.hasImageSearch
+      ? "2. Utilise image_search (1 à 3 requêtes ciblées en anglais : `\"<modèle> product photo\"`, `\"<modèle> press render\"`, `\"<modèle> packaging\"`) pour récolter des candidats images. FILTRE rigoureusement les résultats avant de les inclure (voir Règles)."
+      : "2. (image_search non disponible — renvoie image_candidates: [].)",
+    "3. Si le produit est introuvable ou trop ambigu, appelle submit_product avec { \"not_found\": true, \"reason\": \"…\" }.",
+    "4. Sinon, appelle submit_product avec une fiche complète.",
     "Règles :",
     "- Respecte STRICTEMENT le schéma JSON du tool submit_product (champs, nesting, types). En cas de doute, omets le champ.",
     "- N'invente aucune caractéristique. Omets plutôt.",
@@ -48,40 +58,76 @@ export function buildSystemPrompt(): string {
     "- short_description est un RÉSUMÉ court (≤120 caractères), pas une description complète. La description longue va dans description_html.",
     "- tagline, highlights, feature_blocks, faq sont nestés sous story (ex : { story: { tagline, highlights: [...] } }).",
     "- Pour chaque highlight, choisis une icône parmi cette liste exacte : " + icons + ".",
-    "- image_candidates : N'INVENTE JAMAIS d'URLs. Inclus UNIQUEMENT des URLs présentes telles quelles dans les résultats web_search (copier-coller exact, jamais reconstruire un pattern type `/imgroot/.../001.jpg` ni deviner un nom de fichier). Si web_search n'a renvoyé aucune URL d'image directement utilisable, retourne `image_candidates: []` — l'admin ajoutera les images après. Format des entrées : { url, source_domain, alt? } — JAMAIS un tableau de strings. Privilégie images directes (jpg/png/webp).",
     "- Les descriptions suivent un style Apple : tagline courte et percutante, highlights concis, feature_blocks éditoriaux avec un titre et un corps de 1-2 paragraphes.",
-  ].join("\n");
+    "",
+    "Filtrage des images (CRITIQUE — la qualité du catalogue dépend de ce tri) :",
+    "- N'INVENTE JAMAIS d'URLs. Inclus UNIQUEMENT des URLs reçues telles quelles dans les résultats image_search/web_search (copier-coller exact, jamais reconstruire un pattern ni deviner un slug).",
+    "- GARDER : photo produit isolé sur fond blanc/neutre/transparent, image officielle constructeur (newsroom, presse), photo studio, packaging officiel, vues 360° du produit seul.",
+    "- REJETER : bannières publicitaires (prix surimprimé, slogan, badge promo), listicles (\"Top 10…\", \"Best of…\"), comparatifs multi-produits (plusieurs téléphones côte à côte), captures d'écran de boutiques en ligne, photos d'usage avec branding lourd (femme souriant tenant le produit + logo de site), images avec watermark/logo de site (Tom's Guide, Engadget, GSMArena tag dans le coin), thumbnails YouTube, mèmes, leaks/concepts non confirmés, schémas et exploded views, photos de boîtes ouvertes pleines d'accessoires.",
+    "- Évalue chaque image via son `title` et `source_domain`. Si `title` mentionne \"vs\", \"top\", \"best\", \"comparison\", \"deal\", \"review roundup\", \"hands-on\" : SKIP. Si `source_domain` est un constructeur officiel, un site presse spécialisé reconnu (theverge.com, gsmarena.com pages produit, anandtech.com), ou Wikipedia/Wikimedia : généralement OK.",
+    "- Cible 4-8 images de qualité catalogue. Si tu n'en trouves pas assez après filtrage, retourne moins (ou `image_candidates: []`). Mieux vaut 0 image qu'une bannière promo.",
+    "- Format des entrées : { url, source_domain, alt? }. Privilégie images directes (jpg/png/webp).",
+  ];
+  return lines.join("\n");
 }
 
-export function buildTools(): Anthropic.ToolUnion[] {
-  return [
+export function buildTools(opts: { hasImageSearch: boolean } = { hasImageSearch: true }): Anthropic.ToolUnion[] {
+  const tools: Anthropic.ToolUnion[] = [
     {
       type: "web_search_20250305",
       name: "web_search",
       max_uses: 5,
     },
-    {
-      name: SUBMIT_TOOL_NAME,
-      description: "Soumet la fiche produit complète (ou signale que le produit est introuvable).",
-      input_schema: SUBMIT_PRODUCT_TOOL_SCHEMA,
-    },
   ];
+  if (opts.hasImageSearch) {
+    tools.push({
+      name: IMAGE_SEARCH_TOOL_NAME,
+      description:
+        "Recherche d'images web pour un produit donné. Retourne jusqu'à 20 candidats avec url directe, source_domain, title et thumbnail. À utiliser plusieurs fois avec des requêtes ciblées (anglais de préférence) puis filtrer rigoureusement.",
+      input_schema: {
+        type: "object",
+        required: ["query"],
+        additionalProperties: false,
+        properties: {
+          query: {
+            type: "string",
+            minLength: 2,
+            maxLength: 200,
+            description: "Requête en anglais de préférence (ex: 'iPhone 15 Pro product photo official').",
+          },
+          count: {
+            type: "integer",
+            minimum: 1,
+            maximum: 20,
+            description: "Nombre de résultats demandés (défaut 10).",
+          },
+        },
+      },
+    });
+  }
+  tools.push({
+    name: SUBMIT_TOOL_NAME,
+    description: "Soumet la fiche produit complète (ou signale que le produit est introuvable).",
+    input_schema: SUBMIT_PRODUCT_TOOL_SCHEMA,
+  });
+  return tools;
 }
 
 /**
- * Drive an Anthropic streaming call and yield typed progress events, then a terminal event.
+ * Drive an Anthropic streaming call with a tool-use loop, yielding typed progress events
+ * and a terminal event.
  *
- * Progress mapping (best-effort, based on content_block_start events as they arrive):
- *  - 1st `server_tool_use` (web_search) → "search"
+ * Loop:
+ *  - Stream a turn. As content blocks start, yield progress events.
+ *  - At end of turn, if stop_reason="tool_use", execute every client tool (image_search)
+ *    and append a tool_result message. If submit_product is in the turn, capture its input
+ *    and exit the loop. Repeat (up to MAX_LOOP_ITERATIONS).
+ *
+ * Progress mapping (best-effort):
+ *  - 1st web_search → "search"
  *  - 2nd web_search → "specs"
- *  - 3rd web_search → "images"
- *  - `tool_use` for SUBMIT_TOOL_NAME start → "finalize"
- *
- * Terminal events:
- *  - `done` when submit_product input parses as full AiProductOutput
- *  - `not_found` when submit_product input is `{ not_found: true, reason }`
- *  - `error: invalid_ai_output` when submit_product input fails validation
- *  - `error: api_error` on network / timeout / malformed stream
+ *  - 1st image_search → "images" (overrides "specs" if it comes first)
+ *  - submit_product start → "finalize"
  */
 export async function* researchProduct(
   prompt: string,
@@ -90,51 +136,110 @@ export async function* researchProduct(
 ): AsyncGenerator<ResearchProgress> {
   const model = opts.model ?? MODEL;
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const braveApiKey = opts.braveApiKey ?? null;
+  const hasImageSearch = !!braveApiKey;
 
   const ac = new AbortController();
   const timer = setTimeout(() => ac.abort(), timeoutMs);
 
-  let searchCount = 0;
+  let webSearchCount = 0;
+  let imagesEmitted = false;
   let finalizeEmitted = false;
   let submitInput: unknown = null;
 
+  const tools = buildTools({ hasImageSearch });
+  const system = buildSystemPrompt({ hasImageSearch });
+  const messages: Anthropic.MessageParam[] = [{ role: "user", content: prompt }];
+
   try {
-    const stream = anthropic.messages.stream(
-      {
-        model,
-        max_tokens: 8000,
-        system: buildSystemPrompt(),
-        tools: buildTools(),
-        messages: [{ role: "user", content: prompt }],
-      },
-      { signal: ac.signal },
-    );
+    for (let iter = 0; iter < MAX_LOOP_ITERATIONS; iter++) {
+      const stream = anthropic.messages.stream(
+        {
+          model,
+          max_tokens: 8000,
+          system,
+          tools,
+          messages,
+        },
+        { signal: ac.signal },
+      );
 
-    for await (const event of stream) {
-      if (event.type !== "content_block_start") continue;
-      const block = event.content_block;
-      // server_tool_use (Anthropic-executed web_search) vs tool_use (our submit_product).
-      if (block.type === "server_tool_use" && block.name === "web_search") {
-        searchCount++;
-        if (searchCount === 1) yield { type: "progress", step: "search" };
-        else if (searchCount === 2) yield { type: "progress", step: "specs" };
-        else if (searchCount === 3) yield { type: "progress", step: "images" };
-      } else if (block.type === "tool_use" && block.name === SUBMIT_TOOL_NAME && !finalizeEmitted) {
-        finalizeEmitted = true;
-        yield { type: "progress", step: "finalize" };
+      for await (const event of stream) {
+        if (event.type !== "content_block_start") continue;
+        const block = event.content_block;
+        if (block.type === "server_tool_use" && block.name === "web_search") {
+          webSearchCount++;
+          if (webSearchCount === 1) yield { type: "progress", step: "search" };
+          else if (webSearchCount === 2) yield { type: "progress", step: "specs" };
+        } else if (block.type === "tool_use" && block.name === IMAGE_SEARCH_TOOL_NAME && !imagesEmitted) {
+          imagesEmitted = true;
+          yield { type: "progress", step: "images" };
+        } else if (block.type === "tool_use" && block.name === SUBMIT_TOOL_NAME && !finalizeEmitted) {
+          finalizeEmitted = true;
+          yield { type: "progress", step: "finalize" };
+        }
       }
-    }
 
-    // After the stream completes, pull the fully-assembled message so we can read submit_product's input.
-    const final = await stream.finalMessage();
-    for (const block of final.content) {
-      if (block.type === "tool_use" && block.name === SUBMIT_TOOL_NAME) {
-        submitInput = block.input;
+      const final = await stream.finalMessage();
+      messages.push({ role: "assistant", content: final.content });
+
+      // Capture submit_product if present — that's terminal regardless of stop_reason.
+      const submitBlock = final.content.find(
+        (b): b is Anthropic.ToolUseBlock => b.type === "tool_use" && b.name === SUBMIT_TOOL_NAME,
+      );
+      if (submitBlock) {
+        submitInput = submitBlock.input;
         break;
       }
+
+      if (final.stop_reason !== "tool_use") {
+        // Model stopped without calling submit_product — most often max_tokens or end_turn
+        // after a refusal. Surface as api_error so the UI shows a generic retry message.
+        console.error("[ai-product] stream ended without submit_product", { stop_reason: final.stop_reason });
+        yield { type: "error", code: "api_error" };
+        return;
+      }
+
+      // Run client tools (image_search). server_tool_use blocks (web_search) are already
+      // resolved by Anthropic — don't echo them back as tool_results.
+      const clientToolUses = final.content.filter(
+        (b): b is Anthropic.ToolUseBlock => b.type === "tool_use" && b.name === IMAGE_SEARCH_TOOL_NAME,
+      );
+      if (clientToolUses.length === 0) {
+        // stop_reason=tool_use but no client tool to run — should be impossible (submit_product
+        // was checked above). Defensive bail-out.
+        console.error("[ai-product] tool_use stop without client-runnable tool");
+        yield { type: "error", code: "api_error" };
+        return;
+      }
+
+      const toolResults: Anthropic.ToolResultBlockParam[] = await Promise.all(
+        clientToolUses.map(async (tu): Promise<Anthropic.ToolResultBlockParam> => {
+          try {
+            const result = await searchImages(tu.input as ImageSearchInput, braveApiKey);
+            return {
+              type: "tool_result",
+              tool_use_id: tu.id,
+              content: JSON.stringify(result),
+              is_error: !result.ok,
+            };
+          } catch (err) {
+            console.error("[ai-product] image_search threw", err);
+            return {
+              type: "tool_result",
+              tool_use_id: tu.id,
+              content: JSON.stringify({ ok: false, reason: "fetch_failed" }),
+              is_error: true,
+            };
+          }
+        }),
+      );
+
+      messages.push({ role: "user", content: toolResults });
     }
 
     if (submitInput === null) {
+      console.error("[ai-product] hit MAX_LOOP_ITERATIONS without submit_product");
       yield { type: "error", code: "api_error" };
       return;
     }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -436,6 +436,7 @@ export const aiConfig = sqliteTable(
   {
     id: integer("id").primaryKey(),
     anthropic_api_key: text("anthropic_api_key"),
+    brave_api_key: text("brave_api_key"),
     model: text("model"),
     enabled: integer("enabled").notNull().default(1),
     created_at: text("created_at").notNull().default(sql`(datetime('now'))`),

--- a/lib/validations/ai-config.ts
+++ b/lib/validations/ai-config.ts
@@ -8,6 +8,8 @@ import { z } from "zod";
 //   - random non-Anthropic strings (cheap typo guard before the API call)
 const isMaskShape = (v: string) => v.startsWith("••");
 const isAnthropicKey = (v: string) => v.startsWith("sk-ant-");
+// Brave keys start with `BSA` historically; we don't enforce the prefix
+// since Brave hasn't documented it as stable — only mask-shape vs raw.
 
 export const aiConfigSchema = z.object({
   anthropic_api_key: z
@@ -18,6 +20,11 @@ export const aiConfigSchema = z.object({
       (v) => !v || isMaskShape(v) || isAnthropicKey(v),
       { message: "La clé Anthropic doit commencer par sk-ant-" },
     )
+    .nullable(),
+  brave_api_key: z
+    .string()
+    .trim()
+    .max(200, "Clé API trop longue (max 200 caractères)")
     .nullable(),
   model: z
     .string()


### PR DESCRIPTION
## Summary
- **DB** : `brave_api_key` (nullable) ajoutée à `ai_config` (drizzle 0012, expand-only).
- **Admin** : nouveau champ dans `/ai-settings` avec masque identique à la clé Anthropic.
- **Config** : `getAiSettings` expose `braveApiKey` ; la route wire-le à `researchProduct` via `opts.braveApiKey`.
- **Nouveau** : `lib/ai/image-search.ts` wrappe Brave (timeout, erreurs typées, normalisation `{ url, source_domain, title, thumbnail_url }`).
- **Refactor** : `lib/ai/product-research.ts` — appel one-shot devient une **boucle tool-use** (max 8 itérations). Quand le modèle émet `image_search`, le worker hit Brave, renvoie un `tool_result`, relance le stream jusqu'à `submit_product` ou `end_turn`. Sans `braveApiKey`, le tool n'est pas déclaré et le prompt dit à Claude de renvoyer `image_candidates: []` (fallback actuel préservé).
- **Prompt** : exemples positifs/négatifs pour le tri du modèle (garder : photos produit fond blanc, presse officielle, packaging ; rejeter : bannières promo, listicles, comparatifs, watermarks, screenshots).
- **Timeout** : 90 s → 120 s (multi-tours = plus de wallclock).
- **Tests** : 13 nouveaux ; existing test des 3 web_search réécrit pour matcher le nouveau mapping.

## Why
Anthropic's `web_search` retourne du texte de page, pas les URLs d'images embarquées. Claude était forcé de deviner et hallucinait 100% des URLs (404 sur toutes les URLs sélectionnées en prod, confirmé sur plusieurs runs). Donner au modèle un vrai outil de recherche d'images laisse Brave gérer la découverte d'URLs et Claude gérer le filtrage qualité — chacun joue à son fort.

**Pourquoi tool-use loop et pas post-traitement** : Brave renvoie ~70% d'images impubliables (bannières, listicles, comparatifs multi-produits, watermarks). Le modèle, avec accès aux `title` + `source_domain` de chaque candidat, peut filtrer. Un post-traitement aveugle livrerait du bruit au catalogue.

## Architecture du loop
```
[user prompt] →
  stream turn 1 → web_search × 1-2 (Anthropic-side) → tool_use(image_search)
  ← tool_result(20 candidates from Brave)
  stream turn 2 → maybe another image_search ← tool_result
  stream turn 3 → tool_use(submit_product) ← terminal, parse + return
```
Cap dur à 8 itérations contre runaway.

## Test plan
- [x] `npm run test` — 848/848 pass (13 nouveaux : 8 image-search + 3 admin save brave key + 1 buildTools toggle + 1 braveApiKey config resolution)
- [x] `tsc --noEmit` clean
- [x] `npm run check:migrations` — expand-only `ALTER TABLE ai_config ADD COLUMN brave_api_key text` passes
- [ ] Après deploy : créer une clé Brave gratuite sur https://api-dashboard.search.brave.com/app/keys, la coller dans `/ai-settings`, générer un produit. Le selector devrait afficher 4-8 thumbnails de qualité catalogue. Si Brave n'est pas configurée, le flow tombe sur `image_candidates: []` (comportement actuel post #207).
- [ ] Sur les imports : si certaines URLs Brave échouent à fetch, le log diagnostic de #205/#207 (`[admin/products-ai] image fetch failures`) montrera leur status HTTP — typique pour des URLs source qui bloquent les bots non-Brave.

## Limites connues
- Brave free tier : 2000 req/mois, 1/sec. Avec 1-3 image_search par produit, ~600-1000 produits/mois max sur le free tier.
- Le modèle peut quand même mal filtrer (pas de garantie). Le filet de sécurité reste : Zod rejette URLs invalides, le HEAD-fetch côté Worker drop les 4xx, le selector skip les thumbnails cassés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin UI: add Brave Search API key configuration with masked display and env fallback
  * Product research: optional Brave-driven image search integrated into the research flow; progress events now include images

* **Bug Fixes**
  * Improved image-search input validation, result normalization, and clearer error/reason mapping

* **Tests**
  * Expanded unit tests covering AI config, image search, and product research flows

* **Chores**
  * DB migration and settings/env support for Brave API key
<!-- end of auto-generated comment: release notes by coderabbit.ai -->