### PR TITLE
perf(storefront): reduce initial homepage cards to lower mobile LCP

### DIFF
--- a/app/(storefront)/page.tsx
+++ b/app/(storefront)/page.tsx
@@ -20,6 +20,11 @@ export const metadata: Metadata = {
 };
 
 const HIGHLIGHTED_CATEGORIES = 3;
+// Cards rendered per horizontal section. Kept intentionally low to limit the
+// initial DOM / hydration cost on mobile (each card mounts a client island),
+// which is the main lever on homepage LCP. Sections are scrollable carousels
+// with a "Voir tout" link, so fewer initial cards has minimal UX impact.
+const PRODUCTS_PER_SECTION = 8;
 
 export default async function HomePage() {
   // Start categories early — category sections depend on it
@@ -30,7 +35,7 @@ export default async function HomePage() {
     Promise.all(
       cats.slice(0, HIGHLIGHTED_CATEGORIES).map(async (cat) => ({
         category: cat,
-        products: (await getProductsByCategorySlug(cat.slug, 10)).map(toProductCardData),
+        products: (await getProductsByCategorySlug(cat.slug, PRODUCTS_PER_SECTION)).map(toProductCardData),
       }))
     )
   );
@@ -39,8 +44,8 @@ export default async function HomePage() {
   const [categories, featured, latest, activeBanners, categorySections] =
     await Promise.all([
       categoriesPromise,
-      getFeaturedProducts(10),
-      getLatestProducts(10, true),
+      getFeaturedProducts(PRODUCTS_PER_SECTION),
+      getLatestProducts(PRODUCTS_PER_SECTION, true),
       getActiveBanners().catch((error) => {
         console.error("[homepage] Failed to fetch active banners:", error);
         return [] as Banner[];


### PR DESCRIPTION
## Contexte

Audit SEO + PageSpeed de la home (`https://netereka.ci/`). L'image LCP est **déjà optimale** (preload + `fetchpriority=high` + AVIF + découvrable — les 3 checks Lighthouse « LCP request discovery » passent). Le coût LCP mobile restant est **main-thread** : `render delay` ~480 ms dû au DOM initial lourd (≈445 KB décompressés, ~50 product cards) et à l'hydratation des îlots clients.

## Changement

`app/(storefront)/page.tsx` : `PRODUCTS_PER_SECTION = 8` (au lieu de `10` codé en dur à 3 endroits).

| Section | Avant | Après |
|---|---|---|
| Meilleures ventes | 10 | 8 |
| Nouveautés | 10 | 8 |
| 3 sections catégories | 30 | 24 |
| **Total cartes initiales** | **~50** | **~40** |

Chaque carte monte un `ProductCardActions` (composant client) → réduire le nombre de cartes allège directement l'hydratation et le DOM.

## Impact

- **UX :** inchangée — sections = carrousels horizontaux avec « Voir tout ».
- **SEO :** inchangé — produits toujours dans le HTML, sitemap couvre tout.
- **Tunable :** une seule constante à ajuster (baisser à 6 pour un gain plus marqué).

## Vérification

- ✅ `tsc --noEmit`, ESLint, 873 tests (pre-commit)
- ⚠️ Le gain LCP réel se mesure **après déploiement** (test PageSpeed contre la prod). Comparer ensuite « LCP breakdown → Element render delay ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)