### PR TITLE
fix(storefront): resolve Next.js 16 dev warnings

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -19,12 +19,6 @@ const nextConfig: NextConfig = {
         source: "/:path*",
         headers: securityHeaders,
       },
-      {
-        source: "/_next/static/:path*",
-        headers: [
-          { key: "Cache-Control", value: "public, max-age=31536000, immutable" },
-        ],
-      },
     ];
   },
   experimental: {

--- a/proxy.ts
+++ b/proxy.ts
@@ -7,7 +7,7 @@ const SESSION_COOKIE = "better-auth.session_token";
 const SECURE_SESSION_COOKIE = "__Secure-better-auth.session_token";
 const KV_HERO_PRELOAD_KEY = "hero:lcp:preload-url";
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   const { hostname, pathname } = request.nextUrl;
 
   // Redirect www → apex for SEO canonicalization
@@ -43,7 +43,7 @@ export async function middleware(request: NextRequest) {
     } catch (err) {
       // Expected in local dev without wrangler bindings; should not fire in production.
       if (process.env.NODE_ENV === "production") {
-        console.error("[middleware] KV read failed for hero preload header:", err);
+        console.error("[proxy] KV read failed for hero preload header:", err);
       }
     }
   }


### PR DESCRIPTION
## Summary

- **`middleware.ts` → `proxy.ts`**: Next.js 16 déprécie la convention de fichier `middleware` en faveur de `proxy`. Renommage du fichier et de la fonction exportée (`middleware` → `proxy`). Le `config.matcher` reste identique — même API, même comportement.
- **Suppression du header `Cache-Control` sur `/_next/static/:path*`** dans `next.config.ts`: Next.js gère automatiquement `Cache-Control: public, max-age=31536000, immutable` pour les assets statiques hachés. Surcharger ce header déclenchait un warning et pouvait casser le comportement en dev.

## Test plan

- [ ] `npm run dev` démarre sans les deux warnings
- [ ] Les routes protégées redirigent toujours vers `/auth/sign-in`
- [ ] La redirection `www.netereka.ci` → `netereka.ci` fonctionne
- [ ] Le preload KV du hero LCP sur `/` est toujours injecté

🤖 Generated with [Claude Code](https://claude.com/claude-code)