### PR TITLE
fix(auth): tighten the authorization boundary (lot 2/8)

### DIFF
--- a/__tests__/helpers/mocks.ts
+++ b/__tests__/helpers/mocks.ts
@@ -43,3 +43,34 @@ export const mockAgentSession = {
   },
   session: { id: "sess-4", expiresAt: new Date("2099-01-01") },
 };
+
+// better-auth's admin plugin only auto-clears an expired ban at session
+// *creation* (sign-in) — an existing session's cached/fresh read can still
+// carry banned: true past banExpires. These fixtures exercise both cases:
+// an active ban (no expiry, or expiry in the future) and one that has
+// already lapsed but was never re-signed-in.
+export const mockBannedAdminSession = {
+  user: {
+    id: "admin-2",
+    name: "Banned Admin",
+    email: "banned-admin@netereka.ci",
+    role: "admin",
+    phone: "0708091012",
+    banned: true,
+    banExpires: null,
+  },
+  session: { id: "sess-5", expiresAt: new Date("2099-01-01") },
+};
+
+export const mockExpiredBanAdminSession = {
+  user: {
+    id: "admin-3",
+    name: "Formerly Banned Admin",
+    email: "formerly-banned-admin@netereka.ci",
+    role: "admin",
+    phone: "0708091013",
+    banned: true,
+    banExpires: new Date("2020-01-01"),
+  },
+  session: { id: "sess-6", expiresAt: new Date("2099-01-01") },
+};

--- a/__tests__/helpers/mocks.ts
+++ b/__tests__/helpers/mocks.ts
@@ -104,3 +104,25 @@ export const mockExpiredBanCustomerSession = {
   },
   session: { id: "sess-8", expiresAt: new Date("2099-01-01") },
 };
+
+// requireAuth's normal (cache-hit) read never sees the shape above. better-auth's
+// cache branch (session.mjs) only re-hydrates createdAt/updatedAt into Date
+// objects when reading the cookie payload back out of JSON — banExpires comes
+// through as whatever JSON.parse produced, i.e. an ISO string (or null), not a
+// Date. A privileged guard's fresh D1 read gets a real Date instead (the D1
+// Kysely adapter's output transform converts stored date columns back to Date
+// for dialects with supportsDates: false, which sqlite/D1 is). This fixture
+// pins the string shape so requireAuth is tested at the shape it actually
+// receives on its hot path, not just the shape the privileged guards receive.
+export const mockExpiredBanCustomerSessionFromCache = {
+  user: {
+    id: "user-4",
+    name: "Formerly Banned Customer (cache shape)",
+    email: "formerly-banned-customer-cache@example.com",
+    role: "customer",
+    phone: "0102030408",
+    banned: true,
+    banExpires: "2020-01-01T00:00:00.000Z",
+  },
+  session: { id: "sess-9", expiresAt: new Date("2099-01-01") },
+};

--- a/__tests__/helpers/mocks.ts
+++ b/__tests__/helpers/mocks.ts
@@ -74,3 +74,33 @@ export const mockExpiredBanAdminSession = {
   },
   session: { id: "sess-6", expiresAt: new Date("2099-01-01") },
 };
+
+// Same rationale as the admin fixtures above, for the storefront guard
+// (requireAuth), which reads the cached cookie payload rather than a fresh
+// D1 row — see lib/auth/guards.ts for why that cached payload still carries
+// banned/banExpires.
+export const mockBannedCustomerSession = {
+  user: {
+    id: "user-2",
+    name: "Banned Customer",
+    email: "banned-customer@example.com",
+    role: "customer",
+    phone: "0102030406",
+    banned: true,
+    banExpires: null,
+  },
+  session: { id: "sess-7", expiresAt: new Date("2099-01-01") },
+};
+
+export const mockExpiredBanCustomerSession = {
+  user: {
+    id: "user-3",
+    name: "Formerly Banned Customer",
+    email: "formerly-banned-customer@example.com",
+    role: "customer",
+    phone: "0102030407",
+    banned: true,
+    banExpires: new Date("2020-01-01"),
+  },
+  session: { id: "sess-8", expiresAt: new Date("2099-01-01") },
+};

