### PR TITLE
chore(ci): enable Workers Logs so console output is actually retained

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -35,9 +35,22 @@
       "bucket_name": "netereka-opennext-cache"
     }
   ],
+  // Workers Logs ingests and indexes everything the Worker writes to console.
+  // It was disabled, which meant console output was emitted and then dropped:
+  // nothing was stored, so nothing could be read back. The CSP violation
+  // collector in app/api/csp-report/route.ts depends on this — its whole
+  // purpose is to leave a record an operator reads over the following weeks.
+  //
+  // Retention is 7 days (Workers Paid; 3 on Free), so a report covering a
+  // longer window has to be assembled from successive reads rather than one
+  // query at the end. Persisting to D1 is the alternative if that ever matters.
+  //
+  // invocation_logs stays on: it carries CPU and wall time per request, which
+  // is what tells us whether the sanitizer's bounded scan cost holds under real
+  // traffic. Volume is not a concern at this site's scale.
   "observability": {
     "logs": {
-      "enabled": false,
+      "enabled": true,
       "invocation_logs": true
     }
   }


### PR DESCRIPTION
`observability.logs.enabled` valait `false` dans `wrangler.jsonc`. Tout ce que le Worker écrit dans `console` était donc émis puis **jeté** : rien n'était ingéré, rien stocké, rien relisible ensuite.

## Pourquoi c'est bloquant

Cela annulait silencieusement le collecteur de violations CSP livré par le lot 4. Toute sa raison d'être est de laisser une trace qu'un opérateur relit pendant les semaines suivantes avant de décider s'il applique la politique.

Journaux désactivés, la période d'observation n'aurait produit **aucune donnée** — et le pire est là : l'absence de rapports se serait lue comme « la politique est propre » alors qu'elle signifiait « rien n'a jamais été enregistré ». Exactement le faux négatif que le rapport de la tâche 4.3 met en garde contre, appliqué à lui-même.

Découvert en configurant le rappel hebdomadaire de relecture, pas par la revue — qui s'était concentrée sur la robustesse du point de terminaison sans vérifier qu'il écrivait quelque part.

## Ce que change ce commit

```jsonc
"observability": { "logs": { "enabled": true, "invocation_logs": true } }
```

**Rétention : 7 jours** en offre payante (3 en gratuite). Une fenêtre d'observation plus longue doit donc être reconstituée par lectures successives, pas par une requête unique à la fin. La contrainte est documentée dans la configuration, là où elle s'applique. Si l'historique au-delà de 7 jours devient nécessaire, la persistance en D1 est l'alternative.

`invocation_logs` reste actif : il porte le temps CPU et le temps réel par requête, ce qui permet de confirmer sur du trafic réel le bornage du coût d'analyse de l'assainisseur obtenu au lot 4 — jusqu'ici vérifié uniquement sur des entrées synthétiques. Le volume reste très en deçà de l'allocation incluse à l'échelle de ce site.

## Vérifications

JSONC valide (commentaires retirés, `JSON.parse` propre), `tsc --noEmit`, ESLint et la suite complète passent via le hook de pré-commit. Aucune migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)