### PR TITLE
fix: remediate all audit findings (2 HIGH, 3 MEDIUM, 4 LOW) — WhatsApp bypasses, stored XSS, inventory denial

### DIFF
--- a/__tests__/unit/csv.test.ts
+++ b/__tests__/unit/csv.test.ts
@@ -91,4 +91,28 @@ describe("ordersToCSV", () => {
     const lines = csv.split("\n");
     expect(lines).toHaveLength(1);
   });
+
+  // Security regression (GHSA-v4c5): customer-controlled fields starting with a
+  // formula trigger must be neutralized so they are not evaluated by Excel/Sheets.
+  it("neutralise l'injection de formule dans les champs client", () => {
+    const csv = ordersToCSV([
+      makeOrder({ user_name: '=HYPERLINK("https://evil.example")' }),
+    ]);
+    // The value is quoted (contains a paren/quote) AND prefixed with a single
+    // quote so it renders as text, not a live formula.
+    expect(csv).toContain("'=HYPERLINK");
+    expect(csv).not.toMatch(/(^|,)=HYPERLINK/);
+  });
+
+  it("préfixe les valeurs commençant par + - @ ", () => {
+    expect(ordersToCSV([makeOrder({ delivery_commune: "+225Cocody" })])).toContain("'+225Cocody");
+    expect(ordersToCSV([makeOrder({ delivery_address: "@SUM(A1)" })])).toContain("'@SUM(A1)");
+    expect(ordersToCSV([makeOrder({ user_name: "-2+3" })])).toContain("'-2+3");
+  });
+
+  it("ne modifie pas les valeurs bénignes", () => {
+    const csv = ordersToCSV([makeOrder({ user_name: "Koné Amadou" })]);
+    expect(csv).toContain("Koné Amadou");
+    expect(csv).not.toContain("'Koné");
+  });
 });

--- a/__tests__/unit/sanitize-html.test.ts
+++ b/__tests__/unit/sanitize-html.test.ts
@@ -180,4 +180,20 @@ describe("sanitizeDescriptionHtml", () => {
     expect(result).toContain("color:red");
     expect(result).toContain("font-weight:bold");
   });
+
+  it("strips an UNTERMINATED url( from an inline style attribute", () => {
+    const result = sanitizeDescriptionHtml(
+      '<div style="background:url(https://evil.example/leak">x</div>'
+    );
+    expect(result).not.toContain("url(");
+    expect(result).not.toContain("evil.example");
+  });
+
+  it("strips an UNTERMINATED url( from a <style> block", () => {
+    const result = sanitizeDescriptionHtml(
+      "<style>p { background: url(https://evil.example/leak }</style><p>x</p>"
+    );
+    expect(result).not.toContain("url(");
+    expect(result).not.toContain("evil.example");
+  });
 });

--- a/__tests__/unit/sanitize-html.test.ts
+++ b/__tests__/unit/sanitize-html.test.ts
@@ -129,4 +129,55 @@ describe("sanitizeDescriptionHtml", () => {
     expect(result).toContain(".desc-p1 h2");
     expect(result).toContain(".desc-p1 .promo");
   });
+
+  // Security regression (GHSA-92r4): tags using "/" as the attribute separator
+  // must NOT bypass sanitization. Previously the tag regex only matched
+  // whitespace-separated attributes, so these passed through verbatim.
+  it("neutralizes onerror when '/' is used as the attribute separator", () => {
+    const result = sanitizeDescriptionHtml("<img/src=x/onerror=alert(document.domain)>");
+    // The tag is now parsed: the unquoted src value folds the rest of the
+    // payload inside the quoted src attribute, so onerror is inert (not a
+    // standalone attribute) and cannot fire. Crucially it does NOT pass through
+    // verbatim as it did before the fix.
+    expect(result).toBe('<img src="x/onerror=alert(document.domain)">');
+    expect(result).not.toBe("<img/src=x/onerror=alert(document.domain)>");
+  });
+
+  it("strips a disallowed tag written with a '/' separator", () => {
+    const result = sanitizeDescriptionHtml("<svg/onload=alert(1)>content");
+    expect(result).not.toContain("<svg");
+    expect(result).not.toMatch(/\bonload\s*=/i);
+    expect(result).toContain("content");
+  });
+
+  it("neutralizes an onmouseover handler after a '/' separator on an allowed tag", () => {
+    const result = sanitizeDescriptionHtml("<p/onmouseover=alert(1)>hi</p>");
+    expect(result).not.toMatch(/\bonmouseover\s*=/i);
+    expect(result).toContain("hi");
+  });
+
+  // Security regression (GHSA-m888): inline style must not carry url()/@import/
+  // expression(), which leak outbound requests or execute legacy CSS.
+  it("strips url() from an inline style attribute", () => {
+    const result = sanitizeDescriptionHtml(
+      '<div style="background:url(https://evil.example/leak)">x</div>'
+    );
+    expect(result).not.toContain("url(");
+    expect(result).not.toContain("evil.example");
+    expect(result).toContain("<div");
+  });
+
+  it("strips @import and expression() from an inline style attribute", () => {
+    const result = sanitizeDescriptionHtml(
+      '<div style="width:expression(alert(1));@import \'evil.css\'">x</div>'
+    );
+    expect(result).not.toContain("expression(");
+    expect(result).not.toContain("@import");
+  });
+
+  it("keeps benign inline style declarations intact", () => {
+    const result = sanitizeDescriptionHtml('<div style="color:red;font-weight:bold">x</div>');
+    expect(result).toContain("color:red");
+    expect(result).toContain("font-weight:bold");
+  });
 });

--- a/__tests__/unit/validations/checkout.test.ts
+++ b/__tests__/unit/validations/checkout.test.ts
@@ -48,6 +48,34 @@ describe("checkoutSchema", () => {
     expect(result.success).toBe(false);
   });
 
