### PR TITLE
fix(admin): remove example chips from AI product creation prompt

### DIFF
--- a/components/admin/ai-product/ai-prompt-form.tsx
+++ b/components/admin/ai-product/ai-prompt-form.tsx
@@ -4,8 +4,6 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
-const EXAMPLES = ["iPhone 15 Pro", "Samsung Galaxy A55", "MacBook Air M3", "AirPods Pro 2"];
-
 interface AiPromptFormProps {
   prompt: string;
   onPromptChange: (v: string) => void;
@@ -29,7 +27,7 @@ export function AiPromptForm({ prompt, onPromptChange, onSubmit, disabled, error
           id="ai-prompt"
           value={prompt}
           onChange={(e) => onPromptChange(e.target.value)}
-          placeholder="ex: Samsung Galaxy A55"
+          placeholder="Marque + modèle"
           disabled={disabled}
           autoFocus
           maxLength={200}
@@ -37,20 +35,6 @@ export function AiPromptForm({ prompt, onPromptChange, onSubmit, disabled, error
         <p className="text-xs text-muted-foreground">
           Marque + modèle suffit. Ajoutez la capacité (ex: 128Go) pour un modèle précis.
         </p>
-      </div>
-
-      <div className="flex flex-wrap gap-2">
-        {EXAMPLES.map((ex) => (
-          <button
-            key={ex}
-            type="button"
-            disabled={disabled}
-            onClick={() => onPromptChange(ex)}
-            className="inline-flex min-h-11 items-center rounded-full border bg-background px-4 py-2 text-xs text-muted-foreground transition-colors hover:border-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:opacity-50"
-          >
-            {ex}
-          </button>
-        ))}
       </div>
 
       {error && (


### PR DESCRIPTION
## Summary
- Drop the suggestion chips (iPhone 15 Pro, Samsung Galaxy A55, MacBook Air M3, AirPods Pro 2) under the AI product creation prompt
- Replace the brand-specific placeholder (\"ex: Samsung Galaxy A55\") with a neutral \"Marque + modèle\"
- Remove the now-unused \`EXAMPLES\` constant

## Test plan
- [ ] Open `/admin/products/new/ai` and confirm no example chips render under the input
- [ ] Verify the input placeholder reads \"Marque + modèle\"
- [ ] Type a product name and confirm submission still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified the AI prompt form by removing example suggestion buttons and updating the input placeholder text for improved clarity and streamlined user experience.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kkzakaria/netereka/pull/215)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->