### PR TITLE
fix(seo): en-têtes CORS sur /feed.xml (validation URL Merchant Center)

### DIFF
--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -64,7 +64,14 @@ export async function GET() {
     });
 
     return new Response(xml, {
-      headers: { "Content-Type": "application/xml; charset=utf-8" },
+      headers: {
+        "Content-Type": "application/xml; charset=utf-8",
+        // Public read-only feed: allow cross-origin readers (e.g. Merchant Center's
+        // in-browser URL validator does a fetch() from merchants.google.com).
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+        "Cache-Control": "public, max-age=3600",
+      },
     });
   } catch (error) {
     // Never serve a partial feed: a 500 makes Merchant Center keep the last good feed.


### PR DESCRIPTION
## Problème

Merchant Center refuse l'URL du flux avec « Ce lien ne semble pas valide », alors que `https://netereka.ci/feed.xml` répond **200 + XML valide** à tout fetch côté serveur (curl, UA Googlebot, UA Google-Merchant-Center, profil Chrome). Site déjà **Validé + Revendiqué**.

Cause restante : le validateur d'URL de MC s'exécute **dans le navigateur** et fait un `fetch()` cross-origin depuis `merchants.google.com`. Sans `Access-Control-Allow-Origin`, le navigateur bloque la lecture de la réponse → MC croit le lien injoignable.

## Correctif

Ajout sur la réponse de `/feed.xml` (flux public, lecture seule — aucun risque) :
- `Access-Control-Allow-Origin: *`
- `Access-Control-Allow-Methods: GET, HEAD, OPTIONS`
- `Cache-Control: public, max-age=3600`

## Test

Hook pré-commit (tsc + eslint + vitest) ✓. Vérif post-déploiement : en-tête `access-control-allow-origin: *` présent sur la réponse prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)