### PR TITLE
feat(storefront): enforce the CSP directives that cost no caching

### DIFF
--- a/__tests__/unit/security/headers.test.ts
+++ b/__tests__/unit/security/headers.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   CONTENT_SECURITY_POLICY,
+  CONTENT_SECURITY_POLICY_ENFORCED,
   CSP_ALLOWED_ORIGINS,
+  CSP_ENFORCED_HEADER_KEY,
   CSP_HEADER_KEY,
   CSP_REPORT_GROUP,
   CSP_REPORT_PATH,
@@ -63,6 +65,23 @@ function directive(name: string): string[] | null {
   return null;
 }
 
+/** The same, for the enforcing header — read served, never from the constant. */
+function enforcedDirective(name: string): string[] | null {
+  for (const part of (header(CSP_ENFORCED_HEADER_KEY) ?? "").split(";")) {
+    const tokens = part.trim().split(/\s+/).filter(Boolean);
+    if (tokens[0] === name) return tokens.slice(1);
+  }
+  return null;
+}
+
+/** Directive names present in the enforcing header, served. */
+function enforcedDirectiveNames(): string[] {
+  return (header(CSP_ENFORCED_HEADER_KEY) ?? "")
+    .split(";")
+    .map((part) => part.trim().split(/\s+/)[0])
+    .filter(Boolean);
+}
+
 describe("next.config.ts wiring", () => {
   it("serves the security headers on every route", () => {
     expect(headerRules).toHaveLength(1);
@@ -89,26 +108,36 @@ describe("security headers", () => {
     expect(header("Cross-Origin-Opener-Policy")).toBe("same-origin-allow-popups");
   });
 
-  it("ships the policy report-only and never enforcing", () => {
-    // A report-only policy blocks nothing. Moving to `Content-Security-Policy`
-    // means every inline script must be nonced or hashed, which forces dynamic
-    // rendering on a storefront that is currently cacheable. That is a product
-    // decision — see the task 4.3 decision note — so it must not happen as a
-    // side effect of an unrelated change.
+  it("ships the observing policy report-only, and never enforces it", () => {
+    // A report-only policy blocks nothing. Moving *this* policy to
+    // `Content-Security-Policy` means every inline script must be nonced or
+    // hashed, which forces dynamic rendering on a storefront that is currently
+    // cacheable. That is a product decision — see the task 4.3 decision note —
+    // so it must not happen as a side effect of an unrelated change.
+    //
+    // This originally asserted that no enforcing header existed at all. A
+    // second, enforcing header now does exist, carrying only the four
+    // directives that need no nonce; the check therefore moved from "no
+    // enforcing header" to "the enforcing header is not this policy". The
+    // "enforced CSP subset" block below pins what that header may contain, so
+    // the two together still fail if the observing policy is enforced by any
+    // route — directly, or by widening the subset until it is this policy.
     expect(CSP_HEADER_KEY).toBe("Content-Security-Policy-Report-Only");
     expect(header("Content-Security-Policy-Report-Only")).toBeTruthy();
-    expect(servedHeaders.some((h) => h.key.toLowerCase() === "content-security-policy")).toBe(false);
+    expect(header("Content-Security-Policy")).not.toBe(CONTENT_SECURITY_POLICY);
+    expect(header("Content-Security-Policy")).not.toContain("script-src");
   });
 
   it("keeps X-Frame-Options alongside frame-ancestors, and equivalent to it", () => {
     // CSP3 § 6.4.2.2: an *enforced* frame-ancestors overrides X-Frame-Options,
-    // which "will be ignored". Our disposition is `report`, so that override
-    // does not apply and X-Frame-Options is currently the only control
-    // actually preventing framing. Once the recommended enforcing second
-    // header ships, the two swap roles — so they must keep saying the same
-    // thing ('self' ≡ SAMEORIGIN).
+    // which "will be ignored". That condition is now met — the enforcing
+    // subset header carries `frame-ancestors 'self'` — so the two have swapped
+    // roles: CSP does the blocking, and X-Frame-Options survives only for
+    // agents that do not implement frame-ancestors. They must therefore keep
+    // saying the same thing ('self' ≡ SAMEORIGIN), in all three places.
     expect(header("X-Frame-Options")).toBe("SAMEORIGIN");
     expect(directive("frame-ancestors")).toEqual(["'self'"]);
+    expect(enforcedDirective("frame-ancestors")).toEqual(["'self'"]);
   });
 
   it("declares a reporting endpoint the browsers can actually reach", () => {
@@ -296,5 +325,66 @@ describe("image origin", () => {
     const reloaded = await import("@/lib/security/headers");
 
     expect(reloaded.CSP_ALLOWED_ORIGINS.r2).toBe("https://r2.netereka.ci");
+  });
+});
+
+/**
+ * The enforcing header — the half of the policy that actually blocks.
+ *
+ * It exists because these four directives concern no loaded script, so they
+ * need no nonce and cost no caching. That is also exactly what makes them easy
+ * to widen by accident: adding `default-src` here would quietly put every
+ * fetch under an enforced policy and take the site's caching with it. These
+ * tests fail in both directions — a directive dropped, or one added.
+ */
+describe("enforced CSP subset", () => {
+  it("is served, and is the enforcing header key", () => {
+    expect(header(CSP_ENFORCED_HEADER_KEY)).toBeDefined();
+    expect(CSP_ENFORCED_HEADER_KEY).toBe("Content-Security-Policy");
+  });
+
+  it("serves the enforced policy the constant defines, byte for byte", () => {
+    expect(header(CSP_ENFORCED_HEADER_KEY)).toBe(CONTENT_SECURITY_POLICY_ENFORCED);
+  });
+
+  it.each([
+    ["object-src", "'none'"],
+    ["base-uri", "'none'"],
+    ["form-action", "'self'"],
+    ["frame-ancestors", "'self'"],
+  ])("enforces %s %s", (name, value) => {
+    expect(enforcedDirective(name)).toEqual([value]);
+  });
+
+  // The reason this header can exist at all. Any of these would reintroduce
+  // the nonce requirement and, with it, dynamic rendering on every cached page.
+  it.each(["default-src", "script-src", "style-src", "img-src", "connect-src"])(
+    "does not carry %s",
+    (name) => {
+      expect(enforcedDirective(name)).toBeNull();
+    }
+  );
+
+  it("carries those four directives and nothing else", () => {
+    expect(enforcedDirectiveNames().sort()).toEqual(
+      ["base-uri", "form-action", "frame-ancestors", "object-src"].sort()
+    );
+  });
+
+  // Report-only and enforcing are two policies, and the split is the design.
+  // Collapsing them — by flipping the observing header to enforcement — would
+  // put script-src under enforcement with no nonce and break the storefront.
+  it("keeps the observing policy report-only", () => {
+    expect(CSP_HEADER_KEY).toBe("Content-Security-Policy-Report-Only");
+    expect(header("Content-Security-Policy-Report-Only")).toBeDefined();
+    expect(header(CSP_ENFORCED_HEADER_KEY)).not.toBe(header(CSP_HEADER_KEY));
+  });
+
+  // CSP3 §6.4.2.2: an enforced frame-ancestors makes browsers ignore
+  // X-Frame-Options. That condition is now met, so the two must agree — else
+  // the surviving header states a rule nobody applies.
+  it("agrees with X-Frame-Options on framing", () => {
+    expect(enforcedDirective("frame-ancestors")).toEqual(["'self'"]);
+    expect(header("X-Frame-Options")).toBe("SAMEORIGIN");
   });
 });

--- a/lib/security/headers.ts
+++ b/lib/security/headers.ts
@@ -173,10 +173,51 @@ export const CONTENT_SECURITY_POLICY = CSP_DIRECTIVES.join("; ");
  */
 export const CSP_HEADER_KEY = "Content-Security-Policy-Report-Only";
 
+/**
+ * The subset of the policy above that is actually ENFORCED, shipped as a
+ * second header alongside it.
+ *
+ * A browser evaluates every policy it is given independently, so two headers
+ * are two policies: the one above keeps observing everything, this one blocks
+ * these four. That is the whole reason the split works.
+ *
+ * These four earn enforcement now because **none of them concerns a loaded
+ * script**, which is what makes them free. Enforcing `script-src` would need a
+ * per-request nonce, a nonce cannot be cached, and that would turn
+ * `/p/[slug]` (ISR 1h), `/c/[slug]` (5min) and six 24h static pages into
+ * dynamic renders. These four cost nothing of the sort.
+ *
+ * `base-uri 'none'` is the one worth naming. A `<base href>` silently
+ * re-points every relative URL on the page — scripts, forms, links. The HTML
+ * sanitizer does not allow a `<base>` tag, but this directive defends the
+ * paths the sanitizer never sees, and it is not a duplicate of anything.
+ *
+ * Deliberately absent: `default-src`. Adding one would make this policy govern
+ * every fetch, which is precisely the nonce problem this split exists to
+ * avoid. The test suite fails if `default-src`, `script-src` or `style-src`
+ * appears here, so a future well-meaning widening cannot land quietly.
+ */
+export const CSP_ENFORCED_DIRECTIVES: readonly string[] = [
+  "object-src 'none'",
+  "base-uri 'none'",
+  // Safe for this codebase, and checked rather than assumed: every <form> uses
+  // `action={serverAction}`, which React posts same-origin to the current
+  // route, and no form carries a cross-origin URL action. Social sign-in is a
+  // *navigation* (`authClient.signIn.social()` sets the location), and
+  // `form-action` does not govern navigations.
+  "form-action 'self'",
+  "frame-ancestors 'self'",
+];
+
+export const CONTENT_SECURITY_POLICY_ENFORCED = CSP_ENFORCED_DIRECTIVES.join("; ");
+
+/** Enforcing. See CSP_ENFORCED_DIRECTIVES for why only those four. */
+export const CSP_ENFORCED_HEADER_KEY = "Content-Security-Policy";
+
 export const securityHeaders = [
   { key: "Strict-Transport-Security", value: "max-age=31536000; includeSubDomains; preload" },
   { key: "X-Content-Type-Options", value: "nosniff" },
-  // Kept alongside `frame-ancestors 'self'`, and load-bearing today.
+  // Kept alongside `frame-ancestors 'self'`, and now mostly a fallback.
   //
   // CSP3 § 6.4.2.2 is not a "browsers may differ" situation, it is a rule:
   // "the frame-ancestors directive overrides the X-Frame-Options header. If a
@@ -184,18 +225,19 @@ export const securityHeaders = [
   // frame-ancestors AND WHOSE DISPOSITION IS 'enforce', then the
   // X-Frame-Options header will be ignored, per HTML's processing model."
   //
-  // The qualifier is what matters here. Our policy's disposition is `report`,
-  // so the override does not apply and a report-only frame-ancestors blocks
-  // nothing: X-Frame-Options is currently the *only* control actually
-  // preventing this site from being framed. Removing it because "the CSP
-  // covers framing" would drop clickjacking protection to zero.
+  // That condition is now met. `frame-ancestors 'self'` ships in the ENFORCING
+  // header below, so every browser implementing CSP ignores this line outright.
   //
-  // The consequence to plan for: the moment `frame-ancestors 'self'` ships in
-  // an ENFORCING policy — which is exactly what the recommended second header
-  // does — every browser implementing CSP ignores this header outright, and it
-  // survives only for any that do not. At that point the two must still agree
-  // ('self' ≡ SAMEORIGIN, as they do), or it becomes a dead header stating a
-  // rule nobody applies. A test asserts both are present and equivalent.
+  // It stays for two reasons rather than being deleted. It still works in any
+  // agent that honours X-Frame-Options without implementing `frame-ancestors`,
+  // and this audience is mobile-heavy in a market where old and embedded
+  // browsers are not rare. And if the enforcing header is ever removed — by
+  // accident or in a rollback — deleting this line would silently drop
+  // clickjacking protection to zero rather than back to where it was.
+  //
+  // The two must therefore keep saying the same thing: 'self' ≡ SAMEORIGIN, as
+  // they do. A test asserts both are present and equivalent, so they cannot
+  // drift into a header stating a rule nobody applies.
   { key: "X-Frame-Options", value: "SAMEORIGIN" },
   { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
   { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
@@ -222,4 +264,9 @@ export const securityHeaders = [
   // gain.
   { key: "Reporting-Endpoints", value: `${CSP_REPORT_GROUP}="${CSP_REPORT_PATH}"` },
   { key: CSP_HEADER_KEY, value: CONTENT_SECURITY_POLICY },
+  // Two policies, deliberately. The one above observes everything and blocks
+  // nothing; this one blocks four directives and observes nothing. Neither
+  // weakens the other — a browser must satisfy every enforcing policy it is
+  // given, and report-only policies never block.
+  { key: CSP_ENFORCED_HEADER_KEY, value: CONTENT_SECURITY_POLICY_ENFORCED },
 ];


### PR DESCRIPTION
Suite du lot 4. La CSP est servie en **observation** depuis son déploiement, parce que l'appliquer entièrement exigerait un nonce par requête pour les scripts RSC en ligne de Next.js — et un nonce ne se met pas en cache, ce qui transformerait `/p/[slug]` (ISR 1 h), `/c/[slug]` (5 min) et six pages statiques 24 h en rendus dynamiques.

Quatre directives ne concernent **aucun script chargé**. Elles n'ont donc besoin d'aucun nonce et ne coûtent rien :

```
object-src 'none'; base-uri 'none'; form-action 'self'; frame-ancestors 'self'
```

Un navigateur évalue chaque politique qu'il reçoit indépendamment : ces quatre partent donc dans un **second en-tête, celui-là appliqué**, à côté de celui qui observe. La politique d'observation n'est pas touchée et reste en report-only.

## Ce que ça ferme réellement

`base-uri 'none'` est la plus intéressante : un `<base href>` injecté re-pointe silencieusement **toutes** les URL relatives de la page — scripts, formulaires, liens. L'assainisseur HTML n'autorise pas la balise `<base>`, mais cette directive défend les chemins que l'assainisseur ne voit jamais. Ce n'est pas un doublon.

## `form-action` : audité, pas supposé

C'est la seule des quatre qui pourrait casser un parcours vivant. Vérification faite : tous les `<form>` de l'application utilisent `action={serverAction}`, que React poste en same-origin vers la route courante, et aucun ne porte d'URL d'action externe. La connexion sociale est une **navigation** (`authClient.signIn.social()` positionne l'emplacement), or `form-action` ne gouverne pas les navigations.

## `X-Frame-Options` conservé, délibérément

CSP3 §6.4.2.2 : un `frame-ancestors` **appliqué** fait ignorer `X-Frame-Options`. Cette condition est désormais remplie, donc l'en-tête devient inerte dans tout navigateur implémentant CSP.

Il reste malgré tout, pour deux raisons. Il fonctionne encore dans les agents qui honorent `X-Frame-Options` sans implémenter `frame-ancestors` — ce qui n'est pas négligeable sur une audience ouest-africaine très majoritairement mobile. Et si ce second en-tête était retiré, par accident ou par rollback, avoir supprimé la ligne ferait tomber la protection contre le clickjacking à **zéro** au lieu de revenir à l'état antérieur. Un test vérifie que les trois énoncés sur le cadrage disent la même chose.

## Vérifications

`tsc --noEmit` propre, ESLint propre, **1 296 tests**.

Les tests lisent le tableau que `next.config.ts` **sert réellement**, pas les constantes — un test qui épinglait une constante sans vérifier son branchement avait déjà laissé passer la suppression de tous les en-têtes de sécurité au lot 4.

Chacun a été vérifié contre **huit mutations**, toutes appliquées puis annulées :

| Mutation | Tests en échec |
|---|---|
| En-tête appliqué supprimé | 10 |
| `base-uri` retiré | 2 |
| `object-src` retiré | 1 |
| `form-action` retiré | 2 |
| `frame-ancestors` retiré | 4 |
| `default-src` ajouté | 2 |
| `script-src` ajouté | 3 |
| Politique observante passée en appliqué | 9 |

Aucune n'est passée silencieusement. L'interdiction de `default-src`, `script-src` et `style-src` dans cet en-tête est ce qui empêche un élargissement bien intentionné de réintroduire le problème du nonce.

## Ce que ça ne change pas

La période d'observation continue à l'identique : la politique d'observation reste en report-only, et son collecteur non plus n'est pas touché. Le passage au nonce reste une décision distincte, à prendre au vu des journaux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)