### PR TITLE
feat(admin): vision-based watermark filter on Brave candidates

### DIFF
--- a/__tests__/unit/ai/image-vision-filter.test.ts
+++ b/__tests__/unit/ai/image-vision-filter.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { filterByVision } from "@/lib/ai/image-vision-filter";
+import type Anthropic from "@anthropic-ai/sdk";
+import type { ImageSearchResultItem } from "@/lib/ai/image-search";
+
+function makeAnthropic(toolInput: unknown, opts: { throws?: Error } = {}): Anthropic {
+  return {
+    messages: {
+      create: opts.throws
+        ? vi.fn().mockRejectedValue(opts.throws)
+        : vi.fn().mockResolvedValue({
+            content: [
+              { type: "tool_use", id: "tu_1", name: "report_filtering", input: toolInput },
+            ],
+            stop_reason: "tool_use",
+          }),
+    },
+  } as unknown as Anthropic;
+}
+
+function candidate(i: number, opts: { thumb?: string | null } = {}): ImageSearchResultItem {
+  return {
+    url: `https://x.test/${i}.jpg`,
+    source_domain: "x.test",
+    title: `Image ${i}`,
+    thumbnail_url: opts.thumb === undefined ? `https://imgs.search.brave.com/${i}.jpg` : opts.thumb,
+  };
+}
+
+describe("filterByVision", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("retourne le sous-ensemble indiqué par keep_indexes", async () => {
+    const anthropic = makeAnthropic({ keep_indexes: [0, 2] });
+    const candidates = [candidate(0), candidate(1), candidate(2)];
+
+    const result = await filterByVision(candidates, anthropic);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].url).toBe(candidates[0].url);
+    expect(result[1].url).toBe(candidates[2].url);
+  });
+
+  it("retourne tableau vide quand keep_indexes est vide", async () => {
+    const anthropic = makeAnthropic({ keep_indexes: [] });
+    const result = await filterByVision([candidate(0), candidate(1)], anthropic);
+    expect(result).toEqual([]);
+  });
+
+  it("retourne tableau vide pour input vide sans appel API", async () => {
+    const createMock = vi.fn();
+    const anthropic = { messages: { create: createMock } } as unknown as Anthropic;
+    const result = await filterByVision([], anthropic);
+    expect(result).toEqual([]);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it("garde les candidats sans thumbnail_url (impossibles à inspecter)", async () => {
+    const anthropic = makeAnthropic({ keep_indexes: [0] });
+    const candidates = [
+      candidate(0), // index 0 dans inspectable (a un thumb)
+      candidate(1, { thumb: null }), // pas de thumb — gardé par défaut
+      candidate(2), // index 1 dans inspectable
+    ];
+
+    const result = await filterByVision(candidates, anthropic);
+
+    // keep_indexes: [0] → index 0 dans inspectable = candidate(0)
+    // candidate(1) gardé car non-inspectable
+    // candidate(2) rejeté
+    expect(result.map((c) => c.url)).toEqual([candidates[0].url, candidates[1].url]);
+  });
+
+  it("retourne tous les candidats si vision API throws (graceful degradation)", async () => {
+    const anthropic = makeAnthropic(undefined, { throws: new Error("network") });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const candidates = [candidate(0), candidate(1)];
+
+    const result = await filterByVision(candidates, anthropic);
+
+    expect(result).toEqual(candidates);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("retourne tous les candidats si la réponse n'a pas de tool_use", async () => {
+    const anthropic = {
+      messages: {
+        create: vi.fn().mockResolvedValue({
+          content: [{ type: "text", text: "no idea" }],
+          stop_reason: "end_turn",
+        }),
+      },
+    } as unknown as Anthropic;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const candidates = [candidate(0), candidate(1)];
+
+    const result = await filterByVision(candidates, anthropic);
+
+    expect(result).toEqual(candidates);
+    warnSpy.mockRestore();
+  });
+
+  it("retourne tous les candidats si keep_indexes manquant ou non-array", async () => {
+    const anthropic = makeAnthropic({ wrong: "shape" });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const candidates = [candidate(0), candidate(1)];
+
+    const result = await filterByVision(candidates, anthropic);
+
+    expect(result).toEqual(candidates);
+    warnSpy.mockRestore();
+  });
+
+  it("ignore les index hors-limites et non-entiers dans keep_indexes", async () => {
+    const anthropic = makeAnthropic({ keep_indexes: [0, 99, -1, "abc", 1.5, 2] });
+    const candidates = [candidate(0), candidate(1), candidate(2)];
+
+    const result = await filterByVision(candidates, anthropic);
+
+    // 0 et 2 valides ; 99 hors-limites silencieusement ignoré ; -1, "abc", 1.5 rejetés par filtre
+    expect(result.map((c) => c.url)).toEqual([candidates[0].url, candidates[2].url]);
+  });
+
+  it("envoie chaque image avec son contexte (source_domain + title)", async () => {
+    const createMock = vi.fn().mockResolvedValue({
+      content: [{ type: "tool_use", id: "tu_1", name: "report_filtering", input: { keep_indexes: [] } }],
+    });
+    const anthropic = { messages: { create: createMock } } as unknown as Anthropic;
+
+    await filterByVision([candidate(0), candidate(1)], anthropic);
+
+    const params = createMock.mock.calls[0][0];
+    const userContent = params.messages[0].content;
+    expect(userContent[0]).toEqual({ type: "text", text: "Image 0 (x.test) — Image 0" });
+    expect(userContent[1]).toEqual({
+      type: "image",
+      source: { type: "url", url: "https://imgs.search.brave.com/0.jpg" },
+    });
+    // Force le tool_use via tool_choice pour éviter une réponse texte évasive
+    expect(params.tool_choice).toEqual({ type: "tool", name: "report_filtering" });
+  });
+});

--- a/__tests__/unit/ai/image-vision-filter.test.ts
+++ b/__tests__/unit/ai/image-vision-filter.test.ts
@@ -71,6 +71,42 @@ describe("filterByVision", () => {
     expect(result.map((c) => c.url)).toEqual([candidates[0].url, candidates[1].url]);
   });
 
+  it("traduit display index → index original quand un no-thumb précède un thumb gardé", async () => {
+    // Anti-régression : si quelqu'un drop la translation et matche keep_indexes
+    // contre l'array original, ce test échoue car keep_indexes:[1] retournerait
+    // candidate(1) (no-thumb) au lieu de candidate(2) (display idx 1).
+    const anthropic = makeAnthropic({ keep_indexes: [1] });
+    const candidates = [
+      candidate(0), // display idx 0
+      candidate(1, { thumb: null }), // pass-through
+      candidate(2), // display idx 1
+    ];
+
+    const result = await filterByVision(candidates, anthropic);
+
+    // keep_indexes:[1] → candidate(2) (display idx 1)
+    // candidate(1) gardé car non-inspectable
+    // candidate(0) rejeté
+    expect(result.map((c) => c.url)).toEqual([candidates[1].url, candidates[2].url]);
+  });
+
+  it("retourne tous les candidats sans appel API si AUCUN n'a de thumbnail", async () => {
+    const createMock = vi.fn();
+    const anthropic = { messages: { create: createMock } } as unknown as Anthropic;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const candidates = [candidate(0, { thumb: null }), candidate(1, { thumb: null })];
+
+    const result = await filterByVision(candidates, anthropic);
+
+    expect(result).toEqual(candidates);
+    expect(createMock).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("no inspectable thumbnails"),
+      candidates.length,
+    );
+    warnSpy.mockRestore();
+  });
+
   it("retourne tous les candidats si vision API throws (graceful degradation)", async () => {
     const anthropic = makeAnthropic(undefined, { throws: new Error("network") });
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/__tests__/unit/ai/product-research.test.ts
+++ b/__tests__/unit/ai/product-research.test.ts
@@ -23,12 +23,19 @@ interface StubTurn {
  * Tracks `passedMessages` so tests can assert the conversation thread shape
  * across turns (assistant content + tool_result echoes).
  */
-function makeAnthropicStub(turnsOrEvents: StubTurn[] | StubEvent[]): Anthropic & { calls(): unknown[] } {
+function makeAnthropicStub(
+  turnsOrEvents: StubTurn[] | StubEvent[],
+  opts: { visionToolInput?: unknown } = {},
+): Anthropic & { calls(): unknown[] } {
   const turns: StubTurn[] = Array.isArray(turnsOrEvents) && turnsOrEvents.length > 0 && "events" in (turnsOrEvents[0] as object)
     ? (turnsOrEvents as StubTurn[])
     : [{ events: turnsOrEvents as StubEvent[], stop_reason: "end_turn" }];
   let turnIdx = 0;
   const passedMessages: unknown[] = [];
+
+  // Vision filter calls `messages.create` (non-streaming) — return a stub
+  // tool_use with the configured keep_indexes so the candidates pass through.
+  const visionInput = opts.visionToolInput ?? { keep_indexes: [] };
 
   const stub = {
     messages: {
@@ -60,6 +67,12 @@ function makeAnthropicStub(turnsOrEvents: StubTurn[] | StubEvent[]): Anthropic &
           }),
         };
       },
+      create: async () => ({
+        content: [
+          { type: "tool_use", id: "vision_tu", name: "report_filtering", input: visionInput },
+        ],
+        stop_reason: "tool_use",
+      }),
     },
     calls: () => passedMessages,
   };
@@ -170,11 +183,19 @@ describe("researchProduct", () => {
   it("multi-turn happy path : image_search → tool_result → submit_product", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({
-        results: [{ properties: { url: "https://samsung.com/a.jpg" }, source: "samsung.com", title: "x" }],
+        results: [{
+          properties: { url: "https://samsung.com/a.jpg" },
+          source: "samsung.com",
+          title: "x",
+          thumbnail: { src: "https://imgs.search.brave.com/a.jpg" },
+        }],
       }), { status: 200, headers: { "content-type": "application/json" } }),
     );
     vi.stubGlobal("fetch", fetchMock);
 
+    // The stub's `messages.create` is called once by the vision filter inside
+    // image_search execution; we make it return keep_indexes:[0] so the
+    // candidate passes through.
     const anthropic = makeAnthropicStub([
       {
         events: [
@@ -189,7 +210,7 @@ describe("researchProduct", () => {
         ],
         stop_reason: "end_turn",
       },
-    ]);
+    ], { visionToolInput: { keep_indexes: [0] } });
 
     const events = await drain(researchProduct("Galaxy A55", anthropic, { braveApiKey: "test-key" }));
 

--- a/lib/ai/image-vision-filter.ts
+++ b/lib/ai/image-vision-filter.ts
@@ -1,18 +1,20 @@
 import type Anthropic from "@anthropic-ai/sdk";
 import type { ImageSearchResultItem } from "@/lib/ai/image-search";
+import { MODEL } from "@/lib/ai/product-research";
 
 /**
  * Vision-based filtering pass over image_search candidates.
  *
- * Brave returns the URLs that text-based filtering (title + source_domain)
- * can't catch the watermarks, fine-print logos, surimprime­d text, banner
- * overlays embedded *in the pixels*. This pass sends each thumbnail to
+ * Brave returns URLs that text-based filtering (title + source_domain) can't
+ * reliably vet — watermarks, fine-print logos, overlaid text, banner overlays
+ * are embedded in the pixels themselves. This pass sends each thumbnail to
  * Claude with vision and asks for a per-image keep/reject decision.
  *
- * Cost (Sonnet 4.6, ~10 thumbnails @ ~330 tokens each + prompt):
- *   ~3-5k input tokens + ~100 output tokens ≈ $0.005-0.01 per generation.
+ * Cost (as of 2026-05, Sonnet 4.6 @ $3/M input + $15/M output) for ~10
+ * thumbnails: ~3-5k input tokens + ~100 output tokens ≈ $0.01-0.02/generation.
  *
- * Latency: +3-6s in the typical case (single non-streaming call).
+ * Latency: typically +3-6s (single non-streaming call). Anthropic fetches the
+ * thumbnail URLs server-side, so a slow Brave CDN can dominate latency.
  *
  * Failure mode is graceful: if the vision call throws or times out, the
  * caller keeps the unfiltered Brave results — better to ship some
@@ -20,7 +22,14 @@ import type { ImageSearchResultItem } from "@/lib/ai/image-search";
  */
 
 const FILTER_TOOL_NAME = "report_filtering";
+
+// Generous: vision is typically 1-3s, but Anthropic's URL-fetch path can stall
+// on slow CDNs. Stays well under the 120s outer-loop ceiling so an image_search
+// → tool_result round can complete inside the research budget.
 const DEFAULT_TIMEOUT_MS = 30_000;
+
+// `keep_indexes: [0..9]` is ~30 tokens; 256 leaves ample headroom for the
+// tool-use envelope and longer arrays if MAX_COUNT in image-search.ts grows.
 const MAX_OUTPUT_TOKENS = 256;
 
 const SYSTEM_PROMPT = [
@@ -66,6 +75,21 @@ export interface VisionFilterOptions {
 }
 
 /**
+ * Classify a thrown Anthropic SDK error into a stable category for logging.
+ * Same shape conventions as `classifyError` in product-research.ts but
+ * inlined here to avoid a circular import.
+ */
+function classifyVisionError(err: unknown, aborted: boolean): string {
+  const e = err as { name?: string; status?: number; message?: string };
+  if (aborted) return "timeout";
+  if (e?.name === "AbortError" || e?.name === "APIUserAbortError") return "timeout";
+  if (e?.status === 401 || e?.status === 403) return "auth_failed";
+  if (e?.status === 429) return "rate_limited";
+  if (typeof e?.status === "number" && e.status >= 500) return "upstream_unavailable";
+  return "unknown";
+}
+
+/**
  * Filter candidates by sending each thumbnail to Claude vision. Returns the
  * subset Claude flagged as keepable. On any failure, returns the original list
  * unchanged so the upstream tool_result still reaches the model.
@@ -83,7 +107,13 @@ export async function filterByVision(
   const inspectable = candidates
     .map((c, i) => ({ c, i, thumb: c.thumbnail_url }))
     .filter((x): x is { c: ImageSearchResultItem; i: number; thumb: string } => !!x.thumb);
-  if (inspectable.length === 0) return candidates;
+  if (inspectable.length === 0) {
+    console.warn(
+      "[vision-filter] no inspectable thumbnails (Brave returned %d items, none with thumbnail_url) — skipping vision pass",
+      candidates.length,
+    );
+    return candidates;
+  }
 
   const ac = new AbortController();
   const timer = setTimeout(() => ac.abort(), opts.timeoutMs ?? DEFAULT_TIMEOUT_MS);
@@ -100,7 +130,7 @@ export async function filterByVision(
 
     const response = await anthropic.messages.create(
       {
-        model: opts.model ?? "claude-sonnet-4-6",
+        model: opts.model ?? MODEL,
         max_tokens: MAX_OUTPUT_TOKENS,
         system: SYSTEM_PROMPT,
         tools: [FILTER_TOOL],
@@ -114,7 +144,16 @@ export async function filterByVision(
       (b): b is Anthropic.ToolUseBlock => b.type === "tool_use" && b.name === FILTER_TOOL_NAME,
     );
     if (!toolUse) {
-      console.warn("[vision-filter] no tool_use in response — keeping all candidates");
+      // tool_choice forced the model toward our tool, so a missing tool_use
+      // here is either a max_tokens cap or a model refusal — both are code
+      // defects worth surfacing with full context.
+      console.warn("[vision-filter] no matching tool_use in response — keeping all candidates", {
+        stop_reason: response.stop_reason,
+        block_types: response.content.map((b) => b.type),
+        tool_names: response.content
+          .filter((b): b is Anthropic.ToolUseBlock => b.type === "tool_use")
+          .map((b) => b.name),
+      });
       return candidates;
     }
 
@@ -123,28 +162,59 @@ export async function filterByVision(
       console.warn("[vision-filter] keep_indexes missing or not array — keeping all candidates");
       return candidates;
     }
-    const keepSet = new Set(
-      input.keep_indexes.filter((n): n is number => Number.isInteger(n) && n >= 0),
+    const rawIndexes = input.keep_indexes;
+    const validIndexes = rawIndexes.filter(
+      (n): n is number => Number.isInteger(n) && n >= 0 && n < inspectable.length,
     );
+    if (validIndexes.length !== rawIndexes.length) {
+      console.warn(
+        "[vision-filter] dropped %d invalid keep_indexes (input had %d, %d valid)",
+        rawIndexes.length - validIndexes.length,
+        rawIndexes.length,
+        validIndexes.length,
+        { raw: rawIndexes },
+      );
+    }
+    const keepSet = new Set(validIndexes);
 
     // Translate display indexes → original candidate indexes, preserving
     // candidates that had no thumbnail (we never asked Claude about those).
-    const noThumbIndexes = new Set(
-      candidates.map((c, i) => (c.thumbnail_url ? -1 : i)).filter((i) => i >= 0),
-    );
-    const keptOriginalIndexes = new Set<number>();
-    inspectable.forEach((x, displayIdx) => {
-      if (keepSet.has(displayIdx)) keptOriginalIndexes.add(x.i);
+    // e.g. candidates [A, B(noThumb), C] where Claude sees [A, C] as displayIdx
+    // [0, 1]; keep_indexes:[1] → keptOriginalIndexes:{2}; B is preserved by
+    // noThumbIndexes:{1}.
+    const filtered = candidates.filter((c, i) => {
+      if (!c.thumbnail_url) return true; // no-thumb pass-through
+      const displayIdx = inspectable.findIndex((x) => x.i === i);
+      return displayIdx !== -1 && keepSet.has(displayIdx);
     });
 
-    const filtered = candidates.filter((_, i) => keptOriginalIndexes.has(i) || noThumbIndexes.has(i));
-
-    console.log("[vision-filter] kept %d/%d candidates (%d untestable kept by default)",
-      filtered.length, candidates.length, noThumbIndexes.size);
+    if (filtered.length === 0 && candidates.length > 0) {
+      // Vision rejected EVERY candidate — usually a sign the prompt is too
+      // aggressive or the model regressed on this query class. Worth a louder
+      // signal than the routine "kept N/M" log so prompt regressions surface.
+      console.warn(
+        "[vision-filter] rejected ALL candidates (0/%d kept) — possible prompt regression",
+        candidates.length,
+      );
+    } else {
+      const inspectedKept = filtered.filter((c) => c.thumbnail_url).length;
+      const passthrough = filtered.length - inspectedKept;
+      console.log(
+        "[vision-filter] kept %d/%d candidates (%d inspected, %d untestable kept by default)",
+        filtered.length, candidates.length, inspectedKept, passthrough,
+      );
+    }
 
     return filtered;
   } catch (err) {
-    console.warn("[vision-filter] failed, keeping unfiltered Brave results:", err);
+    const reason = classifyVisionError(err, ac.signal.aborted);
+    const e = err as { name?: string; status?: number; message?: string };
+    console.warn("[vision-filter] failed, keeping unfiltered Brave results", {
+      reason,
+      err_name: e?.name,
+      err_status: e?.status,
+      err_message: e?.message,
+    });
     return candidates;
   } finally {
     clearTimeout(timer);

--- a/lib/ai/image-vision-filter.ts
+++ b/lib/ai/image-vision-filter.ts
@@ -1,0 +1,152 @@
+import type Anthropic from "@anthropic-ai/sdk";
+import type { ImageSearchResultItem } from "@/lib/ai/image-search";
+
+/**
+ * Vision-based filtering pass over image_search candidates.
+ *
+ * Brave returns the URLs that text-based filtering (title + source_domain)
+ * can't catch the watermarks, fine-print logos, surimprime­d text, banner
+ * overlays embedded *in the pixels*. This pass sends each thumbnail to
+ * Claude with vision and asks for a per-image keep/reject decision.
+ *
+ * Cost (Sonnet 4.6, ~10 thumbnails @ ~330 tokens each + prompt):
+ *   ~3-5k input tokens + ~100 output tokens ≈ $0.005-0.01 per generation.
+ *
+ * Latency: +3-6s in the typical case (single non-streaming call).
+ *
+ * Failure mode is graceful: if the vision call throws or times out, the
+ * caller keeps the unfiltered Brave results — better to ship some
+ * watermarked images than to drop the whole tool_result back to the model.
+ */
+
+const FILTER_TOOL_NAME = "report_filtering";
+const DEFAULT_TIMEOUT_MS = 30_000;
+const MAX_OUTPUT_TOKENS = 256;
+
+const SYSTEM_PROMPT = [
+  "Tu filtres des images candidates pour une fiche produit e-commerce.",
+  "Pour CHAQUE image numérotée, juge si elle est utilisable comme image de catalogue.",
+  "GARDER (utilisable) :",
+  "- Photo produit propre, fond blanc/neutre/transparent, produit isolé.",
+  "- Image officielle constructeur (newsroom, presse studio).",
+  "- Photo packaging officielle.",
+  "- Vue produit dans contexte d'usage neutre, sans branding lourd.",
+  "REJETER (non utilisable) :",
+  "- Watermark ou logo de site web visible (Tom's Guide, Engadget, GSMArena, 91mobiles, etc., même très fin).",
+  "- Texte surimprimé : prix, slogan, badge promo, \"Top 10\", \"vs\", \"review\".",
+  "- Bannière publicitaire ou capture d'écran d'un site e-commerce.",
+  "- Comparatif multi-produits (plusieurs appareils côte à côte).",
+  "- Schémas, exploded views, leaks/concepts non confirmés.",
+  "- Mèmes, thumbnails YouTube clickbait.",
+  "Renvoie via le tool report_filtering la liste des INDEX (0-based) à GARDER.",
+  "Si rien n'est utilisable, retourne un tableau vide.",
+].join("\n");
+
+const FILTER_TOOL: Anthropic.Tool = {
+  name: FILTER_TOOL_NAME,
+  description: "Indique quelles images garder pour le catalogue produit.",
+  input_schema: {
+    type: "object",
+    required: ["keep_indexes"],
+    additionalProperties: false,
+    properties: {
+      keep_indexes: {
+        type: "array",
+        items: { type: "integer", minimum: 0 },
+        description:
+          "Index 0-based des images à garder. Tableau vide si aucune n'est utilisable.",
+      },
+    },
+  },
+};
+
+export interface VisionFilterOptions {
+  model?: string;
+  timeoutMs?: number;
+}
+
+/**
+ * Filter candidates by sending each thumbnail to Claude vision. Returns the
+ * subset Claude flagged as keepable. On any failure, returns the original list
+ * unchanged so the upstream tool_result still reaches the model.
+ */
+export async function filterByVision(
+  candidates: ImageSearchResultItem[],
+  anthropic: Anthropic,
+  opts: VisionFilterOptions = {},
+): Promise<ImageSearchResultItem[]> {
+  if (candidates.length === 0) return candidates;
+
+  // Only candidates with a thumbnail_url can be inspected — Brave occasionally
+  // returns a result with properties.url but no thumbnail. For those, we can't
+  // run vision — keep them in the output so we don't silently drop them.
+  const inspectable = candidates
+    .map((c, i) => ({ c, i, thumb: c.thumbnail_url }))
+    .filter((x): x is { c: ImageSearchResultItem; i: number; thumb: string } => !!x.thumb);
+  if (inspectable.length === 0) return candidates;
+
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), opts.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+
+  try {
+    const userContent: Anthropic.ContentBlockParam[] = [];
+    inspectable.forEach((x, displayIdx) => {
+      userContent.push({ type: "text", text: `Image ${displayIdx} (${x.c.source_domain}) — ${x.c.title || "sans titre"}` });
+      userContent.push({
+        type: "image",
+        source: { type: "url", url: x.thumb },
+      });
+    });
+
+    const response = await anthropic.messages.create(
+      {
+        model: opts.model ?? "claude-sonnet-4-6",
+        max_tokens: MAX_OUTPUT_TOKENS,
+        system: SYSTEM_PROMPT,
+        tools: [FILTER_TOOL],
+        tool_choice: { type: "tool", name: FILTER_TOOL_NAME },
+        messages: [{ role: "user", content: userContent }],
+      },
+      { signal: ac.signal },
+    );
+
+    const toolUse = response.content.find(
+      (b): b is Anthropic.ToolUseBlock => b.type === "tool_use" && b.name === FILTER_TOOL_NAME,
+    );
+    if (!toolUse) {
+      console.warn("[vision-filter] no tool_use in response — keeping all candidates");
+      return candidates;
+    }
+
+    const input = toolUse.input as { keep_indexes?: unknown };
+    if (!Array.isArray(input.keep_indexes)) {
+      console.warn("[vision-filter] keep_indexes missing or not array — keeping all candidates");
+      return candidates;
+    }
+    const keepSet = new Set(
+      input.keep_indexes.filter((n): n is number => Number.isInteger(n) && n >= 0),
+    );
+
+    // Translate display indexes → original candidate indexes, preserving
+    // candidates that had no thumbnail (we never asked Claude about those).
+    const noThumbIndexes = new Set(
+      candidates.map((c, i) => (c.thumbnail_url ? -1 : i)).filter((i) => i >= 0),
+    );
+    const keptOriginalIndexes = new Set<number>();
+    inspectable.forEach((x, displayIdx) => {
+      if (keepSet.has(displayIdx)) keptOriginalIndexes.add(x.i);
+    });
+
+    const filtered = candidates.filter((_, i) => keptOriginalIndexes.has(i) || noThumbIndexes.has(i));
+
+    console.log("[vision-filter] kept %d/%d candidates (%d untestable kept by default)",
+      filtered.length, candidates.length, noThumbIndexes.size);
+
+    return filtered;
+  } catch (err) {
+    console.warn("[vision-filter] failed, keeping unfiltered Brave results:", err);
+    return candidates;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/lib/ai/product-research.ts
+++ b/lib/ai/product-research.ts
@@ -235,14 +235,19 @@ export async function* researchProduct(
         clientToolUses.map(async (tu): Promise<Anthropic.ToolResultBlockParam> => {
           try {
             const result = await searchImages(tu.input as ImageSearchInput, braveApiKey);
-            // Vision pass: text-based filtering can't catch watermarks /
-            // surimprime­d text / banner overlays embedded in pixels. We send
-            // each thumbnail back to Claude with vision before handing the
-            // results to the research-loop model. Failures degrade silently —
-            // the unfiltered Brave list still reaches the model.
-            const finalResult = result.ok && result.results.length > 0
-              ? { ok: true as const, results: await filterByVision(result.results, anthropic, { model }) }
-              : result;
+            // Vision pass — see lib/ai/image-vision-filter.ts header for
+            // rationale + failure mode. Wrapped in its own try/catch so a
+            // post-processing throw never loses the Brave results we already
+            // have; the model gets the unfiltered list instead of api_error.
+            let finalResult = result;
+            if (result.ok && result.results.length > 0) {
+              try {
+                finalResult = { ok: true, results: await filterByVision(result.results, anthropic, { model }) };
+              } catch (visionErr) {
+                console.warn("[ai-product] vision filter threw outside its catch — using unfiltered Brave results", visionErr);
+                finalResult = result;
+              }
+            }
             // is_error: true tells the model the tool genuinely failed (vs.
             // returning empty results). Without this Claude may treat a
             // 429/auth_failed as "no images found" and blindly retry, exhausting

--- a/lib/ai/product-research.ts
+++ b/lib/ai/product-research.ts
@@ -3,6 +3,7 @@ import { parseAiToolInput, type AiProductOutput } from "@/lib/validations/produc
 import { HIGHLIGHT_ICON_NAMES } from "@/lib/validations/product-story";
 import { SUBMIT_PRODUCT_TOOL_SCHEMA } from "@/lib/ai/submit-tool-schema";
 import { searchImages, type ImageSearchInput } from "@/lib/ai/image-search";
+import { filterByVision } from "@/lib/ai/image-vision-filter";
 
 export type ResearchErrorCode =
   | "invalid_ai_output"       // Claude returned a submit_product payload we couldn't parse
@@ -234,6 +235,14 @@ export async function* researchProduct(
         clientToolUses.map(async (tu): Promise<Anthropic.ToolResultBlockParam> => {
           try {
             const result = await searchImages(tu.input as ImageSearchInput, braveApiKey);
+            // Vision pass: text-based filtering can't catch watermarks /
+            // surimprime­d text / banner overlays embedded in pixels. We send
+            // each thumbnail back to Claude with vision before handing the
+            // results to the research-loop model. Failures degrade silently —
+            // the unfiltered Brave list still reaches the model.
+            const finalResult = result.ok && result.results.length > 0
+              ? { ok: true as const, results: await filterByVision(result.results, anthropic, { model }) }
+              : result;
             // is_error: true tells the model the tool genuinely failed (vs.
             // returning empty results). Without this Claude may treat a
             // 429/auth_failed as "no images found" and blindly retry, exhausting
@@ -242,8 +251,8 @@ export async function* researchProduct(
             return {
               type: "tool_result",
               tool_use_id: tu.id,
-              content: JSON.stringify(result),
-              is_error: !result.ok,
+              content: JSON.stringify(finalResult),
+              is_error: !finalResult.ok,
             };
           } catch (err) {
             console.error("[ai-product] image_search threw", err);


### PR DESCRIPTION
## Summary
- New `lib/ai/image-vision-filter.ts` : `filterByVision()` envoie chaque thumbnail Brave à Claude avec vision + un tool `report_filtering` qui retourne les `keep_indexes` à conserver.
- Wire dans `product-research.ts` — pass vision exécutée pendant le `tool_result` du tool `image_search`, avant que le modèle ne voie les candidats.
- 9 nouveaux tests + augmentation du stub multi-turn pour exposer `messages.create`.

## Why
La prod confirme que le filtrage textuel (`title` + `source_domain`) laisse passer des watermarks fins (logos de site, bandeaux discrets). Le modèle ne peut pas les voir — ils sont dans les pixels, pas dans les métadonnées.

Solution : passer les thumbnails à Claude avec vision avant de retourner le `tool_result` du tool `image_search`. Vision juge chaque image sur des critères pixel-level (watermark visible, texte surimprimé, bannière, comparatif multi-produits, etc.) et garde uniquement les images catalogue-ready.

## Coût / latence
- ~3-5 k tokens input (10 thumbnails à ~330 tokens chacun + prompt) + ~100 tokens output ≈ **$0.005-0.01 / génération** (Sonnet 4.6)
- Latence : +3-6 s typique (single `messages.create` non-streaming, hors loop principal)
- Le timeout interne de 30 s sur la pass vision protège la latence globale (le timeout principal de 120 s reste largement suffisant)

## Failure mode
Graceful : vision API throw / timeout / réponse mal formée → `console.warn` + retour de la liste Brave non filtrée. Le `tool_result` reste valide, la génération aboutit, l'admin verra les watermarks comme avant — pas pire que sans le vision filter.

## Test plan
- [x] `npm run test` — 871/871 (10 nouveaux : 9 vision-filter + 1 stub augmenté)
- [x] `tsc --noEmit` clean
- [ ] Après deploy, générer un produit (ex. *Honor Magic 8 Pro*) — la grille selector ne devrait plus contenir les images watermarkées qu'on voyait avant. Si une slips through, son thumbnail apparaît dans `wrangler tail` via le log `[vision-filter] kept N/M candidates`.
- [ ] Si le vision pass échoue côté Anthropic (rare), `console.warn` `[vision-filter] failed, keeping unfiltered Brave results` apparaîtra et la génération continue avec les candidats Brave bruts — fallback testé.

## Trade-offs assumés
- **Coût supplémentaire** : ~$0.005-0.01/génération (~10× plus que sans vision). Volume admin = négligeable.
- **Pas de seconde clé API** : utilise la même clé Anthropic que le modèle principal.
- **Pas de cache** : chaque génération refait la pass. Ajouter un cache R2 par thumbnail_url serait possible mais complexifie pour un gain marginal (les recherches diffèrent à chaque produit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI-powered vision filtering added to image search results to improve relevance; preserves images when analysis is unavailable and falls back safely on failures.

* **Tests**
  * Expanded unit and integration tests for image filtering covering many edge cases (empty inputs, invalid indexes, API errors, thumbnail handling) to improve reliability and resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->