### PR TITLE
fix(storefront): harden the order pipeline (lot 3/8)

### DIFF
--- a/.github/workflows/reap-pending-orders.yml
+++ b/.github/workflows/reap-pending-orders.yml
@@ -1,0 +1,64 @@
+name: Reap Pending Orders
+
+# Triggers the /api/cron/reap-pending-orders route on a schedule.
+# @opennextjs/cloudflare does not expose a Workers scheduled() handler
+# alongside the main Next.js worker, so that route cannot be a native
+# Cloudflare Cron Trigger — see app/api/cron/reap-pending-orders/route.ts's
+# top comment and task-3.2-report.md for the full rationale. This workflow
+# is the external scheduler instead: it authenticates with a bearer secret
+# and does nothing else, so it needs no GitHub API access.
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: reap-pending-orders
+  cancel-in-progress: false
+
+jobs:
+  reap:
+    name: Sweep stale pending orders
+    runs-on: ubuntu-latest
+
+    steps:
+      # Inputs/secrets are routed through env: and read back as shell
+      # variables, never interpolated into the run: script body — the same
+      # discipline deploy.yml and rollback.yml already apply (see
+      # GHSA-rgmp-r8hv-xf4h for what happens when that rule is skipped).
+      #
+      # The bearer secret is passed to curl via a piped `-K -` config
+      # (stdin), not as a `-H` argv value: on a shared machine, argv is
+      # visible to other processes via the process list, and the secret in
+      # a plain -H flag would be too. -K - keeps it out of argv entirely.
+      - name: Call the reaper endpoint
+        env:
+          CRON_TARGET_URL: ${{ vars.CRON_REAP_ORDERS_URL }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: |
+          if [ -z "$CRON_TARGET_URL" ]; then
+            echo "::error::CRON_REAP_ORDERS_URL repository variable is not set — configure it in Settings > Secrets and variables > Actions > Variables."
+            exit 1
+          fi
+          if [ -z "$CRON_SECRET" ]; then
+            echo "::error::CRON_SECRET repository secret is not set — configure it in Settings > Secrets and variables > Actions > Secrets (same value as the CRON_SECRET Worker secret)."
+            exit 1
+          fi
+
+          RESPONSE_FILE=$(mktemp)
+          HTTP_CODE=$(printf 'header = "Authorization: Bearer %s"\n' "$CRON_SECRET" | \
+            curl -sS -K - -o "$RESPONSE_FILE" -w "%{http_code}" \
+              --connect-timeout 5 --max-time 30 \
+              -X POST "$CRON_TARGET_URL")
+
+          echo "HTTP status: $HTTP_CODE"
+          echo "Response body:"
+          cat "$RESPONSE_FILE"
+
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "::error::Reaper endpoint returned HTTP $HTTP_CODE — see response body above. A wrong/missing secret on either side is the most common cause."
+            exit 1
+          fi

--- a/.github/workflows/reap-pending-orders.yml
+++ b/.github/workflows/reap-pending-orders.yml
@@ -4,9 +4,9 @@ name: Reap Pending Orders
 # @opennextjs/cloudflare does not expose a Workers scheduled() handler
 # alongside the main Next.js worker, so that route cannot be a native
 # Cloudflare Cron Trigger — see app/api/cron/reap-pending-orders/route.ts's
-# top comment and task-3.2-report.md for the full rationale. This workflow
-# is the external scheduler instead: it authenticates with a bearer secret
-# and does nothing else, so it needs no GitHub API access.
+# top comment for the technical rationale. This workflow is the external
+# scheduler instead: it authenticates with a bearer secret and does nothing
+# else, so it needs no GitHub API access.
 
 on:
   schedule:
@@ -34,6 +34,26 @@ jobs:
       # (stdin), not as a `-H` argv value: on a shared machine, argv is
       # visible to other processes via the process list, and the secret in
       # a plain -H flag would be too. -K - keeps it out of argv entirely.
+      #
+      # The route's own reapStalePendingOrders() catches per-order failures
+      # and tallies them as `skipped` rather than throwing — the route still
+      # returns 200 with those counts. A plain "fail on non-2xx" check can't
+      # tell a healthy no-op apart from a run where every order failed (e.g.
+      # sustained refund failures reverting rows to pending), so this step
+      # also inspects the response body itself: it fails the job outright
+      # when skipped > 0, and surfaces cancelled/skipped/hasMore in the job
+      # summary, not just the raw log, so an unhealthy run is visible without
+      # anyone having to open it.
+      #
+      # hasMore ("there is more backlog than this call drained") is wired
+      # into a small bounded loop below, capped at MAX_CALLS regardless of
+      # what the route reports — never an unbounded "keep calling until
+      # done" loop. In steady state (the common case: little to no backlog)
+      # this loop runs once and exits immediately on hasMore=false. Only a
+      # large backlog causes more than one call, and even then it is capped
+      # per run; a backlog bigger than MAX_CALLS * REAP_BATCH_SIZE simply
+      # keeps draining on subsequent hourly runs (or an operator can trigger
+      # workflow_dispatch again sooner) rather than looping unboundedly here.
       - name: Call the reaper endpoint
         env:
           CRON_TARGET_URL: ${{ vars.CRON_REAP_ORDERS_URL }}
@@ -48,17 +68,57 @@ jobs:
             exit 1
           fi
 
-          RESPONSE_FILE=$(mktemp)
-          HTTP_CODE=$(printf 'header = "Authorization: Bearer %s"\n' "$CRON_SECRET" | \
-            curl -sS -K - -o "$RESPONSE_FILE" -w "%{http_code}" \
-              --connect-timeout 5 --max-time 30 \
-              -X POST "$CRON_TARGET_URL")
+          MAX_CALLS=5
+          CALLS_MADE=0
+          TOTAL_CANCELLED=0
+          TOTAL_SKIPPED=0
+          TOTAL_PROCESSED=0
+          HAS_MORE=true
 
-          echo "HTTP status: $HTTP_CODE"
-          echo "Response body:"
-          cat "$RESPONSE_FILE"
+          while [ "$HAS_MORE" = "true" ] && [ "$CALLS_MADE" -lt "$MAX_CALLS" ]; do
+            CALLS_MADE=$((CALLS_MADE + 1))
+            RESPONSE_FILE=$(mktemp)
+            HTTP_CODE=$(printf 'header = "Authorization: Bearer %s"\n' "$CRON_SECRET" | \
+              curl -sS -K - -o "$RESPONSE_FILE" -w "%{http_code}" \
+                --connect-timeout 5 --max-time 30 \
+                -X POST "$CRON_TARGET_URL")
 
-          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
-            echo "::error::Reaper endpoint returned HTTP $HTTP_CODE — see response body above. A wrong/missing secret on either side is the most common cause."
+            echo "Call $CALLS_MADE — HTTP status: $HTTP_CODE"
+            echo "Response body:"
+            cat "$RESPONSE_FILE"
+
+            if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+              echo "::error::Reaper endpoint returned HTTP $HTTP_CODE on call $CALLS_MADE — see response body above. A wrong/missing secret on either side is the most common cause."
+              exit 1
+            fi
+
+            CANCELLED=$(jq -r '.cancelled // 0' "$RESPONSE_FILE")
+            SKIPPED=$(jq -r '.skipped // 0' "$RESPONSE_FILE")
+            PROCESSED=$(jq -r '.total // 0' "$RESPONSE_FILE")
+            HAS_MORE=$(jq -r '.hasMore // false' "$RESPONSE_FILE")
+
+            TOTAL_CANCELLED=$((TOTAL_CANCELLED + CANCELLED))
+            TOTAL_SKIPPED=$((TOTAL_SKIPPED + SKIPPED))
+            TOTAL_PROCESSED=$((TOTAL_PROCESSED + PROCESSED))
+          done
+
+          {
+            echo "## Reap pending orders — summary"
+            echo ""
+            echo "| Metric | Value |"
+            echo "|---|---|"
+            echo "| Calls made | $CALLS_MADE (bounded at $MAX_CALLS per run) |"
+            echo "| Cancelled | $TOTAL_CANCELLED |"
+            echo "| Skipped | $TOTAL_SKIPPED |"
+            echo "| Total attempted | $TOTAL_PROCESSED |"
+            echo "| Backlog remaining after this run (hasMore) | $HAS_MORE |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$HAS_MORE" = "true" ]; then
+            echo "::warning::hasMore is still true after $MAX_CALLS calls this run — the backlog is larger than this run could drain. It will keep draining on the next hourly run, or trigger workflow_dispatch manually to drain it sooner."
+          fi
+
+          if [ "$TOTAL_SKIPPED" -gt 0 ]; then
+            echo "::error::$TOTAL_SKIPPED order(s) were skipped across this run — reapStalePendingOrders logs the per-order reason server-side (Worker logs). Sustained skips can mean refund failures reverting rows back to pending. Failing this run so it is not indistinguishable from a healthy no-op."
             exit 1
           fi

--- a/.github/workflows/reap-pending-orders.yml
+++ b/.github/workflows/reap-pending-orders.yml
@@ -92,10 +92,32 @@ jobs:
               exit 1
             fi
 
-            CANCELLED=$(jq -r '.cancelled // 0' "$RESPONSE_FILE")
-            SKIPPED=$(jq -r '.skipped // 0' "$RESPONSE_FILE")
-            PROCESSED=$(jq -r '.total // 0' "$RESPONSE_FILE")
-            HAS_MORE=$(jq -r '.hasMore // false' "$RESPONSE_FILE")
+            # A 2xx response is not enough on its own: a body that is valid
+            # JSON but missing these fields (or carrying them with the wrong
+            # type — e.g. a string instead of a number) would otherwise fall
+            # through the `// default` operators below and produce a green
+            # run reporting all-zero counts, exactly the silent-failure mode
+            # this workflow's health reporting exists to catch. So the shape
+            # is validated explicitly before anything is extracted: `jq -e`
+            # exits non-zero both when the body isn't valid JSON at all and
+            # when this boolean expression evaluates to false, and the `and`
+            # chain short-circuits (a jq guarantee) so `floor` is never
+            # applied to a non-number.
+            if ! jq -e '
+                (type == "object")
+                and (has("cancelled") and ((.cancelled | type) == "number") and ((.cancelled | floor) == .cancelled))
+                and (has("skipped") and ((.skipped | type) == "number") and ((.skipped | floor) == .skipped))
+                and (has("total") and ((.total | type) == "number") and ((.total | floor) == .total))
+                and (has("hasMore") and ((.hasMore | type) == "boolean"))
+              ' "$RESPONSE_FILE" > /dev/null 2>&1; then
+              echo "::error::Reaper endpoint returned a 2xx response on call $CALLS_MADE whose body is not valid JSON, or is missing cancelled/skipped/total (integers) or hasMore (boolean), or carries them with the wrong type — see response body above. Treating this as a failure rather than defaulting to zero."
+              exit 1
+            fi
+
+            CANCELLED=$(jq -r '.cancelled' "$RESPONSE_FILE")
+            SKIPPED=$(jq -r '.skipped' "$RESPONSE_FILE")
+            PROCESSED=$(jq -r '.total' "$RESPONSE_FILE")
+            HAS_MORE=$(jq -r '.hasMore' "$RESPONSE_FILE")
 
             TOTAL_CANCELLED=$((TOTAL_CANCELLED + CANCELLED))
             TOTAL_SKIPPED=$((TOTAL_SKIPPED + SKIPPED))

--- a/__tests__/unit/actions/admin-orders.test.ts
+++ b/__tests__/unit/actions/admin-orders.test.ts
@@ -150,6 +150,67 @@ describe("updateOrderStatus", () => {
     expect(mocks.notifyOrderStatusUpdate).not.toHaveBeenCalled();
   });
 
+  // A cancelled order whose stock was never returned is the state the
+  // compensation exists to prevent, so the revert must actually run and the
+  // action must report failure rather than a success it did not achieve.
+  it("revient au statut précédent et signale l'échec si le remboursement du stock échoue", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.queryFirst
+      .mockReset()
+      .mockResolvedValueOnce({ ...mockOrder, status: "confirmed" })
+      .mockResolvedValue({ email: "c@t.com", name: "C" });
+    mocks.refundOrderStock.mockRejectedValue(new Error("D1 batch failed"));
+    const bindMock = vi.fn().mockReturnValue({
+      run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+    });
+    mocks.dbPrepare.mockReturnValue({ bind: bindMock });
+
+    const result = await updateOrderStatus("order-1", "cancelled");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/remise à son statut précédent/i);
+    // Second prepare/bind = the compensating revert back to 'confirmed',
+    // guarded on the status this call just wrote.
+    expect(bindMock).toHaveBeenCalledWith("confirmed", "order-1", "cancelled");
+    expect(mocks.notifyOrderStatusUpdate).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  // The revert is a second, independent D1 call and can fail on its own.
+  // It must not escape as an unhandled rejection: the caller still needs an
+  // ActionResult, and its wording must not claim a revert that never
+  // happened — "reverted" and "could not revert" are different incidents.
+  it("renvoie un échec explicite, sans lever, si la tentative de retour arrière échoue aussi", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.queryFirst
+      .mockReset()
+      .mockResolvedValueOnce({ ...mockOrder, status: "confirmed" })
+      .mockResolvedValue({ email: "c@t.com", name: "C" });
+    mocks.refundOrderStock.mockRejectedValue(new Error("D1 batch failed"));
+    mocks.dbPrepare.mockReturnValue({
+      bind: vi.fn().mockReturnValue({
+        run: vi
+          .fn()
+          .mockResolvedValueOnce({ meta: { changes: 1 } })
+          .mockRejectedValueOnce(new Error("D1 unavailable during revert")),
+      }),
+    });
+
+    const result = await updateOrderStatus("order-1", "cancelled");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/vérification manuelle/i);
+    expect(result.error).not.toMatch(/remise à son statut précédent/i);
+    const call = errorSpy.mock.calls.find((c) => /revert also failed/i.test(String(c[0])));
+    expect(call).toBeDefined();
+    const [message, context, refundErr, revertErr] = call!;
+    expect(message).toMatch(/revert also failed/i);
+    expect(context).toMatchObject({ orderId: "order-1", intendedRevertTo: "confirmed" });
+    expect(refundErr).toBeInstanceOf(Error);
+    expect(revertErr).toBeInstanceOf(Error);
+    errorSpy.mockRestore();
+  });
+
   it("redirige si non admin", async () => {
     mocks.getSession.mockResolvedValue(mockCustomerSession);
     await expect(updateOrderStatus("order-1", "confirmed")).rejects.toThrow("NEXT_REDIRECT");

--- a/__tests__/unit/actions/admin-orders.test.ts
+++ b/__tests__/unit/actions/admin-orders.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   queryFirst: vi.fn(),
   execute: vi.fn(),
   refundOrderStock: vi.fn(),
+  cancelOrderFromStatus: vi.fn(),
   getAdminOrders: vi.fn(),
   getAdminOrderCount: vi.fn(),
   notifyOrderStatusUpdate: vi.fn(),
@@ -34,7 +35,10 @@ vi.mock("@/lib/cloudflare/context", () => ({
     }),
   }),
 }));