+  // Security regression (GHSA-7f5h): the items array must be bounded to mirror
+  // the cart cap so a direct createOrder call can't submit an unbounded list.
+  it("rejette un panier de plus de 50 articles distincts", () => {
+    const many = Array.from({ length: 51 }, (_, i) => ({
+      productId: `prod-${i}`,
+      variantId: null,
+      quantity: 1,
+    }));
+    const result = checkoutSchema.safeParse({
+      ...validCheckoutWithSavedAddress,
+      items: many,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepte exactement 50 articles distincts", () => {
+    const fifty = Array.from({ length: 50 }, (_, i) => ({
+      productId: `prod-${i}`,
+      variantId: null,
+      quantity: 1,
+    }));
+    const result = checkoutSchema.safeParse({
+      ...validCheckoutWithSavedAddress,
+      items: fifty,
+    });
+    expect(result.success).toBe(true);
+  });
+
   it("rejette une quantité à 0", () => {
     const result = checkoutSchema.safeParse({
       ...validCheckoutWithSavedAddress,

--- a/__tests__/unit/workers/whatsapp/session.test.ts
+++ b/__tests__/unit/workers/whatsapp/session.test.ts
@@ -39,34 +39,17 @@ describe("findOrCreateSession", () => {
     expect(mockDb.prepare).toHaveBeenCalledTimes(1);
   });
 
-  it("creates new session and auto-links if phone matches a user", async () => {
-    mockDb._statement.first.mockResolvedValueOnce(null);
-    mockDb._statement.first.mockResolvedValueOnce({ id: "usr_42" });
-    mockDb._statement.run.mockResolvedValueOnce({ success: true });
-    mockDb._statement.first.mockResolvedValueOnce({
-      id: "new_sess",
-      wa_phone: "2250700000000",
-      user_id: "usr_42",
-      is_verified: 1,
-      status: "active",
-      created_at: "2026-04-13T10:00:00Z",
-      updated_at: "2026-04-13T10:00:00Z",
-    });
-
-    const session = await findOrCreateSession(mockDb as unknown as D1Database, "2250700000000");
-
-    expect(session.user_id).toBe("usr_42");
-    expect(session.is_verified).toBe(1);
-  });
-
-  it("creates unlinked session if no user matches", async () => {
-    mockDb._statement.first.mockResolvedValueOnce(null);
-    mockDb._statement.first.mockResolvedValueOnce(null);
-    mockDb._statement.run.mockResolvedValueOnce({ success: true });
+  // Security regression (GHSA-4v42): a new session must NEVER be auto-linked or
+  // auto-verified from a user.phone match — phone is a self-asserted, unverified
+  // signup field. Linking must go through the email-OTP flow instead.
+  it("creates an unlinked, unverified session even when a phone would match", async () => {
+    mockDb._statement.first.mockResolvedValueOnce(null); // no existing session
+    mockDb._statement.run.mockResolvedValueOnce({ success: true }); // INSERT
     mockDb._statement.first.mockResolvedValueOnce({
       id: "new_sess",
       wa_phone: "2250700000000",
       user_id: null,
+      pending_user_id: null,
       is_verified: 0,
       status: "active",
       created_at: "2026-04-13T10:00:00Z",
@@ -77,5 +60,16 @@ describe("findOrCreateSession", () => {
 
     expect(session.user_id).toBeNull();
     expect(session.is_verified).toBe(0);
+    // It must not query the `user` table by phone at all.
+    const phoneLookup = mockDb.prepare.mock.calls
+      .map((c) => String(c[0]))
+      .find((sql) => /FROM user\b/i.test(sql) && /phone/i.test(sql));
+    expect(phoneLookup).toBeUndefined();
+    // The INSERT must hard-code an unlinked/unverified row.
+    const insertSql = mockDb.prepare.mock.calls
+      .map((c) => String(c[0]))
+      .find((sql) => sql.includes("INSERT OR IGNORE INTO whatsapp_sessions"));
+    expect(insertSql).toContain("user_id, is_verified");
+    expect(insertSql).toMatch(/VALUES\s*\(\?,\s*\?,\s*NULL,\s*0,/);
   });
 });

--- a/__tests__/unit/workers/whatsapp/tools/account.test.ts
+++ b/__tests__/unit/workers/whatsapp/tools/account.test.ts
@@ -29,6 +29,7 @@ function createMockCtx(
       id: "session-1",
       wa_phone: "2250700000000",
       user_id: null,
+      pending_user_id: null,
       is_verified: 0,
       otp_code: null,
       otp_expires_at: null,
@@ -87,6 +88,36 @@ describe("linkAccount", () => {
     expect(sendOtpEmail).toHaveBeenCalledWith("test-key", "user@example.com", expect.stringMatching(/^\d{6}$/));
   });
 
+  // Security regression: linkAccount must stage the account as PENDING only and
+  // must NOT link/verify the session before the OTP is confirmed. Otherwise an
+  // attacker knowing a victim's email would gain access (GHSA OTP-bypass).
+  it("stages pending_user_id (not user_id) and does NOT verify before OTP", async () => {
+    const ctx = createMockCtx(mockDb);
+    mockDb._statement.first.mockResolvedValueOnce({ id: "victim-999", email: "victim@example.com" });
+    mockDb._statement.run.mockResolvedValueOnce({ success: true });
+
+    await linkAccount(ctx, { email: "victim@example.com" });
+
+    // The staging UPDATE must write pending_user_id, never user_id.
+    const updateSql = mockDb.prepare.mock.calls
+      .map((c) => String(c[0]))
+      .find((sql) => sql.includes("UPDATE whatsapp_sessions"));
+    expect(updateSql).toBeDefined();
+    expect(updateSql).toContain("pending_user_id");
+    expect(updateSql).not.toMatch(/\buser_id\s*=/);
+    // The victim id is bound (as pending), but the in-memory session stays
+    // unlinked and unverified until verifyOtp runs.
+    expect(mockDb._statement.bind).toHaveBeenCalledWith(
+      expect.stringMatching(/^\d{6}$/),
+      expect.any(String),
+      "victim-999",
+      expect.any(String),
+      "session-1"
+    );
+    expect(ctx.session.user_id).toBeNull();
+    expect(ctx.session.is_verified).toBe(0);
+  });
+
   it("returns error when RESEND_API_KEY is not configured", async () => {
     const ctx = createMockCtx(mockDb);
     ctx.env.RESEND_API_KEY = undefined;
@@ -115,7 +146,7 @@ describe("verifyOtp", () => {
     mockDb._statement.first.mockResolvedValueOnce({
       otp_code: null,
       otp_expires_at: null,
-      user_id: null,
+      pending_user_id: null,
     });
 
     const result = await verifyOtp(ctx, { code: "123456" });
@@ -130,7 +161,7 @@ describe("verifyOtp", () => {
     mockDb._statement.first.mockResolvedValueOnce({
       otp_code: "123456",
       otp_expires_at: expiredTime,
-      user_id: "user-123",
+      pending_user_id: "user-123",
     });
 
     const result = await verifyOtp(ctx, { code: "123456" });
@@ -145,7 +176,7 @@ describe("verifyOtp", () => {
     mockDb._statement.first.mockResolvedValueOnce({
       otp_code: "999999",
       otp_expires_at: futureTime,
-      user_id: "user-123",
+      pending_user_id: "user-123",
     });
 
     const result = await verifyOtp(ctx, { code: "111111" });
@@ -160,15 +191,22 @@ describe("verifyOtp", () => {
     mockDb._statement.first.mockResolvedValueOnce({
       otp_code: "654321",
       otp_expires_at: futureTime,
-      user_id: "user-456",
+      pending_user_id: "user-456",
     });
     mockDb._statement.run.mockResolvedValueOnce({ success: true });
 
     const result = await verifyOtp(ctx, { code: "654321" });
 
     expect(result.success).toBe(true);
-    // In-memory session should be updated
+    // In-memory session should be updated: the pending account is promoted to
+    // the trusted user_id only now, after the OTP was confirmed.
     expect(ctx.session.is_verified).toBe(1);
     expect(ctx.session.user_id).toBe("user-456");
+    expect(ctx.session.pending_user_id).toBeNull();
+    // The promotion UPDATE must copy pending_user_id → user_id.
+    const promoteSql = mockDb.prepare.mock.calls
+      .map((c) => String(c[0]))
+      .find((sql) => sql.includes("is_verified = 1"));
+    expect(promoteSql).toContain("user_id = pending_user_id");
   });
 });

--- a/__tests__/unit/workers/whatsapp/tools/account.test.ts
+++ b/__tests__/unit/workers/whatsapp/tools/account.test.ts
@@ -63,14 +63,19 @@ describe("linkAccount", () => {
     expect(result.error).toMatch(/already linked/i);
   });
 
-  it("returns error if no user found with that email", async () => {
+  it("does not reveal whether an account exists (uniform response, no OTP sent)", async () => {
+    const { sendOtpEmail } = await import("../../../../../workers/whatsapp/src/email");
     const ctx = createMockCtx(mockDb);
-    mockDb._statement.first.mockResolvedValueOnce(null);
+    mockDb._statement.first.mockResolvedValueOnce(null); // no user
 
     const result = await linkAccount(ctx, { email: "unknown@example.com" });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toMatch(/no account found/i);
+    // Uniform success — must NOT disclose that the account does not exist.
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+    const data = result.data as { message: string };
+    expect(data.message).toMatch(/si un compte existe/i);
+    expect(sendOtpEmail).not.toHaveBeenCalled();
   });
 
   it("sends OTP and returns success when user is found", async () => {
@@ -118,17 +123,38 @@ describe("linkAccount", () => {
     expect(ctx.session.is_verified).toBe(0);
   });
 
-  it("returns error when RESEND_API_KEY is not configured", async () => {
+  it("returns the uniform message (not an oracle) when RESEND_API_KEY is missing", async () => {
+    const { sendOtpEmail } = await import("../../../../../workers/whatsapp/src/email");
     const ctx = createMockCtx(mockDb);
     ctx.env.RESEND_API_KEY = undefined;
 
     mockDb._statement.first.mockResolvedValueOnce({ id: "user-123", email: "user@example.com" });
-    mockDb._statement.run.mockResolvedValueOnce({ success: true });
+
+    const result = await linkAccount(ctx, { email: "user@example.com" });
+
+    // A missing key must not become an existence oracle: same uniform message,
+    // no send attempted.
+    expect(result.success).toBe(true);
+    const data = result.data as { message: string };
+    expect(data.message).toMatch(/si un compte existe/i);
+    expect(sendOtpEmail).not.toHaveBeenCalled();
+  });
+
+  it("rate-limits repeated link attempts (per session) without disclosing existence", async () => {
+    const { sendOtpEmail } = await import("../../../../../workers/whatsapp/src/email");
+    const ctx = createMockCtx(mockDb);
+    // Session already at the cap.
+    (ctx.env.KV.get as ReturnType<typeof vi.fn>).mockImplementation((key: string) =>
+      Promise.resolve(key.includes(":session:") ? "5" : null)
+    );
 
     const result = await linkAccount(ctx, { email: "user@example.com" });
 
     expect(result.success).toBe(false);
-    expect(result.error).toContain("email");
+    expect(result.error).toMatch(/trop de demandes/i);
+    // Must short-circuit before any DB lookup or email send.
+    expect(mockDb.prepare).not.toHaveBeenCalled();
+    expect(sendOtpEmail).not.toHaveBeenCalled();
   });
 });
 

--- a/__tests__/unit/workers/whatsapp/tools/account.test.ts
+++ b/__tests__/unit/workers/whatsapp/tools/account.test.ts
@@ -193,7 +193,7 @@ describe("verifyOtp", () => {
       otp_expires_at: futureTime,
       pending_user_id: "user-456",
     });
-    mockDb._statement.run.mockResolvedValueOnce({ success: true });
+    mockDb._statement.run.mockResolvedValueOnce({ meta: { changes: 1 } });
 
     const result = await verifyOtp(ctx, { code: "654321" });
 
@@ -203,10 +203,30 @@ describe("verifyOtp", () => {
     expect(ctx.session.is_verified).toBe(1);
     expect(ctx.session.user_id).toBe("user-456");
     expect(ctx.session.pending_user_id).toBeNull();
-    // The promotion UPDATE must copy pending_user_id → user_id.
+    // The promotion UPDATE must copy pending_user_id → user_id and be guarded.
     const promoteSql = mockDb.prepare.mock.calls
       .map((c) => String(c[0]))
       .find((sql) => sql.includes("is_verified = 1"));
     expect(promoteSql).toContain("user_id = pending_user_id");
+    expect(promoteSql).toContain("pending_user_id IS NOT NULL");
+  });
+
+  // If the pending/OTP state was cleared concurrently, the guarded UPDATE
+  // affects 0 rows: the session must NOT be marked verified/linked.
+  it("does not verify when the promotion UPDATE affects no rows", async () => {
+    const ctx = createMockCtx(mockDb);
+    const futureTime = new Date(Date.now() + 600000).toISOString();
+    mockDb._statement.first.mockResolvedValueOnce({
+      otp_code: "654321",
+      otp_expires_at: futureTime,
+      pending_user_id: "user-456",
+    });
+    mockDb._statement.run.mockResolvedValueOnce({ meta: { changes: 0 } });
+
+    const result = await verifyOtp(ctx, { code: "654321" });
+
+    expect(result.success).toBe(false);
+    expect(ctx.session.is_verified).toBe(0);
+    expect(ctx.session.user_id).toBeNull();
   });
 });

--- a/__tests__/unit/workers/whatsapp/tools/cart.test.ts
+++ b/__tests__/unit/workers/whatsapp/tools/cart.test.ts
@@ -22,6 +22,7 @@ function createMockCtx(mockDb: ReturnType<typeof createMockD1>): ToolContext {
       id: "session-1",
       wa_phone: "2250700000000",
       user_id: null,
+      pending_user_id: null,
       is_verified: 0,
       otp_code: null,
       otp_expires_at: null,

--- a/__tests__/unit/workers/whatsapp/tools/catalogue.test.ts
+++ b/__tests__/unit/workers/whatsapp/tools/catalogue.test.ts
@@ -22,6 +22,7 @@ function createMockCtx(mockDb: ReturnType<typeof createMockD1>): ToolContext {
       id: "s",
       wa_phone: "0",
       user_id: null,
+      pending_user_id: null,
       is_verified: 0,
       otp_code: null,
       otp_expires_at: null,

--- a/__tests__/unit/workers/whatsapp/tools/escalation.test.ts
+++ b/__tests__/unit/workers/whatsapp/tools/escalation.test.ts
@@ -30,6 +30,7 @@ function createMockCtx(mockDb: ReturnType<typeof createMockD1>): ToolContext {
       id: "session-1",
       wa_phone: "2250700000000",
       user_id: null,
+      pending_user_id: null,
       is_verified: 0,
       otp_code: null,
       otp_expires_at: null,

--- a/__tests__/unit/workers/whatsapp/tools/orders.test.ts
+++ b/__tests__/unit/workers/whatsapp/tools/orders.test.ts
@@ -22,7 +22,8 @@ function createMockD1() {
 
 function createMockCtx(
   mockDb: ReturnType<typeof createMockD1>,
-  userId: string | null = "user-1"
+  userId: string | null = "user-1",
+  isVerified: 0 | 1 = 1
 ): ToolContext {
   return {
     db: mockDb as unknown as D1Database,
@@ -30,7 +31,8 @@ function createMockCtx(
       id: "session-1",
       wa_phone: "2250700000000",
       user_id: userId,
-      is_verified: 1,
+      pending_user_id: null,
+      is_verified: isVerified,
       otp_code: null,
       otp_expires_at: null,
       status: "active" as const,
@@ -61,6 +63,24 @@ describe("createOrder", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/link/i);
+  });
+
+  // Security regression: a session that carries a user_id but is NOT verified
+  // (the state produced by linkAccount before OTP) must be refused. Gating on
+  // user_id alone was the OTP-bypass vuln (GHSA).
+  it("refuses an unverified session even when user_id is present", async () => {
+    const ctx = createMockCtx(mockDb, "victim-999", 0);
+
+    const result = await createOrder(ctx, {
+      address: "123 Rue Principale",
+      commune: "Cocody",
+      phone: "0700000000",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/link/i);
+    // Must short-circuit before touching the DB.
+    expect(mockDb.prepare).not.toHaveBeenCalled();
   });
 
   it("returns error if cart is empty", async () => {
@@ -237,6 +257,15 @@ describe("getOrderStatus", () => {
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/link/i);
   });
+
+  it("refuses an unverified session even when user_id is present", async () => {
+    const ctx = createMockCtx(mockDb, "victim-999", 0);
+
+    const result = await getOrderStatus(ctx, { order_number: "ORD-ABC123" });
+
+    expect(result.success).toBe(false);
+    expect(mockDb.prepare).not.toHaveBeenCalled();
+  });
 });
 
 // ─── listOrders ───────────────────────────────────────────────────────────────
@@ -255,6 +284,15 @@ describe("listOrders", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/link/i);
+  });
+
+  it("refuses an unverified session even when user_id is present", async () => {
+    const ctx = createMockCtx(mockDb, "victim-999", 0);
+
+    const result = await listOrders(ctx, {});
+
+    expect(result.success).toBe(false);
+    expect(mockDb.prepare).not.toHaveBeenCalled();
   });
 
   it("returns list of recent orders", async () => {

--- a/drizzle/0014_tricky_shinko_yamashiro.sql
+++ b/drizzle/0014_tricky_shinko_yamashiro.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `whatsapp_sessions` ADD `pending_user_id` text REFERENCES user(id);

--- a/drizzle/0015_reset_legacy_wa_sessions.sql
+++ b/drizzle/0015_reset_legacy_wa_sessions.sql
@@ -1,0 +1,17 @@
+-- Custom SQL migration file, put your code below! --
+
+-- Security remediation (GHSA-4v42): before this release, findOrCreateSession
+-- auto-linked and auto-verified a WhatsApp session whenever the inbound number
+-- matched an unverified, self-asserted user.phone. Existing rows created that
+-- way still carry user_id + is_verified = 1 and would remain trusted by the
+-- order tools. There is no provenance flag to tell phone-auto-verified sessions
+-- apart from genuinely OTP-verified ones, so conservatively reset ALL sessions
+-- to unlinked/unverified. Affected users simply re-link once via the email-OTP
+-- flow (link_account + verifyOtp). This is a data reset, not a schema change.
+UPDATE whatsapp_sessions
+SET user_id = NULL,
+    pending_user_id = NULL,
+    is_verified = 0,
+    otp_code = NULL,
+    otp_expires_at = NULL,
+    updated_at = datetime('now');

--- a/drizzle/0015_reset_legacy_wa_sessions.sql
+++ b/drizzle/0015_reset_legacy_wa_sessions.sql
@@ -5,13 +5,23 @@
 -- matched an unverified, self-asserted user.phone. Existing rows created that
 -- way still carry user_id + is_verified = 1 and would remain trusted by the
 -- order tools. There is no provenance flag to tell phone-auto-verified sessions
--- apart from genuinely OTP-verified ones, so conservatively reset ALL sessions
--- to unlinked/unverified. Affected users simply re-link once via the email-OTP
--- flow (link_account + verifyOtp). This is a data reset, not a schema change.
+-- apart from genuinely OTP-verified ones, so conservatively reset every session
+-- that carries link/verification/OTP state to unlinked/unverified. Affected
+-- users simply re-link once via the email-OTP flow (link_account + verifyOtp).
+-- This is a data reset, not a schema change.
+--
+-- The WHERE clause scopes the write to rows that actually hold state, so
+-- already-clean sessions are skipped (no full-table rewrite); whatsapp_sessions
+-- holds one row per WhatsApp sender and is small in practice.
 UPDATE whatsapp_sessions
 SET user_id = NULL,
     pending_user_id = NULL,
     is_verified = 0,
     otp_code = NULL,
     otp_expires_at = NULL,
-    updated_at = datetime('now');
+    updated_at = datetime('now')
+WHERE user_id IS NOT NULL
+   OR pending_user_id IS NOT NULL
+   OR is_verified <> 0
+   OR otp_code IS NOT NULL
+   OR otp_expires_at IS NOT NULL;

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,3056 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "91f33629-cadc-4323-a49c-a6c2f6e3bc4d",
+  "prevId": "29df640c-3502-48b9-a297-84d67c9336c8",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_account_userId": {
+          "name": "idx_account_userId",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "idx_account_provider": {
+          "name": "idx_account_provider",
+          "columns": [
+            "providerId",
+            "accountId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "addresses": {
+      "name": "addresses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Domicile'"
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "street": {
+          "name": "street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commune": {
+          "name": "commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Abidjan'"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_addresses_user": {
+          "name": "idx_addresses_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "addresses_user_id_user_id_fk": {
+          "name": "addresses_user_id_user_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "addresses_zone_id_delivery_zones_id_fk": {
+          "name": "addresses_zone_id_delivery_zones_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "delivery_zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_config": {
+      "name": "ai_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anthropic_api_key": {
+          "name": "anthropic_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "brave_api_key": {
+          "name": "brave_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "ai_config_singleton_id": {
+          "name": "ai_config_singleton_id",
+          "value": "\"ai_config\".\"id\" = 1"
+        },
+        "ai_config_enabled_bool": {
+          "name": "ai_config_enabled_bool",
+          "value": "\"ai_config\".\"enabled\" in (0, 1)"
+        }
+      }
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_audit_log_actor": {
+          "name": "idx_audit_log_actor",
+          "columns": [
+            "actor_id"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_log_action": {
+          "name": "idx_audit_log_action",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_log_created": {
+          "name": "idx_audit_log_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "banner_gradients": {
+      "name": "banner_gradients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_from": {
+          "name": "color_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_to": {
+          "name": "color_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "banners": {
+      "name": "banners",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "badge_text": {
+          "name": "badge_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "badge_color": {
+          "name": "badge_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'mint'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cta_text": {
+          "name": "cta_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Découvrir'"
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bg_gradient_from": {
+          "name": "bg_gradient_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#183C78'"
+        },
+        "bg_gradient_to": {
+          "name": "bg_gradient_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#1E4A8F'"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_banners_active_order": {
+          "name": "idx_banners_active_order",
+          "columns": [
+            "is_active",
+            "display_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "idx_categories_slug": {
+          "name": "idx_categories_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "idx_categories_parent": {
+          "name": "idx_categories_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "categories_parent_id_categories_id_fk": {
+          "name": "categories_parent_id_categories_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "delivery_zones": {
+      "name": "delivery_zones",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commune": {
+          "name": "commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fee": {
+          "name": "fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimated_hours": {
+          "name": "estimated_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 24
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "order_items": {
+      "name": "order_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_name": {
+          "name": "variant_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_order_items_order": {
+          "name": "idx_order_items_order",
+          "columns": [
+            "order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "order_items_order_id_orders_id_fk": {
+          "name": "order_items_order_id_orders_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_items_product_id_products_id_fk": {
+          "name": "order_items_product_id_products_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_items_variant_id_product_variants_id_fk": {
+          "name": "order_items_variant_id_product_variants_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "order_status_history": {
+      "name": "order_status_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_order_status_history_order": {
+          "name": "idx_order_status_history_order",
+          "columns": [
+            "order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "order_status_history_order_id_orders_id_fk": {
+          "name": "order_status_history_order_id_orders_id_fk",
+          "tableFrom": "order_status_history",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "orders": {
+      "name": "orders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_number": {
+          "name": "order_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_fee": {
+          "name": "delivery_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "promo_code_id": {
+          "name": "promo_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'web'"
+        },
+        "delivery_address": {
+          "name": "delivery_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_commune": {
+          "name": "delivery_commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_phone": {
+          "name": "delivery_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_instructions": {
+          "name": "delivery_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "estimated_delivery": {
+          "name": "estimated_delivery",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "internal_notes": {
+          "name": "internal_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivery_person_id": {
+          "name": "delivery_person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivery_person_name": {
+          "name": "delivery_person_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preparing_at": {
+          "name": "preparing_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_at": {
+          "name": "shipping_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "returned_at": {
+          "name": "returned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "return_reason": {
+          "name": "return_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "orders_order_number_unique": {
+          "name": "orders_order_number_unique",
+          "columns": [
+            "order_number"
+          ],
+          "isUnique": true
+        },
+        "idx_orders_user": {
+          "name": "idx_orders_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_orders_status": {
+          "name": "idx_orders_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_orders_number": {
+          "name": "idx_orders_number",
+          "columns": [
+            "order_number"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "orders_user_id_user_id_fk": {
+          "name": "orders_user_id_user_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "orders_promo_code_id_promo_codes_id_fk": {
+          "name": "orders_promo_code_id_promo_codes_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "promo_codes",
+          "columnsFrom": [
+            "promo_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product_attributes": {
+      "name": "product_attributes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_product_attributes_product": {
+          "name": "idx_product_attributes_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "product_attributes_product_id_products_id_fk": {
+          "name": "product_attributes_product_id_products_id_fk",
+          "tableFrom": "product_attributes",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product_images": {
+      "name": "product_images",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_product_images_product": {
+          "name": "idx_product_images_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "product_images_product_id_products_id_fk": {
+          "name": "product_images_product_id_products_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_images_variant_id_product_variants_id_fk": {
+          "name": "product_images_variant_id_product_variants_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product_variants": {
+      "name": "product_variants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compare_price": {
+          "name": "compare_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "product_variants_sku_unique": {
+          "name": "product_variants_sku_unique",
+          "columns": [
+            "sku"
+          ],
+          "isUnique": true
+        },
+        "idx_product_variants_product": {
+          "name": "idx_product_variants_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "product_variants_product_id_products_id_fk": {
+          "name": "product_variants_product_id_products_id_fk",
+          "tableFrom": "product_variants",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "products": {
+      "name": "products",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description_type": {
+          "name": "description_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'richtext'"
+        },
+        "short_description": {
+          "name": "short_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_price": {
+          "name": "base_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compare_price": {
+          "name": "compare_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "low_stock_threshold": {
+          "name": "low_stock_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        },
+        "weight_grams": {
+          "name": "weight_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta_title": {
+          "name": "meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "highlights": {
+          "name": "highlights",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feature_blocks": {
+          "name": "feature_blocks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "faq": {
+          "name": "faq",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "products_slug_unique": {
+          "name": "products_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "products_sku_unique": {
+          "name": "products_sku_unique",
+          "columns": [
+            "sku"
+          ],
+          "isUnique": true
+        },
+        "idx_products_slug": {
+          "name": "idx_products_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "idx_products_category": {
+          "name": "idx_products_category",
+          "columns": [
+            "category_id"
+          ],
+          "isUnique": false
+        },
+        "idx_products_active": {
+          "name": "idx_products_active",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        },
+        "idx_products_featured": {
+          "name": "idx_products_featured",
+          "columns": [
+            "is_featured"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "products_category_id_categories_id_fk": {
+          "name": "products_category_id_categories_id_fk",
+          "tableFrom": "products",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "promo_codes": {
+      "name": "promo_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discount_value": {
+          "name": "discount_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "min_order_amount": {
+          "name": "min_order_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "promo_codes_code_unique": {
+          "name": "promo_codes_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reviews": {
+      "name": "reviews",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_verified_purchase": {
+          "name": "is_verified_purchase",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_reviews_product": {
+          "name": "idx_reviews_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        },
+        "idx_reviews_user": {
+          "name": "idx_reviews_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reviews_product_id_products_id_fk": {
+          "name": "reviews_product_id_products_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_user_id_user_id_fk": {
+          "name": "reviews_user_id_user_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "rating_range": {
+          "name": "rating_range",
+          "value": "\"reviews\".\"rating\" BETWEEN 1 AND 5"
+        }
+      }
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_session_userId": {
+          "name": "idx_session_userId",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stores": {
+      "name": "stores",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "google_maps_url": {
+          "name": "google_maps_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "opening_hours": {
+          "name": "opening_hours",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_stores_active_order": {
+          "name": "idx_stores_active_order",
+          "columns": [
+            "is_active",
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'customer'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "banReason": {
+          "name": "banReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banExpires": {
+          "name": "banExpires",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'customer'"
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'email'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_phone_unique": {
+          "name": "users_phone_unique",
+          "columns": [
+            "phone"
+          ],
+          "isUnique": true
+        },
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "idx_users_phone": {
+          "name": "idx_users_phone",
+          "columns": [
+            "phone"
+          ],
+          "isUnique": false
+        },
+        "idx_users_is_active": {
+          "name": "idx_users_is_active",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "whatsapp_carts": {
+      "name": "whatsapp_carts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_wa_carts_session": {
+          "name": "idx_wa_carts_session",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "whatsapp_carts_session_id_whatsapp_sessions_id_fk": {
+          "name": "whatsapp_carts_session_id_whatsapp_sessions_id_fk",
+          "tableFrom": "whatsapp_carts",
+          "tableTo": "whatsapp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "whatsapp_carts_product_id_products_id_fk": {
+          "name": "whatsapp_carts_product_id_products_id_fk",
+          "tableFrom": "whatsapp_carts",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "whatsapp_carts_variant_id_product_variants_id_fk": {
+          "name": "whatsapp_carts_variant_id_product_variants_id_fk",
+          "tableFrom": "whatsapp_carts",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "whatsapp_config": {
+      "name": "whatsapp_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_number_id": {
+          "name": "phone_number_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_phone_number": {
+          "name": "display_phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verify_token": {
+          "name": "verify_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "business_account_id": {
+          "name": "business_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "admin_phones": {
+          "name": "admin_phones",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "whatsapp_messages": {
+      "name": "whatsapp_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "wa_message_id": {
+          "name": "wa_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_wa_messages_session": {
+          "name": "idx_wa_messages_session",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_wa_messages_created": {
+          "name": "idx_wa_messages_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_wa_messages_wa_id": {
+          "name": "idx_wa_messages_wa_id",
+          "columns": [
+            "wa_message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "whatsapp_messages_session_id_whatsapp_sessions_id_fk": {
+          "name": "whatsapp_messages_session_id_whatsapp_sessions_id_fk",
+          "tableFrom": "whatsapp_messages",
+          "tableTo": "whatsapp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "whatsapp_sessions": {
+      "name": "whatsapp_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "wa_phone": {
+          "name": "wa_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_user_id": {
+          "name": "pending_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "otp_code": {
+          "name": "otp_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "otp_expires_at": {
+          "name": "otp_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "whatsapp_sessions_wa_phone_unique": {
+          "name": "whatsapp_sessions_wa_phone_unique",
+          "columns": [
+            "wa_phone"
+          ],
+          "isUnique": true
+        },
+        "idx_wa_sessions_phone": {
+          "name": "idx_wa_sessions_phone",
+          "columns": [
+            "wa_phone"
+          ],
+          "isUnique": false
+        },
+        "idx_wa_sessions_user": {
+          "name": "idx_wa_sessions_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "whatsapp_sessions_user_id_user_id_fk": {
+          "name": "whatsapp_sessions_user_id_user_id_fk",
+          "tableFrom": "whatsapp_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "whatsapp_sessions_pending_user_id_user_id_fk": {
+          "name": "whatsapp_sessions_pending_user_id_user_id_fk",
+          "tableFrom": "whatsapp_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "pending_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wishlist": {
+      "name": "wishlist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "wishlist_user_product_unique": {
+          "name": "wishlist_user_product_unique",
+          "columns": [
+            "user_id",
+            "product_id"
+          ],
+          "isUnique": true
+        },
+        "idx_wishlist_user": {
+          "name": "idx_wishlist_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_wishlist_product": {
+          "name": "idx_wishlist_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wishlist_user_id_user_id_fk": {
+          "name": "wishlist_user_id_user_id_fk",
+          "tableFrom": "wishlist",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wishlist_product_id_products_id_fk": {
+          "name": "wishlist_product_id_products_id_fk",
+          "tableFrom": "wishlist",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,3056 @@
+{
+  "id": "c1a3e196-c934-43fa-968e-665c94098be8",
+  "prevId": "91f33629-cadc-4323-a49c-a6c2f6e3bc4d",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_account_userId": {
+          "name": "idx_account_userId",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "idx_account_provider": {
+          "name": "idx_account_provider",
+          "columns": [
+            "providerId",
+            "accountId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "userId"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "addresses": {
+      "name": "addresses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Domicile'"
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "street": {
+          "name": "street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commune": {
+          "name": "commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Abidjan'"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_addresses_user": {
+          "name": "idx_addresses_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "addresses_user_id_user_id_fk": {
+          "name": "addresses_user_id_user_id_fk",
+          "tableFrom": "addresses",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "addresses_zone_id_delivery_zones_id_fk": {
+          "name": "addresses_zone_id_delivery_zones_id_fk",
+          "tableFrom": "addresses",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "tableTo": "delivery_zones",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_config": {
+      "name": "ai_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anthropic_api_key": {
+          "name": "anthropic_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "brave_api_key": {
+          "name": "brave_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "ai_config_singleton_id": {
+          "name": "ai_config_singleton_id",
+          "value": "\"ai_config\".\"id\" = 1"
+        },
+        "ai_config_enabled_bool": {
+          "name": "ai_config_enabled_bool",
+          "value": "\"ai_config\".\"enabled\" in (0, 1)"
+        }
+      }
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_audit_log_actor": {
+          "name": "idx_audit_log_actor",
+          "columns": [
+            "actor_id"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_log_action": {
+          "name": "idx_audit_log_action",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_log_created": {
+          "name": "idx_audit_log_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "banner_gradients": {
+      "name": "banner_gradients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_from": {
+          "name": "color_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_to": {
+          "name": "color_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "banners": {
+      "name": "banners",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "badge_text": {
+          "name": "badge_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "badge_color": {
+          "name": "badge_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'mint'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cta_text": {
+          "name": "cta_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Découvrir'"
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bg_gradient_from": {
+          "name": "bg_gradient_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#183C78'"
+        },
+        "bg_gradient_to": {
+          "name": "bg_gradient_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#1E4A8F'"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_banners_active_order": {
+          "name": "idx_banners_active_order",
+          "columns": [
+            "is_active",
+            "display_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "idx_categories_slug": {
+          "name": "idx_categories_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "idx_categories_parent": {
+          "name": "idx_categories_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "categories_parent_id_categories_id_fk": {
+          "name": "categories_parent_id_categories_id_fk",
+          "tableFrom": "categories",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "tableTo": "categories",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "delivery_zones": {
+      "name": "delivery_zones",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commune": {
+          "name": "commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fee": {
+          "name": "fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimated_hours": {
+          "name": "estimated_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 24
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "order_items": {
+      "name": "order_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_name": {
+          "name": "variant_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_order_items_order": {
+          "name": "idx_order_items_order",
+          "columns": [
+            "order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "order_items_order_id_orders_id_fk": {
+          "name": "order_items_order_id_orders_id_fk",
+          "tableFrom": "order_items",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "tableTo": "orders",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "order_items_product_id_products_id_fk": {
+          "name": "order_items_product_id_products_id_fk",
+          "tableFrom": "order_items",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "tableTo": "products",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "order_items_variant_id_product_variants_id_fk": {
+          "name": "order_items_variant_id_product_variants_id_fk",
+          "tableFrom": "order_items",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "tableTo": "product_variants",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "order_status_history": {
+      "name": "order_status_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_order_status_history_order": {
+          "name": "idx_order_status_history_order",
+          "columns": [
+            "order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "order_status_history_order_id_orders_id_fk": {
+          "name": "order_status_history_order_id_orders_id_fk",
+          "tableFrom": "order_status_history",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "tableTo": "orders",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "orders": {
+      "name": "orders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_number": {
+          "name": "order_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_fee": {
+          "name": "delivery_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "promo_code_id": {
+          "name": "promo_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'web'"
+        },
+        "delivery_address": {
+          "name": "delivery_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_commune": {
+          "name": "delivery_commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_phone": {
+          "name": "delivery_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_instructions": {
+          "name": "delivery_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "estimated_delivery": {
+          "name": "estimated_delivery",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "internal_notes": {
+          "name": "internal_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivery_person_id": {
+          "name": "delivery_person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivery_person_name": {
+          "name": "delivery_person_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preparing_at": {
+          "name": "preparing_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_at": {
+          "name": "shipping_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "returned_at": {
+          "name": "returned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "return_reason": {
+          "name": "return_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "orders_order_number_unique": {
+          "name": "orders_order_number_unique",
+          "columns": [
+            "order_number"
+          ],
+          "isUnique": true
+        },
+        "idx_orders_user": {
+          "name": "idx_orders_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_orders_status": {
+          "name": "idx_orders_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_orders_number": {
+          "name": "idx_orders_number",
+          "columns": [
+            "order_number"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "orders_user_id_user_id_fk": {
+          "name": "orders_user_id_user_id_fk",
+          "tableFrom": "orders",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "orders_promo_code_id_promo_codes_id_fk": {
+          "name": "orders_promo_code_id_promo_codes_id_fk",
+          "tableFrom": "orders",
+          "columnsFrom": [
+            "promo_code_id"
+          ],
+          "tableTo": "promo_codes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product_attributes": {
+      "name": "product_attributes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_product_attributes_product": {
+          "name": "idx_product_attributes_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "product_attributes_product_id_products_id_fk": {
+          "name": "product_attributes_product_id_products_id_fk",
+          "tableFrom": "product_attributes",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "tableTo": "products",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product_images": {
+      "name": "product_images",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_product_images_product": {
+          "name": "idx_product_images_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "product_images_product_id_products_id_fk": {
+          "name": "product_images_product_id_products_id_fk",
+          "tableFrom": "product_images",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "tableTo": "products",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "product_images_variant_id_product_variants_id_fk": {
+          "name": "product_images_variant_id_product_variants_id_fk",
+          "tableFrom": "product_images",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "tableTo": "product_variants",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product_variants": {
+      "name": "product_variants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compare_price": {
+          "name": "compare_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "product_variants_sku_unique": {
+          "name": "product_variants_sku_unique",
+          "columns": [
+            "sku"
+          ],
+          "isUnique": true
+        },
+        "idx_product_variants_product": {
+          "name": "idx_product_variants_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "product_variants_product_id_products_id_fk": {
+          "name": "product_variants_product_id_products_id_fk",
+          "tableFrom": "product_variants",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "tableTo": "products",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "products": {
+      "name": "products",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description_type": {
+          "name": "description_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'richtext'"
+        },
+        "short_description": {
+          "name": "short_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_price": {
+          "name": "base_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compare_price": {
+          "name": "compare_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "low_stock_threshold": {
+          "name": "low_stock_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        },
+        "weight_grams": {
+          "name": "weight_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta_title": {
+          "name": "meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "highlights": {
+          "name": "highlights",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feature_blocks": {
+          "name": "feature_blocks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "faq": {
+          "name": "faq",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "products_slug_unique": {
+          "name": "products_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "products_sku_unique": {
+          "name": "products_sku_unique",
+          "columns": [
+            "sku"
+          ],
+          "isUnique": true
+        },
+        "idx_products_slug": {
+          "name": "idx_products_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "idx_products_category": {
+          "name": "idx_products_category",
+          "columns": [
+            "category_id"
+          ],
+          "isUnique": false
+        },
+        "idx_products_active": {
+          "name": "idx_products_active",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        },
+        "idx_products_featured": {
+          "name": "idx_products_featured",
+          "columns": [
+            "is_featured"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "products_category_id_categories_id_fk": {
+          "name": "products_category_id_categories_id_fk",
+          "tableFrom": "products",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "tableTo": "categories",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "promo_codes": {
+      "name": "promo_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discount_value": {
+          "name": "discount_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "min_order_amount": {
+          "name": "min_order_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "promo_codes_code_unique": {
+          "name": "promo_codes_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reviews": {
+      "name": "reviews",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_verified_purchase": {
+          "name": "is_verified_purchase",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_reviews_product": {
+          "name": "idx_reviews_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        },
+        "idx_reviews_user": {
+          "name": "idx_reviews_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reviews_product_id_products_id_fk": {
+          "name": "reviews_product_id_products_id_fk",
+          "tableFrom": "reviews",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "tableTo": "products",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "reviews_user_id_user_id_fk": {
+          "name": "reviews_user_id_user_id_fk",
+          "tableFrom": "reviews",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "rating_range": {
+          "name": "rating_range",
+          "value": "\"reviews\".\"rating\" BETWEEN 1 AND 5"
+        }
+      }
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_session_userId": {
+          "name": "idx_session_userId",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "userId"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stores": {
+      "name": "stores",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "google_maps_url": {
+          "name": "google_maps_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "opening_hours": {
+          "name": "opening_hours",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_stores_active_order": {
+          "name": "idx_stores_active_order",
+          "columns": [
+            "is_active",
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'customer'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "banReason": {
+          "name": "banReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banExpires": {
+          "name": "banExpires",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'customer'"
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'email'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_phone_unique": {
+          "name": "users_phone_unique",
+          "columns": [
+            "phone"
+          ],
+          "isUnique": true
+        },
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "idx_users_phone": {
+          "name": "idx_users_phone",
+          "columns": [
+            "phone"
+          ],
+          "isUnique": false
+        },
+        "idx_users_is_active": {
+          "name": "idx_users_is_active",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "whatsapp_carts": {
+      "name": "whatsapp_carts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_wa_carts_session": {
+          "name": "idx_wa_carts_session",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "whatsapp_carts_session_id_whatsapp_sessions_id_fk": {
+          "name": "whatsapp_carts_session_id_whatsapp_sessions_id_fk",
+          "tableFrom": "whatsapp_carts",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "tableTo": "whatsapp_sessions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "whatsapp_carts_product_id_products_id_fk": {
+          "name": "whatsapp_carts_product_id_products_id_fk",
+          "tableFrom": "whatsapp_carts",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "tableTo": "products",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "whatsapp_carts_variant_id_product_variants_id_fk": {
+          "name": "whatsapp_carts_variant_id_product_variants_id_fk",
+          "tableFrom": "whatsapp_carts",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "tableTo": "product_variants",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "whatsapp_config": {
+      "name": "whatsapp_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_number_id": {
+          "name": "phone_number_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_phone_number": {
+          "name": "display_phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verify_token": {
+          "name": "verify_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "business_account_id": {
+          "name": "business_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "admin_phones": {
+          "name": "admin_phones",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "whatsapp_messages": {
+      "name": "whatsapp_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "wa_message_id": {
+          "name": "wa_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_wa_messages_session": {
+          "name": "idx_wa_messages_session",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_wa_messages_created": {
+          "name": "idx_wa_messages_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_wa_messages_wa_id": {
+          "name": "idx_wa_messages_wa_id",
+          "columns": [
+            "wa_message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "whatsapp_messages_session_id_whatsapp_sessions_id_fk": {
+          "name": "whatsapp_messages_session_id_whatsapp_sessions_id_fk",
+          "tableFrom": "whatsapp_messages",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "tableTo": "whatsapp_sessions",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "whatsapp_sessions": {
+      "name": "whatsapp_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "wa_phone": {
+          "name": "wa_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_user_id": {
+          "name": "pending_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "otp_code": {
+          "name": "otp_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "otp_expires_at": {
+          "name": "otp_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "whatsapp_sessions_wa_phone_unique": {
+          "name": "whatsapp_sessions_wa_phone_unique",
+          "columns": [
+            "wa_phone"
+          ],
+          "isUnique": true
+        },
+        "idx_wa_sessions_phone": {
+          "name": "idx_wa_sessions_phone",
+          "columns": [
+            "wa_phone"
+          ],
+          "isUnique": false
+        },
+        "idx_wa_sessions_user": {
+          "name": "idx_wa_sessions_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "whatsapp_sessions_user_id_user_id_fk": {
+          "name": "whatsapp_sessions_user_id_user_id_fk",
+          "tableFrom": "whatsapp_sessions",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "whatsapp_sessions_pending_user_id_user_id_fk": {
+          "name": "whatsapp_sessions_pending_user_id_user_id_fk",
+          "tableFrom": "whatsapp_sessions",
+          "columnsFrom": [
+            "pending_user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wishlist": {
+      "name": "wishlist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "wishlist_user_product_unique": {
+          "name": "wishlist_user_product_unique",
+          "columns": [
+            "user_id",
+            "product_id"
+          ],
+          "isUnique": true
+        },
+        "idx_wishlist_user": {
+          "name": "idx_wishlist_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_wishlist_product": {
+          "name": "idx_wishlist_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wishlist_user_id_user_id_fk": {
+          "name": "wishlist_user_id_user_id_fk",
+          "tableFrom": "wishlist",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "wishlist_product_id_products_id_fk": {
+          "name": "wishlist_product_id_products_id_fk",
+          "tableFrom": "wishlist",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "tableTo": "products",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1781654945850,
       "tag": "0013_previous_may_parker",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "6",
+      "when": 1782945122381,
+      "tag": "0014_tricky_shinko_yamashiro",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1782945122381,
       "tag": "0014_tricky_shinko_yamashiro",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "6",
+      "when": 1783142846777,
+      "tag": "0015_reset_legacy_wa_sessions",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/csv/orders.ts
+++ b/lib/csv/orders.ts
@@ -2,7 +2,14 @@ import type { AdminOrder } from "@/lib/db/types";
 
 function escapeCSV(value: string | null | undefined): string {
   if (value == null) return "";
-  const str = String(value);
+  let str = String(value);
+  // Neutralize spreadsheet formula/DDE injection: a cell that begins with
+  // = + - @ (or a leading tab/CR) is evaluated as a formula by Excel/Google
+  // Sheets. Customer-controlled fields (name, address, commune) flow here, so
+  // prefix any such value with a single quote to force literal-text rendering.
+  if (/^[=+\-@\t\r]/.test(str)) {
+    str = `'${str}`;
+  }
   if (str.includes('"') || str.includes(",") || str.includes("\n")) {
     return `"${str.replace(/"/g, '""')}"`;
   }

--- a/lib/db/orders.ts
+++ b/lib/db/orders.ts
@@ -222,14 +222,35 @@ export async function cancelOrder(
   reason: string
 ): Promise<boolean> {
   const db = await getDB();
+
+  // Resolve the pending order owned by this user first, so we can release its
+  // reserved stock. Without this, a customer self-cancel left stock permanently
+  // decremented ('cancelled' is a terminal state, so no admin path could ever
+  // refund it) — a cost-free denial-of-inventory. See GHSA (stock-refund gap).
+  const order = await db
+    .prepare(
+      "SELECT id FROM orders WHERE order_number = ? AND user_id = ? AND status = 'pending'"
+    )
+    .bind(orderNumber, userId)
+    .first<{ id: string }>();
+  if (!order) return false;
+
   const result = await db
     .prepare(
       `UPDATE orders SET status = 'cancelled', cancelled_at = datetime('now'), cancellation_reason = ?, updated_at = datetime('now')
-       WHERE order_number = ? AND user_id = ? AND status = 'pending'`
+       WHERE id = ? AND status = 'pending'`
     )
-    .bind(reason, orderNumber, userId)
+    .bind(reason, order.id)
     .run();
-  return result.meta.changes > 0;
+
+  // Refund only when THIS call performed the pending→cancelled transition. The
+  // status guard makes the UPDATE affect the row exactly once, so concurrent
+  // cancels cannot double-refund.
+  if (result.meta.changes > 0) {
+    await refundOrderStock(order.id);
+    return true;
+  }
+  return false;
 }
 
 /**

--- a/lib/db/orders.ts
+++ b/lib/db/orders.ts
@@ -246,11 +246,27 @@ export async function cancelOrder(
   // Refund only when THIS call performed the pending→cancelled transition. The
   // status guard makes the UPDATE affect the row exactly once, so concurrent
   // cancels cannot double-refund.
-  if (result.meta.changes > 0) {
+  if (result.meta.changes === 0) return false;
+
+  try {
     await refundOrderStock(order.id);
-    return true;
+  } catch (err) {
+    // Compensate to keep cancellation and stock consistent: if the refund
+    // fails, revert the order to 'pending' so its stock stays reserved
+    // (invariant: a cancelled order has always had its reserved stock
+    // returned). The status guard means only this call transitioned the row,
+    // so the revert targets exactly the row we just cancelled.
+    await db
+      .prepare(
+        `UPDATE orders SET status = 'pending', cancelled_at = NULL, cancellation_reason = NULL, updated_at = datetime('now')
+         WHERE id = ? AND status = 'cancelled'`
+      )
+      .bind(order.id)
+      .run();
+    console.error(`cancelOrder: stock refund failed for order ${order.id}, reverted to pending`, err);
+    return false;
   }
-  return false;
+  return true;
 }
 
 /**

--- a/lib/db/orders.ts
+++ b/lib/db/orders.ts
@@ -109,18 +109,25 @@ export async function createOrderWithItems(
     );
   }
 
-  // 4. Increment promo code used_count
+  // 4. Increment promo code used_count. The WHERE guard re-checks max_uses at
+  //    write time so a capped code cannot be redeemed beyond its limit under
+  //    concurrency (the read-side check in validatePromoCode is not atomic with
+  //    this increment). The result is verified after the batch.
+  let promoUpdateIndex = -1;
   if (orderData.promoCodeId) {
+    promoUpdateIndex = statements.length;
     statements.push(
       db
         .prepare(
-          "UPDATE promo_codes SET used_count = used_count + 1 WHERE id = ?"
+          "UPDATE promo_codes SET used_count = used_count + 1 WHERE id = ? AND (max_uses IS NULL OR used_count < max_uses)"
         )
         .bind(orderData.promoCodeId)
     );
   }
 
   const results = await db.batch(statements);
+  const promoApplied =
+    promoUpdateIndex !== -1 && results[promoUpdateIndex].meta.changes > 0;
 
   // 5. Verify all stock decrements succeeded
   for (let i = 0; i < stockUpdateIndices.length; i++) {
@@ -145,8 +152,8 @@ export async function createOrderWithItems(
             )
             .bind(prev.quantity, prev.productId);
         }),
-        // Restore promo used_count if it was incremented
-        ...(orderData.promoCodeId
+        // Restore promo used_count only if the guarded increment actually applied
+        ...(promoApplied && orderData.promoCodeId
           ? [
               db
                 .prepare(
@@ -160,6 +167,34 @@ export async function createOrderWithItems(
         `Stock insuffisant pour ${items[i].productName} (mise a jour concurrente)`
       );
     }
+  }
+
+  // 6. Verify the promo increment applied. If a promo was requested but the
+  //    guarded UPDATE affected no rows, the code hit max_uses concurrently
+  //    between validation and now — roll the whole order back (delete order +
+  //    items, restore every stock decrement) so a capped promo can never be
+  //    over-redeemed. The promo was NOT incremented, so it needs no restore.
+  if (promoUpdateIndex !== -1 && !promoApplied) {
+    await db.batch([
+      db.prepare("DELETE FROM order_items WHERE order_id = ?").bind(orderId),
+      db.prepare("DELETE FROM orders WHERE id = ?").bind(orderId),
+      ...items.map((it) =>
+        it.variantId
+          ? db
+              .prepare(
+                "UPDATE product_variants SET stock_quantity = stock_quantity + ? WHERE id = ?"
+              )
+              .bind(it.quantity, it.variantId)
+          : db
+              .prepare(
+                "UPDATE products SET stock_quantity = stock_quantity + ? WHERE id = ?"
+              )
+              .bind(it.quantity, it.productId)
+      ),
+    ]);
+    throw new Error(
+      "Ce code promo n'est plus disponible (limite d'utilisation atteinte)."
+    );
   }
 
   return { orderId, orderNumber: orderData.orderNumber };

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -456,6 +456,10 @@ export const whatsappSessions = sqliteTable("whatsapp_sessions", {
   id: text("id").primaryKey(),
   wa_phone: text("wa_phone").unique().notNull(),
   user_id: text("user_id").references(() => user.id),
+  // Account pending OTP verification. Written by linkAccount BEFORE the OTP is
+  // confirmed; promoted to user_id only by verifyOtp on success. Order tools
+  // must never trust pending_user_id — see is_verified gating.
+  pending_user_id: text("pending_user_id").references(() => user.id),
   otp_code: text("otp_code"),
   otp_expires_at: text("otp_expires_at"),
   is_verified: integer("is_verified").notNull().default(0),

--- a/lib/utils/sanitize-html.ts
+++ b/lib/utils/sanitize-html.ts
@@ -15,6 +15,24 @@ const DANGEROUS_URI_RE = /^\s*(javascript|data|vbscript)\s*:/i;
 const EVENT_HANDLER_RE = /^on[a-z]/i;
 
 /**
+ * Remove dangerous CSS constructs from a style value or <style> block body.
+ * Strips @import, url(...) and expression(...) — including UNTERMINATED forms
+ * (a bare `url(` with no closing paren), because browsers recover from an
+ * unclosed url() and would still issue the request, so matching only the
+ * balanced form would leave an exfiltration bypass.
+ */
+function stripDangerousCss(css: string): string {
+  // The optional closing paren (\)?) makes each pattern consume BOTH balanced
+  // forms — url(x) — and unterminated ones — url(x  — up to the next ")" or the
+  // end of the value, so a bare `url(https://evil/…` is removed entirely rather
+  // than leaving the host behind.
+  return css
+    .replace(/@import\b[^;]*;?/gi, "")
+    .replace(/url\s*\([^)]*\)?/gi, "")
+    .replace(/expression\s*\([^)]*\)?/gi, "");
+}
+
+/**
  * Sanitize admin-authored HTML for product descriptions.
  */
 const MAX_INPUT_LENGTH = 512_000; // 500KB — reject oversized input
@@ -38,9 +56,7 @@ export function sanitizeDescriptionHtml(html: string, productId?: string): strin
   result = result.replace(
     /<style[^>]*>([\s\S]*?)<\/style>/gi,
     (_match, cssContent: string) => {
-      let css = cssContent;
-      css = css.replace(/@import\b[^;]*;?/gi, "");
-      css = css.replace(/url\s*\([^)]*\)/gi, "");
+      let css = stripDangerousCss(cssContent);
       css = css.trim();
       if (!css) return "";
       if (productId) {
@@ -91,10 +107,7 @@ export function sanitizeDescriptionHtml(html: string, productId?: string): strin
           // Inline style values were not filtered, unlike <style> blocks, so
           // style="background:url(https://evil/…)" exfiltrated visitor requests
           // on load (GHSA-m888). Strip the same dangerous CSS constructs here.
-          cleanValue = cleanValue
-            .replace(/@import\b[^;]*;?/gi, "")
-            .replace(/url\s*\([^)]*\)/gi, "")
-            .replace(/expression\s*\([^)]*\)/gi, "");
+          cleanValue = stripDangerousCss(cleanValue);
         }
         const safeValue = cleanValue.replace(/"/g, "&quot;");
         attrs.push(`${attrName}="${safeValue}"`);

--- a/lib/utils/sanitize-html.ts
+++ b/lib/utils/sanitize-html.ts
@@ -60,9 +60,14 @@ export function sanitizeDescriptionHtml(html: string, productId?: string): strin
     },
   );
 
-  // 3. Process all HTML tags: strip disallowed tags, strip dangerous attributes
+  // 3. Process all HTML tags: strip disallowed tags, strip dangerous attributes.
+  // The attribute section may be separated from the tag name by whitespace OR a
+  // solidus ("/") — the HTML tokenizer treats "/" as an attribute separator, so
+  // <img/src=x/onerror=alert(1)> is a valid <img> with an onerror handler. The
+  // separator class MUST include "/" ([\s/]); matching only \s let such tags
+  // pass through verbatim and defeated sanitization entirely (GHSA-92r4).
   result = result.replace(
-    /<\/?([a-zA-Z][a-zA-Z0-9]*)((?:\s+[^>]*)?)\s*\/?>/g,
+    /<\/?([a-zA-Z][a-zA-Z0-9]*)((?:[\s/][^>]*)?)\s*\/?>/g,
     (match, tagName: string, attrsStr: string) => {
       const tag = tagName.toLowerCase();
       if (tag === "style") return match; // already processed
@@ -81,7 +86,17 @@ export function sanitizeDescriptionHtml(html: string, productId?: string): strin
         if (EVENT_HANDLER_RE.test(attrName)) continue;
         if (!ALLOWED_ATTRS.has(attrName)) continue;
         if ((attrName === "href" || attrName === "src") && DANGEROUS_URI_RE.test(attrValue)) continue;
-        const safeValue = attrValue.replace(/"/g, "&quot;");
+        let cleanValue = attrValue;
+        if (attrName === "style") {
+          // Inline style values were not filtered, unlike <style> blocks, so
+          // style="background:url(https://evil/…)" exfiltrated visitor requests
+          // on load (GHSA-m888). Strip the same dangerous CSS constructs here.
+          cleanValue = cleanValue
+            .replace(/@import\b[^;]*;?/gi, "")
+            .replace(/url\s*\([^)]*\)/gi, "")
+            .replace(/expression\s*\([^)]*\)/gi, "");
+        }
+        const safeValue = cleanValue.replace(/"/g, "&quot;");
         attrs.push(`${attrName}="${safeValue}"`);
       }
 

--- a/lib/validations/checkout.ts
+++ b/lib/validations/checkout.ts
@@ -30,7 +30,10 @@ export const checkoutSchema = z
 
     promoCode: z.string().max(50).optional(),
 
-    items: z.array(cartItemSchema).min(1, "Le panier est vide"),
+    // Cap the number of distinct line items to mirror the cart's MAX_CART_ITEMS
+    // (actions/cart.ts). Without this, a direct createOrder call could submit an
+    // unbounded items array, producing an oversized IN (...) query and D1 batch.
+    items: z.array(cartItemSchema).min(1, "Le panier est vide").max(50, "Trop d'articles dans le panier"),
   })
   .refine(
     (data) => {

--- a/workers/whatsapp/src/session.ts
+++ b/workers/whatsapp/src/session.ts
@@ -12,22 +12,22 @@ export async function findOrCreateSession(
 
   if (existing) return existing;
 
-  // Auto-link by phone number if a user matches
-  const matchedUser = await db
-    .prepare("SELECT id FROM user WHERE phone = ? OR phone = ?")
-    .bind(waPhone, `+${waPhone}`)
-    .first<{ id: string }>();
-
   const id = crypto.randomUUID();
   const now = new Date().toISOString();
 
-  // INSERT OR IGNORE to handle race condition (concurrent first messages)
+  // Always create sessions UNLINKED and UNVERIFIED. Account linking must go
+  // through the email-OTP flow (link_account + verifyOtp). We must NOT auto-link
+  // or auto-verify from a user.phone match: phone is a self-asserted, unverified,
+  // non-unique signup field, so trusting it would hand account access (order
+  // history + order creation) to whoever controls a matching WhatsApp number
+  // (e.g. telecom number recycling). See GHSA-4v42.
+  // INSERT OR IGNORE to handle race condition (concurrent first messages).
   await db
     .prepare(
       `INSERT OR IGNORE INTO whatsapp_sessions (id, wa_phone, user_id, is_verified, status, created_at, updated_at)
-       VALUES (?, ?, ?, ?, 'active', ?, ?)`
+       VALUES (?, ?, NULL, 0, 'active', ?, ?)`
     )
-    .bind(id, waPhone, matchedUser?.id ?? null, matchedUser ? 1 : 0, now, now)
+    .bind(id, waPhone, now, now)
     .run();
 
   // Always re-fetch by wa_phone (works whether our INSERT succeeded or was ignored)

--- a/workers/whatsapp/src/tools/account.ts
+++ b/workers/whatsapp/src/tools/account.ts
@@ -9,7 +9,7 @@ interface UserRow {
 interface SessionOtpRow {
   otp_code: string | null;
   otp_expires_at: string | null;
-  user_id: string | null;
+  pending_user_id: string | null;
 }
 
 function generateOtp(): string {
@@ -38,10 +38,14 @@ export async function linkAccount(
   const otp = generateOtp();
   const expiresAt = new Date(Date.now() + 10 * 60 * 1000).toISOString();
 
+  // Stage the target account as PENDING only. It must not become the trusted
+  // ctx.session.user_id until the OTP emailed below is confirmed in verifyOtp;
+  // otherwise an attacker who merely knows a victim's email would be linked
+  // before proving ownership. See GHSA (OTP account-linking bypass).
   await ctx.db
     .prepare(
       `UPDATE whatsapp_sessions
-       SET otp_code = ?, otp_expires_at = ?, user_id = ?, updated_at = ?
+       SET otp_code = ?, otp_expires_at = ?, pending_user_id = ?, updated_at = ?
        WHERE id = ?`
     )
     .bind(otp, expiresAt, user.id, new Date().toISOString(), ctx.session.id)
@@ -69,11 +73,11 @@ export async function verifyOtp(
   params: { code: string }
 ): Promise<ToolResult> {
   const row = await ctx.db
-    .prepare("SELECT otp_code, otp_expires_at, user_id FROM whatsapp_sessions WHERE id = ?")
+    .prepare("SELECT otp_code, otp_expires_at, pending_user_id FROM whatsapp_sessions WHERE id = ?")
     .bind(ctx.session.id)
     .first<SessionOtpRow>();
 
-  if (!row?.otp_code || !row?.otp_expires_at) {
+  if (!row?.otp_code || !row?.otp_expires_at || !row?.pending_user_id) {
     return { success: false, error: "No verification pending. Please use the link account command first." };
   }
 
@@ -101,10 +105,13 @@ export async function verifyOtp(
     return { success: false, error: `Code incorrect (tentative ${attempts}/5). Vérifiez votre email et réessayez.` };
   }
 
+  // OTP confirmed: promote the pending account to the trusted user_id and mark
+  // the session verified atomically, clearing the OTP + pending staging.
   await ctx.db
     .prepare(
       `UPDATE whatsapp_sessions
-       SET is_verified = 1, otp_code = NULL, otp_expires_at = NULL, updated_at = ?
+       SET is_verified = 1, user_id = pending_user_id, pending_user_id = NULL,
+           otp_code = NULL, otp_expires_at = NULL, updated_at = ?
        WHERE id = ?`
     )
     .bind(new Date().toISOString(), ctx.session.id)
@@ -112,7 +119,8 @@ export async function verifyOtp(
 
   // Update in-memory session
   ctx.session.is_verified = 1;
-  ctx.session.user_id = row.user_id;
+  ctx.session.user_id = row.pending_user_id;
+  ctx.session.pending_user_id = null;
 
   return {
     success: true,

--- a/workers/whatsapp/src/tools/account.ts
+++ b/workers/whatsapp/src/tools/account.ts
@@ -58,6 +58,12 @@ export async function linkAccount(
 
   // Advance the per-session counter for every attempt (registered or not) so
   // blind enumeration is throttled regardless of the lookup result.
+  // NOTE: KV has no atomic increment, so these caps are best-effort — a tight
+  // burst of concurrent messages can slip a few extra through. That is an
+  // acceptable defense-in-depth throttle here (the existence oracle and the
+  // unbounded-bombing primitive are already closed by the uniform response and
+  // these caps); a strictly atomic limit would need the Cloudflare Rate
+  // Limiting API or a Durable Object, which is overkill for this throttle.
   await ctx.env.KV.put(sessionKey, String(sessionCount + 1), { expirationTtl: LINK_WINDOW_TTL });
 
   const user = await ctx.db
@@ -76,6 +82,12 @@ export async function linkAccount(
     console.error("[account] RESEND_API_KEY not configured, cannot send OTP");
     return { success: true, data: { message: LINK_UNIFORM_MESSAGE } };
   }
+
+  // Reserve the per-target-email slot BEFORE sending, so the send happens only
+  // once the counter is advanced — a burst can't fire many emails and then
+  // increment. Combined with the uniform response, this caps how many real OTP
+  // emails any single address can receive per window.
+  await ctx.env.KV.put(emailKey, String(emailCount + 1), { expirationTtl: LINK_WINDOW_TTL });
 
   const otp = generateOtp();
   const expiresAt = new Date(Date.now() + 10 * 60 * 1000).toISOString();
@@ -99,9 +111,6 @@ export async function linkAccount(
     // Uniform response — do not turn a delivery failure into an oracle.
     return { success: true, data: { message: LINK_UNIFORM_MESSAGE } };
   }
-
-  // Count successful sends per target email to cap bombing of that address.
-  await ctx.env.KV.put(emailKey, String(emailCount + 1), { expirationTtl: LINK_WINDOW_TTL });
 
   return { success: true, data: { message: LINK_UNIFORM_MESSAGE } };
 }

--- a/workers/whatsapp/src/tools/account.ts
+++ b/workers/whatsapp/src/tools/account.ts
@@ -106,16 +106,24 @@ export async function verifyOtp(
   }
 
   // OTP confirmed: promote the pending account to the trusted user_id and mark
-  // the session verified atomically, clearing the OTP + pending staging.
-  await ctx.db
+  // the session verified, clearing the OTP + pending staging. The WHERE guard
+  // requires the OTP/pending state we validated to still be present, so a
+  // concurrent re-link or parallel verify that cleared pending_user_id cannot
+  // cause us to persist user_id = NULL and still report success.
+  const promote = await ctx.db
     .prepare(
       `UPDATE whatsapp_sessions
        SET is_verified = 1, user_id = pending_user_id, pending_user_id = NULL,
            otp_code = NULL, otp_expires_at = NULL, updated_at = ?
-       WHERE id = ?`
+       WHERE id = ? AND otp_code = ? AND pending_user_id IS NOT NULL`
     )
-    .bind(new Date().toISOString(), ctx.session.id)
+    .bind(new Date().toISOString(), ctx.session.id, row.otp_code)
     .run();
+
+  if (promote.meta.changes === 0) {
+    // Pending/OTP state changed underneath us — do not mark the session verified.
+    return { success: false, error: "La vérification a échoué. Veuillez demander un nouveau code." };
+  }
 
   // Update in-memory session
   ctx.session.is_verified = 1;

--- a/workers/whatsapp/src/tools/account.ts
+++ b/workers/whatsapp/src/tools/account.ts
@@ -18,6 +18,18 @@ function generateOtp(): string {
   return String(100000 + (arr[0] % 900000));
 }
 
+// Uniform response used for every non-error outcome of linkAccount so the tool
+// never reveals whether an email is registered (no account-existence oracle).
+const LINK_UNIFORM_MESSAGE =
+  "Si un compte existe pour cette adresse, un code de vérification a été envoyé. Envoyez-moi le code à 6 chiffres pour lier votre compte.";
+
+// Rate-limit windows (KV TTL, seconds) and caps. Per-session throttles blind
+// enumeration attempts; per-target-email throttles OTP email bombing of a
+// specific victim across attacker-controlled numbers. See GHSA-6m6p.
+const LINK_WINDOW_TTL = 3600;
+const LINK_MAX_PER_SESSION = 5;
+const LINK_MAX_PER_EMAIL = 3;
+
 export async function linkAccount(
   ctx: ToolContext,
   params: { email: string }
@@ -26,13 +38,43 @@ export async function linkAccount(
     return { success: false, error: "Account already linked to this WhatsApp session." };
   }
 
+  const email = params.email.trim().toLowerCase();
+  const sessionKey = `wa:link_attempts:session:${ctx.session.id}`;
+  const emailKey = `wa:link_attempts:email:${email}`;
+
+  const [sessionCountStr, emailCountStr] = await Promise.all([
+    ctx.env.KV.get(sessionKey),
+    ctx.env.KV.get(emailKey),
+  ]);
+  const sessionCount = sessionCountStr ? parseInt(sessionCountStr, 10) : 0;
+  const emailCount = emailCountStr ? parseInt(emailCountStr, 10) : 0;
+
+  if (sessionCount >= LINK_MAX_PER_SESSION || emailCount >= LINK_MAX_PER_EMAIL) {
+    return {
+      success: false,
+      error: "Trop de demandes de vérification. Veuillez réessayer plus tard.",
+    };
+  }
+
+  // Advance the per-session counter for every attempt (registered or not) so
+  // blind enumeration is throttled regardless of the lookup result.
+  await ctx.env.KV.put(sessionKey, String(sessionCount + 1), { expirationTtl: LINK_WINDOW_TTL });
+
   const user = await ctx.db
     .prepare("SELECT id, email FROM user WHERE LOWER(email) = LOWER(?)")
-    .bind(params.email)
+    .bind(email)
     .first<UserRow>();
 
+  // Uniform response for unregistered emails — never disclose non-existence.
   if (!user) {
-    return { success: false, error: "No account found with that email address." };
+    return { success: true, data: { message: LINK_UNIFORM_MESSAGE } };
+  }
+
+  if (!ctx.env.RESEND_API_KEY) {
+    // Return the uniform message (not a distinct error) so a missing key can't
+    // be combined into an existence oracle; the failure is only logged.
+    console.error("[account] RESEND_API_KEY not configured, cannot send OTP");
+    return { success: true, data: { message: LINK_UNIFORM_MESSAGE } };
   }
 
   const otp = generateOtp();
@@ -51,21 +93,17 @@ export async function linkAccount(
     .bind(otp, expiresAt, user.id, new Date().toISOString(), ctx.session.id)
     .run();
 
-  if (!ctx.env.RESEND_API_KEY) {
-    console.error("[account] RESEND_API_KEY not configured, cannot send OTP");
-    return { success: false, error: "Le service email n'est pas disponible. Veuillez réessayer plus tard." };
-  }
-
   const emailResult = await sendOtpEmail(ctx.env.RESEND_API_KEY, user.email, otp);
   if (!emailResult.success) {
     console.error(`[account] OTP email failed for ${user.email}: ${emailResult.error}`);
-    return { success: false, error: "Impossible d'envoyer l'email de vérification. Veuillez réessayer." };
+    // Uniform response — do not turn a delivery failure into an oracle.
+    return { success: true, data: { message: LINK_UNIFORM_MESSAGE } };
   }
 
-  return {
-    success: true,
-    data: { message: `Un code de vérification a été envoyé à ${user.email}. Envoyez-moi le code à 6 chiffres pour lier votre compte.` },
-  };
+  // Count successful sends per target email to cap bombing of that address.
+  await ctx.env.KV.put(emailKey, String(emailCount + 1), { expirationTtl: LINK_WINDOW_TTL });
+
+  return { success: true, data: { message: LINK_UNIFORM_MESSAGE } };
 }
 
 export async function verifyOtp(

--- a/workers/whatsapp/src/tools/orders.ts
+++ b/workers/whatsapp/src/tools/orders.ts
@@ -43,7 +43,7 @@ export async function createOrder(
   ctx: ToolContext,
   params: { address: string; commune: string; phone: string; instructions?: string }
 ): Promise<ToolResult & { data?: unknown }> {
-  if (!ctx.session.user_id) {
+  if (ctx.session.is_verified !== 1 || !ctx.session.user_id) {
     return {
       success: false,
       error: "Your account is not linked. Please link your account before placing an order.",
@@ -193,7 +193,7 @@ export async function getOrderStatus(
   ctx: ToolContext,
   params: { order_number: string }
 ): Promise<ToolResult & { data?: unknown }> {
-  if (!ctx.session.user_id) {
+  if (ctx.session.is_verified !== 1 || !ctx.session.user_id) {
     return {
       success: false,
       error: "Your account is not linked. Please link your account to view orders.",
@@ -232,7 +232,7 @@ export async function listOrders(
   ctx: ToolContext,
   params: { limit?: number }
 ): Promise<ToolResult & { data?: unknown }> {
-  if (!ctx.session.user_id) {
+  if (ctx.session.is_verified !== 1 || !ctx.session.user_id) {
     return {
       success: false,
       error: "Your account is not linked. Please link your account to view orders.",

--- a/workers/whatsapp/src/types.ts
+++ b/workers/whatsapp/src/types.ts
@@ -90,6 +90,9 @@ export interface WhatsAppSession {
   id: string;
   wa_phone: string;
   user_id: string | null;
+  // Account awaiting OTP confirmation. Promoted to user_id by verifyOtp on
+  // success. Never trusted by order tools — those gate on is_verified.
+  pending_user_id: string | null;
   is_verified: number;
   otp_code: string | null;
   otp_expires_at: string | null;


### PR DESCRIPTION
## Résumé

Corrige les 2 findings **HIGH** et le **MEDIUM** couplé de la surface WhatsApp, issus de l'audit de sécurité. Détails complets (traces, PoC) dans les GitHub Security Advisories privés associés — non reproduits ici (repo public).

## Correctifs

### 🔴 HIGH — Gate OTP des outils de commande WhatsApp (`GHSA-crg6-hg52-fvcr`)
Les outils `create_order` / `get_order_status` / `list_orders` autorisaient sur la **présence** d'un compte lié (`session.user_id`) au lieu de la **vérification OTP** (`session.is_verified`). Comme `linkAccount` écrivait le `user_id` cible **avant** confirmation de l'OTP, l'accès au compte d'un tiers était possible en connaissant seulement son email.

- Nouvelle colonne nullable `pending_user_id` sur `whatsapp_sessions` (migration `0014`, `ADD COLUMN` rétro-compatible).
- `linkAccount` stocke désormais `pending_user_id` (compte *en attente*) — ne touche plus à `user_id` / `is_verified`.
- `verifyOtp` promeut `pending_user_id → user_id` + `is_verified=1` **uniquement** après OTP validé.
- Les 3 outils de commande exigent `is_verified === 1 && user_id`.

### 🔴 HIGH — Restitution du stock à l'annulation client (`GHSA-gmm8-xwrv-mmg9`)
Le chemin client `cancelOrder` passait la commande à `cancelled` sans jamais restituer le stock réservé (état terminal → aucun remboursement admin possible ensuite), permettant un déni d'inventaire gratuit en COD.

- `cancelOrder` restitue le stock via `refundOrderStock`, uniquement quand *cet* appel effectue la transition `pending→cancelled` (garde de statut → pas de double remboursement en concurrence).

### 🟠 MEDIUM — Fin de l'auto-vérification par téléphone (`GHSA-4v42-gwwv-q4r2`)
`findOrCreateSession` marquait une session `is_verified=1` + liée sur simple correspondance d'un `user.phone` (champ auto-déclaré, jamais vérifié, non unique) — ce qui satisfaisait aussi le nouveau gate ci-dessus.

- Les sessions sont toujours créées **non liées / non vérifiées** ; le lien passe obligatoirement par le flux OTP email. La recherche par téléphone dans la table `user` est supprimée.

## Changement de comportement
Les utilisateurs auparavant liés automatiquement par numéro de téléphone devront se lier **une fois** via le code OTP email (`link_account` → `verifyOtp`). C'est le compromis de sécurité recommandé par l'advisory.

## Migration
`drizzle/0014_*` — `ALTER TABLE whatsapp_sessions ADD pending_user_id text REFERENCES user(id);` (nullable, expand/contract-safe, `check:migrations` OK).

## Tests & vérifications
- ✅ `tsc --noEmit` (racine + worker)
- ✅ ESLint
- ✅ Suite complète **904 tests** (dont des tests de régression sécurité : session non vérifiée avec `user_id` refusée avant tout accès DB ; `linkAccount` ne stocke que `pending_user_id` ; pas d'auto-lien par téléphone)

## Suite
Findings restants (advisories privés séparés) : `GHSA-92r4` (XSS sanitizer), `GHSA-6m6p` (rate-limit `link_account`) et 4 LOW.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Findings supplémentaires corrigés (après la revue)

- 🟠 **MEDIUM `GHSA-92r4`** — XSS stocké : sanitizer regex contourné via le séparateur `/`. La classe de séparateur inclut désormais `/` (`[\s/]`) → les tags sont parsés et les event handlers neutralisés. Sink public `dangerouslySetInnerHTML`.
- 🟠 **MEDIUM `GHSA-6m6p`** — `link_account` : rate-limit KV (par session + par email cible) + réponse **uniforme** (fin de l'oracle d'existence de compte et du bombardement d'e-mails OTP).
- 🔵 **LOW `GHSA-m888`** — exfil CSS via l'attribut `style` : filtrage de `url()` / `@import` / `expression()` dans la valeur (même fichier que le XSS).

Tests : **912** au total (+7). `tsc` (racine + worker) ✓ · ESLint ✓.


### Findings LOW corrigés

- 🔵 **LOW `GHSA-v4c5`** — injection de formule CSV (export commandes) : `escapeCSV` préfixe désormais `= + - @` (tab/CR) d'une apostrophe.
- 🔵 **LOW `GHSA-x7w8`** — TOCTOU promo : incrément `used_count` gardé (`AND (max_uses IS NULL OR used_count < max_uses)`) + vérification/rollback de la commande si dépassement concurrent.
- 🔵 **LOW `GHSA-7f5h`** — `checkoutSchema.items` borné à `.max(50)` (miroir de `MAX_CART_ITEMS`).

**Toutes les vulnérabilités de l'audit (2 HIGH + 3 MEDIUM + 4 LOW) sont désormais corrigées.** Tests : **919** · `tsc` (racine + worker) ✓ · ESLint ✓.
