### PR TITLE
fix(ci): select most-recent deployment when resolving canary to promote

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -42,8 +42,12 @@ jobs:
             # whose `deployed_percentage` defaults to 0 — auto-promoting one of
             # those would bypass canary entirely and route 100% of traffic to
             # an untested version.
+            # `wrangler deployments list --json` returns ASCENDING order
+            # (oldest first), so `.[0]` is the oldest deployment — never the
+            # current canary. Sort by created_on desc and take the most recent
+            # deployment, then pick the version in the canary split.
             VID=$(npx wrangler deployments list --json \
-              | jq -r '.[0].versions
+              | jq -r 'sort_by(.created_on) | reverse | .[0].versions
                        | map(select((.percentage // 0) > 0 and (.percentage // 0) < 100))
                        | first
                        | .version_id')

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -47,7 +47,7 @@ jobs:
             # current canary. Sort by created_on desc and take the most recent
             # deployment, then pick the version in the canary split.
             VID=$(npx wrangler deployments list --json \
-              | jq -r 'sort_by(.created_on) | reverse | .[0].versions
+              | jq -r 'sort_by(.created_on) | reverse | (.[0].versions // [])
                        | map(select((.percentage // 0) > 0 and (.percentage // 0) < 100))
                        | first
                        | .version_id')


### PR DESCRIPTION
## Problème

Le workflow `promote.yml` (étape « Resolve target version_id ») échoue systématiquement à l'auto-détection du canari — ce qui force à promouvoir via le dashboard Cloudflare et laisse s'accumuler les issues « Pending promotion » orphelines (#206, #214, #216, #217, #226…).

**Cause :** `wrangler deployments list --json` renvoie l'ordre **ascendant (plus ancien en premier)**. L'étape prenait `.[0]` → le déploiement le **plus ancien**, jamais le canari courant. Résultat : soit « no canary found » (si le plus ancien est un 100% mono-version), soit un risque de cibler un vieux canari périmé.

C'est exactement le gotcha documenté dans le `CLAUDE.md` :
> `wrangler deployments list --json` returns ascending order (oldest first). Always `sort_by(.created_on) | reverse | .[0]`.

## Correctif

```diff
- | jq -r '.[0].versions
+ | jq -r 'sort_by(.created_on) | reverse | .[0].versions
            | map(select((.percentage // 0) > 0 and (.percentage // 0) < 100))
            | first | .version_id'
```

## Vérification (contre données réelles + simulation)

| Test | Résultat |
|---|---|
| YAML valide | ✅ |
| `jq` corrigé, état réel (récent = 100%) | → `null` ✅ (rien à promouvoir = correct) |
| Simulation canari 10/90 récent | → bonne version (à 10%) ✅ |
| Contre-preuve ancien `.[0]` | → pioche un canari de mai (le bug) ❌ |

Aucun changement de comportement hors résolution de version ; les étapes Deploy 100% / seed KV / close issues restent intactes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)