--- a/__tests__/unit/actions/account.test.ts
+++ b/__tests__/unit/actions/account.test.ts
@@ -10,10 +10,14 @@ const mocks = vi.hoisted(() => ({
   }),
   updateUser: vi.fn(),
   changePasswordApi: vi.fn(),
+  cookieStoreSet: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({ redirect: mocks.redirect }));
-vi.mock("next/headers", () => ({ headers: vi.fn().mockResolvedValue(new Headers()) }));
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+  cookies: vi.fn().mockResolvedValue({ set: mocks.cookieStoreSet }),
+}));
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 vi.mock("@/lib/auth", () => ({
   initAuth: vi.fn().mockResolvedValue({
@@ -65,7 +69,10 @@ describe("changePassword", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.getSession.mockResolvedValue(mockCustomerSession);
-    mocks.changePasswordApi.mockResolvedValue({});
+    mocks.changePasswordApi.mockResolvedValue({
+      response: { token: null, user: mockCustomerSession.user },
+      headers: new Headers(),
+    });
   });
 
   it("change le mot de passe avec des données valides", async () => {
@@ -104,5 +111,77 @@ describe("changePassword", () => {
     });
     expect(result.success).toBe(false);
     expect(result.error).toContain("Mot de passe actuel incorrect");
+  });
+
+  it("révoque les autres sessions de l'utilisateur", async () => {
+    await changePassword({
+      currentPassword: "ancien123",
+      newPassword: "nouveau123",
+      confirmPassword: "nouveau123",
+    });
+
+    expect(mocks.changePasswordApi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({ revokeOtherSessions: true }),
+      })
+    );
+  });
+
+  it("demande les en-têtes de réponse pour pouvoir réappliquer le cookie de session", async () => {
+    await changePassword({
+      currentPassword: "ancien123",
+      newPassword: "nouveau123",
+      confirmPassword: "nouveau123",
+    });
+
+    expect(mocks.changePasswordApi).toHaveBeenCalledWith(
+      expect.objectContaining({ returnHeaders: true })
+    );
+  });
+
+  it("réapplique le nouveau cookie de session renvoyé par better-auth", async () => {
+    // revokeOtherSessions:true fait tourner TOUTES les sessions, y compris celle
+    // de l'appelant : better-auth renvoie un nouveau cookie de session via les
+    // en-têtes de réponse plutôt que de l'exclure de la révocation. Sans ce
+    // report, le navigateur qui vient de changer son mot de passe pointerait
+    // vers une session supprimée et serait déconnecté à la prochaine vérification.
+    const setCookieHeaders = new Headers();
+    setCookieHeaders.append(
+      "set-cookie",
+      "better-auth.session_token=new-token-value; Path=/; HttpOnly; SameSite=Lax"
+    );
+    mocks.changePasswordApi.mockResolvedValue({
+      response: { token: "new-token-value", user: mockCustomerSession.user },
+      headers: setCookieHeaders,
+    });
+
+    const result = await changePassword({
+      currentPassword: "ancien123",
+      newPassword: "nouveau123",
+      confirmPassword: "nouveau123",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mocks.cookieStoreSet).toHaveBeenCalledWith(
+      "better-auth.session_token",
+      "new-token-value",
+      expect.objectContaining({ httpOnly: true })
+    );
+  });
+
+  it("n'échoue pas si better-auth ne renvoie aucun cookie à réappliquer", async () => {
+    mocks.changePasswordApi.mockResolvedValue({
+      response: { token: null, user: mockCustomerSession.user },
+      headers: new Headers(),
+    });
+
+    const result = await changePassword({
+      currentPassword: "ancien123",
+      newPassword: "nouveau123",
+      confirmPassword: "nouveau123",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mocks.cookieStoreSet).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/unit/actions/account.test.ts
+++ b/__tests__/unit/actions/account.test.ts
@@ -199,15 +199,26 @@ describe("changePassword", () => {
     // Max-Age et le préfixe __Secure- une fois déployé. Un rejeu qui ne
     // traiterait que le premier cookie du Set-Cookie serait une régression
     // critique — ce test couvre donc les deux, avec leurs attributs complets.
-    const setCookieHeaders = new Headers();
-    setCookieHeaders.append(
-      "set-cookie",
-      "__Secure-better-auth.session_token=new-token-value; Max-Age=604800; Path=/; HttpOnly; Secure; SameSite=Lax"
-    );
-    setCookieHeaders.append(
-      "set-cookie",
-      "__Secure-better-auth.session_data=new-session-payload; Max-Age=300; Path=/; HttpOnly; Secure; SameSite=Lax"
-    );
+    //
+    // headers.get("set-cookie") joins multi-value headers with ", " and would
+    // make this test pass "by accident" via that heuristic even for an
+    // implementation that never calls getSetCookie(). To prove the
+    // implementation actually reads through getSetCookie() — and not a
+    // join-then-split fallback — get("set-cookie") is made to throw here: any
+    // regression back to it fails loudly instead of silently degrading.
+    const setCookieHeaders = {
+      get: (name: string) => {
+        throw new Error(
+          `get(${JSON.stringify(name)}) was called — the implementation must read ` +
+            "Set-Cookie via getSetCookie(), not get(), to avoid the comma-joined " +
+            "multi-header parsing hazard."
+        );
+      },
+      getSetCookie: () => [
+        "__Secure-better-auth.session_token=new-token-value; Max-Age=604800; Path=/; HttpOnly; Secure; SameSite=Lax",
+        "__Secure-better-auth.session_data=new-session-payload; Max-Age=300; Path=/; HttpOnly; Secure; SameSite=Lax",
+      ],
+    } as unknown as Headers;
     mocks.changePasswordApi.mockResolvedValue({
       response: { token: "new-token-value", user: mockCustomerSession.user },
       headers: setCookieHeaders,

--- a/__tests__/unit/actions/account.test.ts
+++ b/__tests__/unit/actions/account.test.ts
@@ -139,12 +139,104 @@ describe("changePassword", () => {
     );
   });
 
-  it("réapplique le nouveau cookie de session renvoyé par better-auth", async () => {
+  it("réapplique tous les cookies de session renvoyés par better-auth", async () => {
     // revokeOtherSessions:true fait tourner TOUTES les sessions, y compris celle
     // de l'appelant : better-auth renvoie un nouveau cookie de session via les
     // en-têtes de réponse plutôt que de l'exclure de la révocation. Sans ce
     // report, le navigateur qui vient de changer son mot de passe pointerait
     // vers une session supprimée et serait déconnecté à la prochaine vérification.
+    //
+    // En production, cookieCache.enabled est actif : setSessionCookie émet
+    // toujours DEUX cookies (session_token + session_data), avec Secure,
+    // Max-Age et le préfixe __Secure- une fois déployé. Un rejeu qui ne
+    // traiterait que le premier cookie du Set-Cookie serait une régression
+    // critique — ce test couvre donc les deux, avec leurs attributs complets.
+    const setCookieHeaders = new Headers();
+    setCookieHeaders.append(
+      "set-cookie",
+      "__Secure-better-auth.session_token=new-token-value; Max-Age=604800; Path=/; HttpOnly; Secure; SameSite=Lax"
+    );
+    setCookieHeaders.append(
+      "set-cookie",
+      "__Secure-better-auth.session_data=new-session-payload; Max-Age=300; Path=/; HttpOnly; Secure; SameSite=Lax"
+    );
+    mocks.changePasswordApi.mockResolvedValue({
+      response: { token: "new-token-value", user: mockCustomerSession.user },
+      headers: setCookieHeaders,
+    });
+
+    const result = await changePassword({
+      currentPassword: "ancien123",
+      newPassword: "nouveau123",
+      confirmPassword: "nouveau123",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mocks.cookieStoreSet).toHaveBeenCalledTimes(2);
+    expect(mocks.cookieStoreSet).toHaveBeenNthCalledWith(
+      1,
+      "__Secure-better-auth.session_token",
+      "new-token-value",
+      {
+        maxAge: 604800,
+        path: "/",
+        httpOnly: true,
+        secure: true,
+        sameSite: "lax",
+      }
+    );
+    expect(mocks.cookieStoreSet).toHaveBeenNthCalledWith(
+      2,
+      "__Secure-better-auth.session_data",
+      "new-session-payload",
+      {
+        maxAge: 300,
+        path: "/",
+        httpOnly: true,
+        secure: true,
+        sameSite: "lax",
+      }
+    );
+  });
+
+  it("journalise un avertissement mais réussit tout de même si better-auth ne renvoie aucun cookie à réappliquer", async () => {
+    // revokeOtherSessions est désormais toujours à true, donc l'absence d'un
+    // set-cookie n'est plus un cas bénin : la rotation de session n'a pas été
+    // exposée et le cookie de l'appelant pointe vers une session supprimée.
+    // Le changement de mot de passe a néanmoins réussi côté serveur — échouer
+    // l'action serait pire pour l'utilisateur — donc ce cas doit rester
+    // observable (avertissement journalisé) plutôt qu'invisible.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mocks.changePasswordApi.mockResolvedValue({
+      response: { token: null, user: mockCustomerSession.user },
+      headers: new Headers(),
+    });
+
+    const result = await changePassword({
+      currentPassword: "ancien123",
+      newPassword: "nouveau123",
+      confirmPassword: "nouveau123",
+    });
+
+    expect(result.success).toBe(true);
+    expect(mocks.cookieStoreSet).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("[changePassword]"));
+
+    warnSpy.mockRestore();
+  });
+
+  it("réussit et journalise l'erreur si la réapplication du cookie échoue après un changement de mot de passe déjà effectué", async () => {
+    // Le mot de passe a déjà changé et les sessions ont déjà été révoquées
+    // côté serveur avant que ce rejeu ne s'exécute (setSessionCookie a déjà
+    // tourné dans update-user.mjs). Si cookies().set() lève ici — ce que
+    // Next.js fait hors d'un contexte de mutation autorisé, la raison même
+    // pour laquelle nextCookies() en amont capture la même opération — cela
+    // ne doit jamais être rapporté comme « mot de passe incorrect » : ce
+    // serait faire croire à l'appelant que rien ne s'est passé.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.cookieStoreSet.mockImplementation(() => {
+      throw new Error("cookies() called outside a mutable context");
+    });
     const setCookieHeaders = new Headers();
     setCookieHeaders.append(
       "set-cookie",
@@ -162,26 +254,9 @@ describe("changePassword", () => {
     });
 
     expect(result.success).toBe(true);
-    expect(mocks.cookieStoreSet).toHaveBeenCalledWith(
-      "better-auth.session_token",
-      "new-token-value",
-      expect.objectContaining({ httpOnly: true })
-    );
-  });
+    expect(result.error).toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("[changePassword]"), expect.any(Error));
 
-  it("n'échoue pas si better-auth ne renvoie aucun cookie à réappliquer", async () => {
-    mocks.changePasswordApi.mockResolvedValue({
-      response: { token: null, user: mockCustomerSession.user },
-      headers: new Headers(),
-    });
-
-    const result = await changePassword({
-      currentPassword: "ancien123",
-      newPassword: "nouveau123",
-      confirmPassword: "nouveau123",
-    });
-
-    expect(result.success).toBe(true);
-    expect(mocks.cookieStoreSet).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 });

--- a/__tests__/unit/actions/account.test.ts
+++ b/__tests__/unit/actions/account.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { APIError } from "better-auth";
 import { mockCustomerSession } from "../../helpers/mocks";
 
 const mocks = vi.hoisted(() => ({
@@ -103,7 +104,11 @@ describe("changePassword", () => {
   });
 
   it("retourne une erreur si le mot de passe actuel est incorrect", async () => {
-    mocks.changePasswordApi.mockRejectedValue(new Error("Invalid"));
+    // Forme réelle levée par better-auth (update-user.mjs) avant toute
+    // écriture — APIError.from("BAD_REQUEST", BASE_ERROR_CODES.INVALID_PASSWORD).
+    mocks.changePasswordApi.mockRejectedValue(
+      new APIError("BAD_REQUEST", { code: "INVALID_PASSWORD", message: "Invalid password" })
+    );
     const result = await changePassword({
       currentPassword: "mauvais",
       newPassword: "nouveau123",
@@ -111,6 +116,49 @@ describe("changePassword", () => {
     });
     expect(result.success).toBe(false);
     expect(result.error).toContain("Mot de passe actuel incorrect");
+  });
+
+  it("ne signale pas « mot de passe incorrect » quand l'échec survient après l'écriture du nouveau mot de passe", async () => {
+    // revokeOtherSessions:true fait tourner deleteUserSessions puis
+    // createSession APRÈS que le nouveau hash a été écrit (update-user.mjs) :
+    // une erreur ici (D1 transitoire, hook admin qui échoue) ne doit jamais
+    // être confondue avec l'échec de vérification du mot de passe actuel.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.changePasswordApi.mockRejectedValue(
+      new APIError("INTERNAL_SERVER_ERROR", { code: "FAILED_TO_GET_SESSION" })
+    );
+
+    const result = await changePassword({
+      currentPassword: "ancien123",
+      newPassword: "nouveau123",
+      confirmPassword: "nouveau123",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).not.toContain("Mot de passe actuel incorrect");
+    expect(result.error).toMatch(/nouveau mot de passe/i);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[changePassword]"),
+      expect.anything()
+    );
+
+    errorSpy.mockRestore();
+  });
+
+  it("ne signale pas « mot de passe incorrect » pour une erreur qui n'est pas une APIError", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.changePasswordApi.mockRejectedValue(new Error("D1 transient failure"));
+
+    const result = await changePassword({
+      currentPassword: "ancien123",
+      newPassword: "nouveau123",
+      confirmPassword: "nouveau123",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).not.toContain("Mot de passe actuel incorrect");
+
+    errorSpy.mockRestore();
   });
 
   it("révoque les autres sessions de l'utilisateur", async () => {

--- a/__tests__/unit/admin-page-guards.test.ts
+++ b/__tests__/unit/admin-page-guards.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const PII_PAGES = [
+  "app/(admin)/dashboard/page.tsx",
+  "app/(admin)/orders/page.tsx",
+  "app/(admin)/orders/[id]/page.tsx",
+  "app/(admin)/orders/[id]/invoice/page.tsx",
+  "app/(admin)/customers/page.tsx",
+];
+
+describe("admin pages exposing customer data", () => {
+  it.each(PII_PAGES)("%s calls requireAdmin()", (page) => {
+    const source = readFileSync(resolve(__dirname, "../..", page), "utf8");
+    expect(source).toMatch(/requireAdmin\s*\(/);
+  });
+});

--- a/__tests__/unit/auth-config.test.ts
+++ b/__tests__/unit/auth-config.test.ts
@@ -35,6 +35,16 @@ describe("auth configuration — account linking", () => {
   });
 });
 
+describe("auth configuration — password reset", () => {
+  it("revokes every other session when a user resets their password via OTP", () => {
+    // Without this, resetPasswordEmailOTP (email-otp/routes.mjs) writes the
+    // new hash but never calls deleteUserSessions — an attacker's session
+    // would survive the very recovery step meant to end it.
+    const opts = buildAuthOptions(env);
+    expect(opts.emailAndPassword?.revokeSessionsOnPasswordReset).toBe(true);
+  });
+});
+
 describe("auth configuration — rate limiting", () => {
   it("derives the client IP from Cloudflare's trusted header, not X-Forwarded-For", () => {
     const opts = buildAuthOptions(env);

--- a/__tests__/unit/auth-guards.test.ts
+++ b/__tests__/unit/auth-guards.test.ts
@@ -6,6 +6,8 @@ import {
   mockAgentSession,
   mockBannedAdminSession,
   mockExpiredBanAdminSession,
+  mockBannedCustomerSession,
+  mockExpiredBanCustomerSession,
 } from "../helpers/mocks";
 
 const mocks = vi.hoisted(() => ({
@@ -38,6 +40,18 @@ describe("requireAuth", () => {
     mocks.getSession.mockResolvedValue(null);
     await expect(requireAuth()).rejects.toThrow("NEXT_REDIRECT");
     expect(mocks.redirect).toHaveBeenCalledWith("/auth/sign-in");
+  });
+
+  it("redirige vers / pour un client activement banni", async () => {
+    mocks.getSession.mockResolvedValue(mockBannedCustomerSession);
+    await expect(requireAuth()).rejects.toThrow("NEXT_REDIRECT");
+    expect(mocks.redirect).toHaveBeenCalledWith("/");
+  });
+
+  it("ne bloque pas un client dont le bannissement a expiré", async () => {
+    mocks.getSession.mockResolvedValue(mockExpiredBanCustomerSession);
+    const session = await requireAuth();
+    expect(session).toEqual(mockExpiredBanCustomerSession);
   });
 });
 

--- a/__tests__/unit/auth-guards.test.ts
+++ b/__tests__/unit/auth-guards.test.ts
@@ -8,6 +8,7 @@ import {
   mockExpiredBanAdminSession,
   mockBannedCustomerSession,
   mockExpiredBanCustomerSession,
+  mockExpiredBanCustomerSessionFromCache,
 } from "../helpers/mocks";
 
 const mocks = vi.hoisted(() => ({
@@ -52,6 +53,17 @@ describe("requireAuth", () => {
     mocks.getSession.mockResolvedValue(mockExpiredBanCustomerSession);
     const session = await requireAuth();
     expect(session).toEqual(mockExpiredBanCustomerSession);
+  });
+
+  // requireAuth reads the cookie-cache branch of getSession, where banExpires
+  // comes back as an ISO string (not a Date — see the fixture's comment in
+  // __tests__/helpers/mocks.ts). This is the actual runtime shape on the
+  // storefront's hot path, distinct from the Date shape the privileged
+  // guards' fresh D1 reads receive.
+  it("ne bloque pas un client dont le bannissement a expiré (forme cache : banExpires en chaîne ISO)", async () => {
+    mocks.getSession.mockResolvedValue(mockExpiredBanCustomerSessionFromCache);
+    const session = await requireAuth();
+    expect(session).toEqual(mockExpiredBanCustomerSessionFromCache);
   });
 });
 

--- a/__tests__/unit/auth-guards.test.ts
+++ b/__tests__/unit/auth-guards.test.ts
@@ -250,4 +250,14 @@ describe("privileged guards bypass the session cookie cache", () => {
 
     expect(session.user.role).toBe("admin");
   });
+
+  it("rejects an admin whose ban has not expired yet (banExpires in the future)", async () => {
+    mocks.getSession.mockResolvedValue({
+      ...mockAdminSession,
+      user: { ...mockAdminSession.user, banned: true, banExpires: new Date(Date.now() + 60_000) },
+    });
+
+    await expect(requireAdmin()).rejects.toThrow("NEXT_REDIRECT");
+    expect(mocks.redirect).toHaveBeenCalledWith("/");
+  });
 });

--- a/__tests__/unit/auth-guards.test.ts
+++ b/__tests__/unit/auth-guards.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { mockCustomerSession, mockAdminSession, mockSuperAdminSession, mockAgentSession } from "../helpers/mocks";
+import {
+  mockCustomerSession,
+  mockAdminSession,
+  mockSuperAdminSession,
+  mockAgentSession,
+  mockBannedAdminSession,
+  mockExpiredBanAdminSession,
+} from "../helpers/mocks";
 
 const mocks = vi.hoisted(() => ({
   getSession: vi.fn(),
@@ -164,5 +171,83 @@ describe("requireSuperAdmin", () => {
     mocks.getSession.mockResolvedValue(null);
     await expect(requireSuperAdmin()).rejects.toThrow("NEXT_REDIRECT");
     expect(mocks.redirect).toHaveBeenCalledWith("/auth/sign-in");
+  });
+});
+
+describe("privileged guards bypass the session cookie cache", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("requireAdmin reads session state fresh", async () => {
+    mocks.getSession.mockResolvedValue(mockAdminSession);
+
+    await requireAdmin();
+
+    expect(mocks.getSession).toHaveBeenCalledWith(
+      expect.objectContaining({ query: { disableCookieCache: true } })
+    );
+  });
+
+  it("requireSuperAdmin reads session state fresh", async () => {
+    mocks.getSession.mockResolvedValue(mockSuperAdminSession);
+
+    await requireSuperAdmin();
+
+    expect(mocks.getSession).toHaveBeenCalledWith(
+      expect.objectContaining({ query: { disableCookieCache: true } })
+    );
+  });
+
+  it("requireAnyAdmin reads session state fresh", async () => {
+    mocks.getSession.mockResolvedValue(mockAgentSession);
+
+    await requireAnyAdmin();
+
+    expect(mocks.getSession).toHaveBeenCalledWith(
+      expect.objectContaining({ query: { disableCookieCache: true } })
+    );
+  });
+
+  it("requireAuth keeps using the cookie cache (storefront perf path is untouched)", async () => {
+    mocks.getSession.mockResolvedValue(mockCustomerSession);
+
+    await requireAuth();
+
+    const call = mocks.getSession.mock.calls[0][0];
+    expect(call).not.toHaveProperty("query");
+  });
+
+  it("rejects a banned admin even when the session says role=admin", async () => {
+    mocks.getSession.mockResolvedValue(mockBannedAdminSession);
+
+    await expect(requireAdmin()).rejects.toThrow("NEXT_REDIRECT");
+    expect(mocks.redirect).toHaveBeenCalledWith("/");
+  });
+
+  it("rejects a banned super_admin", async () => {
+    mocks.getSession.mockResolvedValue({
+      ...mockSuperAdminSession,
+      user: { ...mockSuperAdminSession.user, banned: true, banExpires: null },
+    });
+
+    await expect(requireSuperAdmin()).rejects.toThrow("NEXT_REDIRECT");
+    expect(mocks.redirect).toHaveBeenCalledWith("/");
+  });
+
+  it("rejects a banned staff member via requireAnyAdmin", async () => {
+    mocks.getSession.mockResolvedValue({
+      ...mockAgentSession,
+      user: { ...mockAgentSession.user, banned: true, banExpires: null },
+    });
+
+    await expect(requireAnyAdmin()).rejects.toThrow("NEXT_REDIRECT");
+    expect(mocks.redirect).toHaveBeenCalledWith("/");
+  });
+
+  it("does not lock out an admin whose ban already expired", async () => {
+    mocks.getSession.mockResolvedValue(mockExpiredBanAdminSession);
+
+    const session = await requireAdmin();
+
+    expect(session.user.role).toBe("admin");
   });
 });

--- a/__tests__/unit/auth-roles.test.ts
+++ b/__tests__/unit/auth-roles.test.ts
@@ -37,6 +37,22 @@ describe("role access control", () => {
     expect(userPerms).toContain("ban");
   });
 
+  // list-user-sessions / revoke-user-session / revoke-user-sessions
+  // (admin.mjs routes.mjs) let the holder enumerate and revoke ANY user's
+  // sessions, including a super_admin's — staff-management, not customer
+  // moderation. Reserved for super_admin like the other staff-only grants.
+  it("does not let the admin role list or revoke sessions", () => {
+    const sessionPerms = adminRole.statements.session ?? [];
+    expect(sessionPerms).not.toContain("list");
+    expect(sessionPerms).not.toContain("revoke");
+  });
+
+  it("reserves session list/revoke for super_admin", () => {
+    const sessionPerms = superAdminRole.statements.session ?? [];
+    expect(sessionPerms).toContain("list");
+    expect(sessionPerms).toContain("revoke");
+  });
+
   // The vulnerable state was never a bad role object — adminRole/superAdminRole
   // above can both be correct while the plugin config still wires the wrong
   // one to "admin" (e.g. `admin: superAdminRole`). This pins the wiring

--- a/__tests__/unit/auth-roles.test.ts
+++ b/__tests__/unit/auth-roles.test.ts
@@ -1,5 +1,17 @@
 import { describe, it, expect } from "vitest";
-import { adminRole, superAdminRole } from "@/lib/auth/index";
+import { adminRole, superAdminRole, buildAuthOptions } from "@/lib/auth/index";
+
+const env = {
+  BETTER_AUTH_SECRET: "test-secret",
+  SITE_URL: "https://netereka.ci",
+  TURNSTILE_SECRET_KEY: "test-turnstile",
+  GOOGLE_CLIENT_ID: "g",
+  GOOGLE_CLIENT_SECRET: "g",
+  FACEBOOK_APP_ID: "f",
+  FACEBOOK_APP_SECRET: "f",
+  APPLE_CLIENT_ID: "a",
+  APPLE_CLIENT_SECRET: "a",
+} as never;
 
 describe("role access control", () => {
   it("does not let the admin role change roles", () => {
@@ -23,5 +35,22 @@ describe("role access control", () => {
     const userPerms = adminRole.statements.user ?? [];
     expect(userPerms).toContain("list");
     expect(userPerms).toContain("ban");
+  });
+
+  // The vulnerable state was never a bad role object — adminRole/superAdminRole
+  // above can both be correct while the plugin config still wires the wrong
+  // one to "admin" (e.g. `admin: superAdminRole`). This pins the wiring
+  // itself: admin.mjs (better-auth 1.6.25) returns the plugin's original
+  // options object verbatim as `options` on the returned plugin, so the
+  // exact role instances passed into admin({ roles: {...} }) are readable
+  // back out and compared by reference — the same pattern
+  // auth-config.test.ts uses for the captcha plugin's `endpoints` option.
+  it("wires the reduced role to admin and the full role to super_admin in the plugin config", () => {
+    const opts = buildAuthOptions(env);
+    const adminPlugin = opts.plugins?.find((p) => p.id === "admin");
+    const roles = (adminPlugin as { options?: { roles?: Record<string, unknown> } })?.options?.roles;
+
+    expect(roles?.admin).toBe(adminRole);
+    expect(roles?.super_admin).toBe(superAdminRole);
   });
 });

--- a/__tests__/unit/auth-roles.test.ts
+++ b/__tests__/unit/auth-roles.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { adminRole, superAdminRole } from "@/lib/auth/index";
+
+describe("role access control", () => {
+  it("does not let the admin role change roles", () => {
+    expect(adminRole.statements.user ?? []).not.toContain("set-role");
+  });
+
+  it("does not let the admin role set passwords, delete or impersonate users", () => {
+    const userPerms = adminRole.statements.user ?? [];
+    expect(userPerms).not.toContain("set-password");
+    expect(userPerms).not.toContain("delete");
+    expect(userPerms).not.toContain("impersonate");
+  });
+
+  it("reserves those capabilities for super_admin", () => {
+    const userPerms = superAdminRole.statements.user ?? [];
+    expect(userPerms).toContain("set-role");
+    expect(userPerms).toContain("set-password");
+  });
+
+  it("still lets admin ban and list users", () => {
+    const userPerms = adminRole.statements.user ?? [];
+    expect(userPerms).toContain("list");
+    expect(userPerms).toContain("ban");
+  });
+});

--- a/actions/account.ts
+++ b/actions/account.ts
@@ -1,7 +1,8 @@
 "use server";
 
-import { headers } from "next/headers";
+import { cookies, headers } from "next/headers";
 import { revalidatePath } from "next/cache";
+import { parseSetCookieHeader, toCookieOptions } from "better-auth/cookies";
 import { requireAuth } from "@/lib/auth/guards";
 import { initAuth } from "@/lib/auth";
 import { profileSchema, changePasswordSchema, type ProfileInput, type ChangePasswordInput } from "@/lib/validations/account";
@@ -46,13 +47,32 @@ export async function changePassword(input: ChangePasswordInput): Promise<Action
 
   try {
     const auth = await initAuth();
-    await auth.api.changePassword({
+    const { headers: responseHeaders } = await auth.api.changePassword({
       headers: await headers(),
       body: {
         currentPassword: parsed.data.currentPassword,
         newPassword: parsed.data.newPassword,
+        // Changer son mot de passe est le geste de reprise de contrôle après
+        // compromission : laisser les autres sessions actives le vide de sens.
+        revokeOtherSessions: true,
       },
+      returnHeaders: true,
     });
+
+    // revokeOtherSessions rotates every session for the user, including the
+    // caller's, and better-auth reissues a fresh one on responseHeaders. This
+    // app has no nextCookies plugin to forward that Set-Cookie automatically,
+    // so without this the browser that just changed its password would keep
+    // pointing at a session row that no longer exists and get signed out on
+    // the next cache-bypassing check — apply it the same way nextCookies does.
+    const setCookieHeader = responseHeaders.get("set-cookie");
+    if (setCookieHeader) {
+      const cookieStore = await cookies();
+      parseSetCookieHeader(setCookieHeader).forEach((value, key) => {
+        if (!key) return;
+        cookieStore.set(key, value.value, toCookieOptions(value));
+      });
+    }
   } catch {
     return { success: false, error: "Mot de passe actuel incorrect" };
   }

--- a/actions/account.ts
+++ b/actions/account.ts
@@ -45,9 +45,10 @@ export async function changePassword(input: ChangePasswordInput): Promise<Action
     };
   }
 
+  const auth = await initAuth();
+  let responseHeaders: Headers;
   try {
-    const auth = await initAuth();
-    const { headers: responseHeaders } = await auth.api.changePassword({
+    ({ headers: responseHeaders } = await auth.api.changePassword({
       headers: await headers(),
       body: {
         currentPassword: parsed.data.currentPassword,
@@ -57,24 +58,45 @@ export async function changePassword(input: ChangePasswordInput): Promise<Action
         revokeOtherSessions: true,
       },
       returnHeaders: true,
-    });
+    }));
+  } catch {
+    return { success: false, error: "Mot de passe actuel incorrect" };
+  }
 
-    // revokeOtherSessions rotates every session for the user, including the
-    // caller's, and better-auth reissues a fresh one on responseHeaders. This
-    // app has no nextCookies plugin to forward that Set-Cookie automatically,
-    // so without this the browser that just changed its password would keep
-    // pointing at a session row that no longer exists and get signed out on
-    // the next cache-bypassing check — apply it the same way nextCookies does.
-    const setCookieHeader = responseHeaders.get("set-cookie");
-    if (setCookieHeader) {
+  // À partir d'ici, le mot de passe a déjà été changé et toutes les sessions
+  // ont déjà été supprimées côté serveur : revokeOtherSessions fait tourner
+  // TOUTES les sessions de l'utilisateur, y compris celle de l'appelant, et
+  // better-auth en réémet une nouvelle via responseHeaders. Une erreur dans
+  // ce qui suit ne doit donc jamais être signalée comme « mot de passe
+  // incorrect » — ce serait faire croire à l'appelant que rien ne s'est
+  // passé, alors que son mot de passe a changé et que sa session a été
+  // révoquée.
+  const setCookieHeader = responseHeaders.get("set-cookie");
+  if (setCookieHeader) {
+    try {
       const cookieStore = await cookies();
       parseSetCookieHeader(setCookieHeader).forEach((value, key) => {
         if (!key) return;
         cookieStore.set(key, value.value, toCookieOptions(value));
       });
+    } catch (error) {
+      // Même posture que le plugin nextCookies() en amont : Next.js lève une
+      // exception depuis ResponseCookies.set en dehors d'un contexte de
+      // mutation autorisé. Le changement de mot de passe et la rotation de
+      // session ont déjà réussi côté serveur ; échouer à rejouer le nouveau
+      // cookie ici ne doit pas être remonté comme un échec, mais cela laisse
+      // le navigateur de l'appelant pointer vers une session morte — journaliser
+      // pour que ce ne soit pas invisible.
+      console.error("[changePassword] échec de réapplication du cookie de session", error);
     }
-  } catch {
-    return { success: false, error: "Mot de passe actuel incorrect" };
+  } else {
+    // revokeOtherSessions est désormais toujours à true, donc l'endpoint
+    // better-auth appelle toujours setSessionCookie : l'absence d'un
+    // set-cookie signifie que la rotation n'a pas été exposée et que le
+    // cookie de l'appelant pointe maintenant vers une session supprimée.
+    // Pas fatal (le changement de mot de passe a bien réussi), mais ne doit
+    // pas rester silencieux.
+    console.warn("[changePassword] revokeOtherSessions n'a produit aucun set-cookie à réappliquer");
   }
 
   return { success: true };

--- a/actions/account.ts
+++ b/actions/account.ts
@@ -101,14 +101,23 @@ export async function changePassword(input: ChangePasswordInput): Promise<Action
   // incorrect » — ce serait faire croire à l'appelant que rien ne s'est
   // passé, alors que son mot de passe a changé et que sa session a été
   // révoquée.
-  const setCookieHeader = responseHeaders.get("set-cookie");
-  if (setCookieHeader) {
+  // cookieCache is enabled (lib/auth/index.ts), so a session rotation emits
+  // TWO separate Set-Cookie headers (session_token + session_data).
+  // Headers.get("set-cookie") joins multi-value headers with ", " per the
+  // Fetch spec, leaving parseSetCookieHeader to split that string back apart
+  // heuristically. Headers.getSetCookie() is the WHATWG-standard API that
+  // returns each Set-Cookie header as its own entry — read through it instead
+  // so replaying the rotation never depends on a comma-splitting heuristic.
+  const setCookies = responseHeaders.getSetCookie();
+  if (setCookies.length > 0) {
     try {
       const cookieStore = await cookies();
-      parseSetCookieHeader(setCookieHeader).forEach((value, key) => {
-        if (!key) return;
-        cookieStore.set(key, value.value, toCookieOptions(value));
-      });
+      for (const setCookie of setCookies) {
+        parseSetCookieHeader(setCookie).forEach((value, key) => {
+          if (!key) return;
+          cookieStore.set(key, value.value, toCookieOptions(value));
+        });
+      }
     } catch (error) {
       // Même posture que le plugin nextCookies() en amont : Next.js lève une
       // exception depuis ResponseCookies.set en dehors d'un contexte de

--- a/actions/account.ts
+++ b/actions/account.ts
@@ -3,10 +3,27 @@
 import { cookies, headers } from "next/headers";
 import { revalidatePath } from "next/cache";
 import { parseSetCookieHeader, toCookieOptions } from "better-auth/cookies";
+import { APIError } from "better-auth";
 import { requireAuth } from "@/lib/auth/guards";
 import { initAuth } from "@/lib/auth";
 import { profileSchema, changePasswordSchema, type ProfileInput, type ChangePasswordInput } from "@/lib/validations/account";
 import type { ActionResult } from "@/lib/types/actions";
+
+// better-auth's /change-password handler (update-user.mjs) throws this exact
+// shape — APIError with status "BAD_REQUEST" and body.code "INVALID_PASSWORD"
+// — only from the current-password verify step, which runs BEFORE the new
+// hash is written. Every other failure in that handler (including
+// deleteUserSessions/createSession, which run AFTER the write when
+// revokeOtherSessions is set) is a different code, a different status, or not
+// an APIError at all — so only this exact match may be reported to the user
+// as "your current password was wrong".
+function isInvalidCurrentPasswordError(error: unknown): boolean {
+  return (
+    error instanceof APIError &&
+    error.status === "BAD_REQUEST" &&
+    error.body?.code === "INVALID_PASSWORD"
+  );
+}
 
 export async function updateProfile(input: ProfileInput): Promise<ActionResult> {
   await requireAuth();
@@ -59,8 +76,21 @@ export async function changePassword(input: ChangePasswordInput): Promise<Action
       },
       returnHeaders: true,
     }));
-  } catch {
-    return { success: false, error: "Mot de passe actuel incorrect" };
+  } catch (error) {
+    if (isInvalidCurrentPasswordError(error)) {
+      return { success: false, error: "Mot de passe actuel incorrect" };
+    }
+    // Anything else here happened after the new hash was already persisted
+    // (revokeOtherSessions:true runs deleteUserSessions then createSession
+    // after that write — a transient D1 error or a session.create.before hook
+    // throwing lands here too). Reporting "mot de passe incorrect" would tell
+    // the caller nothing changed, when in fact their password did.
+    console.error("[changePassword] échec après l'écriture du nouveau mot de passe", error);
+    return {
+      success: false,
+      error:
+        "Une erreur est survenue après la mise à jour de votre mot de passe. Réessayez de vous connecter avec le nouveau mot de passe.",
+    };
   }
 
   // À partir d'ici, le mot de passe a déjà été changé et toutes les sessions

--- a/app/(admin)/ai-settings/page.tsx
+++ b/app/(admin)/ai-settings/page.tsx
@@ -1,3 +1,4 @@
+// Guard: no requireAdmin() on this page — getAiConfig() (actions/admin/ai-config.ts) calls it.
 import { getAiConfig } from "@/actions/admin/ai-config";
 import { AiConfigForm } from "@/components/admin/ai/ai-config-form";
 

--- a/app/(admin)/customers/page.tsx
+++ b/app/(admin)/customers/page.tsx
@@ -8,6 +8,7 @@ import {
   getAdminCustomers,
   getAdminCustomerCount,
 } from "@/lib/db/admin/customers";
+import { requireAdmin } from "@/lib/auth/guards";
 
 interface Props {
   searchParams: Promise<{
@@ -21,6 +22,8 @@ interface Props {
 const PAGE_SIZE = 20;
 
 export default async function CustomersPage({ searchParams }: Props) {
+  await requireAdmin();
+
   const params = await searchParams;
   const requestedPage = Math.max(1, Number(params.page) || 1);
 

--- a/app/(admin)/dashboard/page.tsx
+++ b/app/(admin)/dashboard/page.tsx
@@ -2,8 +2,11 @@ import { getDashboardStats } from "@/lib/db/admin/dashboard";
 import { AdminHeader } from "@/components/admin/admin-header";
 import { AdminPageHeader } from "@/components/admin/admin-page-header";
 import { StatsCard } from "@/components/admin/stats-card";
+import { requireAdmin } from "@/lib/auth/guards";
 
 export default async function DashboardPage() {
+  await requireAdmin();
+
   const stats = await getDashboardStats();
 
   return (

--- a/app/(admin)/orders/[id]/invoice/page.tsx
+++ b/app/(admin)/orders/[id]/invoice/page.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { getAdminOrderById } from "@/lib/db/admin/orders";
 import { formatPrice } from "@/lib/utils";
 import { InvoicePrintButton } from "./print-button";
+import { requireAdmin } from "@/lib/auth/guards";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -20,6 +21,8 @@ function formatDate(dateStr: string): string {
 }
 
 export default async function InvoicePage({ params }: Props) {
+  await requireAdmin();
+
   const { id } = await params;
   const order = await getAdminOrderById(id);
 

--- a/app/(admin)/orders/[id]/page.tsx
+++ b/app/(admin)/orders/[id]/page.tsx
@@ -8,6 +8,7 @@ import { AdminPageHeader } from "@/components/admin/admin-page-header";
 import { getAdminOrderById } from "@/lib/db/admin/orders";
 import { OrderMainContent } from "./_components/order-main-content";
 import { OrderSidebarAsync, OrderSidebarSkeleton } from "./_components/order-sidebar";
+import { requireAdmin } from "@/lib/auth/guards";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -17,6 +18,8 @@ interface Props {
 const backIcon = <HugeiconsIcon icon={ArrowLeft02Icon} size={20} />;
 
 export default async function OrderDetailPage({ params }: Props) {
+  await requireAdmin();
+
   const { id } = await params;
   const order = await getAdminOrderById(id);
 

--- a/app/(admin)/orders/page.tsx
+++ b/app/(admin)/orders/page.tsx
@@ -10,6 +10,7 @@ import {
   getDistinctCommunes,
 } from "@/lib/db/admin/orders";
 import type { OrderListItem } from "@/lib/db/types";
+import { requireAdmin } from "@/lib/auth/guards";
 
 interface Props {
   searchParams: Promise<{
@@ -25,6 +26,8 @@ interface Props {
 const PAGE_SIZE = 20;
 
 export default async function OrdersPage({ searchParams }: Props) {
+  await requireAdmin();
+
   const params = await searchParams;
   const page = Math.max(1, Number(params.page) || 1);
   const filters = {

--- a/app/(admin)/whatsapp/analytics/page.tsx
+++ b/app/(admin)/whatsapp/analytics/page.tsx
@@ -1,3 +1,4 @@
+// Guard: no requireAdmin() on this page — getWhatsAppStats() (actions/admin/whatsapp.ts) calls it.
 import { getWhatsAppStats } from "@/actions/admin/whatsapp";
 import { WhatsAppAnalytics } from "@/components/admin/whatsapp/whatsapp-analytics";
 

--- a/app/(admin)/whatsapp/conversations/[id]/page.tsx
+++ b/app/(admin)/whatsapp/conversations/[id]/page.tsx
@@ -1,3 +1,4 @@
+// Guard: no requireAdmin() on this page — getConversationMessages() (actions/admin/whatsapp.ts) calls it.
 import { getConversationMessages } from "@/actions/admin/whatsapp";
 import { ConversationDetail } from "@/components/admin/whatsapp/conversation-detail";
 import { notFound } from "next/navigation";

--- a/app/(admin)/whatsapp/conversations/page.tsx
+++ b/app/(admin)/whatsapp/conversations/page.tsx
@@ -1,3 +1,4 @@
+// Guard: no requireAdmin() on this page — getConversations() (actions/admin/whatsapp.ts) calls it.
 import Link from "next/link";
 import { AdminHeader } from "@/components/admin/admin-header";
 import { AdminPageHeader } from "@/components/admin/admin-page-header";

--- a/app/(admin)/whatsapp/settings/page.tsx
+++ b/app/(admin)/whatsapp/settings/page.tsx
@@ -1,3 +1,4 @@
+// Guard: no requireAdmin() on this page — getWhatsAppConfig() (actions/admin/whatsapp.ts) calls it.
 import { getWhatsAppConfig } from "@/actions/admin/whatsapp";
 import { WhatsAppConfigForm } from "@/components/admin/whatsapp/whatsapp-config-form";
 

--- a/lib/auth/guards.ts
+++ b/lib/auth/guards.ts
@@ -99,6 +99,10 @@ export async function requireSuperAdmin(): Promise<SuperAdminSession> {
   return session as SuperAdminSession;
 }
 
+// Deliberately does not check isActivelyBanned(): this only gates *guest-only*
+// pages (redirects an authenticated caller away). A banned user is still an
+// authenticated user for this purpose. If a caller ever needs "authenticated
+// and not banned", use requireAuth() instead of this function.
 export async function requireGuest(): Promise<void> {
   const auth = await initAuth();
   const session = await auth.api.getSession({
@@ -107,6 +111,10 @@ export async function requireGuest(): Promise<void> {
   if (session) redirect("/");
 }
 
+// Deliberately does not check isActivelyBanned(): this returns whatever
+// session exists, banned or not, for callers that only need to know who (if
+// anyone) is signed in. A caller that needs "authenticated and not banned"
+// must check isActivelyBanned() itself or use requireAuth() instead.
 export async function getOptionalSession(): Promise<Session | null> {
   const auth = await initAuth();
   const session = await auth.api.getSession({

--- a/lib/auth/guards.ts
+++ b/lib/auth/guards.ts
@@ -24,17 +24,13 @@ export async function requireAuth(): Promise<Session> {
   return session as Session;
 }
 
-// Privileged guards cannot accept the signed session cookie at face value:
-// session.cookieCache (lib/auth/index.ts) is enabled with a 5-minute
-// lifetime so ordinary storefront requests skip a D1 round trip. A ban or
-// role change made from the admin UI does not invalidate that cookie, so
-// requireAuth()'s cached read could keep authorizing a revoked principal
-// for up to 300s. `query: { disableCookieCache: true }` makes better-auth's
-// /get-session handler skip its cache branch and re-read session + user
-// from D1 (better-auth/dist/api/routes/session.mjs), so a revocation is
-// enforced on the very next admin request. This intentionally bypasses
-// requireAuth() rather than calling it, so the storefront's cache-backed
-// path is untouched.
+// Privileged guards require an authoritative read of session state rather
+// than the signed cookie's last-known snapshot, so a ban or role change is
+// enforced starting with the very next admin request. `disableCookieCache`
+// makes better-auth's /get-session handler skip its cache branch and
+// re-read session + user from D1 (better-auth/dist/api/routes/session.mjs).
+// This intentionally bypasses requireAuth() rather than calling it, so the
+// storefront keeps its existing cache-backed read path.
 async function getFreshSession() {
   const auth = await initAuth();
   return auth.api.getSession({
@@ -47,7 +43,7 @@ async function getFreshSession() {
 // session is created (sign-in) — an already-open session that reads as
 // banned:true keeps that value forever unless banExpires has since passed,
 // in which case it should no longer block access here.
-function isActivelyBanned(user: { banned?: boolean | null; banExpires?: Date | null }): boolean {
+function isActivelyBanned(user: Pick<Session["user"], "banned" | "banExpires">): boolean {
   if (!user.banned) return false;
   if (!user.banExpires) return true;
   return new Date(user.banExpires).getTime() > Date.now();

--- a/lib/auth/guards.ts
+++ b/lib/auth/guards.ts
@@ -24,8 +24,39 @@ export async function requireAuth(): Promise<Session> {
   return session as Session;
 }
 
+// Privileged guards cannot accept the signed session cookie at face value:
+// session.cookieCache (lib/auth/index.ts) is enabled with a 5-minute
+// lifetime so ordinary storefront requests skip a D1 round trip. A ban or
+// role change made from the admin UI does not invalidate that cookie, so
+// requireAuth()'s cached read could keep authorizing a revoked principal
+// for up to 300s. `query: { disableCookieCache: true }` makes better-auth's
+// /get-session handler skip its cache branch and re-read session + user
+// from D1 (better-auth/dist/api/routes/session.mjs), so a revocation is
+// enforced on the very next admin request. This intentionally bypasses
+// requireAuth() rather than calling it, so the storefront's cache-backed
+// path is untouched.
+async function getFreshSession() {
+  const auth = await initAuth();
+  return auth.api.getSession({
+    headers: await headers(),
+    query: { disableCookieCache: true },
+  });
+}
+
+// better-auth's admin plugin only clears an expired ban when a *new*
+// session is created (sign-in) — an already-open session that reads as
+// banned:true keeps that value forever unless banExpires has since passed,
+// in which case it should no longer block access here.
+function isActivelyBanned(user: { banned?: boolean | null; banExpires?: Date | null }): boolean {
+  if (!user.banned) return false;
+  if (!user.banExpires) return true;
+  return new Date(user.banExpires).getTime() > Date.now();
+}
+
 export async function requireAnyAdmin(): Promise<AnyAdminSession> {
-  const session = await requireAuth();
+  const session = await getFreshSession();
+  if (!session) redirect("/auth/sign-in");
+  if (isActivelyBanned(session.user)) redirect("/");
   const role = session.user.role;
   if (role !== "agent" && role !== "admin" && role !== "super_admin") {
     redirect("/");
@@ -34,14 +65,18 @@ export async function requireAnyAdmin(): Promise<AnyAdminSession> {
 }
 
 export async function requireAdmin(): Promise<AdminSession> {
-  const session = await requireAuth();
+  const session = await getFreshSession();
+  if (!session) redirect("/auth/sign-in");
+  if (isActivelyBanned(session.user)) redirect("/");
   const role = session.user.role;
   if (role !== "admin" && role !== "super_admin") redirect("/");
   return session as AdminSession;
 }
 
 export async function requireSuperAdmin(): Promise<SuperAdminSession> {
-  const session = await requireAuth();
+  const session = await getFreshSession();
+  if (!session) redirect("/auth/sign-in");
+  if (isActivelyBanned(session.user)) redirect("/");
   if (session.user.role !== "super_admin") redirect("/");
   return session as SuperAdminSession;
 }

--- a/lib/auth/guards.ts
+++ b/lib/auth/guards.ts
@@ -51,7 +51,21 @@ async function getFreshSession() {
 // session is created (sign-in) — an already-open session that reads as
 // banned:true keeps that value forever unless banExpires has since passed,
 // in which case it should no longer block access here.
-function isActivelyBanned(user: Pick<Session["user"], "banned" | "banExpires">): boolean {
+//
+// `banExpires` is typed `Date | string | null` rather than following
+// `Session["user"]["banExpires"]` (which better-auth types as `Date`)
+// because that type only holds on a fresh D1 read. requireAuth's normal
+// path reads the session-cache cookie instead: better-auth's cache-hit
+// branch (better-auth/dist/api/routes/session.mjs) re-hydrates only
+// `createdAt`/`updatedAt` into `Date`s when it deserialises the cached
+// payload — `banExpires` comes straight out of `JSON.parse` as an ISO
+// string (or null). `new Date(...)` normalizes either shape, so behavior
+// is correct either way, but the annotation must say so or it lies about
+// what a caller on the cache path actually receives.
+function isActivelyBanned(user: {
+  banned?: Session["user"]["banned"];
+  banExpires?: Date | string | null;
+}): boolean {
   if (!user.banned) return false;
   if (!user.banExpires) return true;
   return new Date(user.banExpires).getTime() > Date.now();

--- a/lib/auth/guards.ts
+++ b/lib/auth/guards.ts
@@ -21,6 +21,14 @@ export async function requireAuth(): Promise<Session> {
     headers: await headers(),
   });
   if (!session) redirect("/auth/sign-in");
+  // Storefront read stays on the cache-backed path (no `query` key — see the
+  // dedicated test pinning this) rather than paying a D1 read on every
+  // authenticated request. That cached cookie payload already carries
+  // `banned`/`banExpires` (better-auth's admin plugin declares them without
+  // `returned: false`, so the cache-write and cache-read parsers both keep
+  // them), so this check is free: it enforces a ban within the cache's
+  // configured TTL instead of forcing a fresh read on the storefront.
+  if (isActivelyBanned(session.user)) redirect("/");
   return session as Session;
 }
 

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -32,10 +32,17 @@ export const superAdminRole = ac.newRole({
 
 // admin manages the storefront and can moderate customers (ban/list), but
 // not staff accounts — set-role, set-password, delete and impersonate stay
-// with super_admin (see above).
+// with super_admin (see above). Session management (list-user-sessions,
+// revoke-user-session, revoke-user-sessions — admin.mjs routes.mjs) is also
+// staff-management: those endpoints let the holder enumerate and revoke ANY
+// user's sessions, including a super_admin's. No app code calls them
+// (grepped actions/, lib/, app/, components/, workers/ for
+// revokeUserSession(s)/listUserSessions/listSessions/revokeSession — only
+// hit is the unrelated revokeSessionsOnPasswordReset flag below), so admin
+// keeps none of the session statements; they stay with super_admin.
 export const adminRole = ac.newRole({
   user: ["create", "list", "ban"],
-  session: ["list", "revoke"],
+  session: [],
 });
 
 const noPermsRole = ac.newRole({ user: [], session: [] });

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -15,7 +15,27 @@ const adminStatements = {
   session: ["list", "revoke", "delete"],
 } as const;
 const ac = createAccessControl(adminStatements);
-const staffRole = ac.newRole({ user: [...adminStatements.user], session: [...adminStatements.session] });
+
+// super_admin keeps the full staff-management set: it is the only role
+// allowed to change roles, set passwords, delete accounts or impersonate —
+// capabilities that must never be reachable through the raw
+// /api/auth/admin/* endpoints by anyone below super_admin, since those
+// endpoints are gated only by this ACL (the app's requireSuperAdmin() guard
+// only covers the Server Actions, not the plugin's own routes).
+export const superAdminRole = ac.newRole({
+  user: ["create", "list", "set-role", "set-password", "ban", "delete", "impersonate"],
+  session: ["list", "revoke", "delete"],
+});
+
+// admin manages the storefront and can moderate customers (ban/list), but
+// not staff accounts. Omitting set-role/set-password/delete/impersonate here
+// is what closes self-promotion through the raw endpoint — the plugin's own
+// permission check is the only gate on that route.
+export const adminRole = ac.newRole({
+  user: ["create", "list", "ban"],
+  session: ["list", "revoke"],
+});
+
 const noPermsRole = ac.newRole({ user: [], session: [] });
 
 // better-auth's captcha plugin defaults to only
@@ -162,8 +182,8 @@ export function buildAuthOptions(cfEnv: CloudflareEnv) {
         defaultRole: "customer",
         adminRoles: ["admin", "super_admin"],
         roles: {
-          admin: staffRole,
-          super_admin: staffRole,
+          admin: adminRole,
+          super_admin: superAdminRole,
           agent: noPermsRole,
           customer: noPermsRole,
         },

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -7,30 +7,32 @@ import { D1Dialect } from "kysely-d1";
 import { sendEmail } from "@/lib/notifications/email";
 import { otpEmail } from "@/lib/notifications/templates";
 
-// ACL for the better-auth admin plugin — mirrors the library's defaultStatements.
-// Required to declare super_admin, agent, and customer as known roles so the
-// plugin's hasPermission() check can resolve them (defaultRoles only knows "admin" + "user").
+// Statement universe for the better-auth admin plugin's ACL: every action
+// any role declared below may be granted. Scoped to what a role in this app
+// actually needs, not the plugin's full defaultStatements — e.g. "get" and
+// "update" (admin/get-user, admin/update-user) are left out because no role
+// holds them and nothing in this app calls those endpoints; a future task
+// wiring one in should add the statement here deliberately. Also declares
+// super_admin, agent, and customer as known roles so the plugin's
+// hasPermission() check can resolve them (defaultRoles only knows "admin" + "user").
 const adminStatements = {
-  user: ["create", "list", "set-role", "ban", "impersonate", "delete", "set-password", "get", "update"],
+  user: ["create", "list", "set-role", "ban", "impersonate", "delete", "set-password"],
   session: ["list", "revoke", "delete"],
 } as const;
 const ac = createAccessControl(adminStatements);
 
-// super_admin keeps the full staff-management set: it is the only role
-// allowed to change roles, set passwords, delete accounts or impersonate —
-// capabilities that must never be reachable through the raw
-// /api/auth/admin/* endpoints by anyone below super_admin, since those
-// endpoints are gated only by this ACL (the app's requireSuperAdmin() guard
-// only covers the Server Actions, not the plugin's own routes).
+// Staff-management capabilities — changing roles, setting passwords,
+// deleting or impersonating accounts — are reserved for super_admin,
+// because this roles map is the authorization boundary the better-auth
+// admin plugin enforces for /api/auth/admin/*.
 export const superAdminRole = ac.newRole({
   user: ["create", "list", "set-role", "set-password", "ban", "delete", "impersonate"],
   session: ["list", "revoke", "delete"],
 });
 
 // admin manages the storefront and can moderate customers (ban/list), but
-// not staff accounts. Omitting set-role/set-password/delete/impersonate here
-// is what closes self-promotion through the raw endpoint — the plugin's own
-// permission check is the only gate on that route.
+// not staff accounts — set-role, set-password, delete and impersonate stay
+// with super_admin (see above).
 export const adminRole = ac.newRole({
   user: ["create", "list", "ban"],
   session: ["list", "revoke"],

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -97,6 +97,18 @@ export function buildAuthOptions(cfEnv: CloudflareEnv) {
     emailAndPassword: {
       enabled: true,
       requireEmailVerification: true,
+      // Password *reset* (forgot-password → OTP) is the path a user takes
+      // when they cannot sign in — the likelier compromise-recovery route of
+      // the two, more so than the in-account password *change*. Without this,
+      // resetPasswordEmailOTP (better-auth/dist/plugins/email-otp/routes.mjs)
+      // writes the new hash but never calls deleteUserSessions, so an
+      // attacker's still-open session survives a reset meant to recover from
+      // exactly that compromise. Verified in 1.6.25 source: the handler for
+      // POST /email-otp/reset-password (authClient.emailOtp.resetPassword,
+      // used by app/(auth)/auth/reset-password) reads this exact option off
+      // ctx.context.options.emailAndPassword and calls
+      // internalAdapter.deleteUserSessions(user.user.id) when it's true.
+      revokeSessionsOnPasswordReset: true,
     },
 
     // Implicit linking would let an OAuth sign-in merge into a pre-existing


### PR DESCRIPTION
Deuxième lot de la remédiation issue de l'audit de sécurité de juillet 2026. Ferme quatre advisories suivis : `GHSA-prpq-c8rr-wrq7` (HIGH), `GHSA-p2pr-4r22-62g3`, `GHSA-4g8r-5p4v-xwv4` et `GHSA-v63p-5752-3cr7`.

## ⚠️ À lire avant de merger

**Personne n'est déconnecté par ce déploiement.** Aucune invalidation de session, aucun changement de schéma, aucune migration. Les sessions en cours continuent.

**Un compte `admin` connecté perd immédiatement quatre capacités d'API** : il ne peut plus appeler `/api/auth/admin/set-role`, `/set-password`, `/remove-user` ni `/impersonate`. Chaque appel `auth.api.*` de l'application a été tracé : la gestion des rôles et la création d'utilisateurs sont derrière `requireSuperAdmin()`, qui conserve ces permissions, et le bannissement est derrière `requireAdmin()`, qui conserve `ban`. **Aucun parcours de l'interface ne casse.** En revanche, un script externe s'authentifiant comme simple `admin` et appelant ces endpoints recevra désormais un 403.

**Le bannissement ne s'applique pas au même rythme selon la surface, et c'est délibéré** : immédiat sur `/admin/*`, jusqu'à cinq minutes sur le storefront. Un client fraîchement banni peut donc encore finaliser une commande dans les cinq minutes qui suivent. Si c'est inacceptable pour le paiement à la livraison, l'escalade consiste à forcer une lecture fraîche sur le parcours client — au prix d'une lecture D1 à chaque requête authentifiée.

**Coût :** deux lectures de session D1 supplémentaires par navigation dans l'administration, pas une — la garde du layout et celle de la page en font chacune une. Négligeable au volume de trafic admin, mais c'est le double de ce que le nom des commits laisse entendre. Le storefront n'est pas affecté.

**Un utilisateur qui change son mot de passe est déconnecté de tous ses autres appareils**, ce qui est l'intention, et son navigateur courant reçoit silencieusement un nouveau cookie. Si ce réapprovisionnement échoue, le journal serveur porte `[changePassword]` et l'utilisateur sera déconnecté à sa navigation suivante.

## Ce que contient le lot

- Les rôles `admin` et `super_admin` ne partagent plus un jeu de permissions unique : la gestion du personnel est réservée à `super_admin`.
- Cinq pages d'administration rendant des données clients reçoivent une garde par page, alignées sur les dix qui en avaient déjà une.
- Les gardes privilégiées lisent l'état de session sans passer par le cache et rejettent un utilisateur activement banni, en tenant compte de l'expiration du bannissement.
- La garde du storefront rejette également un utilisateur banni, en s'appuyant sur la charge utile déjà en cache — **aucune lecture supplémentaire**. Toutes les Server Actions du storefront passant par cette garde, la fermeture opère au niveau des actions, y compris la création de commande.
- Le changement **et** la réinitialisation de mot de passe révoquent les autres sessions.

## Vérifications

`tsc --noEmit` propre, ESLint propre, 985 tests. Chaque tâche a été relue par un agent distinct chargé de la réfuter, et la branche entière a fait l'objet d'une revue finale qui a vérifié chaque affirmation contre la source de `better-auth@1.6.25` plutôt que contre les messages de commit. La fermeture de l'escalade de privilèges a été confirmée en direct : un compte `admin` reçoit un 403 sur l'endpoint brut tout en conservant bannissement et listage.

## Suites connues, non traitées ici

- Quatre pages d'administration (`products/[id]/edit`, `products/new`, `banners/[id]/edit`, `banners/new`) restent sans garde. Elles rendent des données catalogue, pas des données clients, et sortent du périmètre des quatre advisories.
- Le rôle `agent` n'a aujourd'hui aucune capacité fonctionnelle de bout en bout et aucun compte ne le porte. Le supprimer ou le redéfinir est une décision produit.
- Un client banni est renvoyé vers `/` sans explication et sans déconnexion. Il n'est pas piégé — la déconnexion reste accessible depuis le menu — mais l'expérience mérite mieux.
- `getOptionalSession()` reste aveugle au bannissement. Inoffensif aujourd'hui ; l'invariant est désormais documenté dans le code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)