### PR TITLE
perf(seo): cache /feed.xml à 10 min

### DIFF
--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -70,7 +70,7 @@ export async function GET() {
         // in-browser URL validator does a fetch() from merchants.google.com).
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
-        "Cache-Control": "public, max-age=3600",
+        "Cache-Control": "public, max-age=600",
       },
     });
   } catch (error) {


### PR DESCRIPTION
Réduit `Cache-Control` du flux Merchant Center de `max-age=3600` (1 h) à `max-age=600` (10 min) pour que les modifs catalogue (prix/stock) se propagent plus vite.

Hook pré-commit (tsc + eslint + vitest) ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)