### PR TITLE
fix(storefront): revert proxy.ts to middleware.ts for Cloudflare compatibility

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -7,7 +7,7 @@ const SESSION_COOKIE = "better-auth.session_token";
 const SECURE_SESSION_COOKIE = "__Secure-better-auth.session_token";
 const KV_HERO_PRELOAD_KEY = "hero:lcp:preload-url";
 
-export async function proxy(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   const { hostname, pathname } = request.nextUrl;
 
   // Redirect www → apex for SEO canonicalization
@@ -43,7 +43,7 @@ export async function proxy(request: NextRequest) {
     } catch (err) {
       // Expected in local dev without wrangler bindings; should not fire in production.
       if (process.env.NODE_ENV === "production") {
-        console.error("[proxy] KV read failed for hero preload header:", err);
+        console.error("[middleware] KV read failed for hero preload header:", err);
       }
     }
   }


### PR DESCRIPTION
## Contexte

La PR #221 a renommé `middleware.ts` → `proxy.ts` pour suivre la nouvelle convention Next.js 16. Cette migration a cassé le déploiement Cloudflare.

## Cause racine

`proxy.ts` tourne sur le **Node.js runtime** par défaut. Or Cloudflare Workers nécessite l'**Edge runtime**.

La documentation Cloudflare est explicite :

> _"Node.js in Middleware introduced in version 15.2 is not yet supported."_
> — developers.cloudflare.com/workers/framework-guides/web-apps/nextjs

OpenNext 1.19.x confirme avec un `process.exit(1)` explicite à la compilation si un Node.js middleware est détecté.

## Fix

- Revert `proxy.ts` → `middleware.ts` (Edge runtime, seul mode supporté aujourd'hui)
- La deprecation warning Next.js 16 en dev est cosmétique ; le crash en production ne l'est pas

## À faire plus tard

Migrer vers `proxy.ts` lorsque OpenNext/Cloudflare supportera le Node.js middleware (pas de date annoncée).

## Test plan

- [ ] `npm run build:worker` passe sans erreur Node.js middleware
- [ ] Le déploiement canary réussit
- [ ] Les routes protégées redirigent toujours vers `/auth/sign-in`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal middleware structure optimized. No changes to user-facing functionality. All existing features including domain redirection, header injection, and session protection continue to work as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kkzakaria/netereka/pull/222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->