### PR TITLE
feat(seo): ancre #retours sur les CGV (URL politique de retour Merchant Center)

### DIFF
--- a/app/(storefront)/conditions-generales/page.tsx
+++ b/app/(storefront)/conditions-generales/page.tsx
@@ -118,7 +118,7 @@ export default function CGVPage() {
           </p>
         </section>
 
-        <section>
+        <section id="retours" className="scroll-mt-24">
           <h2 className="text-xl font-semibold">7. Droit de rétractation et retours</h2>
           <p>
             Conformément à la réglementation en vigueur en Côte d&apos;Ivoire, le client


### PR DESCRIPTION
## Contexte

Google Merchant Center demande une **URL de politique de retour** lors de la configuration du compte. La section 7 des CGV (« Droit de rétractation et retours ») couvre déjà le sujet mais n'avait pas d'ancre HTML — impossible de pointer Google directement dessus.

## Changement

- `id="retours"` sur la `<section>` 7 des CGV
- `scroll-mt-24` pour que le titre ne passe pas sous le header sticky à l'arrivée sur l'ancre

URL désormais utilisable : `https://netereka.ci/conditions-generales#retours`

## Test

Hook pré-commit (tsc + eslint + vitest, 28 tests) ✓. Changement statique sans logique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)