-vi.mock("@/lib/db/orders", () => ({ refundOrderStock: mocks.refundOrderStock }));
+vi.mock("@/lib/db/orders", () => ({
+  refundOrderStock: mocks.refundOrderStock,
+  cancelOrderFromStatus: mocks.cancelOrderFromStatus,
+}));
 vi.mock("@/lib/db/admin/orders", () => ({
   getAdminOrders: mocks.getAdminOrders,
   getAdminOrderCount: mocks.getAdminOrderCount,
@@ -70,6 +74,12 @@ describe("updateOrderStatus", () => {
       .mockResolvedValueOnce(mockOrder)
       .mockResolvedValue({ email: "c@t.com", name: "Client" });
     mocks.refundOrderStock.mockResolvedValue({ itemsRefunded: 2 });
+    // Fresh default for every test: the guarded UPDATE (and any other
+    // db.prepare(...).bind(...).run() call, e.g. addStatusHistory's INSERT)
+    // succeeds unless a specific test overrides it below.
+    mocks.dbPrepare.mockReturnValue({
+      bind: vi.fn().mockReturnValue({ run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }) }),
+    });
   });
 
   it("confirme une commande pending", async () => {
@@ -104,6 +114,42 @@ describe("updateOrderStatus", () => {
     expect(mocks.refundOrderStock).toHaveBeenCalledWith("order-1");
   });
 
+  // Proves the guarded UPDATE actually carries the current status as a WHERE
+  // predicate — this is the mechanism, not just its effect.
+  it("inclut le statut courant comme garde dans la clause WHERE de la transition", async () => {
+    const runMock = vi.fn().mockResolvedValue({ meta: { changes: 1 } });
+    const bindMock = vi.fn().mockReturnValue({ run: runMock });
+    mocks.dbPrepare.mockReturnValue({ bind: bindMock });
+
+    await updateOrderStatus("order-1", "confirmed");
+
+    expect(bindMock).toHaveBeenCalledWith("confirmed", "order-1", "pending");
+  });
+
+  // This is the direct proof for the race the sweep introduced: if the row's
+  // status changed between this action's read and its write (e.g. the
+  // hourly stale-order sweep cancelled the same pending order concurrently),
+  // the guarded UPDATE affects 0 rows and this action must stop entirely —
+  // no history entry, no refund, no customer notification for a transition
+  // it never actually performed. The pre-fix code had no WHERE guard at all
+  // and no changes check, so this test fails against it (it always reached
+  // refund/notification unconditionally).
+  it("n'ajoute pas d'historique, ne rembourse pas et ne notifie pas si le statut a changé entre-temps", async () => {
+    mocks.queryFirst
+      .mockReset()
+      .mockResolvedValueOnce({ ...mockOrder, status: "confirmed" })
+      .mockResolvedValue({ email: "c@t.com", name: "C" });
+    mocks.dbPrepare.mockReturnValue({
+      bind: vi.fn().mockReturnValue({ run: vi.fn().mockResolvedValue({ meta: { changes: 0 } }) }),
+    });
+
+    const result = await updateOrderStatus("order-1", "cancelled");
+
+    expect(result.success).toBe(false);
+    expect(mocks.refundOrderStock).not.toHaveBeenCalled();
+    expect(mocks.notifyOrderStatusUpdate).not.toHaveBeenCalled();
+  });
+
   it("redirige si non admin", async () => {
     mocks.getSession.mockResolvedValue(mockCustomerSession);
     await expect(updateOrderStatus("order-1", "confirmed")).rejects.toThrow("NEXT_REDIRECT");
@@ -117,13 +163,15 @@ describe("cancelOrderAdmin", () => {
     mocks.queryFirst
       .mockResolvedValueOnce(mockOrder)
       .mockResolvedValue({ email: "c@t.com", name: "C" });
-    mocks.execute.mockResolvedValue({ meta: { changes: 1 } });
-    mocks.refundOrderStock.mockResolvedValue({ itemsRefunded: 1 });
+    mocks.cancelOrderFromStatus.mockResolvedValue(true);
   });
 
   it("annule une commande pending", async () => {
     const result = await cancelOrderAdmin("order-1", "Stock épuisé");
     expect(result.success).toBe(true);
+    expect(mocks.cancelOrderFromStatus).toHaveBeenCalledWith("order-1", "pending", "Stock épuisé", {
+      refund: true,
+    });
   });
 
   it("rejette une annulation depuis 'delivered'", async () => {
@@ -131,6 +179,7 @@ describe("cancelOrderAdmin", () => {
     const result = await cancelOrderAdmin("order-1", "Raison");
     expect(result.success).toBe(false);
     expect(result.error).toContain("Impossible");
+    expect(mocks.cancelOrderFromStatus).not.toHaveBeenCalled();
   });
 
   it("rejette sans raison", async () => {
@@ -140,12 +189,34 @@ describe("cancelOrderAdmin", () => {
 
   it("rembourse le stock par défaut", async () => {
     await cancelOrderAdmin("order-1", "Raison");
-    expect(mocks.refundOrderStock).toHaveBeenCalledWith("order-1");
+    expect(mocks.cancelOrderFromStatus).toHaveBeenCalledWith("order-1", "pending", "Raison", {
+      refund: true,
+    });
   });
 
   it("ne rembourse pas le stock si refundStock=false", async () => {
     await cancelOrderAdmin("order-1", "Raison", false);
-    expect(mocks.refundOrderStock).not.toHaveBeenCalled();
+    expect(mocks.cancelOrderFromStatus).toHaveBeenCalledWith("order-1", "pending", "Raison", {
+      refund: false,
+    });
+  });
+
+  // This is the direct proof for the headline race at the admin action's own
+  // boundary: cancelOrderFromStatus (lib/db/orders.ts) reports "did not
+  // transition this row" whenever a concurrent caller — the hourly
+  // stale-order sweep, or another admin tab — already changed the order's
+  // status. cancelOrderAdmin must treat that as a hard stop: no history
+  // entry, no notification, and (implicitly, since it never even calls
+  // refundOrderStock directly anymore) no second refund attempt layered on
+  // top of whatever cancelOrderFromStatus already did or didn't do.
+  it("échoue proprement, sans historique ni notification, si la transition a déjà eu lieu ailleurs (ex: la purge concurrente)", async () => {
+    mocks.cancelOrderFromStatus.mockResolvedValue(false);
+
+    const result = await cancelOrderAdmin("order-1", "Raison");
+
+    expect(result.success).toBe(false);
+    expect(mocks.dbPrepare).not.toHaveBeenCalled(); // addStatusHistory never ran
+    expect(mocks.notifyOrderStatusUpdate).not.toHaveBeenCalled();
   });
 });
 
@@ -175,6 +246,19 @@ describe("processReturn", () => {
   it("rejette sans raison", async () => {
     const result = await processReturn("order-1", "");
     expect(result.success).toBe(false);
+  });
+
+  // Same guard discipline as updateOrderStatus, applied directly (not via
+  // cancelOrderFromStatus, since "returned" isn't a cancellation): if the
+  // row's status changed between the read above and this UPDATE, the guard
+  // must reject rather than refund a transition this call never performed.
+  it("échoue et ne rembourse pas si le statut a changé entre-temps (garde perdue)", async () => {
+    mocks.execute.mockReset().mockResolvedValueOnce({ meta: { changes: 0 } });
+
+    const result = await processReturn("order-1", "Produit défectueux");
+
+    expect(result.success).toBe(false);
+    expect(mocks.refundOrderStock).not.toHaveBeenCalled();
   });
 });
 

--- a/__tests__/unit/actions/admin-orders.test.ts
+++ b/__tests__/unit/actions/admin-orders.test.ts
@@ -211,6 +211,37 @@ describe("updateOrderStatus", () => {
     errorSpy.mockRestore();
   });
 
+  // The revert is guarded on the status this call just wrote, so it can match
+  // zero rows without throwing if something else moved the order on first.
+  // That leaves the same stuck state as a throwing revert and must not be
+  // reported as a successful one.
+  it("traite un retour arrière sans ligne affectée comme un échec de compensation", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.queryFirst
+      .mockReset()
+      .mockResolvedValueOnce({ ...mockOrder, status: "confirmed" })
+      .mockResolvedValue({ email: "c@t.com", name: "C" });
+    mocks.refundOrderStock.mockRejectedValue(new Error("D1 batch failed"));
+    mocks.dbPrepare.mockReturnValue({
+      bind: vi.fn().mockReturnValue({
+        run: vi
+          .fn()
+          .mockResolvedValueOnce({ meta: { changes: 1 } })
+          .mockResolvedValueOnce({ meta: { changes: 0 } }),
+      }),
+    });
+
+    const result = await updateOrderStatus("order-1", "cancelled");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/vérification manuelle/i);
+    expect(result.error).not.toMatch(/remise à son statut précédent/i);
+    const call = errorSpy.mock.calls.find((c) => /revert also failed/i.test(String(c[0])));
+    expect(call).toBeDefined();
+    expect(String(call![3])).toMatch(/matched no row/i);
+    errorSpy.mockRestore();
+  });
+
   it("redirige si non admin", async () => {
     mocks.getSession.mockResolvedValue(mockCustomerSession);
     await expect(updateOrderStatus("order-1", "confirmed")).rejects.toThrow("NEXT_REDIRECT");

--- a/__tests__/unit/actions/checkout-throttle.test.ts
+++ b/__tests__/unit/actions/checkout-throttle.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { checkOrderRateLimit } from "@/lib/rate-limit/orders";
+
+function makeKV() {
+  const store = new Map<string, string>();
+  return {
+    get: async (k: string) => store.get(k) ?? null,
+    put: async (k: string, v: string) => void store.set(k, v),
+    delete: async (k: string) => void store.delete(k),
+  };
+}
+
+describe("checkOrderRateLimit", () => {
+  it("allows orders below the hourly cap", async () => {
+    const kv = makeKV();
+    for (let i = 0; i < 5; i++) {
+      expect(await checkOrderRateLimit(kv as never, "user-1")).toBe(true);
+    }
+  });
+
+  it("blocks the sixth order in the same window", async () => {
+    const kv = makeKV();
+    for (let i = 0; i < 5; i++) await checkOrderRateLimit(kv as never, "user-1");
+    expect(await checkOrderRateLimit(kv as never, "user-1")).toBe(false);
+  });
+
+  it("counts each user independently", async () => {
+    const kv = makeKV();
+    for (let i = 0; i < 5; i++) await checkOrderRateLimit(kv as never, "user-1");
+    expect(await checkOrderRateLimit(kv as never, "user-2")).toBe(true);
+  });
+});

--- a/__tests__/unit/actions/checkout.test.ts
+++ b/__tests__/unit/actions/checkout.test.ts
@@ -138,7 +138,7 @@ describe("createOrder", () => {
     mocks.getDeliveryZoneByCommune.mockResolvedValue(ZONE);
     mocks.createOrderWithItems.mockResolvedValue({ orderId: "order-1", orderNumber: "ORD-TEST01" });
     mocks.notifyOrderConfirmation.mockResolvedValue(undefined);
-    mocks.queryFirst.mockResolvedValue(null); // no promo code lookups in these tests
+    mocks.queryFirst.mockResolvedValue(null); // no promo row matches by default (see the nested "code promo" describe for cases that supply one)
     mocks.checkOrderRateLimit.mockResolvedValue(true);
     mocks.checkPromoRateLimit.mockResolvedValue(true);
     mocks.getKV.mockResolvedValue({});
@@ -260,14 +260,71 @@ describe("createOrder", () => {
     expect(result.error).toMatch(/introuvable/i);
     expect(mocks.createOrderWithItems).not.toHaveBeenCalled();
   });
+
+  // createOrder resolves a promo code itself (step 8, before its own
+  // throttle at step 9) rather than going through validatePromoCode, so it
+  // needs its own coverage: nothing above exercises this path with a promo
+  // code at all (queryFirst defaults to null, i.e. no promo row, in every
+  // other test in this file).
+  describe("code promo", () => {
+    function orderInput(promoCode: string) {
+      return {
+        ...baseInput([{ productId: "prod-no-variant", variantId: null, quantity: 1 }]),
+        promoCode,
+      };
+    }
+
+    beforeEach(() => {
+      mocks.query.mockImplementation(async (sql: string) => {
+        if (sql.includes("FROM products")) return [NO_VARIANT_PRODUCT];
+        if (sql.includes("FROM product_variants")) return [];
+        return [];
+      });
+    });
+
+    it("rejette un code promo inexistant sans créer de commande", async () => {
+      const result = await createOrder(orderInput("DOESNOTEXIST"));
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe(
+        "Ce code promo est invalide ou n'est pas applicable à votre commande."
+      );
+      expect(mocks.createOrderWithItems).not.toHaveBeenCalled();
+    });
+
+    it("court-circuite avant toute lecture de la table promo_codes une fois le quota de codes promo dépassé, sans créer de commande", async () => {
+      mocks.checkPromoRateLimit.mockResolvedValueOnce(false);
+
+      const result = await createOrder(orderInput("PEU-IMPORTE"));
+
+      expect(result.success).toBe(false);
+      expect(mocks.queryFirst).not.toHaveBeenCalled();
+      expect(mocks.createOrderWithItems).not.toHaveBeenCalled();
+    });
+
+    it("renvoie, une fois le quota de codes promo dépassé, exactement le même résultat qu'un code promo inexistant", async () => {
+      const unknown = await createOrder(orderInput("DOESNOTEXIST"));
+
+      mocks.checkPromoRateLimit.mockResolvedValueOnce(false);
+      const throttled = await createOrder(orderInput("PEU-IMPORTE"));
+
+      expect(throttled).toEqual(unknown);
+      expect(mocks.createOrderWithItems).not.toHaveBeenCalled();
+    });
+
+    it("consulte le débit de codes promo partagé (même clé que validatePromoCode) avec l'id de l'utilisateur authentifié", async () => {
+      await createOrder(orderInput("DOESNOTEXIST"));
+
+      expect(mocks.checkPromoRateLimit).toHaveBeenCalledWith(expect.anything(), "user-1");
+    });
+  });
 });
 
-// This suite closes GHSA-6949-v6px-4wpc: validatePromoCode used to return a
-// different message for "this code doesn't exist" vs "this code exists but
-// isn't applicable" (expired / not yet active / usage cap reached / below
-// the order minimum), which lets an authenticated customer enumerate the
-// promo-code namespace — including unpublished campaigns — one probe at a
-// time. It also had no rate limit, so that enumeration was unbounded.
+// validatePromoCode must respond identically — same message, same
+// PromoResult shape — no matter why a code was rejected, and the throttle's
+// own rejection must be indistinguishable from an ordinary one. Otherwise
+// the response itself tells a caller something about the promo_codes table
+// that they shouldn't be able to learn from the outside.
 describe("validatePromoCode", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -291,7 +348,7 @@ describe("validatePromoCode", () => {
     created_at: "2024-01-01T00:00:00Z",
   };
 
-  it("renvoie exactement le même message quel que soit le motif d'échec (inexistant, expiré, pas encore actif, quota d'utilisation atteint, montant minimum non atteint)", async () => {
+  it("renvoie exactement le même objet quel que soit le motif d'échec (inexistant, expiré, pas encore actif, quota d'utilisation atteint, montant minimum non atteint)", async () => {
     const now = Date.now();
     const failureCases: Array<PromoCode | null> = [
       null, // code doesn't exist at all
@@ -301,15 +358,20 @@ describe("validatePromoCode", () => {
       { ...BASE_PROMO, min_order_amount: 50_000 }, // subtotal (10 000) below minimum
     ];
 
-    const messages: string[] = [];
+    // Comparing full result *objects* (not just `.error`) is deliberate: a
+    // future change that adds a field to only one failure path (e.g. a
+    // `minimumRequired` on the below-minimum branch) would keep a
+    // string-only assertion green while reopening the exact oracle this
+    // fixes — a shape difference is just as much of a leak as a text one.
+    const results: unknown[] = [];
     for (const promoRow of failureCases) {
       mocks.queryFirst.mockResolvedValueOnce(promoRow);
       const result = await validatePromoCode("SOLDES2026", 10_000);
       expect(result.valid).toBe(false);
-      messages.push(result.error as string);
+      results.push(result);
     }
 
-    expect(new Set(messages).size).toBe(1);
+    expect(new Set(results.map((r) => JSON.stringify(r))).size).toBe(1);
   });
 
   it("ne révèle pas le montant minimum de commande dans le message d'échec", async () => {
@@ -340,14 +402,14 @@ describe("validatePromoCode", () => {
     expect(mocks.queryFirst).not.toHaveBeenCalled();
   });
 
-  it("renvoie, une fois le quota dépassé, le même message qu'un code inexistant", async () => {
+  it("renvoie, une fois le quota dépassé, exactement le même objet qu'un code inexistant", async () => {
     mocks.queryFirst.mockResolvedValueOnce(null);
     const unknown = await validatePromoCode("DOESNOTEXIST", 10_000);
 
     mocks.checkPromoRateLimit.mockResolvedValueOnce(false);
     const throttled = await validatePromoCode("PEU-IMPORTE", 10_000);
 
-    expect(throttled.error).toBe(unknown.error);
+    expect(throttled).toEqual(unknown);
   });
 
   it("consulte le débit de codes promo avec l'id de l'utilisateur authentifié", async () => {

--- a/__tests__/unit/actions/checkout.test.ts
+++ b/__tests__/unit/actions/checkout.test.ts
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
   countPendingOrdersForUser: vi.fn(),
   notifyOrderConfirmation: vi.fn(),
   checkOrderRateLimit: vi.fn(),
+  checkPromoRateLimit: vi.fn(),
   getKV: vi.fn(),
 }));
 
@@ -56,6 +57,9 @@ vi.mock("@/lib/notifications", () => ({
 vi.mock("@/lib/rate-limit/orders", () => ({
   checkOrderRateLimit: mocks.checkOrderRateLimit,
 }));
+vi.mock("@/lib/rate-limit/promo", () => ({
+  checkPromoRateLimit: mocks.checkPromoRateLimit,
+}));
 vi.mock("@/lib/cloudflare/context", () => ({
   getKV: mocks.getKV,
 }));
@@ -63,7 +67,8 @@ vi.mock("@/lib/cloudflare/context", () => ({
 // countActiveVariantsByProduct, calculate*) and @/lib/validations/checkout
 // (the real Zod schema) — this is the logic under test.
 
-import { createOrder } from "@/actions/checkout";
+import { createOrder, validatePromoCode } from "@/actions/checkout";
+import type { PromoCode } from "@/lib/db/types";
 
 const NO_VARIANT_PRODUCT = {
   id: "prod-no-variant",
@@ -135,6 +140,7 @@ describe("createOrder", () => {
     mocks.notifyOrderConfirmation.mockResolvedValue(undefined);
     mocks.queryFirst.mockResolvedValue(null); // no promo code lookups in these tests
     mocks.checkOrderRateLimit.mockResolvedValue(true);
+    mocks.checkPromoRateLimit.mockResolvedValue(true);
     mocks.getKV.mockResolvedValue({});
     mocks.countPendingOrdersForUser.mockResolvedValue(0);
   });
@@ -253,5 +259,102 @@ describe("createOrder", () => {
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/introuvable/i);
     expect(mocks.createOrderWithItems).not.toHaveBeenCalled();
+  });
+});
+
+// This suite closes GHSA-6949-v6px-4wpc: validatePromoCode used to return a
+// different message for "this code doesn't exist" vs "this code exists but
+// isn't applicable" (expired / not yet active / usage cap reached / below
+// the order minimum), which lets an authenticated customer enumerate the
+// promo-code namespace — including unpublished campaigns — one probe at a
+// time. It also had no rate limit, so that enumeration was unbounded.
+describe("validatePromoCode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue(mockCustomerSession);
+    mocks.checkPromoRateLimit.mockResolvedValue(true);
+    mocks.getKV.mockResolvedValue({});
+  });
+
+  const BASE_PROMO: PromoCode = {
+    id: "promo-1",
+    code: "SOLDES2026",
+    description: null,
+    discount_type: "percentage",
+    discount_value: 10,
+    min_order_amount: null,
+    max_uses: null,
+    used_count: 0,
+    starts_at: null,
+    expires_at: null,
+    is_active: 1,
+    created_at: "2024-01-01T00:00:00Z",
+  };
+
+  it("renvoie exactement le même message quel que soit le motif d'échec (inexistant, expiré, pas encore actif, quota d'utilisation atteint, montant minimum non atteint)", async () => {
+    const now = Date.now();
+    const failureCases: Array<PromoCode | null> = [
+      null, // code doesn't exist at all
+      { ...BASE_PROMO, expires_at: new Date(now - 86_400_000).toISOString() }, // expired
+      { ...BASE_PROMO, starts_at: new Date(now + 86_400_000).toISOString() }, // not yet active
+      { ...BASE_PROMO, max_uses: 5, used_count: 5 }, // usage cap reached
+      { ...BASE_PROMO, min_order_amount: 50_000 }, // subtotal (10 000) below minimum
+    ];
+
+    const messages: string[] = [];
+    for (const promoRow of failureCases) {
+      mocks.queryFirst.mockResolvedValueOnce(promoRow);
+      const result = await validatePromoCode("SOLDES2026", 10_000);
+      expect(result.valid).toBe(false);
+      messages.push(result.error as string);
+    }
+
+    expect(new Set(messages).size).toBe(1);
+  });
+
+  it("ne révèle pas le montant minimum de commande dans le message d'échec", async () => {
+    mocks.queryFirst.mockResolvedValueOnce({ ...BASE_PROMO, min_order_amount: 50_000 });
+
+    const result = await validatePromoCode("SOLDES2026", 10_000);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).not.toMatch(/50.?000/);
+  });
+
+  it("applique toujours la remise pour un code valide", async () => {
+    mocks.queryFirst.mockResolvedValueOnce(BASE_PROMO);
+
+    const result = await validatePromoCode("SOLDES2026", 10_000);
+
+    expect(result.valid).toBe(true);
+    expect(result.discount).toBe(1_000);
+    expect(result.promoCodeId).toBe("promo-1");
+  });
+
+  it("court-circuite avant toute lecture de la table promo_codes une fois le quota dépassé", async () => {
+    mocks.checkPromoRateLimit.mockResolvedValueOnce(false);
+
+    const result = await validatePromoCode("PEU-IMPORTE", 10_000);
+
+    expect(result.valid).toBe(false);
+    expect(mocks.queryFirst).not.toHaveBeenCalled();
+  });
+
+  it("renvoie, une fois le quota dépassé, le même message qu'un code inexistant", async () => {
+    mocks.queryFirst.mockResolvedValueOnce(null);
+    const unknown = await validatePromoCode("DOESNOTEXIST", 10_000);
+
+    mocks.checkPromoRateLimit.mockResolvedValueOnce(false);
+    const throttled = await validatePromoCode("PEU-IMPORTE", 10_000);
+
+    expect(throttled.error).toBe(unknown.error);
+  });
+
+  it("consulte le débit de codes promo avec l'id de l'utilisateur authentifié", async () => {
+    mocks.queryFirst.mockResolvedValueOnce(null);
+
+    await validatePromoCode("DOESNOTEXIST", 10_000);
+
+    expect(mocks.checkPromoRateLimit).toHaveBeenCalledWith(expect.anything(), "user-1");
   });
 });

--- a/__tests__/unit/actions/checkout.test.ts
+++ b/__tests__/unit/actions/checkout.test.ts
@@ -139,7 +139,7 @@ describe("createOrder", () => {
     mocks.countPendingOrdersForUser.mockResolvedValue(0);
   });
 
-  it("rejette la creation quand le debit de commandes est depasse — sans toucher au stock", async () => {
+  it("rejette la creation quand le debit de commandes est depasse — sans creer de commande", async () => {
     mocks.checkOrderRateLimit.mockResolvedValue(false);
     mocks.query.mockImplementation(async (sql: string) => {
       if (sql.includes("FROM products")) return [NO_VARIANT_PRODUCT];
@@ -153,9 +153,12 @@ describe("createOrder", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/commandes/i);
+    // The throttle is checked right before the write (see actions/checkout.ts's
+    // comment on why: it should only cost a slot on attempts that clear every
+    // other check), so validation/product lookups above it still run — only
+    // the actual order creation is blocked.
     expect(mocks.createOrderWithItems).not.toHaveBeenCalled();
-    // The throttle short-circuits before any product/stock lookup runs.
-    expect(mocks.query).not.toHaveBeenCalled();
+    expect(mocks.checkOrderRateLimit).toHaveBeenCalledTimes(1);
   });
 
   it("rejette la creation quand l'utilisateur a deja trop de commandes en attente", async () => {

--- a/__tests__/unit/actions/checkout.test.ts
+++ b/__tests__/unit/actions/checkout.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockCustomerSession } from "../../helpers/mocks";
+
+// This suite exercises the real createOrder Server Action (actions/checkout.ts)
+// with mocked I/O, rather than only the pure resolveOrderLine/
+// countActiveVariantsByProduct helpers it calls (see checkout-calc.test.ts).
+// Those helper tests can't see a regression at the *call site* itself — e.g.
+// `activeVariantCount: activeVariantCountByProduct.get(product.id) ?? 0`
+// being reduced to a hardcoded `0` — because they never import or execute
+// actions/checkout.ts. These tests do, so that specific mutation fails here.
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  redirect: vi.fn((url: string): never => {
+    const error = new Error(`NEXT_REDIRECT: ${url}`) as Error & { digest: string };
+    error.digest = `NEXT_REDIRECT;${url}`;
+    throw error;
+  }),
+  query: vi.fn(),
+  queryFirst: vi.fn(),
+  getDeliveryZoneByCommune: vi.fn(),
+  getAddressById: vi.fn(),
+  createAddress: vi.fn(),
+  createOrderWithItems: vi.fn(),
+  notifyOrderConfirmation: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({ redirect: mocks.redirect }));
+vi.mock("next/headers", () => ({ headers: vi.fn().mockResolvedValue(new Headers()) }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/auth", () => ({
+  initAuth: vi.fn().mockResolvedValue({ api: { getSession: mocks.getSession } }),
+}));
+vi.mock("@/lib/db", () => ({
+  query: mocks.query,
+  queryFirst: mocks.queryFirst,
+}));
+vi.mock("@/lib/db/delivery-zones", () => ({
+  getDeliveryZoneByCommune: mocks.getDeliveryZoneByCommune,
+}));
+vi.mock("@/lib/db/addresses", () => ({
+  getAddressById: mocks.getAddressById,
+  createAddress: mocks.createAddress,
+}));
+vi.mock("@/lib/db/orders", () => ({
+  createOrderWithItems: mocks.createOrderWithItems,
+}));
+vi.mock("@/lib/notifications", () => ({
+  notifyOrderConfirmation: mocks.notifyOrderConfirmation,
+}));
+// Deliberately NOT mocked: @/lib/utils/checkout (resolveOrderLine,
+// countActiveVariantsByProduct, calculate*) and @/lib/validations/checkout
+// (the real Zod schema) — this is the logic under test.
+
+import { createOrder } from "@/actions/checkout";
+
+const NO_VARIANT_PRODUCT = {
+  id: "prod-no-variant",
+  name: "Casque Bluetooth XYZ",
+  base_price: 10000,
+  stock_quantity: 5,
+  is_active: 1,
+};
+
+const VARIANT_PRODUCT = {
+  id: "prod-with-variant",
+  name: "Smartphone ABC",
+  base_price: 150000, // display-only "starting from" price — lower than any real variant
+  stock_quantity: 5,
+  is_active: 1,
+};
+
+const OTHER_PRODUCT = {
+  id: "prod-other",
+  name: "Autre Produit",
+  base_price: 50000,
+  stock_quantity: 5,
+  is_active: 1,
+};
+
+const VARIANT_A = {
+  id: "variant-a",
+  product_id: "prod-with-variant",
+  name: "256GB",
+  price: 200000,
+  stock_quantity: 3,
+  is_active: 1,
+};
+
+const VARIANT_OF_OTHER_PRODUCT = {
+  id: "variant-other",
+  product_id: "prod-other",
+  name: "Standard",
+  price: 60000,
+  stock_quantity: 3,
+  is_active: 1,
+};
+
+const ZONE = {
+  id: "zone-1",
+  name: "Plateau",
+  commune: "Plateau",
+  fee: 1000,
+  estimated_hours: 24,
+  is_active: 1,
+};
+
+function baseInput(items: Array<{ productId: string; variantId: string | null; quantity: number }>) {
+  return {
+    fullName: "Koné Amadou",
+    phone: "0102030405",
+    street: "Rue des Jardins, Cocody",
+    commune: "Plateau",
+    items,
+  };
+}
+
+describe("createOrder", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue(mockCustomerSession);
+    mocks.getDeliveryZoneByCommune.mockResolvedValue(ZONE);
+    mocks.createOrderWithItems.mockResolvedValue({ orderId: "order-1", orderNumber: "ORD-TEST01" });
+    mocks.notifyOrderConfirmation.mockResolvedValue(undefined);
+    mocks.queryFirst.mockResolvedValue(null); // no promo code lookups in these tests
+  });
+
+  it("accepte un variantId nul pour un produit sans variante, facturé au base_price", async () => {
+    mocks.query.mockImplementation(async (sql: string) => {
+      if (sql.includes("FROM products")) return [NO_VARIANT_PRODUCT];
+      if (sql.includes("FROM product_variants")) return [];
+      return [];
+    });
+
+    const result = await createOrder(
+      baseInput([{ productId: "prod-no-variant", variantId: null, quantity: 1 }])
+    );
+
+    expect(result.success).toBe(true);
+    expect(mocks.createOrderWithItems).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.arrayContaining([
+        expect.objectContaining({ productId: "prod-no-variant", variantId: null, unitPrice: 10000 }),
+      ])
+    );
+  });
+
+  it("rejette un variantId nul pour un produit qui a des variantes actives — appelle le vrai createOrder, pas seulement resolveOrderLine", async () => {
+    mocks.query.mockImplementation(async (sql: string) => {
+      if (sql.includes("FROM products")) return [VARIANT_PRODUCT];
+      if (sql.includes("FROM product_variants")) return [VARIANT_A];
+      return [];
+    });
+
+    const result = await createOrder(
+      baseInput([{ productId: "prod-with-variant", variantId: null, quantity: 1 }])
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/variante/i);
+    expect(mocks.createOrderWithItems).not.toHaveBeenCalled();
+  });
+
+  it("facture depuis la variante quand un variantId valide est fourni", async () => {
+    mocks.query.mockImplementation(async (sql: string) => {
+      if (sql.includes("FROM products")) return [VARIANT_PRODUCT];
+      if (sql.includes("FROM product_variants")) return [VARIANT_A];
+      return [];
+    });
+
+    const result = await createOrder(
+      baseInput([{ productId: "prod-with-variant", variantId: "variant-a", quantity: 1 }])
+    );
+
+    expect(result.success).toBe(true);
+    expect(mocks.createOrderWithItems).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.arrayContaining([
+        expect.objectContaining({ productId: "prod-with-variant", variantId: "variant-a", unitPrice: 200000 }),
+      ])
+    );
+  });
+
+  it("rejette un variantId appartenant à un autre produit", async () => {
+    mocks.query.mockImplementation(async (sql: string) => {
+      if (sql.includes("FROM products")) return [VARIANT_PRODUCT, OTHER_PRODUCT];
+      if (sql.includes("FROM product_variants")) return [VARIANT_A, VARIANT_OF_OTHER_PRODUCT];
+      return [];
+    });
+
+    const result = await createOrder(
+      baseInput([{ productId: "prod-with-variant", variantId: "variant-other", quantity: 1 }])
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/introuvable/i);
+    expect(mocks.createOrderWithItems).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/actions/checkout.test.ts
+++ b/__tests__/unit/actions/checkout.test.ts
@@ -22,7 +22,10 @@ const mocks = vi.hoisted(() => ({
   getAddressById: vi.fn(),
   createAddress: vi.fn(),
   createOrderWithItems: vi.fn(),
+  countPendingOrdersForUser: vi.fn(),
   notifyOrderConfirmation: vi.fn(),
+  checkOrderRateLimit: vi.fn(),
+  getKV: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({ redirect: mocks.redirect }));
@@ -44,9 +47,17 @@ vi.mock("@/lib/db/addresses", () => ({
 }));
 vi.mock("@/lib/db/orders", () => ({
   createOrderWithItems: mocks.createOrderWithItems,
+  countPendingOrdersForUser: mocks.countPendingOrdersForUser,
+  MAX_PENDING_ORDERS_PER_USER: 3,
 }));
 vi.mock("@/lib/notifications", () => ({
   notifyOrderConfirmation: mocks.notifyOrderConfirmation,
+}));
+vi.mock("@/lib/rate-limit/orders", () => ({
+  checkOrderRateLimit: mocks.checkOrderRateLimit,
+}));
+vi.mock("@/lib/cloudflare/context", () => ({
+  getKV: mocks.getKV,
 }));
 // Deliberately NOT mocked: @/lib/utils/checkout (resolveOrderLine,
 // countActiveVariantsByProduct, calculate*) and @/lib/validations/checkout
@@ -123,6 +134,45 @@ describe("createOrder", () => {
     mocks.createOrderWithItems.mockResolvedValue({ orderId: "order-1", orderNumber: "ORD-TEST01" });
     mocks.notifyOrderConfirmation.mockResolvedValue(undefined);
     mocks.queryFirst.mockResolvedValue(null); // no promo code lookups in these tests
+    mocks.checkOrderRateLimit.mockResolvedValue(true);
+    mocks.getKV.mockResolvedValue({});
+    mocks.countPendingOrdersForUser.mockResolvedValue(0);
+  });
+
+  it("rejette la creation quand le debit de commandes est depasse — sans toucher au stock", async () => {
+    mocks.checkOrderRateLimit.mockResolvedValue(false);
+    mocks.query.mockImplementation(async (sql: string) => {
+      if (sql.includes("FROM products")) return [NO_VARIANT_PRODUCT];
+      if (sql.includes("FROM product_variants")) return [];
+      return [];
+    });
+
+    const result = await createOrder(
+      baseInput([{ productId: "prod-no-variant", variantId: null, quantity: 1 }])
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/commandes/i);
+    expect(mocks.createOrderWithItems).not.toHaveBeenCalled();
+    // The throttle short-circuits before any product/stock lookup runs.
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
+
+  it("rejette la creation quand l'utilisateur a deja trop de commandes en attente", async () => {
+    mocks.countPendingOrdersForUser.mockResolvedValue(3);
+    mocks.query.mockImplementation(async (sql: string) => {
+      if (sql.includes("FROM products")) return [NO_VARIANT_PRODUCT];
+      if (sql.includes("FROM product_variants")) return [];
+      return [];
+    });
+
+    const result = await createOrder(
+      baseInput([{ productId: "prod-no-variant", variantId: null, quantity: 1 }])
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/attente/i);
+    expect(mocks.createOrderWithItems).not.toHaveBeenCalled();
   });
 
   it("accepte un variantId nul pour un produit sans variante, facturé au base_price", async () => {

--- a/__tests__/unit/actions/checkout.test.ts
+++ b/__tests__/unit/actions/checkout.test.ts
@@ -139,7 +139,7 @@ describe("createOrder", () => {
     mocks.countPendingOrdersForUser.mockResolvedValue(0);
   });
 
-  it("rejette la creation quand le debit de commandes est depasse — sans creer de commande", async () => {
+  it("rejette la creation quand le debit de commandes est depasse — sans creer de commande ni d'adresse", async () => {
     mocks.checkOrderRateLimit.mockResolvedValue(false);
     mocks.query.mockImplementation(async (sql: string) => {
       if (sql.includes("FROM products")) return [NO_VARIANT_PRODUCT];
@@ -147,17 +147,22 @@ describe("createOrder", () => {
       return [];
     });
 
-    const result = await createOrder(
-      baseInput([{ productId: "prod-no-variant", variantId: null, quantity: 1 }])
-    );
+    const result = await createOrder({
+      ...baseInput([{ productId: "prod-no-variant", variantId: null, quantity: 1 }]),
+      // saveAddress: true exercises the exact bypass a throttled call must not
+      // reach: createAddress is an unconditional INSERT with no dedup and no
+      // per-user cap of its own, and it used to run before the quota check.
+      saveAddress: true,
+    });
 
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/commandes/i);
-    // The throttle is checked right before the write (see actions/checkout.ts's
-    // comment on why: it should only cost a slot on attempts that clear every
-    // other check), so validation/product lookups above it still run — only
-    // the actual order creation is blocked.
+    // The throttle is checked right before the first persistent write (see
+    // actions/checkout.ts's comment on why: it should only cost a slot on
+    // attempts that clear every other check), so read-only validation and
+    // product lookups above it still run — but nothing that writes does.
     expect(mocks.createOrderWithItems).not.toHaveBeenCalled();
+    expect(mocks.createAddress).not.toHaveBeenCalled();
     expect(mocks.checkOrderRateLimit).toHaveBeenCalledTimes(1);
   });
 

--- a/__tests__/unit/api/cron/reap-pending-orders.test.ts
+++ b/__tests__/unit/api/cron/reap-pending-orders.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// This route has no automatic trigger yet (see route.ts's top comment for
+// why: OpenNext 1.19.1 does not expose a scheduled() handler alongside the
+// Next.js worker). It exists as the securable, invokable surface for the
+// reaper regardless of what ends up calling it.
+
+const mocks = vi.hoisted(() => ({
+  getEnv: vi.fn(),
+  reapStalePendingOrders: vi.fn(),
+}));
+
+vi.mock("@/lib/cloudflare/context", () => ({ getEnv: mocks.getEnv }));
+vi.mock("@/lib/db/orders", () => ({ reapStalePendingOrders: mocks.reapStalePendingOrders }));
+
+import { POST } from "@/app/api/cron/reap-pending-orders/route";
+
+function req(headers: Record<string, string> = {}) {
+  return new Request("http://localhost/api/cron/reap-pending-orders", {
+    method: "POST",
+    headers,
+  });
+}
+
+describe("POST /api/cron/reap-pending-orders", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getEnv.mockResolvedValue({ CRON_SECRET: "s3cr3t" });
+    mocks.reapStalePendingOrders.mockResolvedValue({ cancelled: 2, skipped: 0, total: 2 });
+  });
+
+  it("rejects a request with no Authorization header", async () => {
+    const res = await POST(req());
+    expect(res.status).toBe(401);
+    expect(mocks.reapStalePendingOrders).not.toHaveBeenCalled();
+  });
+
+  it("rejects a request with the wrong secret", async () => {
+    const res = await POST(req({ authorization: "Bearer wrong" }));
+    expect(res.status).toBe(401);
+    expect(mocks.reapStalePendingOrders).not.toHaveBeenCalled();
+  });
+
+  it("rejects every request when CRON_SECRET is not configured", async () => {
+    mocks.getEnv.mockResolvedValue({});
+    const res = await POST(req({ authorization: "Bearer s3cr3t" }));
+    expect(res.status).toBe(401);
+    expect(mocks.reapStalePendingOrders).not.toHaveBeenCalled();
+  });
+
+  it("runs the reaper and returns its counts when the secret matches", async () => {
+    const res = await POST(req({ authorization: "Bearer s3cr3t" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ cancelled: 2, skipped: 0, total: 2 });
+    expect(mocks.reapStalePendingOrders).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/unit/api/cron/reap-pending-orders.test.ts
+++ b/__tests__/unit/api/cron/reap-pending-orders.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-// This route has no automatic trigger yet (see route.ts's top comment for
-// why: OpenNext 1.19.1 does not expose a scheduled() handler alongside the
-// Next.js worker). It exists as the securable, invokable surface for the
-// reaper regardless of what ends up calling it.
+// This route is invoked by the "Reap Pending Orders" scheduled GitHub
+// Actions workflow (.github/workflows/reap-pending-orders.yml), not by a
+// native Cloudflare Cron Trigger — see route.ts's top comment for why
+// (OpenNext does not expose a scheduled() handler alongside the Next.js
+// worker).
 
 const mocks = vi.hoisted(() => ({
   getEnv: vi.fn(),
@@ -26,7 +27,7 @@ describe("POST /api/cron/reap-pending-orders", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.getEnv.mockResolvedValue({ CRON_SECRET: "s3cr3t" });
-    mocks.reapStalePendingOrders.mockResolvedValue({ cancelled: 2, skipped: 0, total: 2 });
+    mocks.reapStalePendingOrders.mockResolvedValue({ cancelled: 2, skipped: 0, total: 2, hasMore: false });
   });
 
   it("rejects a request with no Authorization header", async () => {
@@ -52,7 +53,17 @@ describe("POST /api/cron/reap-pending-orders", () => {
     const res = await POST(req({ authorization: "Bearer s3cr3t" }));
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body).toEqual({ cancelled: 2, skipped: 0, total: 2 });
+    expect(body).toEqual({ cancelled: 2, skipped: 0, total: 2, hasMore: false });
     expect(mocks.reapStalePendingOrders).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 500 instead of an unhandled error when reapStalePendingOrders throws", async () => {
+    mocks.reapStalePendingOrders.mockRejectedValue(new Error("D1 unavailable"));
+
+    const res = await POST(req({ authorization: "Bearer s3cr3t" }));
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBeTruthy();
   });
 });

--- a/__tests__/unit/checkout-calc.test.ts
+++ b/__tests__/unit/checkout-calc.test.ts
@@ -5,6 +5,7 @@ import {
   calculateOrderTotal,
   calculateSubtotal,
   resolveOrderLine,
+  countActiveVariantsByProduct,
   type OrderLineInput,
 } from "@/lib/utils/checkout";
 import type { PromoCode } from "@/lib/db/types";
@@ -314,5 +315,80 @@ describe("resolveOrderLine", () => {
 
     expect(result.ok).toBe(false);
     expect(result.ok === false && result.error).toContain("Enceinte Portable ABC");
+  });
+});
+
+// ─── countActiveVariantsByProduct ───
+
+describe("countActiveVariantsByProduct", () => {
+  it("compte les variantes actives par produit", () => {
+    const counts = countActiveVariantsByProduct([
+      { product_id: "p1" },
+      { product_id: "p1" },
+      { product_id: "p2" },
+    ]);
+
+    expect(counts.get("p1")).toBe(2);
+    expect(counts.get("p2")).toBe(1);
+  });
+
+  it("retourne une map vide pour une liste vide", () => {
+    const counts = countActiveVariantsByProduct([]);
+    expect(counts.size).toBe(0);
+  });
+
+  it("un produit absent de la liste n'a pas d'entrée dans la map", () => {
+    const counts = countActiveVariantsByProduct([{ product_id: "p1" }]);
+    expect(counts.get("p2")).toBeUndefined();
+  });
+});
+
+// ─── resolveOrderLine wired through countActiveVariantsByProduct ───
+//
+// These pin the exact composition actions/checkout.ts uses:
+// `countActiveVariantsByProduct(variantsRaw).get(product.id) ?? 0` feeding
+// `resolveOrderLine`'s `activeVariantCount`. If that wiring were ever
+// reduced to a literal 0 (or the counting function stopped counting), these
+// fail — unlike the resolveOrderLine-only tests above, which pass literals
+// directly and can't detect that class of regression.
+
+describe("resolveOrderLine + countActiveVariantsByProduct (wiring)", () => {
+  it("rejette un variantId nul quand le comptage réel détecte des variantes actives", () => {
+    const activeVariantCountByProduct = countActiveVariantsByProduct([
+      { product_id: "p1" },
+      { product_id: "p1" },
+    ]);
+
+    const result = resolveOrderLine({
+      product: {
+        name: "Casque Bluetooth XYZ",
+        base_price: 10000,
+        stock_quantity: 5,
+        activeVariantCount: activeVariantCountByProduct.get("p1") ?? 0,
+      },
+      variant: null,
+      quantity: 1,
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("accepte un variantId nul quand le comptage réel ne trouve aucune variante pour ce produit", () => {
+    const activeVariantCountByProduct = countActiveVariantsByProduct([
+      { product_id: "other-product" },
+    ]);
+
+    const result = resolveOrderLine({
+      product: {
+        name: "Casque Bluetooth XYZ",
+        base_price: 10000,
+        stock_quantity: 5,
+        activeVariantCount: activeVariantCountByProduct.get("p1") ?? 0,
+      },
+      variant: null,
+      quantity: 1,
+    });
+
+    expect(result.ok).toBe(true);
   });
 });

--- a/__tests__/unit/checkout-calc.test.ts
+++ b/__tests__/unit/checkout-calc.test.ts
@@ -4,6 +4,8 @@ import {
   calculateDiscount,
   calculateOrderTotal,
   calculateSubtotal,
+  resolveOrderLine,
+  type OrderLineInput,
 } from "@/lib/utils/checkout";
 import type { PromoCode } from "@/lib/db/types";
 
@@ -218,5 +220,99 @@ describe("calculateSubtotal", () => {
 
   it("gère une quantité de 1", () => {
     expect(calculateSubtotal([{ unitPrice: 99000, quantity: 1 }])).toBe(99000);
+  });
+});
+
+// ─── resolveOrderLine ───
+
+function makeLine(overrides: Partial<OrderLineInput> = {}): OrderLineInput {
+  return {
+    product: {
+      name: "Casque Bluetooth XYZ",
+      base_price: 10000,
+      stock_quantity: 5,
+      activeVariantCount: 0,
+    },
+    variant: null,
+    quantity: 1,
+    ...overrides,
+  };
+}
+
+describe("resolveOrderLine", () => {
+  it("rejette un variantId nul quand le produit a des variantes actives", () => {
+    const result = resolveOrderLine(
+      makeLine({ product: { ...makeLine().product, activeVariantCount: 3 } })
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toMatch(/variante/i);
+  });
+
+  it("accepte un variantId nul quand le produit n'a aucune variante", () => {
+    const result = resolveOrderLine(makeLine());
+
+    expect(result.ok).toBe(true);
+    expect(result.ok === true && result.unitPrice).toBe(10000);
+  });
+
+  it("facture depuis la variante quand elle est fournie", () => {
+    const result = resolveOrderLine(
+      makeLine({
+        product: { ...makeLine().product, activeVariantCount: 3 },
+        variant: { name: "Rouge", price: 15000, stock_quantity: 2 },
+      })
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.ok === true && result.unitPrice).toBe(15000);
+  });
+
+  it("rejette une variante dont le stock est insuffisant", () => {
+    const result = resolveOrderLine(
+      makeLine({
+        product: { ...makeLine().product, activeVariantCount: 1 },
+        variant: { name: "Rouge", price: 15000, stock_quantity: 1 },
+        quantity: 2,
+      })
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toMatch(/stock/i);
+  });
+
+  it("accepte une variante quand le stock est exactement suffisant", () => {
+    const result = resolveOrderLine(
+      makeLine({
+        product: { ...makeLine().product, activeVariantCount: 1 },
+        variant: { name: "Rouge", price: 15000, stock_quantity: 2 },
+        quantity: 2,
+      })
+    );
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejette un produit sans variante dont le stock est insuffisant", () => {
+    const result = resolveOrderLine(makeLine({ quantity: 10 }));
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toMatch(/stock/i);
+  });
+
+  it("mentionne le nom du produit dans le message de garde variante", () => {
+    const result = resolveOrderLine(
+      makeLine({
+        product: {
+          name: "Enceinte Portable ABC",
+          base_price: 20000,
+          stock_quantity: 5,
+          activeVariantCount: 2,
+        },
+      })
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toContain("Enceinte Portable ABC");
   });
 });

--- a/__tests__/unit/lib/db/orders.test.ts
+++ b/__tests__/unit/lib/db/orders.test.ts
@@ -28,7 +28,12 @@ vi.mock("@/lib/cloudflare/context", () => ({
   }),
 }));
 
-import { cancelOrder, countPendingOrdersForUser, reapStalePendingOrders } from "@/lib/db/orders";
+import {
+  cancelOrder,
+  countPendingOrdersForUser,
+  reapStalePendingOrders,
+  createOrderWithItems,
+} from "@/lib/db/orders";
 
 const ITEM = (orderId: string) => ({
   id: `item-${orderId}`,
@@ -135,7 +140,7 @@ describe("reapStalePendingOrders", () => {
 
     const result = await reapStalePendingOrders(24);
 
-    expect(result).toEqual({ cancelled: 2, skipped: 0, total: 2 });
+    expect(result).toEqual({ cancelled: 2, skipped: 0, total: 2, hasMore: false });
     expect(mocks.execute).toHaveBeenCalledTimes(2);
     expect(mocks.dbBatch).toHaveBeenCalledTimes(2);
   });
@@ -161,7 +166,7 @@ describe("reapStalePendingOrders", () => {
 
     const result = await reapStalePendingOrders(24);
 
-    expect(result).toEqual({ cancelled: 1, skipped: 1, total: 2 });
+    expect(result).toEqual({ cancelled: 1, skipped: 1, total: 2, hasMore: false });
     // Refund (dbBatch) only ran for order-1 — order-2 was never touched.
     expect(mocks.dbBatch).toHaveBeenCalledTimes(1);
   });
@@ -171,7 +176,130 @@ describe("reapStalePendingOrders", () => {
 
     const result = await reapStalePendingOrders(24);
 
-    expect(result).toEqual({ cancelled: 0, skipped: 0, total: 0 });
+    expect(result).toEqual({ cancelled: 0, skipped: 0, total: 0, hasMore: false });
     expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
+  it("caps a run at batchSize and reports hasMore when the backlog is larger", async () => {
+    // 5 stale orders exist, but the caller only wants batches of 2 at a time.
+    // The SELECT is mocked to honor LIMIT (batchSize + 1 = 3 rows back),
+    // exactly like the real "ORDER BY created_at ASC LIMIT ?" query would.
+    mocks.query.mockImplementation(async (sql: string) => {
+      if (sql.includes("FROM orders WHERE status = 'pending'")) {
+        return [{ id: "order-1" }, { id: "order-2" }, { id: "order-3" }].slice(0, 3);
+      }
+      if (sql.includes("FROM order_items WHERE order_id = ?")) {
+        return [ITEM("order-x")];
+      }
+      return [];
+    });
+    mocks.execute.mockResolvedValue({ meta: { changes: 1 } });
+    mocks.dbBatch.mockResolvedValue([{ meta: { changes: 1 } }]);
+
+    const result = await reapStalePendingOrders(24, 2);
+
+    // Only 2 of the 3 rows returned by the (LIMIT batchSize+1) query are
+    // actually processed; the 3rd's presence is what signals hasMore.
+    expect(result).toEqual({ cancelled: 2, skipped: 0, total: 2, hasMore: true });
+    expect(mocks.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("tallies an unexpected per-order failure as skipped instead of aborting the rest of the sweep", async () => {
+    mocks.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      if (sql.includes("FROM orders WHERE status = 'pending'")) {
+        return [{ id: "order-1" }, { id: "order-2" }];
+      }
+      if (sql.includes("FROM order_items WHERE order_id = ?")) {
+        return [ITEM(params[0] as string)];
+      }
+      return [];
+    });
+    // order-1's guarded UPDATE itself throws (e.g. a transient D1 error) —
+    // not a refund failure, a failure in cancelPendingOrderById's own guard
+    // statement. order-2 must still be processed normally.
+    mocks.execute.mockImplementation(async (_sql: string, params: unknown[] = []) => {
+      if (params[1] === "order-1") throw new Error("transient D1 error");
+      return { meta: { changes: 1 } };
+    });
+    mocks.dbBatch.mockResolvedValue([{ meta: { changes: 1 } }]);
+
+    const result = await reapStalePendingOrders(24);
+
+    expect(result).toEqual({ cancelled: 1, skipped: 1, total: 2, hasMore: false });
+  });
+});
+
+describe("createOrderWithItems", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const orderData = {
+    userId: "user-1",
+    orderNumber: "ORD-TEST01",
+    subtotal: 10000,
+    deliveryFee: 1000,
+    discountAmount: 0,
+    total: 11000,
+    promoCodeId: null,
+    deliveryAddress: "Rue des Jardins, Plateau, Abidjan",
+    deliveryCommune: "Plateau",
+    deliveryPhone: "0102030405",
+    deliveryInstructions: null,
+    estimatedDelivery: null,
+  };
+
+  const items = [
+    {
+      productId: "prod-1",
+      variantId: null,
+      productName: "Casque",
+      variantName: null,
+      quantity: 1,
+      unitPrice: 10000,
+      totalPrice: 10000,
+    },
+  ];
+
+  it("reserves the order atomically, then decrements stock and inserts items", async () => {
+    mocks.execute.mockResolvedValue({ meta: { changes: 1 } }); // reservation guard passes
+    mocks.dbBatch.mockResolvedValue([
+      { meta: { changes: 1 } }, // stock decrement
+      { meta: { changes: 1 } }, // order_items insert
+    ]);
+
+    const result = await createOrderWithItems(orderData, items);
+
+    expect(result.orderNumber).toBe("ORD-TEST01");
+    expect(mocks.execute).toHaveBeenCalledTimes(1);
+    expect(mocks.execute.mock.calls[0][0]).toMatch(/INSERT INTO orders/);
+    expect(mocks.execute.mock.calls[0][0]).toMatch(/WHERE \(SELECT COUNT\(\*\) FROM orders/);
+    // The order row itself is no longer part of the stock/items batch.
+    expect(mocks.dbBatch).toHaveBeenCalledTimes(1);
+    expect(mocks.dbBatch.mock.calls[0][0]).toHaveLength(2);
+  });
+
+  it("throws and touches neither stock nor items when the concurrent-pending cap guard blocks the reservation", async () => {
+    // This is the burst-safety property: the guard and the write are the
+    // same statement, so a race can only ever produce changes: 0 here — it
+    // cannot let stock or order_items get touched on a blocked reservation.
+    mocks.execute.mockResolvedValue({ meta: { changes: 0 } });
+
+    await expect(createOrderWithItems(orderData, items)).rejects.toThrow(/attente/i);
+
+    expect(mocks.dbBatch).not.toHaveBeenCalled();
+  });
+
+  it("still rolls back the reserved order when a later stock decrement fails", async () => {
+    mocks.execute.mockResolvedValue({ meta: { changes: 1 } }); // reservation succeeds
+    mocks.dbBatch
+      .mockResolvedValueOnce([{ meta: { changes: 0 } }, { meta: { changes: 1 } }]) // stock decrement fails
+      .mockResolvedValueOnce([{ meta: { changes: 1 } }]); // rollback batch (delete order + items, restore stock)
+
+    await expect(createOrderWithItems(orderData, items)).rejects.toThrow(/Stock insuffisant/);
+
+    // First call attempted the write, second call is the rollback — the
+    // order row created by the reservation is what gets deleted there.
+    expect(mocks.dbBatch).toHaveBeenCalledTimes(2);
   });
 });

--- a/__tests__/unit/lib/db/orders.test.ts
+++ b/__tests__/unit/lib/db/orders.test.ts
@@ -1,17 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-// Exercises the guarded pending->cancelled transition shared by the customer
-// self-cancel path (cancelOrder) and the stale-pending reaper
-// (reapStalePendingOrders), plus the concurrent-pending counter that backs
-// the createOrder cap. Mocks @/lib/db (query/queryFirst/execute) and
+// Exercises the guarded ->cancelled transition shared by the customer
+// self-cancel path (cancelOrder), the stale-pending reaper
+// (reapStalePendingOrders), and the admin cancel action's
+// cancelOrderFromStatus, plus the concurrent-pending counter that backs the
+// createOrder cap. Mocks @/lib/db (query/queryFirst/execute),
 // @/lib/cloudflare/context (getDB, used only by refundOrderStock's batch
-// stock update) rather than a real D1 binding.
+// stock update), and @/lib/notifications (the sweep's customer notification)
+// rather than a real D1 binding or Resend call.
 
 const mocks = vi.hoisted(() => ({
   query: vi.fn(),
   queryFirst: vi.fn(),
   execute: vi.fn(),
   dbBatch: vi.fn(),
+  notifyOrderStatusUpdate: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({
@@ -27,9 +30,13 @@ vi.mock("@/lib/cloudflare/context", () => ({
     batch: mocks.dbBatch,
   }),
 }));
+vi.mock("@/lib/notifications", () => ({
+  notifyOrderStatusUpdate: mocks.notifyOrderStatusUpdate,
+}));
 
 import {
   cancelOrder,
+  cancelOrderFromStatus,
   countPendingOrdersForUser,
   reapStalePendingOrders,
   createOrderWithItems,
@@ -72,7 +79,10 @@ describe("cancelOrder", () => {
     expect(result).toBe(true);
     expect(mocks.execute).toHaveBeenCalledTimes(1);
     expect(mocks.execute.mock.calls[0][0]).toMatch(/status = 'cancelled'/);
-    expect(mocks.execute.mock.calls[0][0]).toMatch(/AND status = 'pending'/);
+    // The guard is parameterized (bound, not inlined) so it can be reused
+    // with any fromStatus, not just 'pending' — see cancelOrderFromStatus.
+    expect(mocks.execute.mock.calls[0][0]).toMatch(/AND status = \?/);
+    expect(mocks.execute.mock.calls[0][1]).toEqual(["changed my mind", "order-1", "pending"]);
     expect(mocks.dbBatch).toHaveBeenCalledTimes(1);
   });
 
@@ -100,7 +110,61 @@ describe("cancelOrder", () => {
     expect(result).toBe(false);
     // First execute = the cancel UPDATE, second = the compensating revert.
     expect(mocks.execute).toHaveBeenCalledTimes(2);
-    expect(mocks.execute.mock.calls[1][0]).toMatch(/status = 'pending'/);
+    expect(mocks.execute.mock.calls[1][0]).toMatch(/SET status = \?/);
+    expect(mocks.execute.mock.calls[1][1]).toEqual(["pending", "order-1"]);
+  });
+});
+
+describe("cancelOrderFromStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Proves the admin cancel path (actions/admin/orders.ts::cancelOrderAdmin)
+  // gets the exact same race-safety as the customer/reaper path when it
+  // cancels an order that was NOT pending (e.g. 'confirmed') — the guard is
+  // not hardcoded to 'pending', it is parameterized on whatever fromStatus
+  // the caller passed in.
+  it("guards on an arbitrary fromStatus, not just 'pending'", async () => {
+    mocks.execute.mockResolvedValue({ meta: { changes: 1 } });
+    mocks.query.mockResolvedValue([ITEM("order-1")]);
+    mocks.dbBatch.mockResolvedValue([{ meta: { changes: 1 } }]);
+
+    const result = await cancelOrderFromStatus("order-1", "confirmed", "Rupture de stock");
+
+    expect(result).toBe(true);
+    expect(mocks.execute.mock.calls[0][1]).toEqual(["Rupture de stock", "order-1", "confirmed"]);
+  });
+
+  // This is the direct proof for the headline race: if an admin reads an
+  // order as 'confirmed' but the row was already flipped away from that
+  // status by the time the guarded UPDATE runs (e.g. the sweep cancelled the
+  // *pending* order underneath a stale admin read, or another admin tab beat
+  // this one to it), the guard must reject rather than silently cancelling
+  // and refunding a row this call never actually transitioned. Without the
+  // "AND status = ?" predicate (the pre-fix behavior), this UPDATE would run
+  // unconditionally and refundOrderStock would be called regardless.
+  it("does not refund when a concurrent caller already changed the row's status away from fromStatus", async () => {
+    mocks.execute.mockResolvedValue({ meta: { changes: 0 } });
+
+    const result = await cancelOrderFromStatus("order-1", "confirmed", "Rupture de stock");
+
+    expect(result).toBe(false);
+    expect(mocks.query).not.toHaveBeenCalled();
+    expect(mocks.dbBatch).not.toHaveBeenCalled();
+  });
+
+  // Backs the admin "cancel without refund" option (cancelOrderAdmin's
+  // refundStock=false): the guard still runs, but refundOrderStock must
+  // never be invoked at all when the caller opts out.
+  it("skips refundOrderStock entirely when refund: false", async () => {
+    mocks.execute.mockResolvedValue({ meta: { changes: 1 } });
+
+    const result = await cancelOrderFromStatus("order-1", "pending", "Doublon", { refund: false });
+
+    expect(result).toBe(true);
+    expect(mocks.query).not.toHaveBeenCalled();
+    expect(mocks.dbBatch).not.toHaveBeenCalled();
   });
 });
 
@@ -226,6 +290,68 @@ describe("reapStalePendingOrders", () => {
     const result = await reapStalePendingOrders(24);
 
     expect(result).toEqual({ cancelled: 1, skipped: 1, total: 2, hasMore: false });
+  });
+
+  it("notifies the customer after auto-cancelling their stale order", async () => {
+    mocks.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      if (sql.includes("FROM orders WHERE status = 'pending'")) {
+        return [{ id: "order-1", order_number: "ORD-ABC123", user_id: "user-1" }];
+      }
+      if (sql.includes("FROM order_items WHERE order_id = ?")) {
+        return [ITEM(params[0] as string)];
+      }
+      return [];
+    });
+    mocks.execute.mockResolvedValue({ meta: { changes: 1 } });
+    mocks.dbBatch.mockResolvedValue([{ meta: { changes: 1 } }]);
+    mocks.queryFirst.mockResolvedValue({ email: "client@example.com", name: "Awa" });
+    mocks.notifyOrderStatusUpdate.mockResolvedValue(undefined);
+
+    const result = await reapStalePendingOrders(24);
+
+    expect(result).toEqual({ cancelled: 1, skipped: 0, total: 1, hasMore: false });
+    expect(mocks.queryFirst).toHaveBeenCalledWith(
+      "SELECT email, name FROM user WHERE id = ?",
+      ["user-1"]
+    );
+    expect(mocks.notifyOrderStatusUpdate).toHaveBeenCalledWith(
+      "client@example.com",
+      expect.objectContaining({
+        customerName: "Awa",
+        orderNumber: "ORD-ABC123",
+        newStatus: "cancelled",
+      })
+    );
+  });
+
+  // The headline requirement for the customer-notification fix: a send
+  // failure must be visible only as a log line, never as a change to the
+  // cancelled/skipped tally, and it must not stop the sweep from reaching
+  // the next order in the same batch.
+  it("does not let a notification failure change the tally or abort the rest of the batch", async () => {
+    mocks.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      if (sql.includes("FROM orders WHERE status = 'pending'")) {
+        return [
+          { id: "order-1", order_number: "ORD-1", user_id: "user-1" },
+          { id: "order-2", order_number: "ORD-2", user_id: "user-2" },
+        ];
+      }
+      if (sql.includes("FROM order_items WHERE order_id = ?")) {
+        return [ITEM(params[0] as string)];
+      }
+      return [];
+    });
+    mocks.execute.mockResolvedValue({ meta: { changes: 1 } });
+    mocks.dbBatch.mockResolvedValue([{ meta: { changes: 1 } }]);
+    // Every attempt to look up the customer (or send the email) fails.
+    mocks.queryFirst.mockRejectedValue(new Error("D1 unavailable"));
+
+    const result = await reapStalePendingOrders(24);
+
+    // Both orders still count as cancelled — the refund already committed
+    // and is entirely independent of whether the courtesy email went out.
+    expect(result).toEqual({ cancelled: 2, skipped: 0, total: 2, hasMore: false });
+    expect(mocks.dbBatch).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/__tests__/unit/lib/db/orders.test.ts
+++ b/__tests__/unit/lib/db/orders.test.ts
@@ -302,4 +302,23 @@ describe("createOrderWithItems", () => {
     // order row created by the reservation is what gets deleted there.
     expect(mocks.dbBatch).toHaveBeenCalledTimes(2);
   });
+
+  it("deletes the reserved order row when the batch itself throws, leaving no phantom pending order", async () => {
+    // The reservation (step 0) committed the order row on its own, separate
+    // execute() call, before db.batch ever runs. If that batch throws — a
+    // transient D1 error, a constraint failure — db.batch's own implicit
+    // transaction rolls back the stock decrements and item inserts, but
+    // nothing automatically undoes the already-committed order row. Without
+    // the fix, this order would survive as `pending`, with a real total and
+    // order_number but zero items, holding a concurrent-pending-cap slot
+    // until the reaper cancels it.
+    mocks.execute.mockResolvedValue({ meta: { changes: 1 } }); // reservation succeeds
+    mocks.dbBatch.mockRejectedValue(new Error("D1 unavailable"));
+
+    await expect(createOrderWithItems(orderData, items)).rejects.toThrow(/création de la commande/i);
+
+    // First execute = the reservation INSERT, second = the cleanup DELETE.
+    expect(mocks.execute).toHaveBeenCalledTimes(2);
+    expect(mocks.execute.mock.calls[1][0]).toMatch(/DELETE FROM orders WHERE id = \?/);
+  });
 });

--- a/__tests__/unit/lib/db/orders.test.ts
+++ b/__tests__/unit/lib/db/orders.test.ts
@@ -142,6 +142,26 @@ describe("cancelOrder", () => {
     expect(revertErr).toBeInstanceOf(Error);
     errorSpy.mockRestore();
   });
+
+  // A revert that matches no row does not throw, but leaves the same stuck
+  // state, so it must collapse to the same failure rather than passing for a
+  // successful compensation.
+  it("traite un retour arrière sans ligne affectée comme un échec de compensation", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.queryFirst.mockResolvedValue({ id: "order-1" });
+    mocks.execute
+      .mockResolvedValueOnce({ meta: { changes: 1 } })
+      .mockResolvedValueOnce({ meta: { changes: 0 } });
+    mocks.query.mockResolvedValue([ITEM("order-1")]);
+    mocks.dbBatch.mockRejectedValue(new Error("D1 batch failed"));
+
+    await expect(cancelOrder("ORD-1", "user-1", "changed my mind")).resolves.toBe(false);
+
+    const call = errorSpy.mock.calls.find((c) => /revert also failed/i.test(String(c[0])));
+    expect(call).toBeDefined();
+    expect(String(call![3])).toMatch(/matched no row/i);
+    errorSpy.mockRestore();
+  });
 });
 
 describe("cancelOrderFromStatus", () => {

--- a/__tests__/unit/lib/db/orders.test.ts
+++ b/__tests__/unit/lib/db/orders.test.ts
@@ -113,6 +113,35 @@ describe("cancelOrder", () => {
     expect(mocks.execute.mock.calls[1][0]).toMatch(/SET status = \?/);
     expect(mocks.execute.mock.calls[1][1]).toEqual(["pending", "order-1"]);
   });
+
+  // The compensating revert is a second, independent D1 call, so it can fail
+  // on its own — a failure the first refund-failure test never reaches. It
+  // must collapse to the same `false` the contract already returns rather
+  // than escaping as an unhandled rejection, and both errors must be logged
+  // so the causal chain survives the boolean return.
+  it("returns false instead of throwing when the compensating revert also fails", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.queryFirst.mockResolvedValue({ id: "order-1" });
+    mocks.execute
+      .mockResolvedValueOnce({ meta: { changes: 1 } })
+      .mockRejectedValueOnce(new Error("D1 unavailable during revert"));
+    mocks.query.mockResolvedValue([ITEM("order-1")]);
+    mocks.dbBatch.mockRejectedValue(new Error("D1 batch failed"));
+
+    await expect(cancelOrder("ORD-1", "user-1", "changed my mind")).resolves.toBe(false);
+
+    expect(mocks.execute).toHaveBeenCalledTimes(2);
+    // refundOrderStock logs its own failure first, so select the compensation
+    // log by content rather than by position.
+    const call = errorSpy.mock.calls.find((c) => /revert also failed/i.test(String(c[0])));
+    expect(call).toBeDefined();
+    const [message, context, refundErr, revertErr] = call!;
+    expect(message).toMatch(/revert also failed/i);
+    expect(context).toMatchObject({ orderId: "order-1", intendedRevertTo: "pending" });
+    expect(refundErr).toBeInstanceOf(Error);
+    expect(revertErr).toBeInstanceOf(Error);
+    errorSpy.mockRestore();
+  });
 });
 
 describe("cancelOrderFromStatus", () => {

--- a/__tests__/unit/lib/db/orders.test.ts
+++ b/__tests__/unit/lib/db/orders.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Exercises the guarded pending->cancelled transition shared by the customer
+// self-cancel path (cancelOrder) and the stale-pending reaper
+// (reapStalePendingOrders), plus the concurrent-pending counter that backs
+// the createOrder cap. Mocks @/lib/db (query/queryFirst/execute) and
+// @/lib/cloudflare/context (getDB, used only by refundOrderStock's batch
+// stock update) rather than a real D1 binding.
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  queryFirst: vi.fn(),
+  execute: vi.fn(),
+  dbBatch: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  query: mocks.query,
+  queryFirst: mocks.queryFirst,
+  execute: mocks.execute,
+}));
+vi.mock("@/lib/cloudflare/context", () => ({
+  getDB: vi.fn().mockResolvedValue({
+    // refundOrderStock builds each stock-update statement via db.prepare(...).bind(...)
+    // before handing the array to db.batch(...) — both must be stubbed.
+    prepare: vi.fn().mockReturnValue({ bind: vi.fn().mockReturnValue({}) }),
+    batch: mocks.dbBatch,
+  }),
+}));
+
+import { cancelOrder, countPendingOrdersForUser, reapStalePendingOrders } from "@/lib/db/orders";
+
+const ITEM = (orderId: string) => ({
+  id: `item-${orderId}`,
+  order_id: orderId,
+  product_id: "prod-1",
+  variant_id: null,
+  product_name: "Casque",
+  variant_name: null,
+  quantity: 1,
+  unit_price: 1000,
+  total_price: 1000,
+});
+
+describe("cancelOrder", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns false when no matching pending order is owned by the user", async () => {
+    mocks.queryFirst.mockResolvedValue(null);
+
+    const result = await cancelOrder("ORD-1", "user-1", "changed my mind");
+
+    expect(result).toBe(false);
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
+  it("cancels the order and refunds stock exactly once", async () => {
+    mocks.queryFirst.mockResolvedValue({ id: "order-1" });
+    mocks.execute.mockResolvedValue({ meta: { changes: 1 } });
+    mocks.query.mockResolvedValue([ITEM("order-1")]);
+    mocks.dbBatch.mockResolvedValue([{ meta: { changes: 1 } }]);
+
+    const result = await cancelOrder("ORD-1", "user-1", "changed my mind");
+
+    expect(result).toBe(true);
+    expect(mocks.execute).toHaveBeenCalledTimes(1);
+    expect(mocks.execute.mock.calls[0][0]).toMatch(/status = 'cancelled'/);
+    expect(mocks.execute.mock.calls[0][0]).toMatch(/AND status = 'pending'/);
+    expect(mocks.dbBatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not refund when the guarded UPDATE affects no rows (already cancelled concurrently)", async () => {
+    mocks.queryFirst.mockResolvedValue({ id: "order-1" });
+    mocks.execute.mockResolvedValue({ meta: { changes: 0 } });
+
+    const result = await cancelOrder("ORD-1", "user-1", "changed my mind");
+
+    expect(result).toBe(false);
+    // Only the cancelling UPDATE ran — refundOrderStock (query for items,
+    // then dbBatch) was never reached because changes === 0 short-circuits.
+    expect(mocks.query).not.toHaveBeenCalled();
+    expect(mocks.dbBatch).not.toHaveBeenCalled();
+  });
+
+  it("reverts to pending if the refund throws, and does not report success", async () => {
+    mocks.queryFirst.mockResolvedValue({ id: "order-1" });
+    mocks.execute.mockResolvedValue({ meta: { changes: 1 } });
+    mocks.query.mockResolvedValue([ITEM("order-1")]);
+    mocks.dbBatch.mockRejectedValue(new Error("D1 batch failed"));
+
+    const result = await cancelOrder("ORD-1", "user-1", "changed my mind");
+
+    expect(result).toBe(false);
+    // First execute = the cancel UPDATE, second = the compensating revert.
+    expect(mocks.execute).toHaveBeenCalledTimes(2);
+    expect(mocks.execute.mock.calls[1][0]).toMatch(/status = 'pending'/);
+  });
+});
+
+describe("countPendingOrdersForUser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the pending count for the user", async () => {
+    mocks.queryFirst.mockResolvedValue({ total: 3 });
+    expect(await countPendingOrdersForUser("user-1")).toBe(3);
+  });
+
+  it("returns 0 when there is no row", async () => {
+    mocks.queryFirst.mockResolvedValue(null);
+    expect(await countPendingOrdersForUser("user-1")).toBe(0);
+  });
+});
+
+describe("reapStalePendingOrders", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("cancels every stale pending order and refunds stock for each", async () => {
+    mocks.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      if (sql.includes("FROM orders WHERE status = 'pending'")) {
+        return [{ id: "order-1" }, { id: "order-2" }];
+      }
+      if (sql.includes("FROM order_items WHERE order_id = ?")) {
+        return [ITEM(params[0] as string)];
+      }
+      return [];
+    });
+    mocks.execute.mockResolvedValue({ meta: { changes: 1 } });
+    mocks.dbBatch.mockResolvedValue([{ meta: { changes: 1 } }]);
+
+    const result = await reapStalePendingOrders(24);
+
+    expect(result).toEqual({ cancelled: 2, skipped: 0, total: 2 });
+    expect(mocks.execute).toHaveBeenCalledTimes(2);
+    expect(mocks.dbBatch).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not double-refund an order a concurrent customer cancellation already claimed", async () => {
+    // order-2's guarded UPDATE affects 0 rows: by the time the reaper reaches
+    // it, a concurrent customer cancel already flipped it away from
+    // 'pending'. The reaper must skip the refund for that order entirely.
+    mocks.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      if (sql.includes("FROM orders WHERE status = 'pending'")) {
+        return [{ id: "order-1" }, { id: "order-2" }];
+      }
+      if (sql.includes("FROM order_items WHERE order_id = ?")) {
+        return [ITEM(params[0] as string)];
+      }
+      return [];
+    });
+    mocks.execute.mockImplementation(async (_sql: string, params: unknown[] = []) => {
+      const orderId = params[1];
+      return { meta: { changes: orderId === "order-2" ? 0 : 1 } };
+    });
+    mocks.dbBatch.mockResolvedValue([{ meta: { changes: 1 } }]);
+
+    const result = await reapStalePendingOrders(24);
+
+    expect(result).toEqual({ cancelled: 1, skipped: 1, total: 2 });
+    // Refund (dbBatch) only ran for order-1 — order-2 was never touched.
+    expect(mocks.dbBatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns zero counts when there are no stale pending orders", async () => {
+    mocks.query.mockResolvedValue([]);
+
+    const result = await reapStalePendingOrders(24);
+
+    expect(result).toEqual({ cancelled: 0, skipped: 0, total: 0 });
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/lib/rate-limit/kv-window-limit.test.ts
+++ b/__tests__/unit/lib/rate-limit/kv-window-limit.test.ts
@@ -16,7 +16,19 @@ function makeKV(initial: Map<string, string> = new Map()) {
   const store = new Map(initial);
   return {
     get: vi.fn(async (key: string) => store.get(key) ?? null),
-    put: vi.fn(async (key: string, value: string) => {
+    // Mirrors real Cloudflare KV's documented constraint: expirationTtl below
+    // 60 seconds is rejected outright (the put throws), it isn't silently
+    // accepted. Without this, the mock would happily store any TTL —
+    // including an invalid one — and no assertion in this suite could ever
+    // fail on that basis alone; a future regression that reintroduces a
+    // sub-60s TTL would need someone to notice a specific expected value,
+    // not the test double itself.
+    put: vi.fn(async (key: string, value: string, options?: KVNamespacePutOptions) => {
+      if (options?.expirationTtl !== undefined && options.expirationTtl < 60) {
+        throw new Error(
+          `KV rejects expirationTtl below 60 seconds (got ${options.expirationTtl})`
+        );
+      }
       store.set(key, value);
     }),
     _store: store,
@@ -83,7 +95,8 @@ describe("checkKVRateLimit", () => {
   // a call accepted late in the window would extend it instead of leaving it
   // fixed. This test fails against that implementation because it would
   // observe a `put` for the full 3600s TTL (and an implicit resetAt of
-  // `NOW + WINDOW_MS`) instead of the ~1s remaining in the real window.
+  // `NOW + WINDOW_MS`) instead of the floored TTL reflecting the real
+  // remaining window.
   it("does not extend the window on a call accepted late in it (fixed, not sliding)", async () => {
     const originalReset = NOW + 1_000; // 1 second left in the window
     const kv = makeKV(new Map([["k", bucket(2, originalReset)]]));
@@ -91,12 +104,34 @@ describe("checkKVRateLimit", () => {
     const ok = await checkKVRateLimit(kv, "k", { max: 5, windowSeconds: WINDOW_SECONDS }, NOW);
 
     expect(ok).toBe(true);
-    // resetAt is preserved from the original bucket, and the TTL written
-    // reflects only the ~1s actually remaining, not the full 3600s window.
+    // resetAt is preserved from the original bucket. The TTL written is
+    // floored at 60 (Cloudflare KV's documented minimum — see the mock's
+    // put() above, and the source's own comment) rather than the ~1s
+    // literally remaining; the fresh-window branch above, not the KV TTL,
+    // is what actually re-closes the window once resetAt passes, so
+    // over-extending past resetAt is harmless.
     expect(kv.put).toHaveBeenCalledWith(
       "k",
       bucket(3, originalReset),
-      expect.objectContaining({ expirationTtl: 1 })
+      expect.objectContaining({ expirationTtl: 60 })
+    );
+  });
+
+  // Direct pin for the floor itself: any remaining-time computation under
+  // 60 seconds must still write expirationTtl: 60, never the raw value —
+  // the mock's put() throws on anything below 60, so this test would fail
+  // loudly (not just assert a wrong number) if the floor were removed.
+  it("floors the written TTL at 60 seconds even when only a few seconds remain", async () => {
+    const originalReset = NOW + 5_000; // 5 seconds left in the window
+    const kv = makeKV(new Map([["k", bucket(1, originalReset)]]));
+
+    const ok = await checkKVRateLimit(kv, "k", { max: 5, windowSeconds: WINDOW_SECONDS }, NOW);
+
+    expect(ok).toBe(true);
+    expect(kv.put).toHaveBeenCalledWith(
+      "k",
+      bucket(2, originalReset),
+      expect.objectContaining({ expirationTtl: 60 })
     );
   });
 

--- a/__tests__/unit/lib/rate-limit/kv-window-limit.test.ts
+++ b/__tests__/unit/lib/rate-limit/kv-window-limit.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { checkKVRateLimit } from "@/lib/rate-limit/kv-window-limit";
+
+// Fixed-window behaviour: a bucket is `{ count, resetAt }` in KV, `resetAt`
+// is set once on the first accepted call of a window and never touched by
+// later accepted calls. This pins that contract down — see the doc comment
+// in lib/rate-limit/kv-window-limit.ts and lib/ai/rate-limit.ts for the
+// same trade-off documented independently.
+
+const NOW = 1_000_000_000_000; // fixed epoch for deterministic resetAt
+const WINDOW_SECONDS = 3600;
+const WINDOW_MS = WINDOW_SECONDS * 1000;
+
+function makeKV(initial: Map<string, string> = new Map()) {
+  const store = new Map(initial);
+  return {
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    put: vi.fn(async (key: string, value: string) => {
+      store.set(key, value);
+    }),
+    _store: store,
+  } as unknown as KVNamespace & {
+    put: ReturnType<typeof vi.fn>;
+    get: ReturnType<typeof vi.fn>;
+    _store: Map<string, string>;
+  };
+}
+
+function bucket(count: number, resetAt: number): string {
+  return JSON.stringify({ count, resetAt });
+}
+
+describe("checkKVRateLimit", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("allows the first call (no bucket) and opens a fixed window", async () => {
+    const kv = makeKV();
+
+    const ok = await checkKVRateLimit(kv, "k", { max: 5, windowSeconds: WINDOW_SECONDS }, NOW);
+
+    expect(ok).toBe(true);
+    expect(kv.put).toHaveBeenCalledWith(
+      "k",
+      bucket(1, NOW + WINDOW_MS),
+      expect.objectContaining({ expirationTtl: WINDOW_SECONDS })
+    );
+  });
+
+  it("allows up to max calls within the window", async () => {
+    const kv = makeKV(new Map([["k", bucket(4, NOW + WINDOW_MS)]]));
+
+    const ok = await checkKVRateLimit(kv, "k", { max: 5, windowSeconds: WINDOW_SECONDS }, NOW);
+
+    expect(ok).toBe(true);
+  });
+
+  it("rejects the (max + 1)th call within the window", async () => {
+    const kv = makeKV(new Map([["k", bucket(5, NOW + WINDOW_MS)]]));
+
+    const ok = await checkKVRateLimit(kv, "k", { max: 5, windowSeconds: WINDOW_SECONDS }, NOW);
+
+    expect(ok).toBe(false);
+    expect(kv.put).not.toHaveBeenCalled();
+  });
+
+  it("starts a fresh window once the previous one has closed", async () => {
+    const kv = makeKV(new Map([["k", bucket(5, NOW - 1)]])); // window already closed
+
+    const ok = await checkKVRateLimit(kv, "k", { max: 5, windowSeconds: WINDOW_SECONDS }, NOW);
+
+    expect(ok).toBe(true);
+    expect(kv.put).toHaveBeenCalledWith(
+      "k",
+      bucket(1, NOW + WINDOW_MS),
+      expect.objectContaining({ expirationTtl: WINDOW_SECONDS })
+    );
+  });
+
+  // This is the regression test for the fix: an earlier implementation
+  // re-put the entry with `expirationTtl: windowSeconds` (the *full* window)
+  // on every accepted call, which slides `resetAt` forward every time —
+  // a call accepted late in the window would extend it instead of leaving it
+  // fixed. This test fails against that implementation because it would
+  // observe a `put` for the full 3600s TTL (and an implicit resetAt of
+  // `NOW + WINDOW_MS`) instead of the ~1s remaining in the real window.
+  it("does not extend the window on a call accepted late in it (fixed, not sliding)", async () => {
+    const originalReset = NOW + 1_000; // 1 second left in the window
+    const kv = makeKV(new Map([["k", bucket(2, originalReset)]]));
+
+    const ok = await checkKVRateLimit(kv, "k", { max: 5, windowSeconds: WINDOW_SECONDS }, NOW);
+
+    expect(ok).toBe(true);
+    // resetAt is preserved from the original bucket, and the TTL written
+    // reflects only the ~1s actually remaining, not the full 3600s window.
+    expect(kv.put).toHaveBeenCalledWith(
+      "k",
+      bucket(3, originalReset),
+      expect.objectContaining({ expirationTtl: 1 })
+    );
+  });
+
+  it("concretely: a customer who reaches the cap always recovers within one window of the FIRST call, never later", async () => {
+    // Reproduces the shape of the brief's failure scenario. Under the old
+    // slide-on-every-write behaviour, each accepted call reset the KV entry's
+    // expirationTtl to a full windowSeconds from that call's own time — so a
+    // burst of accepted calls spaced under the window apart kept pushing the
+    // entry's real expiry further into the future than "one window after the
+    // first call" (the brief's concrete case: 5 calls 55 minutes apart delays
+    // recovery to 4.5h after the first call, not 1h). With the fixed window,
+    // four calls in quick succession (all well inside the same window) must
+    // still leave the bucket's resetAt anchored to the FIRST call, and the
+    // cap must free up exactly one window after that first call — not later,
+    // no matter how many accepted calls landed in between.
+    const kv = makeKV();
+    const tenMin = 10 * 60 * 1000;
+
+    let t = NOW;
+    for (let i = 0; i < 4; i++) {
+      const ok = await checkKVRateLimit(kv, "k", { max: 5, windowSeconds: WINDOW_SECONDS }, t);
+      expect(ok).toBe(true);
+      t += tenMin; // NOW, +10, +20, +30 min — all comfortably inside the 60min window
+    }
+
+    // resetAt must still be anchored to the very first call (NOW + 1h), not
+    // slid forward by any of the 3 subsequent accepted calls.
+    const stored = JSON.parse(kv._store.get("k") as string) as { count: number; resetAt: number };
+    expect(stored.resetAt).toBe(NOW + WINDOW_MS);
+    expect(stored.count).toBe(4);
+
+    // A 5th call, still inside the original window, is accepted (count 4 < max 5)...
+    const fifth = await checkKVRateLimit(kv, "k", { max: 5, windowSeconds: WINDOW_SECONDS }, t);
+    expect(fifth).toBe(true);
+
+    // ...and now the cap is hit: a 6th call one tick before the original
+    // window closes is rejected...
+    const sixthWithinWindow = await checkKVRateLimit(
+      kv,
+      "k",
+      { max: 5, windowSeconds: WINDOW_SECONDS },
+      NOW + WINDOW_MS - 1
+    );
+    expect(sixthWithinWindow).toBe(false);
+
+    // ...but recovers exactly one window after the FIRST call, not hours
+    // later as the slide-on-write bug would have caused.
+    const afterOriginalWindow = await checkKVRateLimit(
+      kv,
+      "k",
+      { max: 5, windowSeconds: WINDOW_SECONDS },
+      NOW + WINDOW_MS + 1
+    );
+    expect(afterOriginalWindow).toBe(true);
+  });
+
+  it("isolates counters by key", async () => {
+    const kv = makeKV(new Map([["order:rate:user-1", bucket(5, NOW + WINDOW_MS)]]));
+
+    const ok = await checkKVRateLimit(kv, "order:rate:user-2", { max: 5, windowSeconds: WINDOW_SECONDS }, NOW);
+
+    expect(ok).toBe(true);
+  });
+
+  it("tolerates a pre-migration plain-counter value (old format) by starting fresh", async () => {
+    // The previous implementation stored a bare numeric string (`String(n)`),
+    // not JSON. A value written before this fix must not crash the parser —
+    // it should be treated like any other malformed value: start fresh.
+    const kv = makeKV(new Map([["k", "3"]]));
+
+    const ok = await checkKVRateLimit(kv, "k", { max: 5, windowSeconds: WINDOW_SECONDS }, NOW);
+
+    expect(ok).toBe(true);
+    expect(kv.put).toHaveBeenCalledWith(
+      "k",
+      bucket(1, NOW + WINDOW_MS),
+      expect.objectContaining({ expirationTtl: WINDOW_SECONDS })
+    );
+  });
+});

--- a/actions/admin/orders.ts
+++ b/actions/admin/orders.ts
@@ -166,13 +166,25 @@ export async function updateOrderStatus(
       // Server Action as an unhandled error — the caller still needs a
       // structured ActionResult, and the wording must be honest about which
       // of the two very different outcomes actually happened.
+      //
+      // The revert is itself guarded on the status this call just wrote, so
+      // it can legitimately match zero rows if something else moved the order
+      // on in the meantime (the hourly stale-order sweep, a concurrent admin).
+      // That is a silent failure with exactly the same consequence as a
+      // throwing revert — order stuck, stock unreturned — so it must not be
+      // reported as a successful revert. Route it through the same branch.
       try {
-        await db
+        const revertResult = await db
           .prepare(
             `UPDATE orders SET status = ?${timestampField ? `, ${timestampField} = NULL` : ""}, updated_at = datetime('now') WHERE id = ? AND status = ?`
           )
           .bind(currentStatus, orderId, newStatus)
           .run();
+        if (revertResult.meta.changes === 0) {
+          throw new Error(
+            "compensating revert matched no row (order no longer at the status this call wrote)"
+          );
+        }
       } catch (revertErr) {
         console.error(
           "updateOrderStatus: stock refund failed AND compensating revert also failed — order left stuck",
@@ -421,13 +433,18 @@ export async function processReturn(
     // revert is a second, independent D1 call and gets its own try/catch so
     // its failure can never escape this Server Action unhandled — the caller
     // still needs a structured ActionResult, and the message must be honest
-    // about whether the revert actually happened.
+    // about whether the revert actually happened — including when it matches
+    // zero rows because something else moved the order on, which leaves the
+    // same stuck state as a throwing revert and must be reported the same way.
     try {
-      await execute(
+      const revertResult = await execute(
         `UPDATE orders SET status = ?, returned_at = NULL, return_reason = NULL, updated_at = datetime('now')
          WHERE id = ? AND status = 'returned'`,
         [currentStatus, orderId]
       );
+      if (revertResult.meta.changes === 0) {
+        throw new Error("compensating revert matched no row (order no longer 'returned')");
+      }
     } catch (revertErr) {
       console.error(
         "processReturn: stock refund failed AND compensating revert also failed — order left stuck",

--- a/actions/admin/orders.ts
+++ b/actions/admin/orders.ts
@@ -160,13 +160,32 @@ export async function updateOrderStatus(
       // Compensate: revert the transition so a failed refund never leaves a
       // cancelled/returned order with its stock silently unreturned. The
       // status guard above means only this call performed the transition,
-      // so the revert targets exactly the row this call just changed.
-      await db
-        .prepare(
-          `UPDATE orders SET status = ?${timestampField ? `, ${timestampField} = NULL` : ""}, updated_at = datetime('now') WHERE id = ? AND status = ?`
-        )
-        .bind(currentStatus, orderId, newStatus)
-        .run();
+      // so the revert targets exactly the row this call just changed. The
+      // revert itself gets its own try/catch: it is a second, independent D1
+      // call and can fail on its own, in which case it must not escape this
+      // Server Action as an unhandled error — the caller still needs a
+      // structured ActionResult, and the wording must be honest about which
+      // of the two very different outcomes actually happened.
+      try {
+        await db
+          .prepare(
+            `UPDATE orders SET status = ?${timestampField ? `, ${timestampField} = NULL` : ""}, updated_at = datetime('now') WHERE id = ? AND status = ?`
+          )
+          .bind(currentStatus, orderId, newStatus)
+          .run();
+      } catch (revertErr) {
+        console.error(
+          "updateOrderStatus: stock refund failed AND compensating revert also failed — order left stuck",
+          { orderId, stuckStatus: newStatus, intendedRevertTo: currentStatus },
+          err,
+          revertErr
+        );
+        return {
+          success: false,
+          error:
+            "Échec du remboursement du stock et échec de la tentative d'annulation du changement de statut : la commande est restée au nouveau statut sans que le stock ait été remboursé. Une vérification manuelle est nécessaire.",
+        };
+      }
       console.error(
         "updateOrderStatus: stock refund failed, reverted",
         { orderId, revertedTo: currentStatus },
@@ -398,12 +417,30 @@ export async function processReturn(
     await refundOrderStock(orderId);
   } catch (err) {
     // Compensate: revert to the prior status so a failed refund never
-    // leaves a "returned" order with its stock silently unreturned.
-    await execute(
-      `UPDATE orders SET status = ?, returned_at = NULL, return_reason = NULL, updated_at = datetime('now')
-       WHERE id = ? AND status = 'returned'`,
-      [currentStatus, orderId]
-    );
+    // leaves a "returned" order with its stock silently unreturned. The
+    // revert is a second, independent D1 call and gets its own try/catch so
+    // its failure can never escape this Server Action unhandled — the caller
+    // still needs a structured ActionResult, and the message must be honest
+    // about whether the revert actually happened.
+    try {
+      await execute(
+        `UPDATE orders SET status = ?, returned_at = NULL, return_reason = NULL, updated_at = datetime('now')
+         WHERE id = ? AND status = 'returned'`,
+        [currentStatus, orderId]
+      );
+    } catch (revertErr) {
+      console.error(
+        "processReturn: stock refund failed AND compensating revert also failed — order left stuck",
+        { orderId, stuckStatus: "returned", intendedRevertTo: currentStatus },
+        err,
+        revertErr
+      );
+      return {
+        success: false,
+        error:
+          "Échec du remboursement du stock et échec de la tentative d'annulation du retour : la commande est restée au statut « retournée » sans que le stock ait été remboursé. Une vérification manuelle est nécessaire.",
+      };
+    }
     console.error(
       "processReturn: stock refund failed, reverted",
       { orderId, revertedTo: currentStatus },

--- a/actions/admin/orders.ts
+++ b/actions/admin/orders.ts
@@ -168,7 +168,8 @@ export async function updateOrderStatus(
         .bind(currentStatus, orderId, newStatus)
         .run();
       console.error(
-        `updateOrderStatus: stock refund failed for order ${orderId}, reverted to ${currentStatus}`,
+        "updateOrderStatus: stock refund failed, reverted",
+        { orderId, revertedTo: currentStatus },
         err
       );
       return {
@@ -404,7 +405,8 @@ export async function processReturn(
       [currentStatus, orderId]
     );
     console.error(
-      `processReturn: stock refund failed for order ${orderId}, reverted to ${currentStatus}`,
+      "processReturn: stock refund failed, reverted",
+      { orderId, revertedTo: currentStatus },
       err
     );
     return {

--- a/actions/admin/orders.ts
+++ b/actions/admin/orders.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import { requireAdmin } from "@/lib/auth/guards";
 import { execute, queryFirst } from "@/lib/db";
 import { getDB } from "@/lib/cloudflare/context";
-import { refundOrderStock } from "@/lib/db/orders";
+import { refundOrderStock, cancelOrderFromStatus } from "@/lib/db/orders";
 import {
   getAdminOrders,
   getAdminOrderCount,
@@ -107,37 +107,80 @@ export async function updateOrderStatus(
   if (!order) return { success: false, error: "Commande introuvable" };
 
   const currentStatus = order.status as OrderStatus;
+  const nextStatus = newStatus as OrderStatus;
   const allowed = ORDER_STATUS_TRANSITIONS[currentStatus] || [];
 
-  if (!allowed.includes(newStatus as OrderStatus)) {
+  if (!allowed.includes(nextStatus)) {
     return {
       success: false,
-      error: `Transition de "${ORDER_STATUS_LABELS[currentStatus]}" vers "${ORDER_STATUS_LABELS[newStatus as OrderStatus] || newStatus}" non autorisée`,
+      error: `Transition de "${ORDER_STATUS_LABELS[currentStatus]}" vers "${ORDER_STATUS_LABELS[nextStatus] || newStatus}" non autorisée`,
     };
   }
 
   const db = await getDB();
 
   // Get timestamp field for the new status
-  const timestampField = getStatusTimestampField(newStatus as OrderStatus);
+  const timestampField = getStatusTimestampField(nextStatus);
 
-  if (timestampField) {
-    await db
-      .prepare(
-        `UPDATE orders SET status = ?, ${timestampField} = datetime('now'), updated_at = datetime('now') WHERE id = ?`
-      )
-      .bind(newStatus, orderId)
-      .run();
-  } else {
-    await db
-      .prepare(
-        "UPDATE orders SET status = ?, updated_at = datetime('now') WHERE id = ?"
-      )
-      .bind(newStatus, orderId)
-      .run();
+  // Guarded transition: "AND status = ?" bound to currentStatus (read just
+  // above) means this UPDATE can affect the row at most once, no matter how
+  // many callers race to change it concurrently — another admin tab acting
+  // on the same order, or, for a pending order, the hourly stale-order sweep
+  // cancelling it out from under this call. Without this predicate, a lost
+  // race would silently re-run history/refund/notification against a row
+  // this call never actually transitioned, which is exactly the shape that
+  // let an admin cancel double-refund stock the sweep had already returned.
+  const updateResult = timestampField
+    ? await db
+        .prepare(
+          `UPDATE orders SET status = ?, ${timestampField} = datetime('now'), updated_at = datetime('now') WHERE id = ? AND status = ?`
+        )
+        .bind(newStatus, orderId, currentStatus)
+        .run()
+    : await db
+        .prepare(
+          "UPDATE orders SET status = ?, updated_at = datetime('now') WHERE id = ? AND status = ?"
+        )
+        .bind(newStatus, orderId, currentStatus)
+        .run();
+
+  if (!(updateResult.meta.changes > 0)) {
+    return {
+      success: false,
+      error: `La commande a changé de statut entre-temps (attendu "${ORDER_STATUS_LABELS[currentStatus]}"). Merci de rafraîchir la page.`,
+    };
   }
 
-  // Add history entry
+  // Refund stock for cancellations and returns.
+  // Note: Returns ALWAYS refund stock, even for delivered orders (items returned to warehouse)
+  if (nextStatus === "cancelled" || nextStatus === "returned") {
+    try {
+      await refundOrderStock(orderId);
+    } catch (err) {
+      // Compensate: revert the transition so a failed refund never leaves a
+      // cancelled/returned order with its stock silently unreturned. The
+      // status guard above means only this call performed the transition,
+      // so the revert targets exactly the row this call just changed.
+      await db
+        .prepare(
+          `UPDATE orders SET status = ?${timestampField ? `, ${timestampField} = NULL` : ""}, updated_at = datetime('now') WHERE id = ? AND status = ?`
+        )
+        .bind(currentStatus, orderId, newStatus)
+        .run();
+      console.error(
+        `updateOrderStatus: stock refund failed for order ${orderId}, reverted to ${currentStatus}`,
+        err
+      );
+      return {
+        success: false,
+        error: "Échec du remboursement du stock ; la commande a été remise à son statut précédent.",
+      };
+    }
+  }
+
+  // Add history entry — only reached once the transition (and any required
+  // refund) has actually succeeded, so history never records a change that
+  // was reverted above.
   await addStatusHistory(
     orderId,
     currentStatus,
@@ -146,16 +189,10 @@ export async function updateOrderStatus(
     noteResult.data
   );
 
-  // Refund stock for cancellations and returns
-  // Note: Returns ALWAYS refund stock, even for delivered orders (items returned to warehouse)
-  if (newStatus === "cancelled" || newStatus === "returned") {
-    await refundOrderStock(orderId);
-  }
-
   // Notify customer (fire-and-forget)
   const customer = await getOrderCustomer(order.user_id);
   if (customer) {
-    sendStatusNotification(order, newStatus as OrderStatus, customer, {
+    sendStatusNotification(order, nextStatus, customer, {
       deliveryPersonName: order.delivery_person_name,
       reason: noteResult.data,
     });
@@ -262,15 +299,25 @@ export async function cancelOrderAdmin(
     };
   }
 
-  await execute(
-    `UPDATE orders SET
-       status = 'cancelled',
-       cancelled_at = datetime('now'),
-       cancellation_reason = ?,
-       updated_at = datetime('now')
-     WHERE id = ?`,
-    [reasonResult.data, orderId]
-  );
+  // Reuses the same guarded transition the customer self-cancel path and
+  // the stale-pending sweep use (see lib/db/orders.ts::cancelOrderFromStatus's
+  // doc comment) — its "AND status = ?" predicate, bound to currentStatus
+  // read above, means this call can only ever cancel-and-refund a row it
+  // actually transitioned itself. Without it, an admin cancelling a pending
+  // order the hourly sweep had already cancelled moments earlier would run
+  // its UPDATE unconditionally and call refundOrderStock a second time over
+  // the same order_items — the exact double-refund race this guard closes.
+  const cancelled = await cancelOrderFromStatus(orderId, currentStatus, reasonResult.data, {
+    refund: refundStock,
+  });
+
+  if (!cancelled) {
+    return {
+      success: false,
+      error:
+        "La commande a changé de statut entre-temps (ou le remboursement du stock a échoué). Merci de rafraîchir la page.",
+    };
+  }
 
   await addStatusHistory(
     orderId,
@@ -279,10 +326,6 @@ export async function cancelOrderAdmin(
     session.user.email,
     reasonResult.data
   );
-
-  if (refundStock) {
-    await refundOrderStock(orderId);
-  }
 
   // Notify customer (fire-and-forget)
   const customer = await getOrderCustomer(order.user_id);
@@ -327,15 +370,48 @@ export async function processReturn(
     };
   }
 
-  await execute(
+  // Guarded transition: "AND status = ?" bound to currentStatus means this
+  // UPDATE can affect the row at most once, even if another admin action (or,
+  // for a currentStatus that could also be reached via the sweep — not the
+  // case for "returned" today, but the same discipline as the other
+  // transitions above) races this same order concurrently.
+  const updateResult = await execute(
     `UPDATE orders SET
        status = 'returned',
        returned_at = datetime('now'),
        return_reason = ?,
        updated_at = datetime('now')
-     WHERE id = ?`,
-    [reasonResult.data, orderId]
+     WHERE id = ? AND status = ?`,
+    [reasonResult.data, orderId, currentStatus]
   );
+
+  if (!(updateResult.meta.changes > 0)) {
+    return {
+      success: false,
+      error: `La commande a changé de statut entre-temps (attendu "${ORDER_STATUS_LABELS[currentStatus]}"). Merci de rafraîchir la page.`,
+    };
+  }
+
+  // Returns ALWAYS refund stock (items returned to warehouse)
+  try {
+    await refundOrderStock(orderId);
+  } catch (err) {
+    // Compensate: revert to the prior status so a failed refund never
+    // leaves a "returned" order with its stock silently unreturned.
+    await execute(
+      `UPDATE orders SET status = ?, returned_at = NULL, return_reason = NULL, updated_at = datetime('now')
+       WHERE id = ? AND status = 'returned'`,
+      [currentStatus, orderId]
+    );
+    console.error(
+      `processReturn: stock refund failed for order ${orderId}, reverted to ${currentStatus}`,
+      err
+    );
+    return {
+      success: false,
+      error: "Échec du remboursement du stock ; la commande a été remise à son statut précédent.",
+    };
+  }
 
   await addStatusHistory(
     orderId,
@@ -344,9 +420,6 @@ export async function processReturn(
     session.user.email,
     reasonResult.data
   );
-
-  // Returns ALWAYS refund stock (items returned to warehouse)
-  await refundOrderStock(orderId);
 
   // Notify customer (fire-and-forget)
   const customer = await getOrderCustomer(order.user_id);

--- a/actions/checkout.ts
+++ b/actions/checkout.ts
@@ -15,6 +15,7 @@ import {
   calculateOrderTotal,
   calculateSubtotal,
   resolveOrderLine,
+  countActiveVariantsByProduct,
 } from "@/lib/utils/checkout";
 
 // ---------- internal promo validation (no auth check) ----------
@@ -143,14 +144,8 @@ export async function createOrder(input: CheckoutInput): Promise<CreateOrderResu
   const productMap = new Map(products.map((p) => [p.id, p]));
 
   const variantMap = new Map<string, ProductVariant>();
-  const activeVariantCountByProduct = new Map<string, number>();
-  for (const v of variantsRaw) {
-    variantMap.set(v.id, v);
-    activeVariantCountByProduct.set(
-      v.product_id,
-      (activeVariantCountByProduct.get(v.product_id) ?? 0) + 1
-    );
-  }
+  for (const v of variantsRaw) variantMap.set(v.id, v);
+  const activeVariantCountByProduct = countActiveVariantsByProduct(variantsRaw);
 
   // 6. Validate each cart item
   const validatedItems: Array<{

--- a/actions/checkout.ts
+++ b/actions/checkout.ts
@@ -88,22 +88,15 @@ export async function createOrder(input: CheckoutInput): Promise<CreateOrderResu
   const session = await requireAuth();
   const userId = session.user.id;
 
-  // Throttle: no limiter previously governed order creation — better-auth's
-  // rate limiting only covers /api/auth/* routes, never this Server Action.
-  // Keyed on userId alone (every caller is authenticated), not IP: see
-  // lib/rate-limit/orders.ts for why.
-  const withinRateLimit = await checkOrderRateLimit(await getKV(), userId);
-  if (!withinRateLimit) {
-    return {
-      success: false,
-      error: "Trop de commandes recentes. Merci de reessayer dans un moment.",
-    };
-  }
-
-  // Cap concurrently-open pending orders per user. The rate limit above
-  // bounds creation *velocity* but not how many reservations a single
-  // account can hold open at once; this bounds that directly (see
-  // countPendingOrdersForUser's doc comment in lib/db/orders.ts).
+  // Fast-path cap on concurrently-open pending orders per user — cheap, good
+  // UX (a customer who genuinely already has several orders pending gets a
+  // clear message before spending effort on the rest of validation), but NOT
+  // the authoritative enforcement: this is a plain read, so a burst of
+  // parallel createOrder calls could all read the same under-cap count
+  // before any of them writes. The actual guard against that race is the
+  // atomic guarded INSERT inside createOrderWithItems (see its doc comment
+  // in lib/db/orders.ts) — this check can only ever reject early or agree
+  // with that guard, never let something through it would block.
   const pendingCount = await countPendingOrdersForUser(userId);
   if (pendingCount >= MAX_PENDING_ORDERS_PER_USER) {
     return {
@@ -269,7 +262,31 @@ export async function createOrder(input: CheckoutInput): Promise<CreateOrderResu
   estimatedDate.setHours(estimatedDate.getHours() + zone.estimated_hours);
   const estimatedDelivery = estimatedDate.toISOString();
 
-  // 11. Create order atomically
+  // 11. Throttle: no limiter previously governed order creation — better-auth's
+  //     rate limiting only covers /api/auth/* routes, never this Server Action.
+  //     Keyed on userId alone (every caller is authenticated), not IP: see
+  //     lib/rate-limit/orders.ts for why. Checked here — immediately before the
+  //     actual write — rather than at the top of the action: every check above
+  //     this point (schema, address, delivery zone, product/variant/stock
+  //     resolution, promo code) can legitimately fail on ordinary user error
+  //     (a typo, an item that just sold out) and retrying after fixing it
+  //     should not cost one of the 5 hourly slots. Only attempts that clear
+  //     every other check consume the quota, so it bounds actual
+  //     order-creation attempts without also penalizing failed validation.
+  //     Best-effort by design: KV is eventually consistent, so very
+  //     concurrent requests can slip past this check slightly over the cap —
+  //     accepted here the same way the WhatsApp bot accepts it elsewhere in
+  //     this codebase. It is not the hard boundary; the atomic guard in
+  //     createOrderWithItems is.
+  const withinRateLimit = await checkOrderRateLimit(await getKV(), userId);
+  if (!withinRateLimit) {
+    return {
+      success: false,
+      error: "Trop de commandes recentes. Merci de reessayer dans un moment.",
+    };
+  }
+
+  // 12. Create order atomically
   const orderNumber = generateOrderNumber();
   const deliveryAddressFormatted = `${addressFullName}, ${addressStreet}, ${addressCommune}, ${addressCity}`;
 

--- a/actions/checkout.ts
+++ b/actions/checkout.ts
@@ -242,7 +242,37 @@ export async function createOrder(input: CheckoutInput): Promise<CreateOrderResu
 
   const total = calculateOrderTotal(subtotal, deliveryFee, discountAmount);
 
-  // 9. Optionally save new address
+  // 9. Throttle: no limiter previously governed order creation — better-auth's
+  //    rate limiting only covers /api/auth/* routes, never this Server Action.
+  //    Keyed on userId alone (every caller is authenticated), not IP: see
+  //    lib/rate-limit/orders.ts for why. Checked here — after every read-only
+  //    validation step (schema, address lookup, delivery zone, product/
+  //    variant/stock resolution, promo code) but strictly BEFORE the first
+  //    persistent write (createAddress, right below) — rather than at the
+  //    top of the action, so ordinary user error (a typo, an item that just
+  //    sold out, an invalid promo code) doesn't cost one of the 5 hourly
+  //    slots on retry. It must not move any later than this, though: every
+  //    step from here on can write (createAddress unconditionally inserts a
+  //    row with no dedup or per-user cap of its own) or is the order write
+  //    itself, so a throttled call must never reach any of them — otherwise
+  //    an attacker who has already exhausted their 5 slots gets unlimited
+  //    free address-table writes and product/variant read load by looping
+  //    with saveAddress: true, since no order is ever created to trip the
+  //    pending-count fast path either.
+  //    Best-effort by design: KV is eventually consistent, so very
+  //    concurrent requests can slip past this check slightly over the cap —
+  //    accepted here the same way the WhatsApp bot accepts it elsewhere in
+  //    this codebase. It is not the hard boundary; the atomic guard in
+  //    createOrderWithItems is.
+  const withinRateLimit = await checkOrderRateLimit(await getKV(), userId);
+  if (!withinRateLimit) {
+    return {
+      success: false,
+      error: "Trop de commandes recentes. Merci de reessayer dans un moment.",
+    };
+  }
+
+  // 10. Optionally save new address
   if (!data.savedAddressId && data.saveAddress) {
     await createAddress({
       userId,
@@ -257,34 +287,10 @@ export async function createOrder(input: CheckoutInput): Promise<CreateOrderResu
     });
   }
 
-  // 10. Estimated delivery
+  // 11. Estimated delivery
   const estimatedDate = new Date();
   estimatedDate.setHours(estimatedDate.getHours() + zone.estimated_hours);
   const estimatedDelivery = estimatedDate.toISOString();
-
-  // 11. Throttle: no limiter previously governed order creation — better-auth's
-  //     rate limiting only covers /api/auth/* routes, never this Server Action.
-  //     Keyed on userId alone (every caller is authenticated), not IP: see
-  //     lib/rate-limit/orders.ts for why. Checked here — immediately before the
-  //     actual write — rather than at the top of the action: every check above
-  //     this point (schema, address, delivery zone, product/variant/stock
-  //     resolution, promo code) can legitimately fail on ordinary user error
-  //     (a typo, an item that just sold out) and retrying after fixing it
-  //     should not cost one of the 5 hourly slots. Only attempts that clear
-  //     every other check consume the quota, so it bounds actual
-  //     order-creation attempts without also penalizing failed validation.
-  //     Best-effort by design: KV is eventually consistent, so very
-  //     concurrent requests can slip past this check slightly over the cap —
-  //     accepted here the same way the WhatsApp bot accepts it elsewhere in
-  //     this codebase. It is not the hard boundary; the atomic guard in
-  //     createOrderWithItems is.
-  const withinRateLimit = await checkOrderRateLimit(await getKV(), userId);
-  if (!withinRateLimit) {
-    return {
-      success: false,
-      error: "Trop de commandes recentes. Merci de reessayer dans un moment.",
-    };
-  }
 
   // 12. Create order atomically
   const orderNumber = generateOrderNumber();

--- a/actions/checkout.ts
+++ b/actions/checkout.ts
@@ -14,6 +14,7 @@ import {
   calculateDiscount,
   calculateOrderTotal,
   calculateSubtotal,
+  resolveOrderLine,
 } from "@/lib/utils/checkout";
 
 // ---------- internal promo validation (no auth check) ----------
@@ -93,20 +94,20 @@ export async function createOrder(input: CheckoutInput): Promise<CreateOrderResu
 
   // 2. Start products + variants fetch early (independent of address)
   const productIds = data.items.map((i) => i.productId);
-  const variantIds = data.items.map((i) => i.variantId).filter(Boolean) as string[];
 
   const placeholdersP = productIds.map(() => "?").join(",");
   const productsPromise = query<Product>(
     `SELECT * FROM products WHERE id IN (${placeholdersP}) AND is_active = 1`,
     productIds
   );
-  const variantsPromise =
-    variantIds.length > 0
-      ? query<ProductVariant>(
-          `SELECT * FROM product_variants WHERE id IN (${variantIds.map(() => "?").join(",")}) AND is_active = 1`,
-          variantIds
-        )
-      : Promise.resolve([] as ProductVariant[]);
+  // Fetch every active variant for every product in the cart — not just the
+  // ones referenced by a variantId. This is what lets us compute each
+  // product's activeVariantCount below without a second COUNT query, and it
+  // guarantees a variant can only resolve for a product actually in this cart.
+  const variantsPromise = query<ProductVariant>(
+    `SELECT * FROM product_variants WHERE product_id IN (${placeholdersP}) AND is_active = 1`,
+    productIds
+  );
 
   // 3. Resolve address
   let addressStreet: string;
@@ -142,7 +143,14 @@ export async function createOrder(input: CheckoutInput): Promise<CreateOrderResu
   const productMap = new Map(products.map((p) => [p.id, p]));
 
   const variantMap = new Map<string, ProductVariant>();
-  for (const v of variantsRaw) variantMap.set(v.id, v);
+  const activeVariantCountByProduct = new Map<string, number>();
+  for (const v of variantsRaw) {
+    variantMap.set(v.id, v);
+    activeVariantCountByProduct.set(
+      v.product_id,
+      (activeVariantCountByProduct.get(v.product_id) ?? 0) + 1
+    );
+  }
 
   // 6. Validate each cart item
   const validatedItems: Array<{
@@ -160,41 +168,40 @@ export async function createOrder(input: CheckoutInput): Promise<CreateOrderResu
       return { success: false, error: "Produit introuvable ou indisponible" };
     }
 
+    let variant: ProductVariant | null = null;
     if (cartItem.variantId) {
-      const variant = variantMap.get(cartItem.variantId);
-      if (!variant || variant.product_id !== cartItem.productId) {
+      const candidate = variantMap.get(cartItem.variantId);
+      if (!candidate || candidate.product_id !== cartItem.productId) {
         return { success: false, error: `Variante introuvable pour ${product.name}` };
       }
-      if (variant.stock_quantity < cartItem.quantity) {
-        return {
-          success: false,
-          error: `Stock insuffisant pour ${product.name} - ${variant.name} (${variant.stock_quantity} disponible(s))`,
-        };
-      }
-      validatedItems.push({
-        productId: product.id,
-        variantId: variant.id,
-        productName: product.name,
-        variantName: variant.name,
-        unitPrice: variant.price,
-        quantity: cartItem.quantity,
-      });
-    } else {
-      if (product.stock_quantity < cartItem.quantity) {
-        return {
-          success: false,
-          error: `Stock insuffisant pour ${product.name} (${product.stock_quantity} disponible(s))`,
-        };
-      }
-      validatedItems.push({
-        productId: product.id,
-        variantId: null,
-        productName: product.name,
-        variantName: null,
-        unitPrice: product.base_price,
-        quantity: cartItem.quantity,
-      });
+      variant = candidate;
     }
+
+    const result = resolveOrderLine({
+      product: {
+        name: product.name,
+        base_price: product.base_price,
+        stock_quantity: product.stock_quantity,
+        activeVariantCount: activeVariantCountByProduct.get(product.id) ?? 0,
+      },
+      variant: variant
+        ? { name: variant.name, price: variant.price, stock_quantity: variant.stock_quantity }
+        : null,
+      quantity: cartItem.quantity,
+    });
+
+    if (!result.ok) {
+      return { success: false, error: result.error };
+    }
+
+    validatedItems.push({
+      productId: product.id,
+      variantId: variant?.id ?? null,
+      productName: product.name,
+      variantName: variant?.name ?? null,
+      unitPrice: result.unitPrice,
+      quantity: cartItem.quantity,
+    });
   }
 
   // 7. Calculate totals

--- a/actions/checkout.ts
+++ b/actions/checkout.ts
@@ -5,6 +5,7 @@ import { checkoutSchema, type CheckoutInput, type CheckoutOutput } from "@/lib/v
 import { query, queryFirst } from "@/lib/db";
 import { getKV } from "@/lib/cloudflare/context";
 import { checkOrderRateLimit } from "@/lib/rate-limit/orders";
+import { checkPromoRateLimit } from "@/lib/rate-limit/promo";
 import { getDeliveryZoneByCommune } from "@/lib/db/delivery-zones";
 import { getAddressById, createAddress } from "@/lib/db/addresses";
 import {
@@ -38,10 +39,29 @@ function invalidPromo(error: string): PromoResult {
   return { valid: false, discount: 0, promoCodeId: null, label: null, error };
 }
 
+// A code that doesn't exist, one that's expired, one that hasn't started
+// yet, one that hit its usage cap, and one whose minimum order isn't met
+// all resolve through validatePromoEligibility/queryFirst below with a
+// distinct, specific message each. Surfacing any of that distinction to the
+// caller turns validatePromoCode into an oracle over the promo_codes table:
+// an authenticated customer could tell "this code doesn't exist" apart from
+// "this code exists but isn't active yet", revealing unpublished campaigns
+// and their eligibility thresholds one probe at a time. Collapsing every
+// failure reason — including the rate-limit rejection below — onto this one
+// string closes that channel. validatePromoEligibility itself still returns
+// the specific reason (kept for its own unit tests and internal callers);
+// it's only discarded here, at the boundary that talks back to the client.
+const GENERIC_PROMO_ERROR = "Ce code promo n'est pas applicable à votre commande.";
+
 async function resolvePromoCode(
   code: string,
   subtotal: number
 ): Promise<PromoResult> {
+  // An empty/blank code never reaches the promo_codes table, so returning a
+  // distinct message here doesn't leak anything about which codes exist —
+  // the caller already knows, locally, whether they typed anything. The
+  // storefront form also short-circuits on this before ever calling the
+  // server action, so this is a defence-in-depth path, not the common case.
   if (!code.trim()) {
     return invalidPromo("Veuillez saisir un code promo");
   }
@@ -51,10 +71,10 @@ async function resolvePromoCode(
     [code.trim().toUpperCase()]
   );
 
-  if (!promo) return invalidPromo("Code promo invalide");
+  if (!promo) return invalidPromo(GENERIC_PROMO_ERROR);
 
   const eligibilityError = validatePromoEligibility(promo, subtotal);
-  if (eligibilityError) return invalidPromo(eligibilityError);
+  if (eligibilityError) return invalidPromo(GENERIC_PROMO_ERROR);
 
   const { discount, label } = calculateDiscount(
     promo.discount_type,
@@ -71,7 +91,23 @@ export async function validatePromoCode(
   code: string,
   subtotal: number
 ): Promise<PromoResult> {
-  await requireAuth();
+  const session = await requireAuth();
+
+  // No limiter previously governed promo validation, so an authenticated
+  // account could probe the promo namespace as fast as the network allowed.
+  // Checked before the promo_codes lookup — a throttled call must return
+  // the exact same GENERIC_PROMO_ERROR without ever touching the table,
+  // otherwise the throttle's own rejection becomes a second oracle: a
+  // distinct "too many attempts" reply would confirm that probing was being
+  // counted, and a message that only appears once real lookups have run
+  // would leak the same "code doesn't exist yet" timing this fix closes.
+  // Ceiling is looser than order creation's (lib/rate-limit/promo.ts) since
+  // trying a promo code is a legitimate action customers repeat often.
+  const withinRateLimit = await checkPromoRateLimit(await getKV(), session.user.id);
+  if (!withinRateLimit) {
+    return invalidPromo(GENERIC_PROMO_ERROR);
+  }
+
   return resolvePromoCode(code, subtotal);
 }
 

--- a/actions/checkout.ts
+++ b/actions/checkout.ts
@@ -3,9 +3,15 @@
 import { requireAuth } from "@/lib/auth/guards";
 import { checkoutSchema, type CheckoutInput, type CheckoutOutput } from "@/lib/validations/checkout";
 import { query, queryFirst } from "@/lib/db";
+import { getKV } from "@/lib/cloudflare/context";
+import { checkOrderRateLimit } from "@/lib/rate-limit/orders";
 import { getDeliveryZoneByCommune } from "@/lib/db/delivery-zones";
 import { getAddressById, createAddress } from "@/lib/db/addresses";
-import { createOrderWithItems } from "@/lib/db/orders";
+import {
+  createOrderWithItems,
+  countPendingOrdersForUser,
+  MAX_PENDING_ORDERS_PER_USER,
+} from "@/lib/db/orders";
 import { generateOrderNumber } from "@/lib/utils/order-number";
 import type { Product, ProductVariant, PromoCode } from "@/lib/db/types";
 import { notifyOrderConfirmation } from "@/lib/notifications";
@@ -81,6 +87,31 @@ interface CreateOrderResult {
 export async function createOrder(input: CheckoutInput): Promise<CreateOrderResult> {
   const session = await requireAuth();
   const userId = session.user.id;
+
+  // Throttle: no limiter previously governed order creation — better-auth's
+  // rate limiting only covers /api/auth/* routes, never this Server Action.
+  // Keyed on userId alone (every caller is authenticated), not IP: see
+  // lib/rate-limit/orders.ts for why.
+  const withinRateLimit = await checkOrderRateLimit(await getKV(), userId);
+  if (!withinRateLimit) {
+    return {
+      success: false,
+      error: "Trop de commandes recentes. Merci de reessayer dans un moment.",
+    };
+  }
+
+  // Cap concurrently-open pending orders per user. The rate limit above
+  // bounds creation *velocity* but not how many reservations a single
+  // account can hold open at once; this bounds that directly (see
+  // countPendingOrdersForUser's doc comment in lib/db/orders.ts).
+  const pendingCount = await countPendingOrdersForUser(userId);
+  if (pendingCount >= MAX_PENDING_ORDERS_PER_USER) {
+    return {
+      success: false,
+      error:
+        "Vous avez deja plusieurs commandes en attente de confirmation. Merci d'attendre leur traitement avant d'en passer une nouvelle.",
+    };
+  }
 
   // 1. Validate
   const parsed = checkoutSchema.safeParse(input);

--- a/actions/checkout.ts
+++ b/actions/checkout.ts
@@ -39,19 +39,15 @@ function invalidPromo(error: string): PromoResult {
   return { valid: false, discount: 0, promoCodeId: null, label: null, error };
 }
 
-// A code that doesn't exist, one that's expired, one that hasn't started
-// yet, one that hit its usage cap, and one whose minimum order isn't met
-// all resolve through validatePromoEligibility/queryFirst below with a
-// distinct, specific message each. Surfacing any of that distinction to the
-// caller turns validatePromoCode into an oracle over the promo_codes table:
-// an authenticated customer could tell "this code doesn't exist" apart from
-// "this code exists but isn't active yet", revealing unpublished campaigns
-// and their eligibility thresholds one probe at a time. Collapsing every
-// failure reason — including the rate-limit rejection below — onto this one
-// string closes that channel. validatePromoEligibility itself still returns
-// the specific reason (kept for its own unit tests and internal callers);
-// it's only discarded here, at the boundary that talks back to the client.
-const GENERIC_PROMO_ERROR = "Ce code promo n'est pas applicable à votre commande.";
+// Every failure below returns this exact string, and the same PromoResult
+// shape (via invalidPromo), no matter which check rejected the code — and
+// so does the throttle rejection in validatePromoCode/createOrder. The
+// response must never let a caller distinguish *why* a code was rejected,
+// only *whether* it worked. validatePromoEligibility (lib/utils/checkout.ts)
+// still returns its own specific reason for its own callers and unit tests;
+// it is discarded only here, at the boundary that answers the client.
+const GENERIC_PROMO_ERROR =
+  "Ce code promo est invalide ou n'est pas applicable à votre commande.";
 
 async function resolvePromoCode(
   code: string,
@@ -268,9 +264,28 @@ export async function createOrder(input: CheckoutInput): Promise<CreateOrderResu
   let promoCodeId: string | null = null;
 
   if (data.promoCode) {
+    // Shares validatePromoCode's exact key (promo:rate:${userId}) and
+    // ceiling rather than getting its own — this entry point resolves a
+    // promo code just as directly as validatePromoCode does, and the two
+    // must draw from one combined budget or a caller could get validatePromoCode's
+    // 20/hour here *again* on top of the 20/hour already spent there.
+    // Checked before resolvePromoCode, mirroring validatePromoCode: a
+    // rejected check must never reach the promo_codes table, and must
+    // return the exact same GENERIC_PROMO_ERROR an ordinary invalid code
+    // gets. This sits ahead of createOrder's own throttle (step 9 below)
+    // deliberately, not in spite of it — step 9 exists specifically so a
+    // typo or a stock-out doesn't cost one of the 5 hourly order slots, and
+    // that must still hold for a mistyped promo code. Gating promo
+    // resolution on its own limiter here preserves that while still
+    // bounding how many times this path can resolve a promo code.
+    const withinPromoRateLimit = await checkPromoRateLimit(await getKV(), userId);
+    if (!withinPromoRateLimit) {
+      return { success: false, error: GENERIC_PROMO_ERROR };
+    }
+
     const promoResult = await resolvePromoCode(data.promoCode, subtotal);
     if (!promoResult.valid) {
-      return { success: false, error: promoResult.error ?? "Code promo invalide" };
+      return { success: false, error: GENERIC_PROMO_ERROR };
     }
     discountAmount = promoResult.discount;
     promoCodeId = promoResult.promoCodeId;

--- a/app/api/cron/reap-pending-orders/route.ts
+++ b/app/api/cron/reap-pending-orders/route.ts
@@ -8,7 +8,7 @@ import { reapStalePendingOrders } from "@/lib/db/orders";
 // main worker. Instead, an external scheduler — the "Reap Pending Orders"
 // GitHub Actions workflow (.github/workflows/reap-pending-orders.yml) —
 // calls this route on a schedule (and on manual dispatch) with a bearer
-// secret. See task-3.2-report.md for the full rationale.
+// secret.
 export const dynamic = "force-dynamic";
 
 /** Constant-time string comparison — avoids leaking the secret via response timing. */

--- a/app/api/cron/reap-pending-orders/route.ts
+++ b/app/api/cron/reap-pending-orders/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { getEnv } from "@/lib/cloudflare/context";
+import { reapStalePendingOrders } from "@/lib/db/orders";
+
+// IMPORTANT — this route has no automatic trigger.
+//
+// @opennextjs/cloudflare 1.19.1 does not expose a Workers `scheduled()`
+// handler alongside the Next.js app: the generated `.open-next/worker.js`
+// entry (regenerated on every `build:worker`, from
+// node_modules/@opennextjs/cloudflare/dist/cli/templates/worker.js) only
+// exports `fetch`, and `defineCloudflareConfig`'s `CloudflareOverrides` type
+// has no hook to add one. Wiring a `triggers.crons` entry into the main
+// wrangler.jsonc would therefore point Cloudflare's Cron Triggers at a
+// worker with no `scheduled()` export — a cron that is configured but never
+// actually fires (Cloudflare's own docs list "missing scheduled() export" as
+// the #1 cause of "cron not executing"), which is worse than no cron at all
+// because it looks like protection.
+//
+// This route is the reaper's securable, invokable surface instead: it can
+// be called by whatever triggering mechanism is chosen (most likely a small
+// companion Worker with its own wrangler cron trigger that does a `fetch()`
+// here, mirroring the separate `workers/whatsapp/` deploy already used in
+// this repo — or a scheduled CI job). That decision is intentionally left
+// open; see task-3.2-report.md.
+export const dynamic = "force-dynamic";
+
+/** Constant-time string comparison — avoids leaking the secret via response timing. */
+function timingSafeEqualString(a: string, b: string): boolean {
+  const encoder = new TextEncoder();
+  const aBytes = encoder.encode(a);
+  const bBytes = encoder.encode(b);
+  if (aBytes.length !== bBytes.length) return false;
+  let diff = 0;
+  for (let i = 0; i < aBytes.length; i++) diff |= aBytes[i] ^ bBytes[i];
+  return diff === 0;
+}
+
+export async function POST(request: Request) {
+  const env = await getEnv();
+  const secret = env.CRON_SECRET;
+
+  const authHeader = request.headers.get("authorization") ?? "";
+  const provided = authHeader.startsWith("Bearer ") ? authHeader.slice("Bearer ".length) : "";
+
+  if (!secret || !provided || !timingSafeEqualString(provided, secret)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const result = await reapStalePendingOrders();
+  return NextResponse.json(result);
+}

--- a/app/api/cron/reap-pending-orders/route.ts
+++ b/app/api/cron/reap-pending-orders/route.ts
@@ -2,26 +2,13 @@ import { NextResponse } from "next/server";
 import { getEnv } from "@/lib/cloudflare/context";
 import { reapStalePendingOrders } from "@/lib/db/orders";
 
-// IMPORTANT — this route has no automatic trigger.
-//
-// @opennextjs/cloudflare 1.19.1 does not expose a Workers `scheduled()`
-// handler alongside the Next.js app: the generated `.open-next/worker.js`
-// entry (regenerated on every `build:worker`, from
-// node_modules/@opennextjs/cloudflare/dist/cli/templates/worker.js) only
-// exports `fetch`, and `defineCloudflareConfig`'s `CloudflareOverrides` type
-// has no hook to add one. Wiring a `triggers.crons` entry into the main
-// wrangler.jsonc would therefore point Cloudflare's Cron Triggers at a
-// worker with no `scheduled()` export — a cron that is configured but never
-// actually fires (Cloudflare's own docs list "missing scheduled() export" as
-// the #1 cause of "cron not executing"), which is worse than no cron at all
-// because it looks like protection.
-//
-// This route is the reaper's securable, invokable surface instead: it can
-// be called by whatever triggering mechanism is chosen (most likely a small
-// companion Worker with its own wrangler cron trigger that does a `fetch()`
-// here, mirroring the separate `workers/whatsapp/` deploy already used in
-// this repo — or a scheduled CI job). That decision is intentionally left
-// open; see task-3.2-report.md.
+// @opennextjs/cloudflare does not expose a Workers `scheduled()` handler
+// alongside the Next.js app (the generated worker entry only implements
+// `fetch`), so this sweep cannot be a native Cloudflare Cron Trigger on the
+// main worker. Instead, an external scheduler — the "Reap Pending Orders"
+// GitHub Actions workflow (.github/workflows/reap-pending-orders.yml) —
+// calls this route on a schedule (and on manual dispatch) with a bearer
+// secret. See task-3.2-report.md for the full rationale.
 export const dynamic = "force-dynamic";
 
 /** Constant-time string comparison — avoids leaking the secret via response timing. */
@@ -46,6 +33,16 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const result = await reapStalePendingOrders();
-  return NextResponse.json(result);
+  try {
+    const result = await reapStalePendingOrders();
+    return NextResponse.json(result);
+  } catch (error) {
+    // A batch that has already cancelled some orders and refunded their
+    // stock before hitting an error on a later one is not something to
+    // surface as a silent, uninformative 500 — log what we know and tell
+    // the caller (the scheduled workflow) plainly that the run failed, so
+    // it fails the job instead of reporting a false "nothing to do" green.
+    console.error("reap-pending-orders route: reapStalePendingOrders threw", error);
+    return NextResponse.json({ error: "Internal error while reaping pending orders" }, { status: 500 });
+  }
 }

--- a/components/storefront/product-card-actions.tsx
+++ b/components/storefront/product-card-actions.tsx
@@ -39,7 +39,7 @@ export function ProductCardActions({ product }: Props) {
   const [dialogOpen, setDialogOpen] = useState(false);
   const add = useCartStore((s) => s.add);
 
-  const hasVariants = (product.variant_count ?? 0) > 1;
+  const hasVariants = (product.variant_count ?? 0) > 0;
   const isOutOfStock = product.stock_quantity <= 0;
 
   function handleCartClick(e: React.MouseEvent) {

--- a/components/storefront/product-card.tsx
+++ b/components/storefront/product-card.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 export function ProductCard({ product }: Props) {
-  const hasVariants = (product.variant_count ?? 0) > 1;
+  const hasVariants = (product.variant_count ?? 0) > 0;
   const isOutOfStock = product.stock_quantity <= 0;
   const comparePrice = product.compare_price;
   const hasDiscount = comparePrice != null && comparePrice > product.base_price;

--- a/env.d.ts
+++ b/env.d.ts
@@ -18,6 +18,14 @@ interface CloudflareEnv {
   // Turnstile
   TURNSTILE_SECRET_KEY: string;
 
+  // Bearer secret required to invoke /api/cron/reap-pending-orders. This
+  // route is not currently wired to any automatic scheduler (see that
+  // route's comment) — it exists so the stale-pending-order sweep can be
+  // triggered by whatever mechanism is chosen (a companion Worker's cron
+  // trigger, a scheduled CI job, or manual ops action) without exposing it
+  // unauthenticated.
+  CRON_SECRET?: string;
+
   // Email (Resend)
   RESEND_API_KEY?: string;
   RESEND_FROM_EMAIL?: string; // defaults to "NETEREKA <commandes@netereka.ci>"

--- a/env.d.ts
+++ b/env.d.ts
@@ -18,12 +18,10 @@ interface CloudflareEnv {
   // Turnstile
   TURNSTILE_SECRET_KEY: string;
 
-  // Bearer secret required to invoke /api/cron/reap-pending-orders. This
-  // route is not currently wired to any automatic scheduler (see that
-  // route's comment) — it exists so the stale-pending-order sweep can be
-  // triggered by whatever mechanism is chosen (a companion Worker's cron
-  // trigger, a scheduled CI job, or manual ops action) without exposing it
-  // unauthenticated.
+  // Bearer secret required to invoke /api/cron/reap-pending-orders. Set to
+  // the same value as the CRON_SECRET repository secret used by the
+  // "Reap Pending Orders" GitHub Actions workflow, which calls this route on
+  // a schedule.
   CRON_SECRET?: string;
 
   // Email (Resend)

--- a/lib/ai/rate-limit.ts
+++ b/lib/ai/rate-limit.ts
@@ -40,7 +40,13 @@ export async function checkRateLimit(
   }
 
   const updated: Bucket = { count: bucket.count + 1, resetAt: bucket.resetAt };
-  const remaining = Math.max(1, Math.ceil((bucket.resetAt - now) / 1000));
+  // Floored at 60: Cloudflare KV rejects expirationTtl below 60 seconds
+  // outright (kv.put throws), and a call landing in the final 59 seconds of
+  // a window would otherwise compute exactly that. Safe to over-extend past
+  // resetAt because resetAt itself, not the KV TTL, is what defines the
+  // window — the `resetAt <= now` branch above already re-closes it on the
+  // next call regardless of whether the KV entry has expired yet.
+  const remaining = Math.max(60, Math.ceil((bucket.resetAt - now) / 1000));
   await kv.put(key, JSON.stringify(updated), { expirationTtl: remaining });
   return { ok: true };
 }

--- a/lib/db/orders.ts
+++ b/lib/db/orders.ts
@@ -385,11 +385,31 @@ export async function cancelOrderFromStatus(
     // (invariant: a cancelled order has always had its reserved stock
     // returned). The status guard means only this call transitioned the row,
     // so the revert targets exactly the row we just cancelled.
-    await execute(
-      `UPDATE orders SET status = ?, cancelled_at = NULL, cancellation_reason = NULL, updated_at = datetime('now')
-       WHERE id = ? AND status = 'cancelled'`,
-      [fromStatus, orderId]
-    );
+    //
+    // The revert is a second, independent D1 call and gets its own
+    // try/catch: this function's contract is a plain boolean (every caller —
+    // the customer self-cancel path, the reaper, cancelOrderAdmin — expects
+    // that shape, so it is not changed here), so `false` is already this
+    // function's "structured failure". What must not happen is the revert's
+    // own error escaping as an unhandled rejection instead of also
+    // collapsing to that same `false`. Both the original refund failure and
+    // any revert failure are logged together so the causal chain survives
+    // even though the boolean return can't carry it to the caller.
+    try {
+      await execute(
+        `UPDATE orders SET status = ?, cancelled_at = NULL, cancellation_reason = NULL, updated_at = datetime('now')
+         WHERE id = ? AND status = 'cancelled'`,
+        [fromStatus, orderId]
+      );
+    } catch (revertErr) {
+      console.error(
+        "cancelOrderFromStatus: stock refund failed AND compensating revert also failed — order left stuck",
+        { orderId, stuckStatus: "cancelled", intendedRevertTo: fromStatus },
+        err,
+        revertErr
+      );
+      return false;
+    }
     console.error("cancelOrderFromStatus: stock refund failed, reverted", { orderId, fromStatus }, err);
     return false;
   }

--- a/lib/db/orders.ts
+++ b/lib/db/orders.ts
@@ -395,12 +395,19 @@ export async function cancelOrderFromStatus(
     // collapsing to that same `false`. Both the original refund failure and
     // any revert failure are logged together so the causal chain survives
     // even though the boolean return can't carry it to the caller.
+    // A revert matching zero rows — because something else moved the order on
+    // between the cancel and here — leaves the same stuck state as a throwing
+    // revert, so it collapses to the same branch rather than passing for a
+    // successful revert.
     try {
-      await execute(
+      const revertResult = await execute(
         `UPDATE orders SET status = ?, cancelled_at = NULL, cancellation_reason = NULL, updated_at = datetime('now')
          WHERE id = ? AND status = 'cancelled'`,
         [fromStatus, orderId]
       );
+      if (revertResult.meta.changes === 0) {
+        throw new Error("compensating revert matched no row (order no longer 'cancelled')");
+      }
     } catch (revertErr) {
       console.error(
         "cancelOrderFromStatus: stock refund failed AND compensating revert also failed — order left stuck",

--- a/lib/db/orders.ts
+++ b/lib/db/orders.ts
@@ -101,7 +101,13 @@ export async function createOrderWithItems(
     ]
   );
 
-  if (reservation.meta.changes === 0) {
+  // Fail closed: only a confirmed changes > 0 counts as "reserved". If a
+  // future D1 version ever returned `undefined` for `meta.changes` instead
+  // of `0`, `=== 0` would treat that as "reserved" and continue into stock
+  // decrements and item inserts for a row that was never actually written —
+  // `!(... > 0)` treats anything that isn't affirmatively a successful
+  // write as blocked instead.
+  if (!(reservation.meta.changes > 0)) {
     // Nothing was written — no stock touched, no items inserted, nothing to
     // roll back. A caller retrying immediately after will see the same
     // (accurate, not stale) count on their next attempt.
@@ -113,7 +119,10 @@ export async function createOrderWithItems(
   const statements: D1PreparedStatement[] = [];
   const stockUpdateIndices: number[] = [];
 
-  // 1. Stock decrements FIRST — if these fail, no order row is orphaned
+  // 1. Stock decrements — the order row itself is already committed at this
+  //    point (step 0's guarded reservation, above), so unlike the original
+  //    layout this can no longer prevent an orphaned order row by running
+  //    first; that is now the job of the try/catch around db.batch below.
   for (const item of items) {
     if (item.variantId) {
       stockUpdateIndices.push(statements.length);
@@ -176,7 +185,25 @@ export async function createOrderWithItems(
     );
   }
 
-  const results = await db.batch(statements);
+  let results: D1Result[];
+  try {
+    results = await db.batch(statements);
+  } catch (error) {
+    // db.batch runs as one implicit transaction: if it throws (a transient
+    // D1 error, a constraint failure on an item insert), NONE of the stock
+    // decrements or order_items inserts committed — but the order row itself
+    // was already committed by step 0's guarded reservation, *before* this
+    // batch ever ran. Left alone, that would surface to the customer and to
+    // admin as a `pending` order with a real order_number and total but zero
+    // items, occupying one of the three concurrent-pending-cap slots for up
+    // to REAP_STALE_AFTER_HOURS until the reaper cancels it. Delete the
+    // reservation here so a batch failure leaves nothing behind, mirroring
+    // the compensating-revert discipline cancelPendingOrderById already uses
+    // for the equivalent case on the cancellation path.
+    await execute("DELETE FROM orders WHERE id = ?", [orderId]);
+    console.error(`createOrderWithItems: batch failed for reserved order ${orderId}, reservation deleted`, error);
+    throw new Error(`Échec de la création de la commande ${orderData.orderNumber}`);
+  }
   const promoApplied =
     promoUpdateIndex !== -1 && results[promoUpdateIndex].meta.changes > 0;
 

--- a/lib/db/orders.ts
+++ b/lib/db/orders.ts
@@ -1,8 +1,14 @@
-import { queryFirst, query } from "@/lib/db";
+import { queryFirst, query, execute } from "@/lib/db";
 import { getDB } from "@/lib/cloudflare/context";
 import { nanoid } from "nanoid";
 import type { Order, OrderItem } from "@/lib/db/types";
 export type { Order, OrderItem };
+
+/** Concurrently-open pending orders allowed per user (see createOrder). */
+export const MAX_PENDING_ORDERS_PER_USER = 3;
+
+/** Pending orders older than this are reaped automatically (see reapStalePendingOrders). */
+export const REAP_STALE_AFTER_HOURS = 24;
 
 interface CreateOrderData {
   userId: string;
@@ -251,57 +257,120 @@ export async function getOrderDetail(
   return { order, items };
 }
 
-export async function cancelOrder(
-  orderNumber: string,
-  userId: string,
-  reason: string
-): Promise<boolean> {
-  const db = await getDB();
+/**
+ * Guarded pending→cancelled transition, shared by every caller that needs to
+ * cancel a pending order and release its reserved stock: the customer
+ * self-cancel path (cancelOrder below) and the stale-pending reaper
+ * (reapStalePendingOrders below). Do not duplicate this logic elsewhere —
+ * two independent "cancel and refund" implementations would drift and one
+ * of them would eventually double-refund.
+ *
+ * The single UPDATE statement carries `AND status = 'pending'` as part of
+ * its WHERE clause, so it can affect the row at most once no matter how many
+ * callers race to cancel the same order (a customer clicking "cancel" at the
+ * same moment the reaper sweeps it, or two reaper runs overlapping): only
+ * the caller whose UPDATE actually flips the status sees `meta.changes > 0`
+ * and proceeds to refund; every other concurrent caller sees `changes === 0`
+ * and returns false without touching stock. This is what makes the
+ * transition safe under concurrency — refund is conditioned on this call
+ * having performed the transition, not on the row having been pending
+ * beforehand.
+ */
+async function cancelPendingOrderById(orderId: string, reason: string): Promise<boolean> {
+  const result = await execute(
+    `UPDATE orders SET status = 'cancelled', cancelled_at = datetime('now'), cancellation_reason = ?, updated_at = datetime('now')
+     WHERE id = ? AND status = 'pending'`,
+    [reason, orderId]
+  );
 
-  // Resolve the pending order owned by this user first, so we can release its
-  // reserved stock. Without this, a customer self-cancel left stock permanently
-  // decremented ('cancelled' is a terminal state, so no admin path could ever
-  // refund it) — a cost-free denial-of-inventory. See GHSA (stock-refund gap).
-  const order = await db
-    .prepare(
-      "SELECT id FROM orders WHERE order_number = ? AND user_id = ? AND status = 'pending'"
-    )
-    .bind(orderNumber, userId)
-    .first<{ id: string }>();
-  if (!order) return false;
-
-  const result = await db
-    .prepare(
-      `UPDATE orders SET status = 'cancelled', cancelled_at = datetime('now'), cancellation_reason = ?, updated_at = datetime('now')
-       WHERE id = ? AND status = 'pending'`
-    )
-    .bind(reason, order.id)
-    .run();
-
-  // Refund only when THIS call performed the pending→cancelled transition. The
-  // status guard makes the UPDATE affect the row exactly once, so concurrent
-  // cancels cannot double-refund.
   if (result.meta.changes === 0) return false;
 
   try {
-    await refundOrderStock(order.id);
+    await refundOrderStock(orderId);
   } catch (err) {
     // Compensate to keep cancellation and stock consistent: if the refund
     // fails, revert the order to 'pending' so its stock stays reserved
     // (invariant: a cancelled order has always had its reserved stock
     // returned). The status guard means only this call transitioned the row,
     // so the revert targets exactly the row we just cancelled.
-    await db
-      .prepare(
-        `UPDATE orders SET status = 'pending', cancelled_at = NULL, cancellation_reason = NULL, updated_at = datetime('now')
-         WHERE id = ? AND status = 'cancelled'`
-      )
-      .bind(order.id)
-      .run();
-    console.error(`cancelOrder: stock refund failed for order ${order.id}, reverted to pending`, err);
+    await execute(
+      `UPDATE orders SET status = 'pending', cancelled_at = NULL, cancellation_reason = NULL, updated_at = datetime('now')
+       WHERE id = ? AND status = 'cancelled'`,
+      [orderId]
+    );
+    console.error(`cancelPendingOrderById: stock refund failed for order ${orderId}, reverted to pending`, err);
     return false;
   }
   return true;
+}
+
+export async function cancelOrder(
+  orderNumber: string,
+  userId: string,
+  reason: string
+): Promise<boolean> {
+  // Resolve the pending order owned by this user first, so we can release its
+  // reserved stock. Without this, a customer self-cancel left stock permanently
+  // decremented ('cancelled' is a terminal state, so no admin path could ever
+  // refund it) — a cost-free denial-of-inventory. See GHSA (stock-refund gap).
+  const order = await queryFirst<{ id: string }>(
+    "SELECT id FROM orders WHERE order_number = ? AND user_id = ? AND status = 'pending'",
+    [orderNumber, userId]
+  );
+  if (!order) return false;
+
+  return cancelPendingOrderById(order.id, reason);
+}
+
+/**
+ * Counts a user's currently-open pending orders. Backs the concurrent-pending
+ * cap in createOrder: the hourly rate limit only bounds *velocity*, not the
+ * number of orders simultaneously holding reserved stock — at 5 orders/hour,
+ * an account could otherwise keep ~120 orders perpetually pending (steady
+ * state against the 24h reaper window). Capping concurrently-open pending
+ * orders bounds worst-case reserved stock per user to a small constant
+ * regardless of rate or reaper cadence.
+ */
+export async function countPendingOrdersForUser(userId: string): Promise<number> {
+  const row = await queryFirst<{ total: number }>(
+    "SELECT COUNT(*) as total FROM orders WHERE user_id = ? AND status = 'pending'",
+    [userId]
+  );
+  return row?.total ?? 0;
+}
+
+/**
+ * Cancels every pending order older than `olderThanHours` and releases its
+ * reserved stock, reusing the exact guarded transition customers use to
+ * self-cancel (cancelPendingOrderById) — see that function's doc comment for
+ * why concurrent cancellation of the same order can never double-refund.
+ *
+ * Each order is cancelled independently (not as a single D1 batch): the
+ * guard-then-refund sequence for one order must complete (including its
+ * compensating revert on refund failure) before affecting the next, so a
+ * failure on one stale order never blocks or corrupts the others.
+ */
+export async function reapStalePendingOrders(
+  olderThanHours: number = REAP_STALE_AFTER_HOURS
+): Promise<{ cancelled: number; skipped: number; total: number }> {
+  const staleOrders = await query<{ id: string }>(
+    "SELECT id FROM orders WHERE status = 'pending' AND created_at < datetime('now', ?)",
+    [`-${olderThanHours} hours`]
+  );
+
+  let cancelled = 0;
+  let skipped = 0;
+
+  for (const order of staleOrders) {
+    const ok = await cancelPendingOrderById(
+      order.id,
+      "Commande annulée automatiquement : délai de confirmation dépassé."
+    );
+    if (ok) cancelled++;
+    else skipped++;
+  }
+
+  return { cancelled, skipped, total: staleOrders.length };
 }
 
 /**

--- a/lib/db/orders.ts
+++ b/lib/db/orders.ts
@@ -390,7 +390,7 @@ export async function cancelOrderFromStatus(
        WHERE id = ? AND status = 'cancelled'`,
       [fromStatus, orderId]
     );
-    console.error(`cancelOrderFromStatus: stock refund failed for order ${orderId}, reverted to ${fromStatus}`, err);
+    console.error("cancelOrderFromStatus: stock refund failed, reverted", { orderId, fromStatus }, err);
     return false;
   }
   return true;

--- a/lib/db/orders.ts
+++ b/lib/db/orders.ts
@@ -1,7 +1,8 @@
 import { queryFirst, query, execute } from "@/lib/db";
 import { getDB } from "@/lib/cloudflare/context";
 import { nanoid } from "nanoid";
-import type { Order, OrderItem } from "@/lib/db/types";
+import type { Order, OrderItem, OrderStatus } from "@/lib/db/types";
+import { notifyOrderStatusUpdate } from "@/lib/notifications";
 export type { Order, OrderItem };
 
 /** Concurrently-open pending orders allowed per user (see createOrder). */
@@ -330,50 +331,74 @@ export async function getOrderDetail(
 }
 
 /**
- * Guarded pending→cancelled transition, shared by every caller that needs to
- * cancel a pending order and release its reserved stock: the customer
- * self-cancel path (cancelOrder below) and the stale-pending reaper
- * (reapStalePendingOrders below). Do not duplicate this logic elsewhere —
- * two independent "cancel and refund" implementations would drift and one
- * of them would eventually double-refund.
+ * Guarded ->cancelled transition with stock refund, shared by every caller
+ * that cancels an order: the customer self-cancel path (cancelOrder below),
+ * the stale-pending reaper (reapStalePendingOrders below), and the admin
+ * cancel action (actions/admin/orders.ts::cancelOrderAdmin). Do not
+ * duplicate this logic elsewhere — two independent "cancel and refund"
+ * implementations would drift and one of them would eventually
+ * double-refund.
  *
- * The single UPDATE statement carries `AND status = 'pending'` as part of
- * its WHERE clause, so it can affect the row at most once no matter how many
- * callers race to cancel the same order (a customer clicking "cancel" at the
- * same moment the reaper sweeps it, or two reaper runs overlapping): only
- * the caller whose UPDATE actually flips the status sees `meta.changes > 0`
- * and proceeds to refund; every other concurrent caller sees `changes === 0`
- * and returns false without touching stock. This is what makes the
- * transition safe under concurrency — refund is conditioned on this call
- * having performed the transition, not on the row having been pending
- * beforehand.
+ * The single UPDATE statement carries `AND status = ?` (bound to
+ * `fromStatus`, the status the caller read the order in) as part of its
+ * WHERE clause, so it can affect the row at most once no matter how many
+ * callers race to cancel the same order — a customer clicking "cancel" the
+ * same moment an admin cancels it from the dashboard, or the hourly sweep
+ * cancelling a stale order an operator is clearing by hand at the same time.
+ * Only the caller whose UPDATE actually flips the status sees
+ * `meta.changes > 0` and proceeds to (optionally) refund; every other
+ * concurrent caller sees `changes === 0` and returns false without touching
+ * stock. This is what makes the transition safe under concurrency — refund
+ * is conditioned on *this call* having performed the transition, not on the
+ * row having been read as `fromStatus` moments earlier (a stale,
+ * non-atomic read that a TOCTOU race could invalidate before the write
+ * lands — exactly the shape that let two unguarded admin UPDATEs run
+ * against a row the sweep had already cancelled, double-crediting stock).
+ *
+ * `refund: false` (the admin "cancel without refund" option) skips
+ * refundOrderStock entirely but keeps the same guarded transition — the
+ * race-safety property does not depend on whether a refund happens.
  */
-async function cancelPendingOrderById(orderId: string, reason: string): Promise<boolean> {
+export async function cancelOrderFromStatus(
+  orderId: string,
+  fromStatus: OrderStatus,
+  reason: string,
+  opts: { refund?: boolean } = {}
+): Promise<boolean> {
+  const { refund = true } = opts;
+
   const result = await execute(
     `UPDATE orders SET status = 'cancelled', cancelled_at = datetime('now'), cancellation_reason = ?, updated_at = datetime('now')
-     WHERE id = ? AND status = 'pending'`,
-    [reason, orderId]
+     WHERE id = ? AND status = ?`,
+    [reason, orderId, fromStatus]
   );
 
   if (result.meta.changes === 0) return false;
+
+  if (!refund) return true;
 
   try {
     await refundOrderStock(orderId);
   } catch (err) {
     // Compensate to keep cancellation and stock consistent: if the refund
-    // fails, revert the order to 'pending' so its stock stays reserved
+    // fails, revert the order back to fromStatus so its stock stays reserved
     // (invariant: a cancelled order has always had its reserved stock
     // returned). The status guard means only this call transitioned the row,
     // so the revert targets exactly the row we just cancelled.
     await execute(
-      `UPDATE orders SET status = 'pending', cancelled_at = NULL, cancellation_reason = NULL, updated_at = datetime('now')
+      `UPDATE orders SET status = ?, cancelled_at = NULL, cancellation_reason = NULL, updated_at = datetime('now')
        WHERE id = ? AND status = 'cancelled'`,
-      [orderId]
+      [fromStatus, orderId]
     );
-    console.error(`cancelPendingOrderById: stock refund failed for order ${orderId}, reverted to pending`, err);
+    console.error(`cancelOrderFromStatus: stock refund failed for order ${orderId}, reverted to ${fromStatus}`, err);
     return false;
   }
   return true;
+}
+
+/** Cancels a pending order and refunds its stock. See cancelOrderFromStatus. */
+async function cancelPendingOrderById(orderId: string, reason: string): Promise<boolean> {
+  return cancelOrderFromStatus(orderId, "pending", reason);
 }
 
 export async function cancelOrder(
@@ -424,12 +449,48 @@ export async function countPendingOrdersForUser(userId: string): Promise<number>
   return row?.total ?? 0;
 }
 
+/** Reason recorded on orders (and echoed to the customer) when the sweep cancels them. */
+const REAP_CANCELLATION_REASON =
+  "Commande annulée automatiquement : délai de confirmation dépassé.";
+
+/**
+ * Fire-and-forget-safe customer notification for an automatically-cancelled
+ * order. Every admin-triggered status change already notifies the customer
+ * (see actions/admin/orders.ts's sendStatusNotification); the sweep is the
+ * one path that flips an order to 'cancelled' with no human in the loop, so
+ * without this a customer only finds out by checking their account — on a
+ * cash-on-delivery site where the confirmation call *is* the fulfilment
+ * step, that reads as the shop silently losing their order.
+ *
+ * Awaited by the caller but never allowed to throw past this function:
+ * notifyOrderStatusUpdate itself already swallows send failures (it calls
+ * the Resend-backed sendEmail helper, which never throws, and logs instead),
+ * but the caller additionally wraps this in its own try/catch so a failure
+ * here — however it happens to surface — can never abort the order's
+ * (already-committed) cancellation, and, critically, can never stop the
+ * sweep from moving on to the next order in the batch.
+ */
+async function notifyStaleOrderCancelled(orderNumber: string, userId: string): Promise<void> {
+  const customer = await queryFirst<{ email: string; name: string }>(
+    "SELECT email, name FROM user WHERE id = ?",
+    [userId]
+  );
+  if (!customer) return;
+  await notifyOrderStatusUpdate(customer.email, {
+    customerName: customer.name,
+    orderNumber,
+    newStatus: "cancelled",
+    reason: REAP_CANCELLATION_REASON,
+  });
+}
+
 /**
  * Cancels up to `batchSize` pending orders older than `olderThanHours` and
  * releases their reserved stock, reusing the exact guarded transition
- * customers use to self-cancel (cancelPendingOrderById) — see that
- * function's doc comment for why concurrent cancellation of the same order
- * can never double-refund.
+ * customers use to self-cancel (cancelPendingOrderById, itself a thin
+ * wrapper over the shared cancelOrderFromStatus) — see that function's doc
+ * comment for why concurrent cancellation of the same order (by a customer,
+ * an admin, or another sweep run) can never double-refund.
  *
  * Bounded and resumable: nothing has ever reaped before this task, so the
  * first real invocation could otherwise face the entire historical backlog
@@ -448,14 +509,18 @@ export async function countPendingOrdersForUser(userId: string): Promise<number>
  * (e.g. a transient D1 failure on the guarded UPDATE itself, not just a
  * refund failure) is tallied as `skipped` and logged rather than aborting
  * the rest of the batch, so one bad row can't stop the sweep from reaping
- * everything else it fetched.
+ * everything else it fetched. The customer notification sent after a
+ * successful cancellation is inside that same try/catch and does not affect
+ * the cancelled/skipped tally either way — a notification failure is logged
+ * and the order still counts as cancelled (its stock was genuinely
+ * refunded; only the courtesy email failed).
  */
 export async function reapStalePendingOrders(
   olderThanHours: number = REAP_STALE_AFTER_HOURS,
   batchSize: number = REAP_BATCH_SIZE
 ): Promise<{ cancelled: number; skipped: number; total: number; hasMore: boolean }> {
-  const staleOrders = await query<{ id: string }>(
-    "SELECT id FROM orders WHERE status = 'pending' AND created_at < datetime('now', ?) ORDER BY created_at ASC LIMIT ?",
+  const staleOrders = await query<{ id: string; order_number: string; user_id: string }>(
+    "SELECT id, order_number, user_id FROM orders WHERE status = 'pending' AND created_at < datetime('now', ?) ORDER BY created_at ASC LIMIT ?",
     [`-${olderThanHours} hours`, batchSize + 1]
   );
 
@@ -467,12 +532,20 @@ export async function reapStalePendingOrders(
 
   for (const order of toProcess) {
     try {
-      const ok = await cancelPendingOrderById(
-        order.id,
-        "Commande annulée automatiquement : délai de confirmation dépassé."
-      );
-      if (ok) cancelled++;
-      else skipped++;
+      const ok = await cancelPendingOrderById(order.id, REAP_CANCELLATION_REASON);
+      if (ok) {
+        cancelled++;
+        try {
+          await notifyStaleOrderCancelled(order.order_number, order.user_id);
+        } catch (err) {
+          // The cancellation and refund already committed above — a failed
+          // courtesy email must not undo that, nor stop the loop from
+          // reaching the remaining orders in this batch.
+          console.error(`reapStalePendingOrders: notification failed for order ${order.id}`, err);
+        }
+      } else {
+        skipped++;
+      }
     } catch (err) {
       console.error(`reapStalePendingOrders: unexpected error cancelling order ${order.id}, skipping`, err);
       skipped++;

--- a/lib/db/orders.ts
+++ b/lib/db/orders.ts
@@ -7,8 +7,29 @@ export type { Order, OrderItem };
 /** Concurrently-open pending orders allowed per user (see createOrder). */
 export const MAX_PENDING_ORDERS_PER_USER = 3;
 
-/** Pending orders older than this are reaped automatically (see reapStalePendingOrders). */
+/**
+ * Pending orders older than this are reaped automatically (see
+ * reapStalePendingOrders), AND are excluded from the concurrent-pending cap
+ * (see countPendingOrdersForUser). Sharing one constant for both keeps the
+ * cap self-releasing on its own clock: a customer who hits the cap is never
+ * stuck waiting on the sweep actually running (which depends on an external
+ * trigger, see app/api/cron/reap-pending-orders) — their oldest order simply
+ * stops counting once it turns this old, whether or not anything has swept
+ * it yet.
+ */
 export const REAP_STALE_AFTER_HOURS = 24;
+
+/**
+ * Max stale orders processed per reapStalePendingOrders() call. The sweep
+ * has never run before this task, so the first invocation could otherwise
+ * meet the entire historical backlog in one call — each order costs a
+ * guarded UPDATE, an order_items SELECT, and a stock-refund batch, so an
+ * unbounded loop risks the Workers subrequest ceiling or the invocation
+ * duration limit on a large backlog. Chosen conservatively; the caller
+ * checks `hasMore` and can invoke again to keep draining a large backlog
+ * across multiple runs.
+ */
+export const REAP_BATCH_SIZE = 25;
 
 interface CreateOrderData {
   userId: string;
@@ -42,6 +63,53 @@ export async function createOrderWithItems(
   const db = await getDB();
   const orderId = nanoid();
 
+  // 0. Reserve the order row itself, with the concurrent-pending cap embedded
+  //    in the same statement as the write. This is the actual enforcement
+  //    boundary for MAX_PENDING_ORDERS_PER_USER — actions/checkout.ts's own
+  //    countPendingOrdersForUser check is a read-then-act fast path (cheap,
+  //    good UX, skips the rest of validation for the common case) and is NOT
+  //    safe against a burst of parallel createOrder calls: every one of them
+  //    could read the same "under cap" count before any of them writes. This
+  //    INSERT ... SELECT ... WHERE form can't be raced the same way, because
+  //    the guard and the write are one atomic statement — each row that
+  //    actually commits raises the COUNT the next racing statement sees, so
+  //    only as many inserts as there is room for under the cap can ever
+  //    match the WHERE clause, no matter how many arrive at once. Mirrors the
+  //    existing guarded-UPDATE idiom this function already uses below for
+  //    stock and promo-code redemption.
+  const reservation = await execute(
+    `INSERT INTO orders (id, user_id, order_number, subtotal, delivery_fee, discount_amount, total, promo_code_id, delivery_address, delivery_commune, delivery_phone, delivery_instructions, estimated_delivery)
+     SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+     WHERE (SELECT COUNT(*) FROM orders WHERE user_id = ? AND status = 'pending' AND created_at >= datetime('now', ?)) < ?`,
+    [
+      orderId,
+      orderData.userId,
+      orderData.orderNumber,
+      orderData.subtotal,
+      orderData.deliveryFee,
+      orderData.discountAmount,
+      orderData.total,
+      orderData.promoCodeId,
+      orderData.deliveryAddress,
+      orderData.deliveryCommune,
+      orderData.deliveryPhone,
+      orderData.deliveryInstructions,
+      orderData.estimatedDelivery,
+      orderData.userId,
+      `-${REAP_STALE_AFTER_HOURS} hours`,
+      MAX_PENDING_ORDERS_PER_USER,
+    ]
+  );
+
+  if (reservation.meta.changes === 0) {
+    // Nothing was written — no stock touched, no items inserted, nothing to
+    // roll back. A caller retrying immediately after will see the same
+    // (accurate, not stale) count on their next attempt.
+    throw new Error(
+      "Vous avez deja plusieurs commandes en attente de confirmation. Merci d'attendre leur traitement avant d'en passer une nouvelle."
+    );
+  }
+
   const statements: D1PreparedStatement[] = [];
   const stockUpdateIndices: number[] = [];
 
@@ -68,31 +136,8 @@ export async function createOrderWithItems(
     }
   }
 
-  // 2. Insert order
-  statements.push(
-    db
-      .prepare(
-        `INSERT INTO orders (id, user_id, order_number, subtotal, delivery_fee, discount_amount, total, promo_code_id, delivery_address, delivery_commune, delivery_phone, delivery_instructions, estimated_delivery)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-      )
-      .bind(
-        orderId,
-        orderData.userId,
-        orderData.orderNumber,
-        orderData.subtotal,
-        orderData.deliveryFee,
-        orderData.discountAmount,
-        orderData.total,
-        orderData.promoCodeId,
-        orderData.deliveryAddress,
-        orderData.deliveryCommune,
-        orderData.deliveryPhone,
-        orderData.deliveryInstructions,
-        orderData.estimatedDelivery
-      )
-  );
-
-  // 3. Insert order items
+  // 2. Insert order items (the order row itself was already inserted and
+  //    committed in step 0's guarded reservation, above)
   for (const item of items) {
     const itemId = nanoid();
     statements.push(
@@ -323,54 +368,91 @@ export async function cancelOrder(
 }
 
 /**
- * Counts a user's currently-open pending orders. Backs the concurrent-pending
- * cap in createOrder: the hourly rate limit only bounds *velocity*, not the
- * number of orders simultaneously holding reserved stock — at 5 orders/hour,
- * an account could otherwise keep ~120 orders perpetually pending (steady
- * state against the 24h reaper window). Capping concurrently-open pending
- * orders bounds worst-case reserved stock per user to a small constant
- * regardless of rate or reaper cadence.
+ * Counts a user's currently-open pending orders, scoped to the same
+ * REAP_STALE_AFTER_HOURS window the reaper uses. Backs the concurrent-pending
+ * cap: the hourly rate limit only bounds *velocity*, not the number of
+ * orders simultaneously holding reserved stock — at 5 orders/hour, an account
+ * could otherwise keep ~120 orders perpetually pending (steady state against
+ * the reaper window). Capping concurrently-open pending orders bounds
+ * worst-case reserved stock per user to a small constant regardless of rate
+ * or reaper cadence.
+ *
+ * Excluding orders older than the window (rather than counting every
+ * pending order ever created) makes the cap self-releasing on its own clock:
+ * a customer who legitimately hits the cap is never stuck waiting on staff
+ * action or on the sweep actually having run — their oldest order simply
+ * ages out of the count once it turns REAP_STALE_AFTER_HOURS old, the same
+ * moment it becomes eligible for the reaper to cancel it.
+ *
+ * This function is the fast-path, non-atomic check used by
+ * actions/checkout.ts for a cheap early rejection with a clear message; the
+ * actual enforcement of MAX_PENDING_ORDERS_PER_USER against a burst of
+ * concurrent requests is the guarded INSERT in createOrderWithItems, above.
  */
 export async function countPendingOrdersForUser(userId: string): Promise<number> {
   const row = await queryFirst<{ total: number }>(
-    "SELECT COUNT(*) as total FROM orders WHERE user_id = ? AND status = 'pending'",
-    [userId]
+    "SELECT COUNT(*) as total FROM orders WHERE user_id = ? AND status = 'pending' AND created_at >= datetime('now', ?)",
+    [userId, `-${REAP_STALE_AFTER_HOURS} hours`]
   );
   return row?.total ?? 0;
 }
 
 /**
- * Cancels every pending order older than `olderThanHours` and releases its
- * reserved stock, reusing the exact guarded transition customers use to
- * self-cancel (cancelPendingOrderById) — see that function's doc comment for
- * why concurrent cancellation of the same order can never double-refund.
+ * Cancels up to `batchSize` pending orders older than `olderThanHours` and
+ * releases their reserved stock, reusing the exact guarded transition
+ * customers use to self-cancel (cancelPendingOrderById) — see that
+ * function's doc comment for why concurrent cancellation of the same order
+ * can never double-refund.
+ *
+ * Bounded and resumable: nothing has ever reaped before this task, so the
+ * first real invocation could otherwise face the entire historical backlog
+ * in one call. `ORDER BY created_at ASC LIMIT batchSize + 1` fetches at most
+ * one row more than the batch — if that extra row comes back, there is more
+ * work than this call processed, reported via `hasMore` so the caller (the
+ * scheduled invoker) knows to run again rather than assuming the sweep is
+ * complete. `total` counts only the orders this call actually attempted, not
+ * the full backlog.
  *
  * Each order is cancelled independently (not as a single D1 batch): the
  * guard-then-refund sequence for one order must complete (including its
  * compensating revert on refund failure) before affecting the next, so a
- * failure on one stale order never blocks or corrupts the others.
+ * failure on one stale order never blocks or corrupts the others. The whole
+ * per-order call is additionally wrapped in try/catch — an unexpected error
+ * (e.g. a transient D1 failure on the guarded UPDATE itself, not just a
+ * refund failure) is tallied as `skipped` and logged rather than aborting
+ * the rest of the batch, so one bad row can't stop the sweep from reaping
+ * everything else it fetched.
  */
 export async function reapStalePendingOrders(
-  olderThanHours: number = REAP_STALE_AFTER_HOURS
-): Promise<{ cancelled: number; skipped: number; total: number }> {
+  olderThanHours: number = REAP_STALE_AFTER_HOURS,
+  batchSize: number = REAP_BATCH_SIZE
+): Promise<{ cancelled: number; skipped: number; total: number; hasMore: boolean }> {
   const staleOrders = await query<{ id: string }>(
-    "SELECT id FROM orders WHERE status = 'pending' AND created_at < datetime('now', ?)",
-    [`-${olderThanHours} hours`]
+    "SELECT id FROM orders WHERE status = 'pending' AND created_at < datetime('now', ?) ORDER BY created_at ASC LIMIT ?",
+    [`-${olderThanHours} hours`, batchSize + 1]
   );
+
+  const hasMore = staleOrders.length > batchSize;
+  const toProcess = hasMore ? staleOrders.slice(0, batchSize) : staleOrders;
 
   let cancelled = 0;
   let skipped = 0;
 
-  for (const order of staleOrders) {
-    const ok = await cancelPendingOrderById(
-      order.id,
-      "Commande annulée automatiquement : délai de confirmation dépassé."
-    );
-    if (ok) cancelled++;
-    else skipped++;
+  for (const order of toProcess) {
+    try {
+      const ok = await cancelPendingOrderById(
+        order.id,
+        "Commande annulée automatiquement : délai de confirmation dépassé."
+      );
+      if (ok) cancelled++;
+      else skipped++;
+    } catch (err) {
+      console.error(`reapStalePendingOrders: unexpected error cancelling order ${order.id}, skipping`, err);
+      skipped++;
+    }
   }
 
-  return { cancelled, skipped, total: staleOrders.length };
+  return { cancelled, skipped, total: toProcess.length, hasMore };
 }
 
 /**

--- a/lib/rate-limit/kv-window-limit.ts
+++ b/lib/rate-limit/kv-window-limit.ts
@@ -9,6 +9,20 @@
  * Shared by every per-domain limiter (orders, promo codes, ...) so each one
  * only has to supply its own key prefix and ceiling — the counting logic
  * itself lives in one place.
+ *
+ * The window is genuinely fixed, not sliding: storage is `{ count, resetAt }`
+ * and `resetAt` is captured once, on the first accepted call of each window,
+ * then left untouched by every later call in that same window. This mirrors
+ * `lib/ai/rate-limit.ts`'s documented trade-off exactly (see that file for
+ * the fuller rationale) — an earlier version of this function re-`put` the
+ * entry with a fresh `expirationTtl: windowSeconds` on every accepted call,
+ * which slides the expiry forward each time and means a caller whose calls
+ * are spaced closer together than the window never actually resets: five
+ * calls at fifty-five-minute intervals blocks the sixth call four and a half
+ * hours after the first, not one hour after. Storing `resetAt` and computing
+ * the *remaining* TTL on each write (`resetAt - now`, never the full window)
+ * fixes that: the window closes on its original schedule regardless of how
+ * many accepted calls land inside it.
  */
 export interface KVRateLimitOptions {
   /** Maximum allowed calls within the window (inclusive). */
@@ -17,13 +31,55 @@ export interface KVRateLimitOptions {
   windowSeconds: number;
 }
 
+interface Bucket {
+  count: number;
+  /** Epoch ms at which this window closes and a fresh one starts. */
+  resetAt: number;
+}
+
 export async function checkKVRateLimit(
   kv: KVNamespace,
   key: string,
-  { max, windowSeconds }: KVRateLimitOptions
+  { max, windowSeconds }: KVRateLimitOptions,
+  now: number = Date.now()
 ): Promise<boolean> {
-  const current = Number((await kv.get(key)) ?? 0);
-  if (current >= max) return false;
-  await kv.put(key, String(current + 1), { expirationTtl: windowSeconds });
+  const raw = await kv.get(key);
+  const bucket = raw ? safeParseBucket(raw) : null;
+
+  // No bucket yet, or the previous window already closed: start a fresh
+  // fixed window. Also the safe fallback for a pre-migration value written
+  // by the old plain-counter format (a bare numeric string fails to parse
+  // as a Bucket) — same "repart à zéro" tolerance lib/ai/rate-limit.ts
+  // already applies to malformed KV values.
+  if (!bucket || bucket.resetAt <= now) {
+    const fresh: Bucket = { count: 1, resetAt: now + windowSeconds * 1000 };
+    await kv.put(key, JSON.stringify(fresh), { expirationTtl: windowSeconds });
+    return true;
+  }
+
+  if (bucket.count >= max) return false;
+
+  // Accepted: increment the count but never touch resetAt, and set the
+  // KV entry's TTL to the window's *remaining* time, not the full window —
+  // this is what keeps the window fixed instead of sliding.
+  const updated: Bucket = { count: bucket.count + 1, resetAt: bucket.resetAt };
+  const remainingSeconds = Math.max(1, Math.ceil((bucket.resetAt - now) / 1000));
+  await kv.put(key, JSON.stringify(updated), { expirationTtl: remainingSeconds });
   return true;
+}
+
+function safeParseBucket(raw: string): Bucket | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      typeof parsed === "object" && parsed !== null &&
+      typeof (parsed as Bucket).count === "number" &&
+      typeof (parsed as Bucket).resetAt === "number"
+    ) {
+      return parsed as Bucket;
+    }
+  } catch {
+    /* fall through */
+  }
+  return null;
 }

--- a/lib/rate-limit/kv-window-limit.ts
+++ b/lib/rate-limit/kv-window-limit.ts
@@ -62,8 +62,19 @@ export async function checkKVRateLimit(
   // Accepted: increment the count but never touch resetAt, and set the
   // KV entry's TTL to the window's *remaining* time, not the full window —
   // this is what keeps the window fixed instead of sliding.
+  //
+  // Floored at 60, not 1: Cloudflare KV rejects any expirationTtl below 60
+  // seconds outright (kv.put throws), and a call landing in the final 59
+  // seconds of a window would otherwise compute exactly that. Flooring is
+  // safe because resetAt, not the KV TTL, is what actually defines the
+  // window: the branch above already treats any bucket with `resetAt <= now`
+  // as expired and starts a fresh window regardless of whether the KV entry
+  // itself has expired yet. Over-extending the entry's real expiry a little
+  // past resetAt only means it lingers slightly longer before the next call
+  // naturally overwrites or lets it expire — it can never make the window
+  // look open past resetAt.
   const updated: Bucket = { count: bucket.count + 1, resetAt: bucket.resetAt };
-  const remainingSeconds = Math.max(1, Math.ceil((bucket.resetAt - now) / 1000));
+  const remainingSeconds = Math.max(60, Math.ceil((bucket.resetAt - now) / 1000));
   await kv.put(key, JSON.stringify(updated), { expirationTtl: remainingSeconds });
   return true;
 }

--- a/lib/rate-limit/kv-window-limit.ts
+++ b/lib/rate-limit/kv-window-limit.ts
@@ -1,0 +1,29 @@
+/**
+ * Generic best-effort fixed-window counter backed by a KV namespace.
+ *
+ * KV is eventually consistent, so highly concurrent requests can slightly
+ * exceed `max` under race conditions — accepted here: the goal is to make
+ * abuse (e.g. draining stock, brute-forcing a promo code) impractical, not
+ * to count exactly. The WhatsApp bot already relies on the same trade-off.
+ *
+ * Shared by every per-domain limiter (orders, promo codes, ...) so each one
+ * only has to supply its own key prefix and ceiling — the counting logic
+ * itself lives in one place.
+ */
+export interface KVRateLimitOptions {
+  /** Maximum allowed calls within the window (inclusive). */
+  max: number;
+  /** Window length in seconds; also used as the KV entry's expirationTtl. */
+  windowSeconds: number;
+}
+
+export async function checkKVRateLimit(
+  kv: KVNamespace,
+  key: string,
+  { max, windowSeconds }: KVRateLimitOptions
+): Promise<boolean> {
+  const current = Number((await kv.get(key)) ?? 0);
+  if (current >= max) return false;
+  await kv.put(key, String(current + 1), { expirationTtl: windowSeconds });
+  return true;
+}

--- a/lib/rate-limit/orders.ts
+++ b/lib/rate-limit/orders.ts
@@ -1,0 +1,21 @@
+import { checkKVRateLimit } from "@/lib/rate-limit/kv-window-limit";
+
+const MAX_ORDERS_PER_HOUR = 5;
+const WINDOW_SECONDS = 3600;
+
+/**
+ * Per-user throttle on order creation. Keyed on the authenticated user id
+ * only (createOrder always runs behind requireAuth, so every caller already
+ * has a stable, non-spoofable identity) — not on client IP. Ivorian mobile
+ * carriers commonly put many genuine customers behind the same
+ * cf-connecting-ip via CGNAT, so an IP-keyed cap would risk throttling
+ * unrelated customers for a marginal gain: the exploit this closes is a
+ * single account driving stock to zero, which the user-id key already
+ * defeats directly.
+ */
+export async function checkOrderRateLimit(kv: KVNamespace, userId: string): Promise<boolean> {
+  return checkKVRateLimit(kv, `order:rate:${userId}`, {
+    max: MAX_ORDERS_PER_HOUR,
+    windowSeconds: WINDOW_SECONDS,
+  });
+}

--- a/lib/rate-limit/promo.ts
+++ b/lib/rate-limit/promo.ts
@@ -1,0 +1,26 @@
+import { checkKVRateLimit } from "@/lib/rate-limit/kv-window-limit";
+
+const MAX_PROMO_CHECKS_PER_HOUR = 20;
+const WINDOW_SECONDS = 3600;
+
+/**
+ * Per-user throttle on promo code validation (validatePromoCode). Same
+ * key/identity rationale as checkOrderRateLimit (lib/rate-limit/orders.ts):
+ * keyed on the authenticated user id alone, never IP, since CGNAT on
+ * Ivorian mobile carriers puts many genuine customers behind one IP.
+ *
+ * The ceiling is higher than order creation's (5/hour) because entering a
+ * promo code is a legitimate action a customer repeats often — retyping a
+ * mistyped code, trying a code shared by a friend, checking eligibility
+ * while still adjusting their cart. 20/hour keeps that experience intact
+ * while still bounding how many codes a single account can probe.
+ *
+ * Reuses the generic checkKVRateLimit primitive from task 3.2 unchanged —
+ * this file only supplies its own key prefix and ceiling.
+ */
+export async function checkPromoRateLimit(kv: KVNamespace, userId: string): Promise<boolean> {
+  return checkKVRateLimit(kv, `promo:rate:${userId}`, {
+    max: MAX_PROMO_CHECKS_PER_HOUR,
+    windowSeconds: WINDOW_SECONDS,
+  });
+}

--- a/lib/utils/checkout.ts
+++ b/lib/utils/checkout.ts
@@ -141,3 +141,22 @@ export function resolveOrderLine(input: OrderLineInput): OrderLineResult {
   }
   return { ok: true, unitPrice: product.base_price, availableStock: product.stock_quantity };
 }
+
+/**
+ * Groups a flat list of already-active-filtered variants by their
+ * product_id, returning how many active variants each product has.
+ *
+ * Pulled out of actions/checkout.ts (which builds this from a single query
+ * fetching every active variant for every product in the cart) so the
+ * counting logic that feeds resolveOrderLine's `activeVariantCount` guard
+ * is itself unit-testable, independent of D1.
+ */
+export function countActiveVariantsByProduct(
+  variants: Array<{ product_id: string }>
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const v of variants) {
+    counts.set(v.product_id, (counts.get(v.product_id) ?? 0) + 1);
+  }
+  return counts;
+}

--- a/lib/utils/checkout.ts
+++ b/lib/utils/checkout.ts
@@ -75,3 +75,69 @@ export function calculateSubtotal(
 ): number {
   return items.reduce((sum, item) => sum + item.unitPrice * item.quantity, 0);
 }
+
+// ─── resolveOrderLine ───
+
+export interface OrderLineProductInput {
+  name: string;
+  base_price: number;
+  stock_quantity: number;
+  /** Count of active (is_active = 1) variants for this product. */
+  activeVariantCount: number;
+}
+
+export interface OrderLineVariantInput {
+  name: string;
+  price: number;
+  stock_quantity: number;
+}
+
+export interface OrderLineInput {
+  product: OrderLineProductInput;
+  variant: OrderLineVariantInput | null;
+  quantity: number;
+}
+
+export type OrderLineResult =
+  | { ok: true; unitPrice: number; availableStock: number }
+  | { ok: false; error: string };
+
+/**
+ * Resolves the unit price and stock check for a single order line.
+ *
+ * Security invariant: `base_price` is a display-only figure for products
+ * sold through variants (the lowest of the variant prices), never an
+ * actual sellable price. A null variant is only accepted when the product
+ * has zero active variants; otherwise the caller must supply one of the
+ * product's own active variants (ownership is the caller's responsibility —
+ * this function only receives a variant already verified to belong to the
+ * product).
+ */
+export function resolveOrderLine(input: OrderLineInput): OrderLineResult {
+  const { product, variant, quantity } = input;
+
+  if (variant) {
+    if (variant.stock_quantity < quantity) {
+      return {
+        ok: false,
+        error: `Stock insuffisant pour ${product.name} - ${variant.name} (${variant.stock_quantity} disponible(s))`,
+      };
+    }
+    return { ok: true, unitPrice: variant.price, availableStock: variant.stock_quantity };
+  }
+
+  if (product.activeVariantCount > 0) {
+    return {
+      ok: false,
+      error: `Veuillez sélectionner une variante pour ${product.name}`,
+    };
+  }
+
+  if (product.stock_quantity < quantity) {
+    return {
+      ok: false,
+      error: `Stock insuffisant pour ${product.name} (${product.stock_quantity} disponible(s))`,
+    };
+  }
+  return { ok: true, unitPrice: product.base_price, availableStock: product.stock_quantity };
+}


### PR DESCRIPTION
Troisième lot de la remédiation issue de l'audit de sécurité de juillet 2026. Adresse trois advisories suivis : `GHSA-wfww-7qvh-mpjh` (HIGH), `GHSA-h8mq-qrgm-7wg5` et `GHSA-6949-v6px-4wpc`.

## ⚠️ À lire avant de merger

### Un parcours d'achat qui fonctionne aujourd'hui va cesser de fonctionner

C'est délibéré, mais silencieux jusqu'à la dernière étape du tunnel.

Les paniers sont persistés dans le navigateur. Toute ligne de panier existante portant un produit à variantes **sans variante sélectionnée** sera désormais refusée au paiement avec « Veuillez sélectionner une variante pour {produit} ». Le client devra retirer puis réajouter l'article.

Deux populations sont concernées : les paniers mal tarifés que ce lot vise, et **tous les produits ayant exactement une variante active** — leur bouton d'ajout rapide contournait jusqu'ici le sélecteur. Envisagez un message sur la page panier, ou une migration du panier local qui supprime ces lignes pour que l'échec survienne plus tôt.

### Nouvelles limites par client

- **5 commandes par heure.**
- **20 vérifications de code promo par heure**, budget partagé entre le bouton « appliquer » et la validation au paiement — appliquer puis commander consomme donc deux unités.
- **3 commandes simultanément en attente**, sur une fenêtre glissante de 24 h.

Sur une activité en paiement à la livraison où le passage de `pending` à `confirmed` est un appel téléphonique, **c'est le plafond de 3 qui touchera un vrai client en premier** : quelqu'un qui commande quatre articles séparément un samedi, avant que votre équipe n'en confirme aucun, se verra refuser le quatrième. Comparez votre délai médian de confirmation à ce plafond et relevez-le si les confirmations traînent au-delà d'une journée. Le plafond se libère seul après 24 h, indépendamment de la purge — personne ne reste bloqué durablement.

### Trois valeurs à provisionner, sans quoi la branche est à moitié inerte

1. `CRON_SECRET` en **secret du Worker Cloudflare** (`npx wrangler secret put CRON_SECRET`) — sans lui la route refuse tout par 401.
2. `CRON_SECRET` en **secret de dépôt GitHub**, identique au caractère près.
3. `CRON_REAP_ORDERS_URL` en **variable de dépôt**, par exemple `https://netereka.ci/api/cron/reap-pending-orders`.

Tant que ce n'est pas fait, le workflow horaire **échoue bruyamment chaque heure** — il ne passe pas silencieusement. Notez aussi que les workflows planifiés ne se déclenchent que depuis la branche par défaut : rien ne tournera avant le merge.

### Le premier balayage

Il rencontrera l'intégralité de l'arriéré de commandes en attente de plus de 24 h, à raison de 25 par heure. **Comptez cet arriéré avant de merger** pour savoir s'il s'écoulera en une heure ou en une semaine :

```sql
SELECT COUNT(*) FROM orders WHERE status = 'pending' AND created_at < datetime('now','-24 hours');
```

Les clients concernés reçoivent désormais une notification d'annulation.

## Ce que contient le lot

- Une ligne de commande ne peut plus être tarifée depuis le prix d'affichage quand le produit possède des variantes actives. Sur un article du catalogue, l'écart était de 250 000 XOF facturés contre 700 000 réels.
- La création de commande est limitée en débit, et le plafond de commandes en attente est appliqué **dans l'instruction SQL elle-même**, donc insensible aux rafales parallèles.
- Une purge horaire annule les commandes en attente abandonnées et restitue leur stock, via une route protégée par jeton et un workflow planifié.
- Les réponses de validation de code promo sont uniformes et limitées en débit sur les deux points d'entrée, avec un budget partagé.
- **En prime** : les trois chemins d'annulation côté administration sont désormais gardés et ne remboursent que s'ils ont effectivement opéré la transition. Sans cela, la nouvelle purge automatique aurait pu créditer le stock deux fois en concurrence avec un opérateur.

## Vérifications

`tsc --noEmit` propre, ESLint propre, 1056 tests, aucune migration. Chaque tâche a été relue par un agent distinct chargé de la réfuter, et la branche entière a fait l'objet d'une revue finale. Les propriétés critiques ont été mesurées, pas seulement raisonnées : 10 créations de commande réellement parallèles n'en laissent passer que 3 ; les trois réponses de code promo sont byte-à-byte identiques par les deux points d'entrée ; la matrice des transitions d'administration a été reconstruite pour confirmer qu'aucune action légitime n'est cassée.

## Suites connues, non traitées ici

- **Le Worker WhatsApp porte le même défaut de tarification par variante** sur son propre parcours de commande. `GHSA-wfww-7qvh-mpjh` **ne doit pas être fermé** au merge : la propriété système n'est vraie que sur le parcours web.
- Il subsiste un oracle résiduel borné sur les codes promo lorsque le quota de commandes est épuisé mais pas celui des promos. L'armer coûte cinq commandes réelles et visibles ; jugé acceptable.
- Une perte de stock préexistante lors d'une annulation partielle de décrément mérite sa propre tâche.
- `updateOrderStatus` réimplémente localement l'annulation gardée au lieu d'appeler la fonction partagée. Sûr en l'état, mais c'est un risque de dérive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)