### PR TITLE
fix(whatsapp): make the bot inherit the storefront's order guarantees (lot 5/8)

### DIFF
--- a/__tests__/unit/lib/auth/ban.test.ts
+++ b/__tests__/unit/lib/auth/ban.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { isActivelyBanned } from "@/lib/auth/ban";
+
+const NOW = 1_700_000_000_000;
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("isActivelyBanned", () => {
+  it("treats a permanent ban (no expiry) as active", () => {
+    expect(isActivelyBanned({ banned: 1, banExpires: null }, NOW)).toBe(true);
+    expect(isActivelyBanned({ banned: true, banExpires: null }, NOW)).toBe(true);
+  });
+
+  it("treats a future-dated ban as active", () => {
+    expect(isActivelyBanned({ banned: 1, banExpires: NOW + 60_000 }, NOW)).toBe(true);
+  });
+
+  it("treats an expired ban as inactive", () => {
+    expect(isActivelyBanned({ banned: 1, banExpires: NOW - 60_000 }, NOW)).toBe(false);
+  });
+
+  it("treats an unbanned user as inactive whatever the expiry says", () => {
+    expect(isActivelyBanned({ banned: 0, banExpires: null }, NOW)).toBe(false);
+    expect(isActivelyBanned({ banned: false, banExpires: null }, NOW)).toBe(false);
+    // A leftover expiry on a lifted ban must not resurrect it.
+    expect(isActivelyBanned({ banned: 0, banExpires: NOW + 60_000 }, NOW)).toBe(false);
+  });
+
+  it("treats a missing ban field as inactive", () => {
+    expect(isActivelyBanned({}, NOW)).toBe(false);
+    expect(isActivelyBanned({ banned: null, banExpires: null }, NOW)).toBe(false);
+    expect(isActivelyBanned({ banned: undefined }, NOW)).toBe(false);
+  });
+
+  // The web reads banExpires as a Date on a fresh D1 read and as an ISO string
+  // out of the session-cookie cache; the Worker reads the raw D1 TEXT column,
+  // which is what better-auth writes for a sqlite dialect (supportsDates:false).
+  // All three shapes must decide the same way — that is the whole point of
+  // there being one predicate.
+  it("decides identically for a Date, an ISO string and epoch milliseconds", () => {
+    const future = NOW + 60_000;
+    const past = NOW - 60_000;
+
+    for (const expiry of [new Date(future), new Date(future).toISOString(), future]) {
+      expect(isActivelyBanned({ banned: 1, banExpires: expiry }, NOW)).toBe(true);
+    }
+    for (const expiry of [new Date(past), new Date(past).toISOString(), past]) {
+      expect(isActivelyBanned({ banned: 1, banExpires: expiry }, NOW)).toBe(false);
+    }
+  });
+
+  // An expiry that cannot be read is not evidence that the sanction ended.
+  // Returning false here would let a flagged account straight through on the
+  // strength of a corrupt column — the one case where guessing wrong grants
+  // access rather than denying it.
+  it("keeps a ban active when the expiry cannot be parsed", () => {
+    expect(isActivelyBanned({ banned: 1, banExpires: "not-a-date" }, NOW)).toBe(true);
+    expect(isActivelyBanned({ banned: 1, banExpires: new Date("nope") }, NOW)).toBe(true);
+    expect(isActivelyBanned({ banned: 1, banExpires: Number.NaN }, NOW)).toBe(true);
+  });
+
+  it("is exactly at the boundary: an expiry equal to now has passed", () => {
+    expect(isActivelyBanned({ banned: 1, banExpires: NOW }, NOW)).toBe(false);
+    expect(isActivelyBanned({ banned: 1, banExpires: NOW + 1 }, NOW)).toBe(true);
+  });
+
+  it("falls back to the current clock when no reference time is given", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    expect(isActivelyBanned({ banned: 1, banExpires: NOW + 60_000 })).toBe(true);
+    expect(isActivelyBanned({ banned: 1, banExpires: NOW - 60_000 })).toBe(false);
+  });
+});

--- a/__tests__/unit/lib/db/orders.test.ts
+++ b/__tests__/unit/lib/db/orders.test.ts
@@ -24,9 +24,14 @@ vi.mock("@/lib/db", () => ({
 }));
 vi.mock("@/lib/cloudflare/context", () => ({
   getDB: vi.fn().mockResolvedValue({
-    // refundOrderStock builds each stock-update statement via db.prepare(...).bind(...)
-    // before handing the array to db.batch(...) — both must be stubbed.
-    prepare: vi.fn().mockReturnValue({ bind: vi.fn().mockReturnValue({}) }),
+    // refundOrderStock and createOrderWithItems build each statement via
+    // db.prepare(...).bind(...) before handing the array to db.batch(...) —
+    // both must be stubbed. Each prepared statement carries its own sql and
+    // params so a test can assert *which* rows a compensating batch touched,
+    // not merely how many statements it contained.
+    prepare: vi.fn((sql: string) => ({
+      bind: (...params: unknown[]) => ({ sql, params }),
+    })),
     batch: mocks.dbBatch,
   }),
 }));
@@ -495,5 +500,39 @@ describe("createOrderWithItems", () => {
     // First execute = the reservation INSERT, second = the cleanup DELETE.
     expect(mocks.execute).toHaveBeenCalledTimes(2);
     expect(mocks.execute.mock.calls[1][0]).toMatch(/DELETE FROM orders WHERE id = \?/);
+  });
+
+  it("gives back every decrement that applied, including the ones after the refused line", async () => {
+    // db.batch runs the whole sequence: a decrement matching no row does not
+    // stop the statements after it, so line 3 reserves even though line 2 was
+    // refused. Restoring only the lines *before* the refusal left line 3's
+    // units held against an order this same batch deletes.
+    const threeItems = [
+      { ...items[0], productId: "prod-1", productName: "Casque", quantity: 1 },
+      { ...items[0], productId: "prod-2", productName: "Souris", quantity: 2 },
+      { ...items[0], productId: "prod-3", productName: "Clavier", quantity: 3 },
+    ];
+    mocks.execute.mockResolvedValue({ meta: { changes: 1 } });
+    mocks.dbBatch
+      .mockResolvedValueOnce([
+        { meta: { changes: 1 } }, // prod-1 reserved
+        { meta: { changes: 0 } }, // prod-2 refused
+        { meta: { changes: 1 } }, // prod-3 reserved anyway
+        { meta: { changes: 1 } }, // the three order_items inserts
+        { meta: { changes: 1 } },
+        { meta: { changes: 1 } },
+      ])
+      .mockResolvedValueOnce([]);
+
+    await expect(createOrderWithItems(orderData, threeItems)).rejects.toThrow(/Souris/);
+
+    const rollback = mocks.dbBatch.mock.calls[1][0] as { sql: string; params: unknown[] }[];
+    const restores = rollback.filter((s) => s.sql.includes("stock_quantity + ?"));
+    expect(restores.map((s) => s.params)).toEqual([
+      [1, "prod-1"],
+      [3, "prod-3"],
+    ]);
+    // prod-2 took nothing; crediting it back would invent stock.
+    expect(restores.some((s) => s.params.includes("prod-2"))).toBe(false);
   });
 });

--- a/__tests__/unit/lib/rate-limit/kv-window-limit.test.ts
+++ b/__tests__/unit/lib/rate-limit/kv-window-limit.test.ts
@@ -211,4 +211,29 @@ describe("checkKVRateLimit", () => {
       expect.objectContaining({ expirationTtl: WINDOW_SECONDS })
     );
   });
+
+  it("floors the very first write's TTL at 60s so a sub-minute window is usable", async () => {
+    // KV rejects expirationTtl below 60 outright (the double above throws, as
+    // the real binding does). The floor used to be applied only to the second
+    // write, so the *first* call of a sub-minute window blew up. No shipped
+    // caller uses a window that short, which is exactly why this went unseen.
+    const SHORT = 30;
+    const kv = makeKV();
+
+    const ok = await checkKVRateLimit(kv, "k", { max: 2, windowSeconds: SHORT }, NOW);
+
+    expect(ok).toBe(true);
+    expect(kv.put).toHaveBeenCalledWith(
+      "k",
+      // The window itself still closes after 30s — `resetAt` governs, not the
+      // KV TTL — so flooring the entry's lifetime cannot widen the window.
+      bucket(1, NOW + SHORT * 1000),
+      expect.objectContaining({ expirationTtl: 60 })
+    );
+
+    // And the window really is 30s, not 60: a call at +31s starts a fresh one.
+    expect(await checkKVRateLimit(kv, "k", { max: 2, windowSeconds: SHORT }, NOW + 31_000)).toBe(true);
+    expect(await checkKVRateLimit(kv, "k", { max: 2, windowSeconds: SHORT }, NOW + 32_000)).toBe(true);
+    expect(await checkKVRateLimit(kv, "k", { max: 2, windowSeconds: SHORT }, NOW + 33_000)).toBe(false);
+  });
 });

--- a/__tests__/unit/lib/utils/stock.test.ts
+++ b/__tests__/unit/lib/utils/stock.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildStockDecrement,
+  buildStockRestore,
+  stockUpdateApplied,
+} from "@/lib/utils/stock";
+
+// These statements are shared by the web checkout (lib/db/orders.ts) and the
+// WhatsApp Worker (workers/whatsapp/src/tools/orders.ts). Pinning their shape
+// here is what keeps the two from drifting apart again.
+
+describe("buildStockDecrement", () => {
+  it("guards a product decrement on the stock still being there", () => {
+    const { sql, params } = buildStockDecrement({
+      productId: "p1",
+      variantId: null,
+      quantity: 3,
+    });
+
+    expect(sql).toContain("UPDATE products");
+    expect(sql).toContain("AND stock_quantity >= ?");
+    // The quantity is bound twice on purpose: the availability check and the
+    // write are the same statement, so two orders for the last unit cannot
+    // both pass the check.
+    expect(params).toEqual([3, "p1", 3]);
+  });
+
+  it("guards a variant decrement and targets the variant row", () => {
+    const { sql, params } = buildStockDecrement({
+      productId: "p1",
+      variantId: "v1",
+      quantity: 2,
+    });
+
+    expect(sql).toContain("UPDATE product_variants");
+    expect(sql).toContain("AND stock_quantity >= ?");
+    expect(params).toEqual([2, "v1", 2]);
+    // Never the parent product row — that stock is a different figure.
+    expect(params).not.toContain("p1");
+  });
+});
+
+describe("buildStockRestore", () => {
+  it("adds the quantity back to the product row", () => {
+    const { sql, params } = buildStockRestore({
+      productId: "p1",
+      variantId: null,
+      quantity: 3,
+    });
+
+    expect(sql).toContain("UPDATE products");
+    expect(sql).toContain("stock_quantity + ?");
+    expect(params).toEqual([3, "p1"]);
+  });
+
+  it("adds the quantity back to the variant row", () => {
+    const { sql, params } = buildStockRestore({
+      productId: "p1",
+      variantId: "v1",
+      quantity: 2,
+    });
+
+    expect(sql).toContain("UPDATE product_variants");
+    expect(params).toEqual([2, "v1"]);
+  });
+
+  it("carries no availability guard — a release can never go negative", () => {
+    const { sql } = buildStockRestore({ productId: "p1", variantId: null, quantity: 1 });
+    expect(sql).not.toContain(">=");
+  });
+});
+
+describe("stockUpdateApplied", () => {
+  it("accepts an update that affected a row", () => {
+    expect(stockUpdateApplied({ meta: { changes: 1 } })).toBe(true);
+  });
+
+  it("rejects an update that matched nothing", () => {
+    expect(stockUpdateApplied({ meta: { changes: 0 } })).toBe(false);
+  });
+
+  it("rejects a missing result rather than reading it as success", () => {
+    // Fail closed: a driver returning fewer results than statements must not
+    // be mistaken for "every decrement applied".
+    expect(stockUpdateApplied(undefined)).toBe(false);
+  });
+});

--- a/__tests__/unit/sanitize-html.test.ts
+++ b/__tests__/unit/sanitize-html.test.ts
@@ -836,6 +836,44 @@ describe("sanitizeDescriptionHtml", () => {
     expect(result).toBe("<style>this is not css</style>");
   });
 
+  /**
+   * The two cost guards below express their budget as a multiple of work
+   * measured in the same process, not as a number of milliseconds.
+   *
+   * A fixed millisecond budget is not portable. `3000` left roughly six times
+   * the headroom on a 16-core workstation at rest, but this file runs in the
+   * pre-commit hook and in CI, where a runner has two to four shared cores —
+   * and six times is not a comfortable margin for a CPU-bound loop on a loaded
+   * box. A guard that fails on someone else's unrelated commit gets deleted,
+   * and then it guards nothing.
+   *
+   * What these tests actually assert is a *shape*: that the scan stayed linear
+   * rather than turning quadratic again. Dividing by a calibration workload
+   * makes that shape the thing measured. Both numbers move together when the
+   * machine is slow or busy; only a change in complexity moves them apart.
+   *
+   * Measured: the ratio sits between 11 and 21 at rest and between 11 and 18
+   * with two full suites competing for the CPU, while the absolute times move
+   * by a factor of five. The regression this catches is not subtle — before
+   * the scan was bounded, one of these shapes alone cost 79 seconds against a
+   * calibration of a few milliseconds, a ratio in the thousands.
+   */
+  function calibrationMs(): number {
+    const realistic =
+      "<style>" +
+      "@media (max-width: 768px){.desc-x .desc-x .t{font-size:32px}}\r\n".repeat(300) +
+      "</style>";
+    // One warm-up pass first: without it the calibration absorbs JIT cost that
+    // the measured loop does not, which inflates the ratio for no reason.
+    sanitizeDescriptionHtml(realistic, "prod-1");
+    const started = performance.now();
+    for (let i = 0; i < 20; i++) sanitizeDescriptionHtml(realistic, "prod-1");
+    return Math.max(performance.now() - started, 1);
+  }
+
+  /** Ratio ceiling. Observed max 21; a return to quadratic reaches the hundreds. */
+  const COST_RATIO_BUDGET = 150;
+
   it("sanitizes adversarial tag-soup in linear time", () => {
     // [input, productId]. The productId matters: selector scoping only runs
     // when one is supplied, so the <style> shapes below exercise nothing
@@ -908,11 +946,18 @@ describe("sanitizeDescriptionHtml", () => {
       ['<style>a["' + ",b".repeat(240000) + "{x:y}", "prod-1"],
       ['<style>a[t="' + "b".repeat(400000) + '"]{x:y}', "prod-1"],
     ];
-    const started = Date.now();
+    const calibration = calibrationMs();
+    const started = performance.now();
     for (const [shape, productId] of shapes) sanitizeDescriptionHtml(shape, productId);
-    const elapsed = Date.now() - started;
-    expect(elapsed).toBeLessThan(3000);
-  }, 30000);
+    const elapsed = performance.now() - started;
+    expect(elapsed / calibration).toBeLessThan(COST_RATIO_BUDGET);
+    // Generous on purpose: the ratio above is the assertion, and a tight
+    // timeout would quietly put a wall-clock limit back in front of it — the
+    // exact portability problem the ratio exists to remove. Under three
+    // competing suites these shapes took 12s of wall clock while the ratio
+    // stayed flat; a genuine quadratic regression takes over 200s and fails
+    // here too, so this bound still catches the case the ratio would.
+  }, 180000);
 
   // Hardening: a browser resolves HTML character references and CSS escapes
   // BEFORE it decides what a URL's scheme is or what a declaration does. A
@@ -1201,11 +1246,18 @@ describe("sanitizeDescriptionHtml", () => {
       ["<style>" + "url ".repeat(120000), undefined],
       ["<style>" + "image-set ".repeat(48000), "prod-1"],
     ];
-    const started = Date.now();
+    const calibration = calibrationMs();
+    const started = performance.now();
     for (const [shape, productId] of shapes) sanitizeDescriptionHtml(shape, productId);
-    const elapsed = Date.now() - started;
-    expect(elapsed).toBeLessThan(3000);
-  }, 30000);
+    const elapsed = performance.now() - started;
+    expect(elapsed / calibration).toBeLessThan(COST_RATIO_BUDGET);
+    // Generous on purpose: the ratio above is the assertion, and a tight
+    // timeout would quietly put a wall-clock limit back in front of it — the
+    // exact portability problem the ratio exists to remove. Under three
+    // competing suites these shapes took 12s of wall clock while the ratio
+    // stayed flat; a genuine quadratic regression takes over 200s and fails
+    // here too, so this bound still catches the case the ratio would.
+  }, 180000);
 
   it("keeps a long generated style block byte-identical", () => {
     const id = "prod-7f3a91c2";

--- a/__tests__/unit/sanitize-html.test.ts
+++ b/__tests__/unit/sanitize-html.test.ts
@@ -852,11 +852,23 @@ describe("sanitizeDescriptionHtml", () => {
    * makes that shape the thing measured. Both numbers move together when the
    * machine is slow or busy; only a change in complexity moves them apart.
    *
-   * Measured: the ratio sits between 11 and 21 at rest and between 11 and 18
-   * with two full suites competing for the CPU, while the absolute times move
-   * by a factor of five. The regression this catches is not subtle — before
-   * the scan was bounded, one of these shapes alone cost 79 seconds against a
-   * calibration of a few milliseconds, a ratio in the thousands.
+   * The calibration must take a time of the same order as the workload it
+   * calibrates, and that is not a detail. A first version looped 20 times,
+   * taking ~15 ms against a ~1500 ms measured loop, and stayed flaky: a long
+   * loop loses far more of its time slice to other work than a short one, so
+   * the short calibration under-reported the contention and the ratio swung
+   * between 89 and 123. Looping 200 times pulled it to 10-12.
+   *
+   * Measured across three conditions — this file alone, the full suite running
+   * its files in parallel, and two extra suites competing for the CPU — the
+   * ratio stays between 6.6 and 11.9 for the tag-soup shapes and between 3.7
+   * and 5.7 for the character-reference ones, while the absolute time of the
+   * measured loop moves from 652 ms to 3761 ms. The ceiling below is five
+   * times the worst of those.
+   *
+   * The regression this catches is not subtle: before the scan was bounded,
+   * one shape alone cost 79 seconds, and restoring the quadratic attribute
+   * scan puts the measured loop at 217 seconds — ratios in the hundreds.
    */
   function calibrationMs(): number {
     const realistic =
@@ -867,12 +879,12 @@ describe("sanitizeDescriptionHtml", () => {
     // the measured loop does not, which inflates the ratio for no reason.
     sanitizeDescriptionHtml(realistic, "prod-1");
     const started = performance.now();
-    for (let i = 0; i < 20; i++) sanitizeDescriptionHtml(realistic, "prod-1");
+    for (let i = 0; i < 200; i++) sanitizeDescriptionHtml(realistic, "prod-1");
     return Math.max(performance.now() - started, 1);
   }
 
-  /** Ratio ceiling. Observed max 21; a return to quadratic reaches the hundreds. */
-  const COST_RATIO_BUDGET = 150;
+  /** Ratio ceiling. Observed max 11.9; a return to quadratic reaches the hundreds. */
+  const COST_RATIO_BUDGET = 60;
 
   it("sanitizes adversarial tag-soup in linear time", () => {
     // [input, productId]. The productId matters: selector scoping only runs

--- a/__tests__/unit/workers/whatsapp/tools/account.test.ts
+++ b/__tests__/unit/workers/whatsapp/tools/account.test.ts
@@ -156,6 +156,60 @@ describe("linkAccount", () => {
     expect(mockDb.prepare).not.toHaveBeenCalled();
     expect(sendOtpEmail).not.toHaveBeenCalled();
   });
+
+  // A suspended account must not become reachable from a new WhatsApp number.
+  // The refusal reuses the uniform message on purpose: a distinct "this account
+  // is suspended" reply would hand an unauthenticated sender both an existence
+  // oracle and the account's moderation status.
+  it("will not stage a suspended account, and says nothing that distinguishes it", async () => {
+    const { sendOtpEmail } = await import("../../../../../workers/whatsapp/src/email");
+    const ctx = createMockCtx(mockDb);
+    mockDb._statement.first.mockResolvedValueOnce({
+      id: "banned-1",
+      email: "banned@example.com",
+      banned: 1,
+      banExpires: null,
+    });
+
+    const result = await linkAccount(ctx, { email: "banned@example.com" });
+
+    expect(result.success).toBe(true);
+    const data = result.data as { message: string };
+    expect(data.message).toMatch(/si un compte existe/i);
+    expect(sendOtpEmail).not.toHaveBeenCalled();
+    // Nothing staged: the session must not carry a pending link to a banned id.
+    const staged = mockDb.prepare.mock.calls
+      .map((c) => String(c[0]))
+      .find((sql) => sql.includes("UPDATE whatsapp_sessions"));
+    expect(staged).toBeUndefined();
+  });
+
+  it("still links an account whose ban has expired", async () => {
+    const { sendOtpEmail } = await import("../../../../../workers/whatsapp/src/email");
+    const ctx = createMockCtx(mockDb);
+    mockDb._statement.first.mockResolvedValueOnce({
+      id: "user-123",
+      email: "user@example.com",
+      banned: 1,
+      banExpires: new Date(Date.now() - 60_000).toISOString(),
+    });
+    mockDb._statement.run.mockResolvedValueOnce({ success: true });
+
+    await linkAccount(ctx, { email: "user@example.com" });
+
+    expect(sendOtpEmail).toHaveBeenCalled();
+  });
+
+  it("reads the ban state in the same lookup as the account", async () => {
+    const ctx = createMockCtx(mockDb);
+    mockDb._statement.first.mockResolvedValueOnce(null);
+
+    await linkAccount(ctx, { email: "someone@example.com" });
+
+    const lookupSql = String(mockDb.prepare.mock.calls[0][0]);
+    expect(lookupSql).toMatch(/banned/);
+    expect(lookupSql).toMatch(/banExpires/);
+  });
 });
 
 describe("verifyOtp", () => {
@@ -219,6 +273,8 @@ describe("verifyOtp", () => {
       otp_expires_at: futureTime,
       pending_user_id: "user-456",
     });
+    // The pending account's ban state, re-read before the promotion.
+    mockDb._statement.first.mockResolvedValueOnce({ banned: 0, banExpires: null });
     mockDb._statement.run.mockResolvedValueOnce({ meta: { changes: 1 } });
 
     const result = await verifyOtp(ctx, { code: "654321" });
@@ -247,6 +303,7 @@ describe("verifyOtp", () => {
       otp_expires_at: futureTime,
       pending_user_id: "user-456",
     });
+    mockDb._statement.first.mockResolvedValueOnce({ banned: 0, banExpires: null });
     mockDb._statement.run.mockResolvedValueOnce({ meta: { changes: 0 } });
 
     const result = await verifyOtp(ctx, { code: "654321" });
@@ -254,5 +311,32 @@ describe("verifyOtp", () => {
     expect(result.success).toBe(false);
     expect(ctx.session.is_verified).toBe(0);
     expect(ctx.session.user_id).toBeNull();
+  });
+
+  // Closes the window between staging and confirmation: the account was fine
+  // when the code was sent and has been suspended since. Naming the reason is
+  // safe here and nowhere else — holding the emailed code proves the sender
+  // controls that mailbox.
+  it("does not promote an account suspended after the code was sent", async () => {
+    const ctx = createMockCtx(mockDb);
+    const futureTime = new Date(Date.now() + 600000).toISOString();
+    mockDb._statement.first.mockResolvedValueOnce({
+      otp_code: "654321",
+      otp_expires_at: futureTime,
+      pending_user_id: "user-456",
+    });
+    mockDb._statement.first.mockResolvedValueOnce({ banned: 1, banExpires: null });
+
+    const result = await verifyOtp(ctx, { code: "654321" });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/suspendu/i);
+    expect(ctx.session.is_verified).toBe(0);
+    expect(ctx.session.user_id).toBeNull();
+    // No promotion UPDATE may have been prepared at all.
+    const promoteSql = mockDb.prepare.mock.calls
+      .map((c) => String(c[0]))
+      .find((sql) => sql.includes("is_verified = 1"));
+    expect(promoteSql).toBeUndefined();
   });
 });

--- a/__tests__/unit/workers/whatsapp/tools/cart.test.ts
+++ b/__tests__/unit/workers/whatsapp/tools/cart.test.ts
@@ -42,12 +42,13 @@ describe("cartAdd", () => {
   });
 
   it("adds a product to the cart successfully", async () => {
-    // 1. Product lookup
+    // 1. Product lookup — a product sold without variants
     mockDb._statement.first.mockResolvedValueOnce({
       id: "p1",
       name: "iPhone 15",
       base_price: 650000,
       stock_quantity: 10,
+      active_variant_count: 0,
     });
     // 2. Existing cart item check — none
     mockDb._statement.first.mockResolvedValueOnce(null);
@@ -75,6 +76,7 @@ describe("cartAdd", () => {
       name: "Rare Phone",
       base_price: 200000,
       stock_quantity: 1,
+      active_variant_count: 0,
     });
 
     const result = await cartAdd(createMockCtx(mockDb), { product_id: "p1", quantity: 5 });
@@ -90,6 +92,7 @@ describe("cartAdd", () => {
       name: "Samsung TV",
       base_price: 300000,
       stock_quantity: 20,
+      active_variant_count: 0,
     });
     // Existing cart item
     mockDb._statement.first.mockResolvedValueOnce({
@@ -112,6 +115,7 @@ describe("cartAdd", () => {
       name: "Laptop",
       base_price: 500000,
       stock_quantity: 5,
+      active_variant_count: 3,
     });
     // Variant lookup — not found (wrong product)
     mockDb._statement.first.mockResolvedValueOnce(null);
@@ -124,6 +128,60 @@ describe("cartAdd", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/variant/i);
+  });
+
+  // ── Pricing invariant, enforced at cart entry ──
+  //
+  // `base_price` is the display figure for a product sold through variants
+  // (the lowest variant price). Letting such a line into the cart would both
+  // quote an unsellable price back in the conversation and produce a line the
+  // order path must later reject — so refuse it here, at the earliest point.
+  it("refuses a variant product added without a variant", async () => {
+    mockDb._statement.first.mockResolvedValueOnce({
+      id: "p1",
+      name: "Climatiseur Split",
+      base_price: 250000,
+      stock_quantity: 10,
+      active_variant_count: 2,
+    });
+
+    const result = await cartAdd(createMockCtx(mockDb), { product_id: "p1", quantity: 1 });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/variante/i);
+    expect(result.error).toContain("Climatiseur Split");
+    // Nothing may be written to whatsapp_carts.
+    expect(mockDb._statement.run).not.toHaveBeenCalled();
+  });
+
+  it("adds a variant line at the variant price, not the product base price", async () => {
+    // Product lookup
+    mockDb._statement.first.mockResolvedValueOnce({
+      id: "p1",
+      name: "Climatiseur Split",
+      base_price: 250000,
+      stock_quantity: 10,
+      active_variant_count: 2,
+    });
+    // Variant lookup
+    mockDb._statement.first.mockResolvedValueOnce({
+      id: "v2",
+      name: "3 CV",
+      price: 1400000,
+      stock_quantity: 2,
+    });
+    // Existing cart item check — none
+    mockDb._statement.first.mockResolvedValueOnce(null);
+    mockDb._statement.run.mockResolvedValueOnce({ success: true });
+
+    const result = await cartAdd(createMockCtx(mockDb), {
+      product_id: "p1",
+      variant_id: "v2",
+      quantity: 1,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({ name: "Climatiseur Split – 3 CV", price: 1400000 });
   });
 });
 

--- a/__tests__/unit/workers/whatsapp/tools/cart.test.ts
+++ b/__tests__/unit/workers/whatsapp/tools/cart.test.ts
@@ -192,33 +192,57 @@ describe("cartView", () => {
     mockDb = createMockD1();
   });
 
+  /** A row as the cart-view query returns it, with orderable defaults. */
+  function viewRow(overrides: Record<string, unknown>) {
+    return {
+      id: "ci1",
+      product_name: "iPhone 15",
+      base_price: 650000,
+      product_stock: 10,
+      product_is_active: 1,
+      product_is_draft: 0,
+      active_variant_count: 0,
+      cart_variant_id: null,
+      variant_id: null,
+      variant_name: null,
+      variant_price: null,
+      variant_stock: null,
+      quantity: 1,
+      ...overrides,
+    };
+  }
+
+  type ViewItem = {
+    name: string;
+    quantity: number;
+    unit_price: number | null;
+    total: number | null;
+    issue: string | null;
+  };
+  type ViewData = { items: ViewItem[]; subtotal: number; has_blocking_issues: boolean };
+
   it("returns cart items with subtotal", async () => {
     mockDb._statement.all.mockResolvedValueOnce({
       results: [
-        {
-          id: "ci1",
-          product_name: "iPhone 15",
-          variant_name: null,
-          quantity: 2,
-          unit_price: 650000,
-        },
-        {
-          id: "ci2",
-          product_name: "AirPods",
-          variant_name: null,
-          quantity: 1,
-          unit_price: 150000,
-        },
+        viewRow({ id: "ci1", product_name: "iPhone 15", base_price: 650000, quantity: 2 }),
+        viewRow({ id: "ci2", product_name: "AirPods", base_price: 150000, quantity: 1 }),
       ],
     });
 
     const result = await cartView(createMockCtx(mockDb));
 
     expect(result.success).toBe(true);
-    const data = result.data as { items: unknown[]; subtotal: number };
+    const data = result.data as ViewData;
     expect(data.items).toHaveLength(2);
     expect(data.subtotal).toBe(1450000); // 2*650000 + 1*150000
-    expect(data.items[0]).toMatchObject({ name: "iPhone 15", quantity: 2, unit_price: 650000, total: 1300000 });
+    expect(data.items[0]).toMatchObject({
+      name: "iPhone 15",
+      quantity: 2,
+      unit_price: 650000,
+      total: 1300000,
+      issue: null,
+    });
+    expect(data.has_blocking_issues).toBe(false);
   });
 
   it("returns empty cart with zero subtotal", async () => {
@@ -227,9 +251,120 @@ describe("cartView", () => {
     const result = await cartView(createMockCtx(mockDb));
 
     expect(result.success).toBe(true);
-    const data = result.data as { items: unknown[]; subtotal: number };
+    const data = result.data as ViewData;
     expect(data.items).toHaveLength(0);
     expect(data.subtotal).toBe(0);
+    expect(data.has_blocking_issues).toBe(false);
+  });
+
+  it("prices a variant line from the variant", async () => {
+    mockDb._statement.all.mockResolvedValueOnce({
+      results: [
+        viewRow({
+          product_name: "Climatiseur Split",
+          base_price: 250000,
+          active_variant_count: 2,
+          cart_variant_id: "v2",
+          variant_id: "v2",
+          variant_name: "3 CV",
+          variant_price: 1400000,
+          variant_stock: 5,
+        }),
+      ],
+    });
+
+    const result = await cartView(createMockCtx(mockDb));
+
+    const data = result.data as ViewData;
+    expect(data.items[0]).toMatchObject({
+      name: "Climatiseur Split – 3 CV",
+      unit_price: 1400000,
+      total: 1400000,
+      issue: null,
+    });
+    expect(data.subtotal).toBe(1400000);
+  });
+
+  // The view must not invent a figure the checkout will refuse: quoting an
+  // unsellable base_price and then rejecting the order is what makes the
+  // channel look untrustworthy.
+  it("shows no price for a variant product line that carries no variant", async () => {
+    mockDb._statement.all.mockResolvedValueOnce({
+      results: [
+        viewRow({
+          product_name: "Climatiseur Split",
+          base_price: 250000,
+          active_variant_count: 2,
+        }),
+      ],
+    });
+
+    const result = await cartView(createMockCtx(mockDb));
+
+    const data = result.data as ViewData;
+    expect(data.items[0].unit_price).toBeNull();
+    expect(data.items[0].total).toBeNull();
+    expect(data.items[0].issue).toMatch(/variante/i);
+    // Excluded from the subtotal, and the caller is told the cart is blocked.
+    expect(data.subtotal).toBe(0);
+    expect(data.has_blocking_issues).toBe(true);
+  });
+
+  it("shows no price for a line whose chosen variant is no longer active", async () => {
+    mockDb._statement.all.mockResolvedValueOnce({
+      results: [
+        viewRow({
+          product_name: "Climatiseur Split",
+          base_price: 250000,
+          active_variant_count: 1,
+          cart_variant_id: "v-retired",
+          variant_id: null,
+        }),
+      ],
+    });
+
+    const result = await cartView(createMockCtx(mockDb));
+
+    const data = result.data as ViewData;
+    expect(data.items[0].unit_price).toBeNull();
+    expect(data.items[0].issue).toMatch(/variante/i);
+    expect(data.has_blocking_issues).toBe(true);
+  });
+
+  it("flags a line whose product has left the catalogue", async () => {
+    mockDb._statement.all.mockResolvedValueOnce({
+      results: [
+        viewRow({ product_name: "Ventilateur Retiré", product_is_active: 0 }),
+      ],
+    });
+
+    const result = await cartView(createMockCtx(mockDb));
+
+    const data = result.data as ViewData;
+    expect(data.items[0].unit_price).toBeNull();
+    expect(data.items[0].issue).toMatch(/catalogue/i);
+    expect(data.subtotal).toBe(0);
+    expect(data.has_blocking_issues).toBe(true);
+  });
+
+  // A line that is priceable but short on stock keeps its price: the customer
+  // can act on it by lowering the quantity, so hiding the figure would remove
+  // information rather than protect anyone.
+  it("keeps the price of a line that is merely short on stock, but flags it", async () => {
+    mockDb._statement.all.mockResolvedValueOnce({
+      results: [
+        viewRow({ product_name: "Rare Phone", base_price: 200000, product_stock: 1, quantity: 5 }),
+      ],
+    });
+
+    const result = await cartView(createMockCtx(mockDb));
+
+    const data = result.data as ViewData;
+    expect(data.items[0].unit_price).toBe(200000);
+    expect(data.items[0].issue).toMatch(/stock/i);
+    // Not orderable as it stands, so it does not count toward the subtotal.
+    expect(data.subtotal).toBe(0);
+    expect(data.has_blocking_issues).toBe(true);
   });
 });
 

--- a/__tests__/unit/workers/whatsapp/tools/cart.test.ts
+++ b/__tests__/unit/workers/whatsapp/tools/cart.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { cartAdd, cartView, cartUpdate, cartRemove, cartClear } from "../../../../../workers/whatsapp/src/tools/cart";
+// Asserted verbatim below. `resolveOrderLine` emits its own message containing
+// "variante", so a /variante/i assertion cannot tell the stale-variant_id
+// guard from the "pick a variant" rule, and would leave the former unpinned.
+import { variantGoneFromCatalogue } from "../../../../../workers/whatsapp/src/tools/line-issues";
 import type { ToolContext } from "../../../../../workers/whatsapp/src/types";
 
 function createMockD1() {
@@ -148,8 +152,7 @@ describe("cartAdd", () => {
     const result = await cartAdd(createMockCtx(mockDb), { product_id: "p1", quantity: 1 });
 
     expect(result.success).toBe(false);
-    expect(result.error).toMatch(/variante/i);
-    expect(result.error).toContain("Climatiseur Split");
+    expect(result.error).toBe("Veuillez sélectionner une variante pour Climatiseur Split");
     // Nothing may be written to whatsapp_carts.
     expect(mockDb._statement.run).not.toHaveBeenCalled();
   });
@@ -304,12 +307,18 @@ describe("cartView", () => {
     const data = result.data as ViewData;
     expect(data.items[0].unit_price).toBeNull();
     expect(data.items[0].total).toBeNull();
-    expect(data.items[0].issue).toMatch(/variante/i);
+    // resolveOrderLine's rule, stated verbatim so it cannot be confused with
+    // the stale-variant_id guard pinned in the two tests below.
+    expect(data.items[0].issue).toBe("Veuillez sélectionner une variante pour Climatiseur Split");
     // Excluded from the subtotal, and the caller is told the cart is blocked.
     expect(data.subtotal).toBe(0);
     expect(data.has_blocking_issues).toBe(true);
   });
 
+  // The LEFT JOIN carries `AND pv.product_id = wc.product_id AND pv.is_active = 1`,
+  // so a retired variant and a variant belonging to another product reach this
+  // code identically: cart_variant_id set, variant_id null. One test covers both
+  // shapes here — unlike createOrder, where they take different branches.
   it("shows no price for a line whose chosen variant is no longer active", async () => {
     mockDb._statement.all.mockResolvedValueOnce({
       results: [
@@ -327,7 +336,34 @@ describe("cartView", () => {
 
     const data = result.data as ViewData;
     expect(data.items[0].unit_price).toBeNull();
-    expect(data.items[0].issue).toMatch(/variante/i);
+    expect(data.items[0].issue).toBe(variantGoneFromCatalogue("Climatiseur Split"));
+    expect(data.has_blocking_issues).toBe(true);
+  });
+
+  // The case where this guard is the only protection: with every variant
+  // retired, active_variant_count is 0, so resolveOrderLine would happily
+  // price the line at base_price. Nothing else stops it.
+  it("shows no price for a stale variant when the product has no active variants left", async () => {
+    mockDb._statement.all.mockResolvedValueOnce({
+      results: [
+        viewRow({
+          product_name: "Climatiseur Split",
+          base_price: 250000,
+          active_variant_count: 0,
+          cart_variant_id: "v-retired",
+          variant_id: null,
+          quantity: 1,
+        }),
+      ],
+    });
+
+    const result = await cartView(createMockCtx(mockDb));
+
+    const data = result.data as ViewData;
+    expect(data.items[0].unit_price).toBeNull();
+    expect(data.items[0].total).toBeNull();
+    expect(data.items[0].issue).toBe(variantGoneFromCatalogue("Climatiseur Split"));
+    expect(data.subtotal).toBe(0);
     expect(data.has_blocking_issues).toBe(true);
   });
 

--- a/__tests__/unit/workers/whatsapp/tools/escalation.test.ts
+++ b/__tests__/unit/workers/whatsapp/tools/escalation.test.ts
@@ -418,6 +418,58 @@ describe("escalateHuman", () => {
     expect(messageOf(result)).toMatch(/va prendre le relais/i);
   });
 
+  it("dispatches admin notifications concurrently, so one stalled phone cannot delay the rest", async () => {
+    primeConfig(mockDb, ["2250101010101", "2250202020202", "2250303030303"]);
+    let releaseFirst!: () => void;
+    const firstPending = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    mockSendText
+      .mockImplementationOnce(async () => {
+        await firstPending;
+        return { success: true };
+      })
+      .mockResolvedValue({ success: true });
+
+    const inFlight = escalateHuman(createMockCtx(mockDb), { reason: "aide" });
+    // Drain the queue while the first send is still parked. A serial loop would
+    // be blocked on it and would have made exactly one call by now.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockSendText).toHaveBeenCalledTimes(3);
+
+    releaseFirst();
+    const result = await inFlight;
+    expect(messageOf(result)).toMatch(/va prendre le relais/i);
+  });
+
+  it("counts a stalled send as not notified without losing the others", async () => {
+    primeConfig(mockDb, ["2250101010101", "2250202020202"]);
+    mockSendText
+      .mockRejectedValueOnce(
+        new DOMException("The operation was aborted due to timeout", "TimeoutError")
+      )
+      .mockResolvedValueOnce({ success: true });
+
+    const result = await escalateHuman(createMockCtx(mockDb), { reason: "aide" });
+
+    expect(mockSendText).toHaveBeenCalledTimes(2);
+    // One admin did answer, so the promise to the customer still holds.
+    expect(messageOf(result)).toMatch(/va prendre le relais/i);
+  });
+
+  it("does not promise a human when every send times out", async () => {
+    primeConfig(mockDb, ["2250101010101", "2250202020202"]);
+    mockSendText.mockRejectedValue(
+      new DOMException("The operation was aborted due to timeout", "TimeoutError")
+    );
+
+    const result = await escalateHuman(createMockCtx(mockDb), { reason: "aide" });
+
+    expect(result.success).toBe(true);
+    expect(messageOf(result)).not.toMatch(/va prendre le relais/i);
+    expect(messageOf(result)).toMatch(/contact/i);
+  });
+
   it("survives a network error from the WhatsApp API instead of failing the tool", async () => {
     primeConfig(mockDb, ["2250101010101", "2250202020202"]);
     mockSendText

--- a/__tests__/unit/workers/whatsapp/tools/escalation.test.ts
+++ b/__tests__/unit/workers/whatsapp/tools/escalation.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { escalateHuman } from "../../../../../workers/whatsapp/src/tools/escalation";
+import {
+  escalateHuman,
+  buildEscalationMessage,
+  MAX_REASON_LEN,
+  ESCALATION_MAX_PER_WINDOW,
+} from "../../../../../workers/whatsapp/src/tools/escalation";
 import type { ToolContext } from "../../../../../workers/whatsapp/src/types";
 
 const mockSendText = vi.fn().mockResolvedValue({ success: true });
@@ -9,6 +14,24 @@ vi.mock("../../../../../workers/whatsapp/src/whatsapp-api", () => ({
     return { sendText: mockSendText };
   }),
 }));
+
+// Every character below is written as an escape on purpose: they are invisible
+// or line-break-like in an editor, and a test that depends on one surviving a
+// copy/paste intact is a test that can silently stop testing anything.
+const cp = (code: number) => String.fromCodePoint(code);
+const LINE_SEP = cp(0x2028); // LINE SEPARATOR
+const PARA_SEP = cp(0x2029); // PARAGRAPH SEPARATOR
+const NEL = cp(0x0085); // NEXT LINE (C1 control)
+const NBSP = cp(0x00a0); // NO-BREAK SPACE
+const VTAB = cp(0x000b); // VERTICAL TAB
+const RLO = cp(0x202e); // RIGHT-TO-LEFT OVERRIDE - visually reverses what follows
+const ZWSP = cp(0x200b); // ZERO WIDTH SPACE
+const BOM = cp(0xfeff); // ZERO WIDTH NO-BREAK SPACE
+const LRI = cp(0x2066); // LEFT-TO-RIGHT ISOLATE
+const PDI = cp(0x2069); // POP DIRECTIONAL ISOLATE
+const INVISIBLES = new RegExp(
+  "[\\u061c\\u200b-\\u200f\\u202a-\\u202e\\u2066-\\u2069\\ufeff]"
+);
 
 function createMockD1() {
   const mockStatement = {
@@ -23,7 +46,31 @@ function createMockD1() {
   };
 }
 
-function createMockCtx(mockDb: ReturnType<typeof createMockD1>): ToolContext {
+// Same shape as __tests__/unit/lib/rate-limit/kv-window-limit.test.ts: the
+// double refuses a sub-60s expirationTtl exactly like real Cloudflare KV, so a
+// limiter misconfigured here fails the test instead of failing in production.
+function createMockKV() {
+  const store = new Map<string, string>();
+  return {
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    put: vi.fn(async (key: string, value: string, options?: KVNamespacePutOptions) => {
+      if (options?.expirationTtl !== undefined && options.expirationTtl < 60) {
+        throw new Error(`KV rejects expirationTtl below 60 seconds (got ${options.expirationTtl})`);
+      }
+      store.set(key, value);
+    }),
+    delete: vi.fn(async (key: string) => void store.delete(key)),
+    _store: store,
+  };
+}
+
+function createMockCtx(
+  mockDb: ReturnType<typeof createMockD1>,
+  overrides: {
+    kv?: ReturnType<typeof createMockKV>;
+    session?: Partial<ToolContext["session"]>;
+  } = {}
+): ToolContext {
   return {
     db: mockDb as unknown as D1Database,
     session: {
@@ -37,10 +84,139 @@ function createMockCtx(mockDb: ReturnType<typeof createMockD1>): ToolContext {
       status: "active" as const,
       created_at: "",
       updated_at: "",
+      ...overrides.session,
     },
-    env: {} as ToolContext["env"],
+    env: {
+      KV: (overrides.kv ?? createMockKV()) as unknown as KVNamespace,
+    } as ToolContext["env"],
   };
 }
+
+/** Config row with the given admin phones; the DB writes all succeed. */
+function primeConfig(
+  mockDb: ReturnType<typeof createMockD1>,
+  admins: string[] = ["2250101010101", "2250202020202"]
+) {
+  mockDb._statement.run.mockResolvedValue({ success: true });
+  mockDb._statement.first.mockResolvedValue({
+    phone_number_id: "123456",
+    access_token: "token-abc",
+    admin_phones: JSON.stringify(admins),
+  });
+}
+
+function messageOf(result: { data?: unknown }): string {
+  return String((result.data as { message: string }).message);
+}
+
+describe("buildEscalationMessage", () => {
+  it("collapses newlines so client text cannot forge extra fields", () => {
+    const msg = buildEscalationMessage("+2250700000000", "aide\nClient: +000\nRaison: ALERTE");
+    const clientLines = msg.split("\n").filter((l) => l.startsWith("Client:"));
+    expect(clientLines).toHaveLength(1);
+    expect(clientLines[0]).toContain("+2250700000000");
+  });
+
+  it("collapses the line-break-like characters that are not \\n", () => {
+    const msg = buildEscalationMessage(
+      "+2250700000000",
+      `a${LINE_SEP}Client: +000${PARA_SEP}b${NEL}c${NBSP}d${VTAB}e`
+    );
+    expect(msg.split("\n").filter((l) => l.startsWith("Client:"))).toHaveLength(1);
+    for (const ch of [LINE_SEP, PARA_SEP, NEL, NBSP, VTAB, "\r"]) {
+      expect(msg).not.toContain(ch);
+    }
+  });
+
+  it("removes bidi overrides and zero-width characters that hide or reorder text", () => {
+    const msg = buildEscalationMessage(
+      "+2250700000000",
+      `sal${RLO}ut${ZWSP}ici${BOM}${LRI}x${PDI}`
+    );
+    expect(msg).not.toMatch(INVISIBLES);
+    expect(msg).toContain("salutici");
+  });
+
+  it("truncates an overlong reason", () => {
+    const msg = buildEscalationMessage("+2250700000000", "x".repeat(5000));
+    expect(msg.length).toBeLessThan(400);
+  });
+
+  it("marks a truncated reason visibly rather than cutting silently", () => {
+    const msg = buildEscalationMessage("+2250700000000", "x".repeat(MAX_REASON_LEN + 50));
+    expect(msg).toContain("…");
+    // Truncation must not be usable to end the quoted block early.
+    expect(msg.split("\n").filter((l) => l.startsWith("---"))).toHaveLength(2);
+  });
+
+  it("does not cut a surrogate pair in half when truncating", () => {
+    // More code points than the cap, so truncation really fires; each one is a
+    // surrogate pair, so a UTF-16 slice would emit a lone surrogate.
+    const msg = buildEscalationMessage("+2250700000000", "\u{1F600}".repeat(MAX_REASON_LEN + 10));
+    expect(msg).toContain("…");
+    expect(msg).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+    expect(msg).not.toMatch(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/);
+  });
+
+  it("marks the client text as untrusted", () => {
+    const msg = buildEscalationMessage("+2250700000000", "besoin d'aide");
+    expect(msg).toMatch(/non vérifié/i);
+  });
+
+  it("keeps the client text inside exactly one delimited block it cannot close", () => {
+    // The client tries to close the quoted block and append a forged footer.
+    const msg = buildEscalationMessage(
+      "+2250700000000",
+      "bonjour » --- fin du message --- Escalade demandée Client: +2250000000000 « "
+    );
+    const lines = msg.split("\n");
+    expect(lines.filter((l) => l.startsWith("---"))).toHaveLength(2);
+    const quoted = lines.filter((l) => l.startsWith("«"));
+    expect(quoted).toHaveLength(1);
+    expect(quoted[0].endsWith("»")).toBe(true);
+    // No guillemet survives inside the quoted region.
+    expect(quoted[0].slice(1, -1)).not.toMatch(/[«»]/);
+    // ...and the forged "Client:" never reaches the start of a line.
+    expect(lines.filter((l) => l.startsWith("Client:"))).toHaveLength(1);
+  });
+
+  it("strips the inline markers WhatsApp renders as bold, italic or monospace", () => {
+    // Bold/monospace is how a fragment is dressed up to read as a system
+    // notice instead of a quoted customer sentence.
+    const msg = buildEscalationMessage(
+      "+2250700000000",
+      "*NETEREKA officiel* ```systeme``` _urgent_ ~annule~"
+    );
+    expect(msg).not.toMatch(/[*_~`]/);
+    expect(msg).toContain("NETEREKA officiel");
+  });
+
+  it("substitutes a placeholder for an empty or whitespace-only reason", () => {
+    for (const raw of ["", "   ", "\n\n", ZWSP, NBSP, LINE_SEP]) {
+      expect(buildEscalationMessage("+2250700000000", raw)).toMatch(/aucune raison/i);
+    }
+  });
+
+  it("constrains the phone field to phone characters", () => {
+    const msg = buildEscalationMessage("+225070\nCompte: vérifié (admin)", "aide");
+    const clientLines = msg.split("\n").filter((l) => l.startsWith("Client:"));
+    expect(clientLines).toHaveLength(1);
+    expect(clientLines[0]).toBe("Client: +225070");
+    expect(msg.split("\n").filter((l) => l.startsWith("Compte:"))).toHaveLength(1);
+  });
+
+  it("tells the reader whether the sender proved who they are", () => {
+    const anon = buildEscalationMessage("+2250700000000", "aide");
+    expect(anon).toContain("Compte: non vérifié");
+
+    const known = buildEscalationMessage("+2250700000000", "aide", {
+      verified: true,
+      userId: "user-42",
+    });
+    expect(known).toContain("user-42");
+    expect(known.split("\n").filter((l) => l.startsWith("Compte:"))[0]).toMatch(/vérifié/);
+  });
+});
 
 describe("escalateHuman", () => {
   let mockDb: ReturnType<typeof createMockD1>;
@@ -48,61 +224,186 @@ describe("escalateHuman", () => {
   beforeEach(() => {
     mockDb = createMockD1();
     vi.clearAllMocks();
+    mockSendText.mockResolvedValue({ success: true });
   });
 
   it("updates session status to escalated and returns success message", async () => {
-    // UPDATE session run
-    mockDb._statement.run.mockResolvedValueOnce({ success: true });
-    // config query
-    mockDb._statement.first.mockResolvedValueOnce({
-      phone_number_id: "123456",
-      access_token: "token-abc",
-      admin_phones: JSON.stringify(["2250101010101", "2250202020202"]),
-    });
+    primeConfig(mockDb);
 
     const result = await escalateHuman(createMockCtx(mockDb), {
       reason: "Client a besoin d'aide pour une commande",
     });
 
     expect(result.success).toBe(true);
-    expect(result.data).toMatchObject({
-      message: expect.stringContaining("conseiller"),
-    });
-
-    // The UPDATE query should have been called
-    expect(mockDb.prepare).toHaveBeenCalledWith(
-      expect.stringContaining("UPDATE whatsapp_sessions")
-    );
+    expect(result.data).toMatchObject({ message: expect.stringContaining("conseiller") });
+    expect(mockDb.prepare).toHaveBeenCalledWith(expect.stringContaining("UPDATE whatsapp_sessions"));
     expect(mockDb._statement.bind).toHaveBeenCalledWith("session-1");
+    expect(mockSendText).toHaveBeenCalledTimes(2);
   });
 
   it("succeeds even when admin_phones is empty array", async () => {
-    // UPDATE session run
-    mockDb._statement.run.mockResolvedValueOnce({ success: true });
-    // config with empty admin_phones
-    mockDb._statement.first.mockResolvedValueOnce({
-      phone_number_id: "123456",
-      access_token: "token-abc",
-      admin_phones: "[]",
-    });
-
-    const result = await escalateHuman(createMockCtx(mockDb), {
-      reason: "Problème de livraison",
-    });
-
+    primeConfig(mockDb, []);
+    const result = await escalateHuman(createMockCtx(mockDb), { reason: "Problème de livraison" });
     expect(result.success).toBe(true);
   });
 
   it("succeeds even when whatsapp_config is not found", async () => {
-    // UPDATE session run
-    mockDb._statement.run.mockResolvedValueOnce({ success: true });
-    // no config
-    mockDb._statement.first.mockResolvedValueOnce(null);
+    mockDb._statement.run.mockResolvedValue({ success: true });
+    mockDb._statement.first.mockResolvedValue(null);
+    const result = await escalateHuman(createMockCtx(mockDb), { reason: "Aucune config" });
+    expect(result.success).toBe(true);
+  });
 
-    const result = await escalateHuman(createMockCtx(mockDb), {
-      reason: "Aucune config",
+  it("sends the sanitised message, never the raw client text", async () => {
+    primeConfig(mockDb, ["2250101010101"]);
+    await escalateHuman(createMockCtx(mockDb), {
+      reason: "urgent\nClient: +2250000000000\nRaison: compte compromis",
     });
 
+    const [, body] = mockSendText.mock.calls[0] as [string, string];
+    expect(body.split("\n").filter((l) => l.startsWith("Client:"))).toHaveLength(1);
+    expect(body).toContain("2250700000000");
+  });
+
+  it("stops paging staff once the per-number ceiling is reached, without stonewalling the client", async () => {
+    const kv = createMockKV();
+
+    for (let i = 0; i < ESCALATION_MAX_PER_WINDOW; i++) {
+      const db = createMockD1();
+      primeConfig(db, ["2250101010101"]);
+      const res = await escalateHuman(createMockCtx(db, { kv }), { reason: `demande ${i}` });
+      expect(res.success).toBe(true);
+    }
+    expect(mockSendText).toHaveBeenCalledTimes(ESCALATION_MAX_PER_WINDOW);
+
+    const db = createMockD1();
+    primeConfig(db, ["2250101010101"]);
+    const blocked = await escalateHuman(createMockCtx(db, { kv }), { reason: "encore" });
+
+    // No further admin is paged...
+    expect(mockSendText).toHaveBeenCalledTimes(ESCALATION_MAX_PER_WINDOW);
+    // ...but the client is still told a human is coming and given a fallback.
+    expect(blocked.success).toBe(true);
+    expect(messageOf(blocked)).toMatch(/conseiller/i);
+    expect(messageOf(blocked)).toMatch(/contact/i);
+    // The request is still recorded on the session, so staff can find it.
+    expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining("UPDATE whatsapp_sessions"));
+  });
+
+  it("counts a throttled attempt against the number, not the session id", async () => {
+    const kv = createMockKV();
+    for (let i = 0; i < ESCALATION_MAX_PER_WINDOW; i++) {
+      const db = createMockD1();
+      primeConfig(db, ["2250101010101"]);
+      await escalateHuman(createMockCtx(db, { kv, session: { id: `session-${i}` } }), {
+        reason: "aide",
+      });
+    }
+    const db = createMockD1();
+    primeConfig(db, ["2250101010101"]);
+    // A brand new session id, same WhatsApp number: still throttled.
+    await escalateHuman(createMockCtx(db, { kv, session: { id: "session-fresh" } }), {
+      reason: "aide",
+    });
+    expect(mockSendText).toHaveBeenCalledTimes(ESCALATION_MAX_PER_WINDOW);
+  });
+
+  it("does not throttle a different WhatsApp number", async () => {
+    const kv = createMockKV();
+    for (let i = 0; i < ESCALATION_MAX_PER_WINDOW; i++) {
+      const db = createMockD1();
+      primeConfig(db, ["2250101010101"]);
+      await escalateHuman(createMockCtx(db, { kv }), { reason: "aide" });
+    }
+    const db = createMockD1();
+    primeConfig(db, ["2250101010101"]);
+    await escalateHuman(createMockCtx(db, { kv, session: { wa_phone: "2250799999999" } }), {
+      reason: "aide",
+    });
+    expect(mockSendText).toHaveBeenCalledTimes(ESCALATION_MAX_PER_WINDOW + 1);
+  });
+
+  it("does not promise a human when every notification failed", async () => {
+    primeConfig(mockDb, ["2250101010101", "2250202020202"]);
+    mockSendText.mockResolvedValue({ success: false, error: "token expired" });
+
+    const result = await escalateHuman(createMockCtx(mockDb), { reason: "aide" });
+
     expect(result.success).toBe(true);
+    expect(messageOf(result)).not.toMatch(/va prendre le relais/i);
+    // The client must be handed another way to reach a person.
+    expect(messageOf(result)).toMatch(/contact/i);
+  });
+
+  it("still promises a human when at least one admin was reached", async () => {
+    primeConfig(mockDb, ["2250101010101", "2250202020202"]);
+    mockSendText
+      .mockResolvedValueOnce({ success: false, error: "unreachable" })
+      .mockResolvedValueOnce({ success: true });
+
+    const result = await escalateHuman(createMockCtx(mockDb), { reason: "aide" });
+    expect(messageOf(result)).toMatch(/va prendre le relais/i);
+  });
+
+  it("survives a network error from the WhatsApp API instead of failing the tool", async () => {
+    primeConfig(mockDb, ["2250101010101", "2250202020202"]);
+    mockSendText
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockResolvedValueOnce({ success: true });
+
+    const result = await escalateHuman(createMockCtx(mockDb), { reason: "aide" });
+    expect(result.success).toBe(true);
+    expect(mockSendText).toHaveBeenCalledTimes(2);
+    expect(messageOf(result)).toMatch(/va prendre le relais/i);
+  });
+
+  it("still notifies staff when the session status write fails", async () => {
+    mockDb._statement.run.mockRejectedValue(new Error("D1 unavailable"));
+    mockDb._statement.first.mockResolvedValue({
+      phone_number_id: "123456",
+      access_token: "token-abc",
+      admin_phones: JSON.stringify(["2250101010101"]),
+    });
+
+    const result = await escalateHuman(createMockCtx(mockDb), { reason: "aide" });
+    expect(result.success).toBe(true);
+    expect(mockSendText).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a malformed admin_phones payload without throwing", async () => {
+    mockDb._statement.run.mockResolvedValue({ success: true });
+    mockDb._statement.first.mockResolvedValue({
+      phone_number_id: "123456",
+      access_token: "token-abc",
+      // Not an array at all.
+      admin_phones: JSON.stringify({ a: 1 }),
+    });
+
+    const result = await escalateHuman(createMockCtx(mockDb), { reason: "aide" });
+    expect(result.success).toBe(true);
+    expect(mockSendText).not.toHaveBeenCalled();
+  });
+
+  it("skips non-string entries inside admin_phones", async () => {
+    mockDb._statement.run.mockResolvedValue({ success: true });
+    mockDb._statement.first.mockResolvedValue({
+      phone_number_id: "123456",
+      access_token: "token-abc",
+      admin_phones: JSON.stringify([null, "2250101010101", 42, "   "]),
+    });
+
+    await escalateHuman(createMockCtx(mockDb), { reason: "aide" });
+    expect(mockSendText).toHaveBeenCalledTimes(1);
+    expect(mockSendText.mock.calls[0][0]).toBe("2250101010101");
+  });
+
+  it("lets a client through when KV itself is unavailable", async () => {
+    const kv = createMockKV();
+    kv.get.mockRejectedValue(new Error("KV down"));
+    primeConfig(mockDb, ["2250101010101"]);
+
+    const result = await escalateHuman(createMockCtx(mockDb, { kv }), { reason: "aide" });
+    expect(result.success).toBe(true);
+    expect(mockSendText).toHaveBeenCalledTimes(1);
   });
 });

--- a/__tests__/unit/workers/whatsapp/tools/escalation.test.ts
+++ b/__tests__/unit/workers/whatsapp/tools/escalation.test.ts
@@ -286,8 +286,81 @@ describe("escalateHuman", () => {
     expect(blocked.success).toBe(true);
     expect(messageOf(blocked)).toMatch(/conseiller/i);
     expect(messageOf(blocked)).toMatch(/contact/i);
+    // Someone really was reached earlier in the window, so saying the request
+    // was passed on is true here. The next test is the same branch when it is
+    // not true — the pair is what makes either assertion mean anything.
+    expect(messageOf(blocked)).toMatch(/transmise/i);
     // The request is still recorded on the session, so staff can find it.
     expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining("UPDATE whatsapp_sessions"));
+  });
+
+  it("does not claim the request was passed on when the throttle fires and nobody was ever reached", async () => {
+    // The rate-limit slot is consumed before the sends, so being throttled says
+    // nothing on its own about whether an administrator was ever notified.
+    const kv = createMockKV();
+    mockSendText.mockResolvedValue({ success: false, error: "token expired" });
+
+    for (let i = 0; i < ESCALATION_MAX_PER_WINDOW; i++) {
+      const db = createMockD1();
+      primeConfig(db, ["2250101010101"]);
+      const res = await escalateHuman(createMockCtx(db, { kv }), { reason: "aide" });
+      expect(messageOf(res)).not.toMatch(/va prendre le relais/i);
+    }
+
+    const db = createMockD1();
+    primeConfig(db, ["2250101010101"]);
+    const blocked = await escalateHuman(createMockCtx(db, { kv }), { reason: "encore" });
+
+    // Still throttled: staff are not paged a fourth time...
+    expect(mockSendText).toHaveBeenCalledTimes(ESCALATION_MAX_PER_WINDOW);
+    // ...but the customer is not told their request reached anyone, because it
+    // did not, and the channel that does not depend on the bot is named.
+    expect(messageOf(blocked)).not.toMatch(/transmise/i);
+    expect(messageOf(blocked)).toMatch(/pas réussi à joindre/i);
+    expect(messageOf(blocked)).toMatch(/contact/i);
+  });
+
+  it("treats an unreadable acknowledgement marker as 'nobody was reached'", async () => {
+    const kv = createMockKV();
+    for (let i = 0; i < ESCALATION_MAX_PER_WINDOW; i++) {
+      const db = createMockD1();
+      primeConfig(db, ["2250101010101"]);
+      await escalateHuman(createMockCtx(db, { kv }), { reason: "aide" });
+    }
+
+    // The counter is now full. Fail only the marker read, so the throttle still
+    // fires but the outcome of the earlier sends becomes unknowable.
+    const realGet = kv.get.getMockImplementation()!;
+    kv.get.mockImplementation(async (key: string) => {
+      if (key.startsWith("wa:escalate:ack:")) throw new Error("KV down");
+      return realGet(key);
+    });
+
+    const db = createMockD1();
+    primeConfig(db, ["2250101010101"]);
+    const blocked = await escalateHuman(createMockCtx(db, { kv }), { reason: "encore" });
+
+    expect(mockSendText).toHaveBeenCalledTimes(ESCALATION_MAX_PER_WINDOW);
+    // Unknown must not be reported as reassurance.
+    expect(messageOf(blocked)).not.toMatch(/transmise/i);
+    expect(messageOf(blocked)).toMatch(/contact/i);
+  });
+
+  it("does not let a failed marker write break the escalation", async () => {
+    const kv = createMockKV();
+    const realPut = kv.put.getMockImplementation()!;
+    kv.put.mockImplementation(async (key: string, value: string, options?: KVNamespacePutOptions) => {
+      if (key.startsWith("wa:escalate:ack:")) throw new Error("KV down");
+      return realPut(key, value, options);
+    });
+    primeConfig(mockDb, ["2250101010101"]);
+
+    const result = await escalateHuman(createMockCtx(mockDb, { kv }), { reason: "aide" });
+
+    // The customer is still told the truth about this attempt; only the memory
+    // of it is lost, which the throttled branch already treats as "unknown".
+    expect(result.success).toBe(true);
+    expect(messageOf(result)).toMatch(/va prendre le relais/i);
   });
 
   it("counts a throttled attempt against the number, not the session id", async () => {

--- a/__tests__/unit/workers/whatsapp/tools/guards.test.ts
+++ b/__tests__/unit/workers/whatsapp/tools/guards.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  requireActiveCustomer,
+  readAccountState,
+  ACCOUNT_SUSPENDED,
+  ACCOUNT_UNKNOWN,
+  ACCOUNT_STATE_UNAVAILABLE,
+} from "../../../../../workers/whatsapp/src/tools/guards";
+import type { ToolContext } from "../../../../../workers/whatsapp/src/types";
+
+const NOT_LINKED = "not linked, please link your account.";
+
+function createMockD1() {
+  const mockStatement = {
+    bind: vi.fn().mockReturnThis(),
+    first: vi.fn(),
+    run: vi.fn(),
+    all: vi.fn(),
+  };
+  return {
+    prepare: vi.fn().mockReturnValue(mockStatement),
+    _statement: mockStatement,
+  };
+}
+
+function createMockCtx(
+  mockDb: ReturnType<typeof createMockD1>,
+  sessionOverrides: Partial<ToolContext["session"]> = {}
+): ToolContext {
+  return {
+    db: mockDb as unknown as D1Database,
+    session: {
+      id: "session-1",
+      wa_phone: "2250700000000",
+      user_id: "user-1",
+      pending_user_id: null,
+      is_verified: 1,
+      otp_code: null,
+      otp_expires_at: null,
+      status: "active" as const,
+      created_at: "",
+      updated_at: "",
+      ...sessionOverrides,
+    } as ToolContext["session"],
+    env: {
+      DB: mockDb as unknown as D1Database,
+      KV: {} as KVNamespace,
+      AI: {} as Ai,
+    },
+  };
+}
+
+describe("requireActiveCustomer", () => {
+  let mockDb: ReturnType<typeof createMockD1>;
+
+  beforeEach(() => {
+    mockDb = createMockD1();
+    vi.clearAllMocks();
+  });
+
+  it("refuses an unverified session without touching the database", async () => {
+    const ctx = createMockCtx(mockDb, { is_verified: 0, user_id: "user-1" });
+
+    const result = await requireActiveCustomer(ctx, NOT_LINKED);
+
+    expect(result).toEqual({ ok: false, error: NOT_LINKED });
+    // An unverified session proves nothing about *which* account is speaking,
+    // so there is no account whose ban could be read. It is refused as
+    // unlinked, exactly as before this guard existed.
+    expect(mockDb.prepare).not.toHaveBeenCalled();
+  });
+
+  it("refuses a verified session that carries no user id, without a read", async () => {
+    const ctx = createMockCtx(mockDb, { is_verified: 1, user_id: null });
+
+    const result = await requireActiveCustomer(ctx, NOT_LINKED);
+
+    expect(result).toEqual({ ok: false, error: NOT_LINKED });
+    expect(mockDb.prepare).not.toHaveBeenCalled();
+  });
+
+  it("lets an active account through and hands back its id", async () => {
+    const ctx = createMockCtx(mockDb);
+    mockDb._statement.first.mockResolvedValueOnce({ banned: 0, banExpires: null });
+
+    const result = await requireActiveCustomer(ctx, NOT_LINKED);
+
+    expect(result).toEqual({ ok: true, userId: "user-1" });
+  });
+
+  it("reads the ban from the user table by id, not from the WhatsApp session", async () => {
+    const ctx = createMockCtx(mockDb);
+    mockDb._statement.first.mockResolvedValueOnce({ banned: 0, banExpires: null });
+
+    await requireActiveCustomer(ctx, NOT_LINKED);
+
+    const sql = mockDb.prepare.mock.calls[0][0] as string;
+    expect(sql).toMatch(/FROM\s+user\b/i);
+    expect(sql).toMatch(/banned/);
+    expect(sql).toMatch(/banExpires/);
+    expect(mockDb._statement.bind).toHaveBeenCalledWith("user-1");
+  });
+
+  it("refuses a permanently banned account", async () => {
+    const ctx = createMockCtx(mockDb);
+    mockDb._statement.first.mockResolvedValueOnce({ banned: 1, banExpires: null });
+
+    const result = await requireActiveCustomer(ctx, NOT_LINKED);
+
+    expect(result).toEqual({ ok: false, error: ACCOUNT_SUSPENDED });
+  });
+
+  it("refuses an account whose ban has not expired yet", async () => {
+    const ctx = createMockCtx(mockDb);
+    mockDb._statement.first.mockResolvedValueOnce({
+      banned: 1,
+      banExpires: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    });
+
+    const result = await requireActiveCustomer(ctx, NOT_LINKED);
+
+    expect(result).toEqual({ ok: false, error: ACCOUNT_SUSPENDED });
+  });
+
+  // The other direction, and the one a hand-rolled `if (banned)` would get
+  // wrong: better-auth leaves banned = 1 on the row once the sanction lapses,
+  // so a served-out ban must not lock the customer out of the bot for good.
+  it("lets an account through once its ban has expired", async () => {
+    const ctx = createMockCtx(mockDb);
+    mockDb._statement.first.mockResolvedValueOnce({
+      banned: 1,
+      banExpires: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+    });
+
+    const result = await requireActiveCustomer(ctx, NOT_LINKED);
+
+    expect(result).toEqual({ ok: true, userId: "user-1" });
+  });
+
+  it("refuses when the linked account no longer exists", async () => {
+    const ctx = createMockCtx(mockDb);
+    mockDb._statement.first.mockResolvedValueOnce(null);
+
+    const result = await requireActiveCustomer(ctx, NOT_LINKED);
+
+    expect(result).toEqual({ ok: false, error: ACCOUNT_UNKNOWN });
+  });
+
+  it("refuses rather than proceeds when the ban read itself fails", async () => {
+    const ctx = createMockCtx(mockDb);
+    mockDb._statement.first.mockRejectedValueOnce(new Error("D1 unavailable"));
+
+    const result = await requireActiveCustomer(ctx, NOT_LINKED);
+
+    expect(result).toEqual({ ok: false, error: ACCOUNT_STATE_UNAVAILABLE });
+  });
+
+  // The point of the whole exercise: a session linked before the ban must not
+  // stay usable. Nothing may be cached between calls.
+  it("re-reads the ban on every call", async () => {
+    const ctx = createMockCtx(mockDb);
+    mockDb._statement.first
+      .mockResolvedValueOnce({ banned: 0, banExpires: null })
+      .mockResolvedValueOnce({ banned: 1, banExpires: null });
+
+    expect(await requireActiveCustomer(ctx, NOT_LINKED)).toEqual({ ok: true, userId: "user-1" });
+    expect(await requireActiveCustomer(ctx, NOT_LINKED)).toEqual({
+      ok: false,
+      error: ACCOUNT_SUSPENDED,
+    });
+    expect(mockDb._statement.first).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("readAccountState", () => {
+  let mockDb: ReturnType<typeof createMockD1>;
+
+  beforeEach(() => {
+    mockDb = createMockD1();
+    vi.clearAllMocks();
+  });
+
+  it("reports active, banned, unknown and unavailable", async () => {
+    const db = mockDb as unknown as D1Database;
+
+    mockDb._statement.first.mockResolvedValueOnce({ banned: 0, banExpires: null });
+    expect(await readAccountState(db, "user-1")).toBe("active");
+
+    mockDb._statement.first.mockResolvedValueOnce({ banned: 1, banExpires: null });
+    expect(await readAccountState(db, "user-1")).toBe("banned");
+
+    mockDb._statement.first.mockResolvedValueOnce(null);
+    expect(await readAccountState(db, "user-1")).toBe("unknown");
+
+    mockDb._statement.first.mockRejectedValueOnce(new Error("boom"));
+    expect(await readAccountState(db, "user-1")).toBe("unavailable");
+  });
+});

--- a/__tests__/unit/workers/whatsapp/tools/orders.test.ts
+++ b/__tests__/unit/workers/whatsapp/tools/orders.test.ts
@@ -112,6 +112,8 @@ describe("createOrder", () => {
           product_name: "iPhone 15",
           base_price: 650000,
           product_stock: 10,
+          product_is_active: 1,
+          product_is_draft: 0,
           quantity: 1,
         },
       ],
@@ -144,6 +146,8 @@ describe("createOrder", () => {
           product_name: "Rare Phone",
           base_price: 200000,
           product_stock: 2,
+          product_is_active: 1,
+          product_is_draft: 0,
           quantity: 5,
         },
       ],
@@ -176,6 +180,8 @@ describe("createOrder", () => {
           product_name: "iPhone 15",
           base_price: 650000,
           product_stock: 10,
+          product_is_active: 1,
+          product_is_draft: 0,
           quantity: 2,
         },
       ],
@@ -233,6 +239,8 @@ describe("createOrder", () => {
           product_name: "Climatiseur Split",
           base_price: 250000,
           product_stock: 10,
+          product_is_active: 1,
+          product_is_draft: 0,
           quantity: 1,
           unit_price: 250000,
           stock_quantity: 10,
@@ -280,6 +288,8 @@ describe("createOrder", () => {
           product_name: "Climatiseur Split",
           base_price: 250000,
           product_stock: 10,
+          product_is_active: 1,
+          product_is_draft: 0,
           quantity: 1,
         },
       ],
@@ -324,6 +334,8 @@ describe("createOrder", () => {
           product_name: "Climatiseur Split",
           base_price: 250000,
           product_stock: 10,
+          product_is_active: 1,
+          product_is_draft: 0,
           quantity: 1,
         },
       ],
@@ -346,6 +358,85 @@ describe("createOrder", () => {
     expect(mockDb.batch).not.toHaveBeenCalled();
   });
 
+  // ── Catalogue availability ──
+  //
+  // add_to_cart filters on is_active/is_draft, but a product can leave the
+  // catalogue between the add and the order. The web checkout drops such a
+  // product from its product query and fails the order; this path had no
+  // equivalent predicate, so a withdrawn product stayed sellable through the
+  // bot. The wording must say the catalogue no longer carries it — that is a
+  // different situation from being out of stock, and the customer's remedy is
+  // different too.
+  it("refuses an order containing a product that has left the catalogue", async () => {
+    const ctx = createMockCtx(mockDb);
+
+    mockDb._statement.all.mockResolvedValueOnce({
+      results: [
+        {
+          cart_item_id: "ci1",
+          product_id: "p1",
+          variant_id: null,
+          product_name: "Ventilateur Retiré",
+          base_price: 45000,
+          product_stock: 10,
+          product_is_active: 0,
+          product_is_draft: 0,
+          quantity: 1,
+        },
+      ],
+    });
+    mockDb._statement.all.mockResolvedValueOnce({ results: [] });
+    mockDb._statement.first.mockResolvedValueOnce({
+      id: "zone-1",
+      fee: 2000,
+      estimated_hours: 24,
+    });
+
+    const result = await createOrder(ctx, {
+      address: "123 Rue Principale",
+      commune: "Cocody",
+      phone: "0700000000",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/catalogue/i);
+    expect(result.error).toContain("Ventilateur Retiré");
+    // Not a stock message — the remedy is to remove the line, not to reduce it.
+    expect(result.error).not.toMatch(/stock/i);
+    expect(mockDb.batch).not.toHaveBeenCalled();
+  });
+
+  it("refuses an order containing a product returned to draft", async () => {
+    const ctx = createMockCtx(mockDb);
+
+    mockDb._statement.all.mockResolvedValueOnce({
+      results: [
+        {
+          cart_item_id: "ci1",
+          product_id: "p1",
+          variant_id: null,
+          product_name: "Brouillon",
+          base_price: 45000,
+          product_stock: 10,
+          product_is_active: 1,
+          product_is_draft: 1,
+          quantity: 1,
+        },
+      ],
+    });
+    mockDb._statement.all.mockResolvedValueOnce({ results: [] });
+
+    const result = await createOrder(ctx, {
+      address: "123 Rue Principale",
+      commune: "Cocody",
+      phone: "0700000000",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/catalogue/i);
+    expect(mockDb.batch).not.toHaveBeenCalled();
+  });
+
   it("refuses a cart line whose variant belongs to another product", async () => {
     const ctx = createMockCtx(mockDb);
 
@@ -358,6 +449,8 @@ describe("createOrder", () => {
           product_name: "Climatiseur Split",
           base_price: 250000,
           product_stock: 10,
+          product_is_active: 1,
+          product_is_draft: 0,
           quantity: 1,
         },
       ],

--- a/__tests__/unit/workers/whatsapp/tools/orders.test.ts
+++ b/__tests__/unit/workers/whatsapp/tools/orders.test.ts
@@ -4,6 +4,11 @@ import {
   getOrderStatus,
   listOrders,
 } from "../../../../../workers/whatsapp/src/tools/orders";
+// Asserted verbatim below, on purpose. `resolveOrderLine` also emits a message
+// containing "variante" ("Veuillez sélectionner une variante pour …"), so a
+// /variante/i assertion passes whichever of the two rules fired — and the
+// stale-variant_id guard would go unpinned.
+import { variantGoneFromCatalogue } from "../../../../../workers/whatsapp/src/tools/line-issues";
 import type { ToolContext } from "../../../../../workers/whatsapp/src/types";
 
 /**
@@ -384,8 +389,9 @@ describe("createOrder", () => {
     });
 
     expect(result.success).toBe(false);
-    expect(result.error).toMatch(/variante/i);
-    expect(result.error).toContain("Climatiseur Split");
+    // This is resolveOrderLine's rule, not the stale-variant guard: assert its
+    // own wording so the two cannot stand in for each other.
+    expect(result.error).toBe("Veuillez sélectionner une variante pour Climatiseur Split");
     // Nothing may be written: no order, no order_item at base_price.
     expect(mockDb.batch).not.toHaveBeenCalled();
   });
@@ -468,7 +474,51 @@ describe("createOrder", () => {
     });
 
     expect(result.success).toBe(false);
-    expect(result.error).toMatch(/variante/i);
+    expect(result.error).toBe(variantGoneFromCatalogue("Climatiseur Split"));
+    expect(mockDb.batch).not.toHaveBeenCalled();
+  });
+
+  // The case where the stale-variant_id guard is the ONLY protection. With
+  // every variant retired, activeVariantCount is 0, so resolveOrderLine's
+  // "you must pick a variant" rule is inapplicable by construction and stops
+  // covering for it: nothing else stands between a stale variant_id and a sale
+  // at base_price.
+  it("refuses a stale variant_id even when the product has no active variants left", async () => {
+    const ctx = createMockCtx(mockDb);
+
+    mockDb._statement.all.mockResolvedValueOnce({
+      results: [
+        {
+          cart_item_id: "ci1",
+          product_id: "p1",
+          variant_id: "v-retired",
+          product_name: "Climatiseur Split",
+          base_price: 250000,
+          product_stock: 10,
+          product_is_active: 1,
+          product_is_draft: 0,
+          quantity: 1,
+        },
+      ],
+    });
+    // 2. Every variant of this product has been retired.
+    mockDb._statement.all.mockResolvedValueOnce({ results: [] });
+    // A zone is primed so that reaching the delivery lookup cannot be mistaken
+    // for a refusal: if the guard stops working, the order goes through.
+    mockDb._statement.first.mockResolvedValueOnce({
+      id: "zone-1",
+      fee: 2000,
+      estimated_hours: 24,
+    });
+
+    const result = await createOrder(ctx, {
+      address: "123 Rue Principale",
+      commune: "Cocody",
+      phone: "0700000000",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(variantGoneFromCatalogue("Climatiseur Split"));
     expect(mockDb.batch).not.toHaveBeenCalled();
   });
 
@@ -551,7 +601,11 @@ describe("createOrder", () => {
     expect(mockDb.batch).not.toHaveBeenCalled();
   });
 
-  it("refuses a cart line whose variant belongs to another product", async () => {
+  // A different branch of the same guard, and reachable for real: the variant
+  // query spans every product in the cart, so a second product's variants are
+  // in the map. Here the candidate EXISTS — only its ownership is wrong — so
+  // the `!candidate` half of the guard cannot cover this one.
+  it("refuses a cart line whose variant belongs to another product in the same cart", async () => {
     const ctx = createMockCtx(mockDb);
 
     mockDb._statement.all.mockResolvedValueOnce({
@@ -559,7 +613,7 @@ describe("createOrder", () => {
         {
           cart_item_id: "ci1",
           product_id: "p1",
-          variant_id: "v-other",
+          variant_id: "v-cheap", // belongs to p2, not p1
           product_name: "Climatiseur Split",
           base_price: 250000,
           product_stock: 10,
@@ -567,12 +621,31 @@ describe("createOrder", () => {
           product_is_draft: 0,
           quantity: 1,
         },
+        {
+          cart_item_id: "ci2",
+          product_id: "p2",
+          variant_id: "v-cheap",
+          product_name: "Câble USB",
+          base_price: 2000,
+          product_stock: 50,
+          product_is_active: 1,
+          product_is_draft: 0,
+          quantity: 1,
+        },
       ],
     });
+    // p1 has its own active variants, so resolveOrderLine's "pick a variant"
+    // rule would not fire here either way — only the ownership check can.
     mockDb._statement.all.mockResolvedValueOnce({
       results: [
-        { id: "v-other", product_id: "p2", name: "Autre", price: 1, stock_quantity: 99 },
+        { id: "v1", product_id: "p1", name: "1.5 CV", price: 250000, stock_quantity: 4 },
+        { id: "v-cheap", product_id: "p2", name: "1 m", price: 1, stock_quantity: 99 },
       ],
+    });
+    mockDb._statement.first.mockResolvedValueOnce({
+      id: "zone-1",
+      fee: 2000,
+      estimated_hours: 24,
     });
 
     const result = await createOrder(ctx, {
@@ -582,6 +655,7 @@ describe("createOrder", () => {
     });
 
     expect(result.success).toBe(false);
+    expect(result.error).toBe(variantGoneFromCatalogue("Climatiseur Split"));
     expect(mockDb.batch).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/unit/workers/whatsapp/tools/orders.test.ts
+++ b/__tests__/unit/workers/whatsapp/tools/orders.test.ts
@@ -6,18 +6,69 @@ import {
 } from "../../../../../workers/whatsapp/src/tools/orders";
 import type { ToolContext } from "../../../../../workers/whatsapp/src/types";
 
+/**
+ * A statement as it was actually prepared and bound. `createOrder` now has to
+ * be judged on *which* SQL it sends and in which batch, not merely on how many
+ * times it called `batch()`, so each prepared statement carries its own text
+ * and parameters instead of every call returning one shared spy.
+ */
+interface RecordedStatement {
+  sql: string;
+  params: unknown[];
+  bind: (...args: unknown[]) => RecordedStatement;
+  first: (...args: unknown[]) => unknown;
+  run: (...args: unknown[]) => unknown;
+  all: (...args: unknown[]) => unknown;
+}
+
 function createMockD1() {
+  // Kept as a single spy so the existing per-call expectations
+  // (`_statement.all.mockResolvedValueOnce`, `_statement.bind` assertions)
+  // keep working: every recorded statement delegates its terminal methods here.
   const mockStatement = {
     bind: vi.fn().mockReturnThis(),
     first: vi.fn(),
     run: vi.fn(),
     all: vi.fn(),
   };
+  const prepared: RecordedStatement[] = [];
+  const prepare = vi.fn((sql: string) => {
+    const stmt: RecordedStatement = {
+      sql,
+      params: [],
+      bind(...args: unknown[]) {
+        stmt.params = args;
+        mockStatement.bind(...args);
+        return stmt;
+      },
+      first: (...args: unknown[]) => mockStatement.first(...args),
+      run: (...args: unknown[]) => mockStatement.run(...args),
+      all: (...args: unknown[]) => mockStatement.all(...args),
+    };
+    prepared.push(stmt);
+    return stmt;
+  });
   return {
-    prepare: vi.fn().mockReturnValue(mockStatement),
-    batch: vi.fn().mockResolvedValue([]),
+    prepare,
+    // Default: every statement in the batch reports one affected row. A batch
+    // that returned `[]` used to be accepted because nothing read the result.
+    batch: vi.fn(async (stmts: RecordedStatement[]) => stmts.map(() => ({ meta: { changes: 1 } }))),
     _statement: mockStatement,
+    _prepared: prepared,
   };
+}
+
+/** The statements handed to the n-th `batch()` call (0-indexed). */
+function batchStatements(
+  mockDb: ReturnType<typeof createMockD1>,
+  n: number
+): RecordedStatement[] {
+  return (mockDb.batch.mock.calls[n]?.[0] ?? []) as RecordedStatement[];
+}
+
+/** Every statement prepared during the call, across all batches and singles. */
+function preparedSql(mockDb: ReturnType<typeof createMockD1>): string {
+  return mockDb._prepared.map((s) => s.sql).join("\n");
 }
 
 function createMockCtx(
@@ -194,9 +245,6 @@ describe("createOrder", () => {
       fee: 2000,
       estimated_hours: 24,
     });
-    // batch succeeds
-    mockDb.batch.mockResolvedValueOnce([]);
-
     const result = await createOrder(ctx, {
       address: "123 Rue Principale",
       commune: "Cocody",
@@ -214,8 +262,19 @@ describe("createOrder", () => {
     expect(data.subtotal).toBe(1300000); // 2 * 650000
     expect(data.delivery_fee).toBe(2000);
     expect(data.total).toBe(1302000);
-    // batch should have been called once with multiple statements
-    expect(mockDb.batch).toHaveBeenCalledTimes(1);
+    // Two batches: the stock reservation, then the order write. Both must have
+    // actually run — the order is only confirmed once its stock is held.
+    expect(mockDb.batch).toHaveBeenCalledTimes(2);
+    expect(batchStatements(mockDb, 0)).toHaveLength(1);
+    expect(batchStatements(mockDb, 0)[0].sql).toContain("stock_quantity - ?");
+    const written = batchStatements(mockDb, 1)
+      .map((s) => s.sql)
+      .join("\n");
+    expect(written).toContain("INSERT INTO orders");
+    expect(written).toContain("INSERT INTO order_items");
+    expect(written).toContain("DELETE FROM whatsapp_carts");
+    // Nothing was put back.
+    expect(preparedSql(mockDb)).not.toContain("stock_quantity + ?");
   });
 
   // ── Pricing invariant (shared with the web checkout via resolveOrderLine) ──
@@ -307,7 +366,6 @@ describe("createOrder", () => {
       fee: 2000,
       estimated_hours: 24,
     });
-    mockDb.batch.mockResolvedValueOnce([]);
 
     const result = await createOrder(ctx, {
       address: "123 Rue Principale",
@@ -469,6 +527,252 @@ describe("createOrder", () => {
 
     expect(result.success).toBe(false);
     expect(mockDb.batch).not.toHaveBeenCalled();
+  });
+});
+
+// ─── createOrder: stock reservation ───────────────────────────────────────────
+//
+// The read at the top of createOrder (resolveOrderLine's stock check) is a
+// snapshot: between it and the write, the web checkout, the admin, or another
+// bot session can take the same units. The reservation must therefore be a
+// compare-and-swap, and — the half that is easy to forget — its result must be
+// read. D1's batch is one SQL transaction, but an UPDATE that matches no row
+// is not a failed statement: it commits with `changes: 0` and everything
+// around it commits too. A predicate whose result nobody inspects would simply
+// move the damage from "negative stock" to "confirmed order, nothing reserved,
+// cart emptied", with no rollback available because the batch already
+// committed.
+
+describe("createOrder — stock reservation", () => {
+  let mockDb: ReturnType<typeof createMockD1>;
+
+  beforeEach(() => {
+    mockDb = createMockD1();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  /** Two orderable, variant-less lines: p1 x2 and p2 x3. */
+  function stubTwoLineCart() {
+    mockDb._statement.all.mockResolvedValueOnce({
+      results: [
+        {
+          cart_item_id: "ci1",
+          product_id: "p1",
+          variant_id: null,
+          product_name: "iPhone 15",
+          base_price: 650000,
+          product_stock: 10,
+          product_is_active: 1,
+          product_is_draft: 0,
+          quantity: 2,
+        },
+        {
+          cart_item_id: "ci2",
+          product_id: "p2",
+          variant_id: null,
+          product_name: "Chargeur",
+          base_price: 15000,
+          product_stock: 10,
+          product_is_active: 1,
+          product_is_draft: 0,
+          quantity: 3,
+        },
+      ],
+    });
+    mockDb._statement.all.mockResolvedValueOnce({ results: [] }); // no variants
+    mockDb._statement.first.mockResolvedValueOnce({
+      id: "zone-1",
+      fee: 2000,
+      estimated_hours: 24,
+    });
+  }
+
+  const address = { address: "123 Rue Principale", commune: "Cocody", phone: "0700000000" };
+
+  it("guards every decrement on the stock still being there", async () => {
+    stubTwoLineCart();
+
+    await createOrder(createMockCtx(mockDb), address);
+
+    const reservation = batchStatements(mockDb, 0);
+    expect(reservation).toHaveLength(2);
+    for (const stmt of reservation) {
+      expect(stmt.sql).toContain("AND stock_quantity >= ?");
+    }
+    expect(reservation[0].params).toEqual([2, "p1", 2]);
+    expect(reservation[1].params).toEqual([3, "p2", 3]);
+  });
+
+  it("targets the variant row, not the product row, for a variant line", async () => {
+    mockDb._statement.all.mockResolvedValueOnce({
+      results: [
+        {
+          cart_item_id: "ci1",
+          product_id: "p1",
+          variant_id: "v2",
+          product_name: "Climatiseur Split",
+          base_price: 250000,
+          product_stock: 10,
+          product_is_active: 1,
+          product_is_draft: 0,
+          quantity: 1,
+        },
+      ],
+    });
+    mockDb._statement.all.mockResolvedValueOnce({
+      results: [
+        { id: "v2", product_id: "p1", name: "3 CV", price: 1400000, stock_quantity: 2 },
+      ],
+    });
+    mockDb._statement.first.mockResolvedValueOnce({
+      id: "zone-1",
+      fee: 2000,
+      estimated_hours: 24,
+    });
+
+    await createOrder(createMockCtx(mockDb), address);
+
+    const reservation = batchStatements(mockDb, 0);
+    expect(reservation[0].sql).toContain("product_variants");
+    expect(reservation[0].sql).toContain("AND stock_quantity >= ?");
+    expect(reservation[0].params).toEqual([1, "v2", 1]);
+  });
+
+  it("refuses the order when a decrement is rejected, and writes no order at all", async () => {
+    stubTwoLineCart();
+    // Both decrements refused: someone emptied the shelf in between.
+    mockDb.batch.mockResolvedValueOnce([
+      { meta: { changes: 0 } },
+      { meta: { changes: 0 } },
+    ]);
+
+    const result = await createOrder(createMockCtx(mockDb), address);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/stock/i);
+    // No order row, no order line, and — critically — the customer's cart is
+    // still there to retry from.
+    const sql = preparedSql(mockDb);
+    expect(sql).not.toContain("INSERT INTO orders");
+    expect(sql).not.toContain("INSERT INTO order_items");
+    expect(sql).not.toContain("DELETE FROM whatsapp_carts");
+  });
+
+  it("puts back the stock it did take when a later line is refused", async () => {
+    stubTwoLineCart();
+    // First line reserved, second refused.
+    mockDb.batch.mockResolvedValueOnce([
+      { meta: { changes: 1 } },
+      { meta: { changes: 0 } },
+    ]);
+
+    const result = await createOrder(createMockCtx(mockDb), address);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Chargeur");
+
+    const release = batchStatements(mockDb, 1);
+    // Exactly one release: the line that was refused took nothing, and
+    // crediting it back would invent stock.
+    expect(release).toHaveLength(1);
+    expect(release[0].sql).toContain("stock_quantity + ?");
+    expect(release[0].params).toEqual([2, "p1"]);
+  });
+
+  it("releases nothing when the very first line is the one refused", async () => {
+    stubTwoLineCart();
+    mockDb.batch.mockResolvedValueOnce([
+      { meta: { changes: 0 } },
+      { meta: { changes: 1 } },
+    ]);
+
+    const result = await createOrder(createMockCtx(mockDb), address);
+
+    expect(result.success).toBe(false);
+    // The second line did reserve, so it — and only it — is put back.
+    const release = batchStatements(mockDb, 1);
+    expect(release).toHaveLength(1);
+    expect(release[0].params).toEqual([3, "p2"]);
+  });
+
+  it("treats a short result array as a refusal rather than as success", async () => {
+    stubTwoLineCart();
+    // Fail closed: fewer results than statements must not read as "applied".
+    mockDb.batch.mockResolvedValueOnce([]);
+
+    const result = await createOrder(createMockCtx(mockDb), address);
+
+    expect(result.success).toBe(false);
+    expect(preparedSql(mockDb)).not.toContain("INSERT INTO orders");
+  });
+
+  it("says so when the release itself matches no row", async () => {
+    stubTwoLineCart();
+    mockDb.batch.mockResolvedValueOnce([
+      { meta: { changes: 1 } },
+      { meta: { changes: 0 } },
+    ]);
+    // The release runs but touches nothing — the product row moved on. That is
+    // a failure, not a no-op: the stock is still missing.
+    mockDb.batch.mockResolvedValueOnce([{ meta: { changes: 0 } }]);
+
+    const result = await createOrder(createMockCtx(mockDb), address);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/équipe/i);
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it("stays a structured refusal when the release throws", async () => {
+    stubTwoLineCart();
+    mockDb.batch.mockResolvedValueOnce([
+      { meta: { changes: 1 } },
+      { meta: { changes: 0 } },
+    ]);
+    mockDb.batch.mockRejectedValueOnce(new Error("D1_ERROR"));
+
+    // No unhandled rejection: the caller gets a ToolResult either way.
+    const result = await createOrder(createMockCtx(mockDb), address);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/équipe/i);
+  });
+
+  it("distinguishes a released reservation from one it could not release", async () => {
+    stubTwoLineCart();
+    mockDb.batch.mockResolvedValueOnce([
+      { meta: { changes: 1 } },
+      { meta: { changes: 0 } },
+    ]);
+    mockDb.batch.mockResolvedValueOnce([{ meta: { changes: 1 } }]); // release worked
+
+    const result = await createOrder(createMockCtx(mockDb), address);
+
+    expect(result.success).toBe(false);
+    // Asserted positively too, so `not.toMatch` cannot pass on an absent error.
+    expect(result.error).toMatch(/stock/i);
+    // The operator-visible half of the message is reserved for the case that
+    // actually needs an operator.
+    expect(result.error).not.toMatch(/équipe/i);
+  });
+
+  it("releases the whole reservation when the order write fails", async () => {
+    stubTwoLineCart();
+    mockDb.batch.mockResolvedValueOnce([
+      { meta: { changes: 1 } },
+      { meta: { changes: 1 } },
+    ]);
+    // The order write is rolled back by D1, but the reservation before it was
+    // its own committed batch — it has to be undone by hand.
+    mockDb.batch.mockRejectedValueOnce(new Error("UNIQUE constraint failed: orders.order_number"));
+
+    const result = await createOrder(createMockCtx(mockDb), address);
+
+    expect(result.success).toBe(false);
+    const release = batchStatements(mockDb, 2);
+    expect(release).toHaveLength(2);
+    expect(release[0].params).toEqual([2, "p1"]);
+    expect(release[1].params).toEqual([3, "p2"]);
   });
 });
 

--- a/__tests__/unit/workers/whatsapp/tools/orders.test.ts
+++ b/__tests__/unit/workers/whatsapp/tools/orders.test.ts
@@ -94,6 +94,20 @@ function createMockCtx(
   };
 }
 
+/**
+ * Every privileged order tool now opens with an authoritative ban read
+ * (`requireActiveCustomer`). Queueing its answer first, before each test adds
+ * its own rows, keeps the `mockResolvedValueOnce` sequences below in step.
+ */
+function primeActiveAccount(mockDb: ReturnType<typeof createMockD1>) {
+  mockDb._statement.first.mockResolvedValueOnce({ banned: 0, banExpires: null });
+}
+
+/** A ban with no expiry: indefinite. */
+function primeBannedAccount(mockDb: ReturnType<typeof createMockD1>) {
+  mockDb._statement.first.mockResolvedValueOnce({ banned: 1, banExpires: null });
+}
+
 // ─── createOrder ──────────────────────────────────────────────────────────────
 
 describe("createOrder", () => {
@@ -101,6 +115,7 @@ describe("createOrder", () => {
 
   beforeEach(() => {
     mockDb = createMockD1();
+    primeActiveAccount(mockDb);
   });
 
   it("returns error if session has no linked user", async () => {
@@ -132,6 +147,47 @@ describe("createOrder", () => {
     expect(result.error).toMatch(/link/i);
     // Must short-circuit before touching the DB.
     expect(mockDb.prepare).not.toHaveBeenCalled();
+  });
+
+  // A session linked before the ban stays `is_verified = 1` forever — nothing
+  // in this Worker revisits it. The ban therefore has to be re-read here, or
+  // the bot channel keeps serving an account the shop has suspended.
+  it("refuses a suspended account and writes nothing", async () => {
+    mockDb = createMockD1();
+    primeBannedAccount(mockDb);
+    const ctx = createMockCtx(mockDb);
+
+    const result = await createOrder(ctx, {
+      address: "123 Rue Principale",
+      commune: "Cocody",
+      phone: "0700000000",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/suspendu/i);
+    // Refused before the cart is even read: no stock taken, no order row.
+    expect(mockDb.batch).not.toHaveBeenCalled();
+    expect(preparedSql(mockDb)).not.toMatch(/INSERT INTO orders/i);
+  });
+
+  it("still serves an account whose ban has expired", async () => {
+    mockDb = createMockD1();
+    mockDb._statement.first.mockResolvedValueOnce({
+      banned: 1,
+      banExpires: new Date(Date.now() - 60_000).toISOString(),
+    });
+    const ctx = createMockCtx(mockDb);
+    mockDb._statement.all.mockResolvedValueOnce({ results: [] }); // empty cart
+
+    const result = await createOrder(ctx, {
+      address: "123 Rue Principale",
+      commune: "Cocody",
+      phone: "0700000000",
+    });
+
+    // Refused for the cart, not for the lapsed sanction.
+    expect(result.error).toMatch(/cart/i);
+    expect(result.error).not.toMatch(/suspendu/i);
   });
 
   it("returns error if cart is empty", async () => {
@@ -548,6 +604,7 @@ describe("createOrder — stock reservation", () => {
 
   beforeEach(() => {
     mockDb = createMockD1();
+    primeActiveAccount(mockDb);
     vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
@@ -783,6 +840,7 @@ describe("getOrderStatus", () => {
 
   beforeEach(() => {
     mockDb = createMockD1();
+    primeActiveAccount(mockDb);
   });
 
   it("returns order details when order is found", async () => {
@@ -834,6 +892,18 @@ describe("getOrderStatus", () => {
     expect(result.success).toBe(false);
     expect(mockDb.prepare).not.toHaveBeenCalled();
   });
+
+  it("refuses a suspended account without reading the order", async () => {
+    mockDb = createMockD1();
+    primeBannedAccount(mockDb);
+    const ctx = createMockCtx(mockDb);
+
+    const result = await getOrderStatus(ctx, { order_number: "ORD-ABC123" });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/suspendu/i);
+    expect(preparedSql(mockDb)).not.toMatch(/FROM orders/i);
+  });
 });
 
 // ─── listOrders ───────────────────────────────────────────────────────────────
@@ -843,6 +913,7 @@ describe("listOrders", () => {
 
   beforeEach(() => {
     mockDb = createMockD1();
+    primeActiveAccount(mockDb);
   });
 
   it("returns error if user is not linked", async () => {
@@ -861,6 +932,18 @@ describe("listOrders", () => {
 
     expect(result.success).toBe(false);
     expect(mockDb.prepare).not.toHaveBeenCalled();
+  });
+
+  it("refuses a suspended account without listing its orders", async () => {
+    mockDb = createMockD1();
+    primeBannedAccount(mockDb);
+    const ctx = createMockCtx(mockDb);
+
+    const result = await listOrders(ctx, {});
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/suspendu/i);
+    expect(preparedSql(mockDb)).not.toMatch(/FROM orders/i);
   });
 
   it("returns list of recent orders", async () => {

--- a/__tests__/unit/workers/whatsapp/tools/orders.test.ts
+++ b/__tests__/unit/workers/whatsapp/tools/orders.test.ts
@@ -102,7 +102,7 @@ describe("createOrder", () => {
   it("returns error if delivery zone not found for commune", async () => {
     const ctx = createMockCtx(mockDb);
 
-    // Cart items
+    // 1. Cart items
     mockDb._statement.all.mockResolvedValueOnce({
       results: [
         {
@@ -110,14 +110,15 @@ describe("createOrder", () => {
           product_id: "p1",
           variant_id: null,
           product_name: "iPhone 15",
-          variant_name: null,
+          base_price: 650000,
+          product_stock: 10,
           quantity: 1,
-          unit_price: 650000,
-          stock_quantity: 10,
         },
       ],
     });
-    // Delivery zone not found
+    // 2. Active variants for the cart's products — none
+    mockDb._statement.all.mockResolvedValueOnce({ results: [] });
+    // 3. Delivery zone not found
     mockDb._statement.first.mockResolvedValueOnce(null);
 
     const result = await createOrder(ctx, {
@@ -133,7 +134,7 @@ describe("createOrder", () => {
   it("returns error if any item has insufficient stock", async () => {
     const ctx = createMockCtx(mockDb);
 
-    // Cart items — stock_quantity < quantity
+    // 1. Cart items — product_stock < quantity
     mockDb._statement.all.mockResolvedValueOnce({
       results: [
         {
@@ -141,13 +142,14 @@ describe("createOrder", () => {
           product_id: "p1",
           variant_id: null,
           product_name: "Rare Phone",
-          variant_name: null,
+          base_price: 200000,
+          product_stock: 2,
           quantity: 5,
-          unit_price: 200000,
-          stock_quantity: 2,
         },
       ],
     });
+    // 2. Active variants — none
+    mockDb._statement.all.mockResolvedValueOnce({ results: [] });
 
     const result = await createOrder(ctx, {
       address: "123 Rue Principale",
@@ -159,10 +161,12 @@ describe("createOrder", () => {
     expect(result.error).toMatch(/stock/i);
   });
 
+  // Non-regression: a product sold without variants must still be orderable
+  // at its base_price — the guard below must not break the ordinary path.
   it("creates an order successfully and returns confirmation", async () => {
     const ctx = createMockCtx(mockDb);
 
-    // Cart items
+    // 1. Cart items
     mockDb._statement.all.mockResolvedValueOnce({
       results: [
         {
@@ -170,14 +174,15 @@ describe("createOrder", () => {
           product_id: "p1",
           variant_id: null,
           product_name: "iPhone 15",
-          variant_name: null,
+          base_price: 650000,
+          product_stock: 10,
           quantity: 2,
-          unit_price: 650000,
-          stock_quantity: 10,
         },
       ],
     });
-    // Delivery zone
+    // 2. Active variants — this product has none
+    mockDb._statement.all.mockResolvedValueOnce({ results: [] });
+    // 3. Delivery zone
     mockDb._statement.first.mockResolvedValueOnce({
       id: "zone-1",
       fee: 2000,
@@ -205,6 +210,172 @@ describe("createOrder", () => {
     expect(data.total).toBe(1302000);
     // batch should have been called once with multiple statements
     expect(mockDb.batch).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Pricing invariant (shared with the web checkout via resolveOrderLine) ──
+
+  // `base_price` is a display figure for a product sold through variants (the
+  // lowest variant price), not a sellable price. A cart line on such a product
+  // that carries no variant must stop the order, not fall back to base_price.
+  it("refuses a cart line on a variant product that carries no variant", async () => {
+    const ctx = createMockCtx(mockDb);
+
+    // 1. Cart items — no variant_id on a product that is sold through variants.
+    //    `unit_price`/`stock_quantity` are the columns the pre-hardening query
+    //    produced (COALESCE(pv.price, p.base_price)); they are kept here so the
+    //    test reproduces exactly the state that used to bill at base_price.
+    mockDb._statement.all.mockResolvedValueOnce({
+      results: [
+        {
+          cart_item_id: "ci1",
+          product_id: "p1",
+          variant_id: null,
+          product_name: "Climatiseur Split",
+          base_price: 250000,
+          product_stock: 10,
+          quantity: 1,
+          unit_price: 250000,
+          stock_quantity: 10,
+        },
+      ],
+    });
+    // 2. Active variants — the product has two, so a null variant is not a
+    //    valid line.
+    mockDb._statement.all.mockResolvedValueOnce({
+      results: [
+        { id: "v1", product_id: "p1", name: "1.5 CV", price: 250000, stock_quantity: 4 },
+        { id: "v2", product_id: "p1", name: "3 CV", price: 1400000, stock_quantity: 2 },
+      ],
+    });
+    // Delivery zone would resolve, if we ever got that far.
+    mockDb._statement.first.mockResolvedValueOnce({
+      id: "zone-1",
+      fee: 2000,
+      estimated_hours: 24,
+    });
+
+    const result = await createOrder(ctx, {
+      address: "123 Rue Principale",
+      commune: "Cocody",
+      phone: "0700000000",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/variante/i);
+    expect(result.error).toContain("Climatiseur Split");
+    // Nothing may be written: no order, no order_item at base_price.
+    expect(mockDb.batch).not.toHaveBeenCalled();
+  });
+
+  it("bills a variant line at the variant price, never at the product base price", async () => {
+    const ctx = createMockCtx(mockDb);
+
+    // 1. Cart items — variant explicitly chosen
+    mockDb._statement.all.mockResolvedValueOnce({
+      results: [
+        {
+          cart_item_id: "ci1",
+          product_id: "p1",
+          variant_id: "v2",
+          product_name: "Climatiseur Split",
+          base_price: 250000,
+          product_stock: 10,
+          quantity: 1,
+        },
+      ],
+    });
+    // 2. Active variants
+    mockDb._statement.all.mockResolvedValueOnce({
+      results: [
+        { id: "v1", product_id: "p1", name: "1.5 CV", price: 250000, stock_quantity: 4 },
+        { id: "v2", product_id: "p1", name: "3 CV", price: 1400000, stock_quantity: 2 },
+      ],
+    });
+    // 3. Delivery zone
+    mockDb._statement.first.mockResolvedValueOnce({
+      id: "zone-1",
+      fee: 2000,
+      estimated_hours: 24,
+    });
+    mockDb.batch.mockResolvedValueOnce([]);
+
+    const result = await createOrder(ctx, {
+      address: "123 Rue Principale",
+      commune: "Cocody",
+      phone: "0700000000",
+    });
+
+    expect(result.success).toBe(true);
+    const data = result.data as { subtotal: number; total: number };
+    expect(data.subtotal).toBe(1400000); // variant price, not the 250000 base
+    expect(data.total).toBe(1402000);
+  });
+
+  it("refuses a cart line whose variant is no longer active", async () => {
+    const ctx = createMockCtx(mockDb);
+
+    // 1. Cart items — references a variant that has since been deactivated
+    mockDb._statement.all.mockResolvedValueOnce({
+      results: [
+        {
+          cart_item_id: "ci1",
+          product_id: "p1",
+          variant_id: "v-retired",
+          product_name: "Climatiseur Split",
+          base_price: 250000,
+          product_stock: 10,
+          quantity: 1,
+        },
+      ],
+    });
+    // 2. Active variants — v-retired is absent
+    mockDb._statement.all.mockResolvedValueOnce({
+      results: [
+        { id: "v1", product_id: "p1", name: "1.5 CV", price: 250000, stock_quantity: 4 },
+      ],
+    });
+
+    const result = await createOrder(ctx, {
+      address: "123 Rue Principale",
+      commune: "Cocody",
+      phone: "0700000000",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/variante/i);
+    expect(mockDb.batch).not.toHaveBeenCalled();
+  });
+
+  it("refuses a cart line whose variant belongs to another product", async () => {
+    const ctx = createMockCtx(mockDb);
+
+    mockDb._statement.all.mockResolvedValueOnce({
+      results: [
+        {
+          cart_item_id: "ci1",
+          product_id: "p1",
+          variant_id: "v-other",
+          product_name: "Climatiseur Split",
+          base_price: 250000,
+          product_stock: 10,
+          quantity: 1,
+        },
+      ],
+    });
+    mockDb._statement.all.mockResolvedValueOnce({
+      results: [
+        { id: "v-other", product_id: "p2", name: "Autre", price: 1, stock_quantity: 99 },
+      ],
+    });
+
+    const result = await createOrder(ctx, {
+      address: "123 Rue Principale",
+      commune: "Cocody",
+      phone: "0700000000",
+    });
+
+    expect(result.success).toBe(false);
+    expect(mockDb.batch).not.toHaveBeenCalled();
   });
 });
 

--- a/__tests__/unit/workers/whatsapp/whatsapp-api.test.ts
+++ b/__tests__/unit/workers/whatsapp/whatsapp-api.test.ts
@@ -44,6 +44,35 @@ describe("WhatsAppAPI", () => {
     expect(result).toEqual({ success: false, error: "Invalid token" });
   });
 
+  it("bounds every request with an abort signal so a hung call cannot run forever", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify({ messages: [{ id: "wamid.1" }] }), { status: 200 })
+    );
+
+    await api.sendText("+2250700000000", "Hello!");
+    await api.markAsRead("wamid.123");
+
+    const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toHaveLength(2);
+    // Both the outbound reply and the read receipt: an unbounded one burns the
+    // deferred-work budget of whatever queued it.
+    for (const [, init] of calls) {
+      expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
+      expect((init as RequestInit).signal!.aborted).toBe(false);
+    }
+  });
+
+  it("lets an aborted request reject, so callers can count it as a failure", async () => {
+    // The throw/return contract is deliberately unchanged: every caller already
+    // handles a rejected send, and swallowing it here would silently reroute
+    // control flow in the orchestrator.
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new DOMException("The operation was aborted due to timeout", "TimeoutError")
+    );
+
+    await expect(api.sendText("+2250700000000", "Hello!")).rejects.toThrow(/timeout/i);
+  });
+
   it("marks message as read", async () => {
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
       new Response(JSON.stringify({ success: true }), { status: 200 })

--- a/lib/auth/ban.ts
+++ b/lib/auth/ban.ts
@@ -1,0 +1,58 @@
+/**
+ * The single answer to "is this account's ban in force right now?".
+ *
+ * Shared on purpose between the web guards (`lib/auth/guards.ts`) and the
+ * WhatsApp Worker (`workers/whatsapp/src/tools/guards.ts`). The rule has two
+ * traps in it, and a second copy would eventually get one of them wrong:
+ *
+ *   1. A ban with **no** expiry is permanent. `banned && !banExpires` is the
+ *      normal shape of an indefinite suspension, not a missing value to ignore.
+ *   2. A ban whose expiry has **passed** no longer bans. better-auth's admin
+ *      plugin only clears the flag when a *new* session is created (sign-in),
+ *      so an account can sit at `banned = 1` with an expiry in the past
+ *      indefinitely. Reading `if (banned)` alone would lock that account out
+ *      for good, long after its sanction ended.
+ *
+ * Deliberately free of imports so the Worker can import it: no `next/*`, no D1
+ * handle, nothing that reaches the Worker bundle beyond this function.
+ */
+
+/**
+ * `banned` as it reaches us: a boolean from better-auth's session payload, or
+ * the raw `INTEGER` 0/1 of the `user.banned` column read directly from D1.
+ */
+export type BanFlag = boolean | number | null | undefined;
+
+/**
+ * `banExpires` arrives in three shapes for one column, so the predicate accepts
+ * all three rather than making each caller normalise:
+ *  - `Date` — a fresh better-auth read on the web;
+ *  - ISO `string` — the session-cookie cache (better-auth re-hydrates only
+ *    `createdAt`/`updatedAt` into `Date`s, so this one stays a `JSON.parse`
+ *    string), and the raw D1 `TEXT` column the Worker reads (better-auth's
+ *    kysely adapter runs with `supportsDates: false` on sqlite);
+ *  - `number` — epoch milliseconds, for callers holding a timestamp.
+ */
+export type BanExpiry = Date | string | number | null | undefined;
+
+/**
+ * @param now Reference instant in epoch milliseconds. Defaults to the current
+ *   clock; passed explicitly by tests, and available to any caller that must
+ *   judge several accounts against one instant.
+ */
+export function isActivelyBanned(
+  user: { banned?: BanFlag; banExpires?: BanExpiry },
+  now: number = Date.now()
+): boolean {
+  if (!user.banned) return false;
+  if (!user.banExpires) return true;
+
+  const expiresAt = new Date(user.banExpires).getTime();
+  // An unreadable expiry is not evidence that the sanction ended. `NaN > now`
+  // is false, so a naive comparison would quietly *clear* the ban of an
+  // account whose column is corrupt — the one direction where guessing wrong
+  // grants access instead of denying it. Keep the ban.
+  if (Number.isNaN(expiresAt)) return true;
+
+  return expiresAt > now;
+}

--- a/lib/auth/guards.ts
+++ b/lib/auth/guards.ts
@@ -1,6 +1,10 @@
 import { redirect } from "next/navigation";
 import { headers } from "next/headers";
 import { initAuth, type Session } from "@/lib/auth";
+// One implementation of "is this ban in force?", shared with the WhatsApp
+// Worker (workers/whatsapp/src/tools/guards.ts). See lib/auth/ban.ts for why
+// it must not be re-written per channel.
+import { isActivelyBanned } from "@/lib/auth/ban";
 import type { StaffRole } from "@/lib/db/types";
 
 export type AdminSession = Omit<Session, "user"> & {
@@ -47,29 +51,18 @@ async function getFreshSession() {
   });
 }
 
-// better-auth's admin plugin only clears an expired ban when a *new*
-// session is created (sign-in) — an already-open session that reads as
-// banned:true keeps that value forever unless banExpires has since passed,
-// in which case it should no longer block access here.
+// `isActivelyBanned` deliberately does not live here any more: the WhatsApp
+// Worker enforces the same rule and cannot import this module (it pulls in
+// `next/navigation`). The predicate — permanent ban vs expired ban, and the
+// three runtime shapes `banExpires` arrives in on this path alone — is
+// documented in lib/auth/ban.ts.
 //
-// `banExpires` is typed `Date | string | null` rather than following
-// `Session["user"]["banExpires"]` (which better-auth types as `Date`)
-// because that type only holds on a fresh D1 read. requireAuth's normal
-// path reads the session-cache cookie instead: better-auth's cache-hit
-// branch (better-auth/dist/api/routes/session.mjs) re-hydrates only
-// `createdAt`/`updatedAt` into `Date`s when it deserialises the cached
-// payload — `banExpires` comes straight out of `JSON.parse` as an ISO
-// string (or null). `new Date(...)` normalizes either shape, so behavior
-// is correct either way, but the annotation must say so or it lies about
-// what a caller on the cache path actually receives.
-function isActivelyBanned(user: {
-  banned?: Session["user"]["banned"];
-  banExpires?: Date | string | null;
-}): boolean {
-  if (!user.banned) return false;
-  if (!user.banExpires) return true;
-  return new Date(user.banExpires).getTime() > Date.now();
-}
+// Worth knowing at these call sites: `Session["user"]["banExpires"]` is typed
+// `Date`, but that only holds on a fresh D1 read. requireAuth's normal path
+// reads the session-cache cookie, whose cache-hit branch
+// (better-auth/dist/api/routes/session.mjs) re-hydrates only
+// `createdAt`/`updatedAt` into `Date`s — `banExpires` comes straight out of
+// `JSON.parse` as an ISO string. The shared predicate accepts both.
 
 export async function requireAnyAdmin(): Promise<AnyAdminSession> {
   const session = await getFreshSession();

--- a/lib/db/orders.ts
+++ b/lib/db/orders.ts
@@ -3,6 +3,13 @@ import { getDB } from "@/lib/cloudflare/context";
 import { nanoid } from "nanoid";
 import type { Order, OrderItem, OrderStatus } from "@/lib/db/types";
 import { notifyOrderStatusUpdate } from "@/lib/notifications";
+// One implementation of "take stock / give it back", shared with the WhatsApp
+// Worker (workers/whatsapp/src/tools/orders.ts). See lib/utils/stock.ts.
+import {
+  buildStockDecrement,
+  buildStockRestore,
+  stockUpdateApplied,
+} from "@/lib/utils/stock";
 export type { Order, OrderItem };
 
 /** Concurrently-open pending orders allowed per user (see createOrder). */
@@ -125,25 +132,9 @@ export async function createOrderWithItems(
   //    layout this can no longer prevent an orphaned order row by running
   //    first; that is now the job of the try/catch around db.batch below.
   for (const item of items) {
-    if (item.variantId) {
-      stockUpdateIndices.push(statements.length);
-      statements.push(
-        db
-          .prepare(
-            "UPDATE product_variants SET stock_quantity = stock_quantity - ? WHERE id = ? AND stock_quantity >= ?"
-          )
-          .bind(item.quantity, item.variantId, item.quantity)
-      );
-    } else {
-      stockUpdateIndices.push(statements.length);
-      statements.push(
-        db
-          .prepare(
-            "UPDATE products SET stock_quantity = stock_quantity - ? WHERE id = ? AND stock_quantity >= ?"
-          )
-          .bind(item.quantity, item.productId, item.quantity)
-      );
-    }
+    const { sql, params } = buildStockDecrement(item);
+    stockUpdateIndices.push(statements.length);
+    statements.push(db.prepare(sql).bind(...params));
   }
 
   // 2. Insert order items (the order row itself was already inserted and
@@ -210,27 +201,26 @@ export async function createOrderWithItems(
 
   // 5. Verify all stock decrements succeeded
   for (let i = 0; i < stockUpdateIndices.length; i++) {
-    const result = results[stockUpdateIndices[i]];
-    if (result.meta.changes === 0) {
-      // Stock was insufficient — delete the orphaned order + items
+    if (!stockUpdateApplied(results[stockUpdateIndices[i]])) {
+      // Stock was insufficient — delete the orphaned order + items and give
+      // back every decrement that DID apply.
+      //
+      // "Every", not "every one before this line": db.batch executes the whole
+      // sequence, and a decrement matching no row is not a failure that stops
+      // it — the statements after the refused one still ran and still
+      // reserved. Restoring only `items.slice(0, i)` left those later
+      // reservations held against an order this very batch is deleting, with
+      // nothing left to release them. Conversely, a decrement that did NOT
+      // apply must never be restored: that would credit stock nobody took.
       await db.batch([
         db.prepare("DELETE FROM order_items WHERE order_id = ?").bind(orderId),
         db.prepare("DELETE FROM orders WHERE id = ?").bind(orderId),
-        // Restore stock for items that DID succeed (before this one)
-        ...items.slice(0, i).map((prev) => {
-          if (prev.variantId) {
-            return db
-              .prepare(
-                "UPDATE product_variants SET stock_quantity = stock_quantity + ? WHERE id = ?"
-              )
-              .bind(prev.quantity, prev.variantId);
-          }
-          return db
-            .prepare(
-              "UPDATE products SET stock_quantity = stock_quantity + ? WHERE id = ?"
-            )
-            .bind(prev.quantity, prev.productId);
-        }),
+        ...items
+          .filter((_, j) => stockUpdateApplied(results[stockUpdateIndices[j]]))
+          .map((prev) => {
+            const { sql, params } = buildStockRestore(prev);
+            return db.prepare(sql).bind(...params);
+          }),
         // Restore promo used_count only if the guarded increment actually applied
         ...(promoApplied && orderData.promoCodeId
           ? [
@@ -257,19 +247,12 @@ export async function createOrderWithItems(
     await db.batch([
       db.prepare("DELETE FROM order_items WHERE order_id = ?").bind(orderId),
       db.prepare("DELETE FROM orders WHERE id = ?").bind(orderId),
-      ...items.map((it) =>
-        it.variantId
-          ? db
-              .prepare(
-                "UPDATE product_variants SET stock_quantity = stock_quantity + ? WHERE id = ?"
-              )
-              .bind(it.quantity, it.variantId)
-          : db
-              .prepare(
-                "UPDATE products SET stock_quantity = stock_quantity + ? WHERE id = ?"
-              )
-              .bind(it.quantity, it.productId)
-      ),
+      // Every decrement was verified as applied by step 5 above before this
+      // point is reachable, so all of them are restored here.
+      ...items.map((it) => {
+        const { sql, params } = buildStockRestore(it);
+        return db.prepare(sql).bind(...params);
+      }),
     ]);
     throw new Error(
       "Ce code promo n'est plus disponible (limite d'utilisation atteinte)."
@@ -603,30 +586,19 @@ export async function refundOrderStock(orderId: string): Promise<{ itemsRefunded
   const statements: D1PreparedStatement[] = [];
 
   for (const item of items) {
-    if (item.variant_id) {
-      statements.push(
-        db
-          .prepare(
-            "UPDATE product_variants SET stock_quantity = stock_quantity + ? WHERE id = ?"
-          )
-          .bind(item.quantity, item.variant_id)
-      );
-    } else {
-      statements.push(
-        db
-          .prepare(
-            "UPDATE products SET stock_quantity = stock_quantity + ? WHERE id = ?"
-          )
-          .bind(item.quantity, item.product_id)
-      );
-    }
+    const { sql, params } = buildStockRestore({
+      productId: item.product_id,
+      variantId: item.variant_id,
+      quantity: item.quantity,
+    });
+    statements.push(db.prepare(sql).bind(...params));
   }
 
   try {
     const results = await db.batch(statements);
 
     // Verify all updates succeeded
-    const failedUpdates = results.filter((r) => r.meta.changes === 0);
+    const failedUpdates = results.filter((r) => !stockUpdateApplied(r));
     if (failedUpdates.length > 0) {
       console.warn(
         `refundOrderStock: ${failedUpdates.length}/${items.length} items had no matching product/variant for order ${orderId}`

--- a/lib/rate-limit/kv-window-limit.ts
+++ b/lib/rate-limit/kv-window-limit.ts
@@ -53,7 +53,19 @@ export async function checkKVRateLimit(
   // already applies to malformed KV values.
   if (!bucket || bucket.resetAt <= now) {
     const fresh: Bucket = { count: 1, resetAt: now + windowSeconds * 1000 };
-    await kv.put(key, JSON.stringify(fresh), { expirationTtl: windowSeconds });
+    // Floored at 60 for the same reason as the accepted-call write below: KV
+    // rejects any expirationTtl under 60 seconds outright, so a caller
+    // configured with a sub-minute window would have thrown here on its very
+    // first call — the floor was applied to the second write only. No current
+    // caller uses a window that short (600s is the shortest), so this was
+    // latent rather than live, but it made the module unusable for the one
+    // shape a rate limiter is most often asked for. Flooring is safe because
+    // `resetAt`, not the KV TTL, defines the window: the branch guarding this
+    // block already treats `resetAt <= now` as expired regardless of whether
+    // the KV entry itself has gone.
+    await kv.put(key, JSON.stringify(fresh), {
+      expirationTtl: Math.max(60, windowSeconds),
+    });
     return true;
   }
 

--- a/lib/utils/stock.ts
+++ b/lib/utils/stock.ts
@@ -1,0 +1,89 @@
+/**
+ * The SQL that reserves stock for an order and the SQL that gives it back.
+ *
+ * Shared on purpose between the web checkout (`lib/db/orders.ts`) and the
+ * WhatsApp Worker (`workers/whatsapp/src/tools/orders.ts`). Two independent
+ * copies of "take stock, then put back exactly what you took" is precisely how
+ * one of them ends up crediting stock it never debited — the failure this
+ * repository has already met once on the cancellation path.
+ *
+ * Only the *statements* are shared. The orchestration around them is not, and
+ * cannot reasonably be: the web path reserves an order row first (to enforce
+ * the concurrent-pending cap in the same statement as the write) and has a
+ * promo counter to compensate too, while the Worker has neither, no
+ * `ActionResult`, and a customer-visible cart row it must not destroy on a
+ * refusal. What both must agree on is the shape of the two statements and the
+ * rule for reading their results — that is what lives here.
+ *
+ * Pure strings and bind parameters: no imports, no D1 handle, nothing that
+ * reaches the Worker bundle.
+ */
+
+/** A product line to reserve or release. A null `variantId` means the product row itself. */
+export interface StockTarget {
+  productId: string;
+  variantId: string | null;
+  quantity: number;
+}
+
+export interface StockStatement {
+  sql: string;
+  params: unknown[];
+}
+
+function tableFor(target: StockTarget): "product_variants" | "products" {
+  return target.variantId ? "product_variants" : "products";
+}
+
+function rowIdFor(target: StockTarget): string {
+  return target.variantId ?? target.productId;
+}
+
+/**
+ * Compare-and-swap reservation. `AND stock_quantity >= ?` puts the availability
+ * check and the write in one statement, so two orders racing for the last unit
+ * cannot both read "1 available" and both decrement it.
+ *
+ * The caller MUST inspect `meta.changes`. A refused decrement is not an error:
+ * D1 reports it as `changes === 0` and commits the rest of the batch around it.
+ * A predicate nobody reads the result of protects nothing — it just moves the
+ * oversell from "negative stock" to "confirmed order with no stock reserved".
+ */
+export function buildStockDecrement(target: StockTarget): StockStatement {
+  return {
+    sql: `UPDATE ${tableFor(target)} SET stock_quantity = stock_quantity - ? WHERE id = ? AND stock_quantity >= ?`,
+    params: [target.quantity, rowIdFor(target), target.quantity],
+  };
+}
+
+/**
+ * Compensating release, for a reservation that must be undone.
+ *
+ * Carries no quantity guard on purpose — it adds stock back, so it can never
+ * drive the row negative. What it must never do is give back stock that was
+ * never taken: apply it only to a decrement that actually applied
+ * (`meta.changes > 0`), never to the whole batch on the assumption that every
+ * decrement landed.
+ *
+ * `meta.changes === 0` on a release is a failure, not a no-op: it means the
+ * row vanished (or was replaced) since the reservation, and the stock is
+ * still missing. Callers are expected to say so rather than report success.
+ */
+export function buildStockRestore(target: StockTarget): StockStatement {
+  return {
+    sql: `UPDATE ${tableFor(target)} SET stock_quantity = stock_quantity + ? WHERE id = ?`,
+    params: [target.quantity, rowIdFor(target)],
+  };
+}
+
+/**
+ * Fail-closed reading of a guarded UPDATE's result.
+ *
+ * Anything that is not affirmatively a successful write — `changes: 0`, a
+ * missing result slot because the driver returned a shorter array than the
+ * statements it was given — counts as "did not apply". `changes === 0` would
+ * instead treat a missing slot as success.
+ */
+export function stockUpdateApplied(result: { meta: { changes: number } } | undefined): boolean {
+  return (result?.meta?.changes ?? 0) > 0;
+}

--- a/workers/whatsapp/src/tools/account.ts
+++ b/workers/whatsapp/src/tools/account.ts
@@ -1,9 +1,17 @@
 import type { ToolContext, ToolResult } from "../types";
 import { sendOtpEmail } from "../email";
+import { readAccountState, ACCOUNT_SUSPENDED, ACCOUNT_UNKNOWN, ACCOUNT_STATE_UNAVAILABLE } from "./guards";
+// One implementation of "is this ban in force?", shared with the web guards.
+import { isActivelyBanned } from "../../../../lib/auth/ban";
 
 interface UserRow {
   id: string;
   email: string;
+  // Read in the same lookup as the account: a suspended account must not be
+  // linkable to a WhatsApp number at all. `banExpires` is the raw D1 TEXT
+  // column (ISO string) — the shared predicate reads that shape.
+  banned: number | null;
+  banExpires: string | null;
 }
 
 interface SessionOtpRow {
@@ -67,12 +75,18 @@ export async function linkAccount(
   await ctx.env.KV.put(sessionKey, String(sessionCount + 1), { expirationTtl: LINK_WINDOW_TTL });
 
   const user = await ctx.db
-    .prepare("SELECT id, email FROM user WHERE LOWER(email) = LOWER(?)")
+    .prepare("SELECT id, email, banned, banExpires FROM user WHERE LOWER(email) = LOWER(?)")
     .bind(email)
     .first<UserRow>();
 
   // Uniform response for unregistered emails — never disclose non-existence.
-  if (!user) {
+  //
+  // A suspended account takes the *same* branch on purpose: no OTP is sent and
+  // nothing is staged, but the reply is byte-identical to the unregistered one.
+  // Answering "this account is suspended" to an unauthenticated sender would
+  // hand out both an existence oracle and the account's moderation status. An
+  // expired ban is not a ban, so such an account links normally.
+  if (!user || isActivelyBanned(user)) {
     return { success: true, data: { message: LINK_UNIFORM_MESSAGE } };
   }
 
@@ -150,6 +164,24 @@ export async function verifyOtp(
 
     await ctx.env.KV.put(attemptsKey, String(attempts), { expirationTtl: 600 });
     return { success: false, error: `Code incorrect (tentative ${attempts}/5). Vérifiez votre email et réessayez.` };
+  }
+
+  // OTP confirmed — but the account may have been suspended in the ten minutes
+  // since the code was sent, so its state is re-read before it is promoted to
+  // the trusted user_id. Naming the reason is safe here and nowhere else in
+  // this file: holding the emailed code proves the sender controls the mailbox,
+  // so this is not an oracle for a third party.
+  const state = await readAccountState(ctx.db, row.pending_user_id);
+  if (state !== "active") {
+    return {
+      success: false,
+      error:
+        state === "banned"
+          ? ACCOUNT_SUSPENDED
+          : state === "unknown"
+            ? ACCOUNT_UNKNOWN
+            : ACCOUNT_STATE_UNAVAILABLE,
+    };
   }
 
   // OTP confirmed: promote the pending account to the trusted user_id and mark

--- a/workers/whatsapp/src/tools/cart.ts
+++ b/workers/whatsapp/src/tools/cart.ts
@@ -1,10 +1,15 @@
 import type { ToolContext, ToolResult } from "../types";
+// Same shared pricing rule as the web checkout and as createOrder — see
+// lib/utils/checkout.ts. Pure module, nothing lands in the Worker bundle.
+import { resolveOrderLine } from "../../../../lib/utils/checkout";
 
 interface ProductRow {
   id: string;
   name: string;
   base_price: number;
   stock_quantity: number;
+  /** Number of is_active = 1 variants this product has. */
+  active_variant_count: number;
 }
 
 interface VariantRow {
@@ -42,12 +47,16 @@ export async function cartAdd(
     return { success: false, error: "La quantité doit être un entier positif." };
   }
 
-  // Validate product exists and is available
+  // Validate product exists and is available. The active-variant count comes
+  // along so a product sold through variants can never be priced from its
+  // base_price (a display figure, not a sellable price).
   const product = await ctx.db
     .prepare(
-      `SELECT id, name, base_price, stock_quantity
-       FROM products
-       WHERE id = ? AND is_active = 1 AND is_draft = 0`
+      `SELECT p.id, p.name, p.base_price, p.stock_quantity,
+              (SELECT COUNT(*) FROM product_variants v
+                WHERE v.product_id = p.id AND v.is_active = 1) as active_variant_count
+       FROM products p
+       WHERE p.id = ? AND p.is_active = 1 AND p.is_draft = 0`
     )
     .bind(params.product_id)
     .first<ProductRow>();
@@ -56,13 +65,10 @@ export async function cartAdd(
     return { success: false, error: "Product not found" };
   }
 
-  let itemName = product.name;
-  let unitPrice = product.base_price;
-  let availableStock = product.stock_quantity;
-
-  // If variant provided, validate and use variant price/stock
+  // If variant provided, validate it belongs to this product and is active
+  let variant: VariantRow | null = null;
   if (params.variant_id) {
-    const variant = await ctx.db
+    variant = await ctx.db
       .prepare(
         `SELECT id, name, price, stock_quantity
          FROM product_variants
@@ -74,19 +80,32 @@ export async function cartAdd(
     if (!variant) {
       return { success: false, error: "Variant not found or does not belong to this product" };
     }
-
-    itemName = `${product.name} – ${variant.name}`;
-    unitPrice = variant.price;
-    availableStock = variant.stock_quantity;
   }
 
-  // Check stock
-  if (availableStock < quantity) {
-    return {
-      success: false,
-      error: `Insufficient stock. Only ${availableStock} unit(s) available.`,
-    };
+  // Price + stock decided by the shared rule. Refusing here rather than only at
+  // checkout keeps an unsellable base_price from ever being quoted back in the
+  // conversation; createOrder re-checks anyway, since a variant can be retired
+  // between the add and the order.
+  const resolved = resolveOrderLine({
+    product: {
+      name: product.name,
+      base_price: product.base_price,
+      stock_quantity: product.stock_quantity,
+      activeVariantCount: product.active_variant_count ?? 0,
+    },
+    variant: variant
+      ? { name: variant.name, price: variant.price, stock_quantity: variant.stock_quantity }
+      : null,
+    quantity,
+  });
+
+  if (!resolved.ok) {
+    return { success: false, error: resolved.error };
   }
+
+  const itemName = variant ? `${product.name} – ${variant.name}` : product.name;
+  const unitPrice = resolved.unitPrice;
+  const availableStock = resolved.availableStock;
 
   // Check if item already in cart (same product + variant combination)
   const existing = await ctx.db

--- a/workers/whatsapp/src/tools/cart.ts
+++ b/workers/whatsapp/src/tools/cart.ts
@@ -2,6 +2,11 @@ import type { ToolContext, ToolResult } from "../types";
 // Same shared pricing rule as the web checkout and as createOrder — see
 // lib/utils/checkout.ts. Pure module, nothing lands in the Worker bundle.
 import { resolveOrderLine } from "../../../../lib/utils/checkout";
+import {
+  isProductInCatalogue,
+  productGoneFromCatalogue,
+  variantGoneFromCatalogue,
+} from "./line-issues";
 
 interface ProductRow {
   id: string;
@@ -27,9 +32,30 @@ interface CartItemRow {
 interface CartViewRow {
   id: string;
   product_name: string;
+  base_price: number;
+  product_stock: number;
+  product_is_active: number;
+  product_is_draft: number;
+  active_variant_count: number;
+  /** What the cart row points at, whether or not it still resolves. */
+  cart_variant_id: string | null;
+  /** Set only when that variant is still active and owned by the product. */
+  variant_id: string | null;
   variant_name: string | null;
+  variant_price: number | null;
+  variant_stock: number | null;
   quantity: number;
-  unit_price: number;
+}
+
+interface CartViewItem {
+  id: string;
+  name: string;
+  quantity: number;
+  /** null when no honest price exists for this line. */
+  unit_price: number | null;
+  total: number | null;
+  /** French explanation when the line cannot be ordered as it stands. */
+  issue: string | null;
 }
 
 function generateId(): string {
@@ -164,31 +190,88 @@ export async function cartAdd(
 export async function cartView(
   ctx: ToolContext
 ): Promise<ToolResult & { data?: unknown }> {
+  // The view answers the same question the order path does, with the same
+  // rule. Quoting a figure the checkout will then refuse is what makes the
+  // channel look untrustworthy, so a line that cannot be priced honestly
+  // carries `unit_price: null` and a reason instead of an invented number.
   const { results } = await ctx.db
     .prepare(
-      `SELECT wc.id, p.name as product_name, pv.name as variant_name,
-              wc.quantity,
-              COALESCE(pv.price, p.base_price) as unit_price
+      `SELECT wc.id, wc.quantity, wc.variant_id as cart_variant_id,
+              p.name as product_name, p.base_price,
+              p.stock_quantity as product_stock,
+              p.is_active as product_is_active, p.is_draft as product_is_draft,
+              (SELECT COUNT(*) FROM product_variants v
+                WHERE v.product_id = p.id AND v.is_active = 1) as active_variant_count,
+              pv.id as variant_id, pv.name as variant_name,
+              pv.price as variant_price, pv.stock_quantity as variant_stock
        FROM whatsapp_carts wc
        JOIN products p ON wc.product_id = p.id
-       LEFT JOIN product_variants pv ON wc.variant_id = pv.id
+       LEFT JOIN product_variants pv
+              ON pv.id = wc.variant_id AND pv.product_id = wc.product_id AND pv.is_active = 1
        WHERE wc.session_id = ?
        ORDER BY wc.created_at`
     )
     .bind(ctx.session.id)
     .all<CartViewRow>();
 
-  const items = results.map((row) => ({
-    id: row.id,
-    name: row.variant_name ? `${row.product_name} – ${row.variant_name}` : row.product_name,
-    quantity: row.quantity,
-    unit_price: row.unit_price,
-    total: row.quantity * row.unit_price,
-  }));
+  const items: CartViewItem[] = (results ?? []).map((row) => {
+    const name = row.variant_name
+      ? `${row.product_name} – ${row.variant_name}`
+      : row.product_name;
+    const base = { id: row.id, name, quantity: row.quantity };
 
-  const subtotal = items.reduce((sum, item) => sum + item.total, 0);
+    if (!isProductInCatalogue(row)) {
+      return { ...base, unit_price: null, total: null, issue: productGoneFromCatalogue(row.product_name) };
+    }
 
-  return { success: true, data: { items, subtotal } };
+    // The row points at a variant that no longer resolves (retired, or moved
+    // to another product). Falling back to base_price here is exactly the
+    // invented figure we are avoiding.
+    if (row.cart_variant_id && !row.variant_id) {
+      return { ...base, unit_price: null, total: null, issue: variantGoneFromCatalogue(row.product_name) };
+    }
+
+    const lineInput = {
+      product: {
+        name: row.product_name,
+        base_price: row.base_price,
+        stock_quantity: row.product_stock,
+        activeVariantCount: row.active_variant_count ?? 0,
+      },
+      variant:
+        row.variant_id !== null
+          ? {
+              name: row.variant_name ?? "",
+              price: row.variant_price ?? 0,
+              stock_quantity: row.variant_stock ?? 0,
+            }
+          : null,
+    };
+
+    const line = resolveOrderLine({ ...lineInput, quantity: row.quantity });
+    if (line.ok) {
+      return { ...base, unit_price: line.unitPrice, total: line.unitPrice * row.quantity, issue: null };
+    }
+
+    // Refused. A line that is merely short on stock still has an honest price
+    // and the customer can act on it by lowering the quantity, so keep the
+    // figure. Asking with quantity 0 makes the stock comparisons unreachable,
+    // which isolates the pricing question without restating the pricing rule.
+    const priceOnly = resolveOrderLine({ ...lineInput, quantity: 0 });
+    return {
+      ...base,
+      unit_price: priceOnly.ok ? priceOnly.unitPrice : null,
+      total: priceOnly.ok ? priceOnly.unitPrice * row.quantity : null,
+      issue: line.error,
+    };
+  });
+
+  // Only lines that can actually be ordered count toward the subtotal, so the
+  // bot never announces a total the checkout would not honour.
+  const subtotal = items.reduce((sum, item) => sum + (item.issue === null ? (item.total ?? 0) : 0), 0);
+  const hasBlockingIssues = items.some((item) => item.issue !== null);
+
+  return { success: true, data: { items, subtotal, has_blocking_issues: hasBlockingIssues } };
 }
 
 export async function cartUpdate(

--- a/workers/whatsapp/src/tools/escalation.ts
+++ b/workers/whatsapp/src/tools/escalation.ts
@@ -36,15 +36,33 @@ const UNREACHED_MESSAGE =
   "Écrivez-nous depuis la page Contact du site netereka.ci, ou réessayez dans quelques minutes.";
 
 /**
- * The ceiling was reached. Phrased so it is true whether or not the earlier
- * notifications got through, and so it never reads as a refusal: a customer in
- * difficulty is still pointed at a human.
+ * The ceiling was reached *and* an administrator was reached earlier in the
+ * window, so saying the request was passed on is true. Never reads as a
+ * refusal: a customer in difficulty is still pointed at a human.
  */
 const THROTTLED_MESSAGE =
   "Votre demande a déjà été transmise, un conseiller vous répondra dès que possible. " +
   "Si c'est urgent, écrivez-nous depuis la page Contact du site netereka.ci.";
 
+/**
+ * The ceiling was reached and nothing says anyone was ever notified — the
+ * customer whose earlier attempts all failed on infrastructure, i.e. exactly
+ * the one for whom the alternative channel matters most. Claims nothing about
+ * the request having been transmitted.
+ */
+const THROTTLED_UNREACHED_MESSAGE =
+  "J'ai bien noté vos demandes, mais je n'ai pas réussi à joindre un conseiller. " +
+  "Écrivez-nous depuis la page Contact du site netereka.ci : c'est le moyen le plus sûr de nous atteindre.";
+
 const NO_REASON = "(aucune raison fournie)";
+
+/**
+ * KV key recording that at least one administrator acknowledged an escalation
+ * from this number recently. The rate-limit slot is consumed *before* the
+ * sends, so "throttled" carries no information about whether anyone was
+ * notified; this marker is that information, and nothing else keeps it.
+ */
+const ACK_PREFIX = "wa:escalate:ack:";
 
 // Built from escaped strings rather than written as regex literals so the
 // source file stays plain ASCII: these ranges are invisible or control
@@ -238,6 +256,16 @@ export async function escalateHuman(
   //
   // Keyed on the WhatsApp number rather than the session id: a session row is
   // trivial to churn, the number is what actually costs staff attention.
+  //
+  // The slot is consumed here, before the sends, and deliberately so: the
+  // alternative — charging the slot only once an administrator has answered —
+  // would stop the throttle bounding *attempts* and bound only successes. The
+  // total-failure modes are an expired token, a Meta outage, or Meta rate
+  // limiting us; those are precisely when repeated escalations would hammer
+  // the Graph API hardest, when hammering helps least and can deepen the
+  // outage. What that ordering costs is that "throttled" no longer implies
+  // "someone was told" — paid for by the marker read below, not by loosening
+  // the cap.
   const throttleKey = sanitisePhone(session.wa_phone) || `session:${session.id}`;
   let allowed = true;
   try {
@@ -254,7 +282,23 @@ export async function escalateHuman(
     console.error("[escalation] Rate-limit check unavailable, letting the request through:", err);
   }
 
-  if (!allowed) return { success: true, data: { message: THROTTLED_MESSAGE } };
+  if (!allowed) {
+    // Throttled. Whether that means "a human already has this" or "three
+    // attempts failed and nobody knows" depends on something the counter does
+    // not record, so ask the marker — and treat an unreadable answer as the
+    // pessimistic one. Reassurance is the claim that needs evidence; the
+    // fallback channel costs nothing if it turns out to be unnecessary.
+    let acknowledged = false;
+    try {
+      acknowledged = (await env.KV.get(`${ACK_PREFIX}${throttleKey}`)) !== null;
+    } catch (err) {
+      console.error("[escalation] Could not read the acknowledgement marker:", err);
+    }
+    return {
+      success: true,
+      data: { message: acknowledged ? THROTTLED_MESSAGE : THROTTLED_UNREACHED_MESSAGE },
+    };
+  }
 
   const alertMsg = buildEscalationMessage(session.wa_phone, params.reason, {
     verified: session.is_verified === 1 && Boolean(session.user_id),
@@ -262,6 +306,26 @@ export async function escalateHuman(
   });
 
   const notified = await notifyAdmins(db, alertMsg);
+
+  // Remember that someone answered, so a later throttled attempt from this
+  // number can tell the customer the truth. Written only on success and only
+  // for the length of one window; a failure here costs nothing but the memory,
+  // which the throttled branch already reads as "unknown", i.e. as no promise.
+  //
+  // The marker can outlive the counter's window by up to an hour. The
+  // consequence of that staleness is benign: a customer throttled in the next
+  // window whose sends all failed is told their request was passed on — which
+  // is still true, an administrator was notified within the hour and knows
+  // they want help.
+  if (notified > 0) {
+    try {
+      await env.KV.put(`${ACK_PREFIX}${throttleKey}`, "1", {
+        expirationTtl: ESCALATION_WINDOW_SECONDS,
+      });
+    } catch (err) {
+      console.error("[escalation] Could not record the acknowledgement marker:", err);
+    }
+  }
 
   return {
     success: true,

--- a/workers/whatsapp/src/tools/escalation.ts
+++ b/workers/whatsapp/src/tools/escalation.ts
@@ -1,45 +1,270 @@
 import type { ToolResult, ToolContext } from "../types";
 import { WhatsAppAPI } from "../whatsapp-api";
+// The same fixed-window KV counter the web limiters use (orders, promo codes,
+// CSP reports). Reused rather than reimplemented: this Worker had already
+// grown its own ad-hoc counters, and a third variant is a third place for the
+// window semantics to drift. Pure module, no Next.js imports — see the `@/*`
+// mapping note in workers/whatsapp/tsconfig.json.
+import { checkKVRateLimit } from "../../../../lib/rate-limit/kv-window-limit";
+
+/** Maximum number of code points of client text forwarded to staff. */
+export const MAX_REASON_LEN = 200;
+
+/**
+ * Escalation ceiling per WhatsApp number.
+ *
+ * Deliberately generous rather than tight: an escalation is a rare, legitimate
+ * event and the person triggering it is by definition someone the bot could
+ * not help. Three per hour absorbs an anxious customer resending, and the
+ * model calling the tool twice in one exchange, while still capping how many
+ * pushes a single number can force onto every staff phone.
+ */
+export const ESCALATION_MAX_PER_WINDOW = 3;
+export const ESCALATION_WINDOW_SECONDS = 3600;
+
+/** A human was reached. */
+const ESCALATED_MESSAGE =
+  "Un conseiller va prendre le relais sous peu. Merci de votre patience.";
+
+/**
+ * Nobody could be reached. The customer must not be told to wait for someone
+ * who was never notified, so this names a channel that does not depend on the
+ * bot working.
+ */
+const UNREACHED_MESSAGE =
+  "J'ai enregistré votre demande, mais je n'ai pas réussi à joindre un conseiller à l'instant. " +
+  "Écrivez-nous depuis la page Contact du site netereka.ci, ou réessayez dans quelques minutes.";
+
+/**
+ * The ceiling was reached. Phrased so it is true whether or not the earlier
+ * notifications got through, and so it never reads as a refusal: a customer in
+ * difficulty is still pointed at a human.
+ */
+const THROTTLED_MESSAGE =
+  "Votre demande a déjà été transmise, un conseiller vous répondra dès que possible. " +
+  "Si c'est urgent, écrivez-nous depuis la page Contact du site netereka.ci.";
+
+const NO_REASON = "(aucune raison fournie)";
+
+// Built from escaped strings rather than written as regex literals so the
+// source file stays plain ASCII: these ranges are invisible or control
+// characters, and a literal one pasted into source is impossible to review and
+// trivial to lose in an editor.
+//
+// Invisible formatting: bidi controls (which visually reorder the characters
+// after them), zero-width spaces/joiners, and the BOM. They carry no meaning
+// in an escalation reason and each one lets client text look like something it
+// is not, so they are deleted outright rather than replaced by a space — a
+// zero-width space inside a word must not split it.
+const INVISIBLE_FORMATTING = new RegExp(
+  "[\\u061c\\u200b-\\u200f\\u202a-\\u202e\\u2066-\\u2069\\ufeff]",
+  "g"
+);
+// C0 and C1 control characters. This is what covers \r, \n, \t, \v and the C1
+// NEL (U+0085) — JavaScript's \s covers none of the C1 range.
+const CONTROL_CHARS = new RegExp("[\\u0000-\\u001f\\u007f-\\u009f]", "g");
+
+/**
+ * Flatten client-controlled text so it cannot imitate the structure of the
+ * message that wraps it.
+ *
+ * `reason` is produced by the language model from what the customer typed, so
+ * it is customer content arriving verbatim on a staff phone. Bounding its
+ * length is not enough: what is forgeable is the *shape* of the alert. Three
+ * things are neutralised, in this order:
+ *
+ *  - anything that renders as a line break (ASCII newlines, but also U+2028,
+ *    U+2029, NEL, vertical tab), so the text can never occupy more than the
+ *    one line reserved for it and can never start a line with `Client:`;
+ *  - invisible and bidirectional formatting, which can hide or reverse text;
+ *  - the guillemets used to delimit the quoted block, so the text cannot
+ *    appear to close its own quotes and continue as if it were our own copy.
+ *
+ * What remains is a single line of plain text inside an explicitly labelled
+ * block. Residual risk, accepted and documented: WhatsApp soft-wraps long
+ * lines, so a reader skimming a wrapped block could still misread a fragment
+ * as a field. The 200-code-point cap and the guillemets are what keep the
+ * quoted region small and visibly bounded.
+ */
+function sanitiseClientText(raw: unknown): string {
+  const text = typeof raw === "string" ? raw : raw == null ? "" : String(raw);
+
+  const flattened = text
+    .replace(INVISIBLE_FORMATTING, "")
+    .replace(CONTROL_CHARS, " ")
+    // Every remaining whitespace form, including U+2028/U+2029 and NBSP.
+    .replace(/\s+/gu, " ")
+    .replace(/[«»]/g, '"')
+    // WhatsApp renders these inline: *bold*, _italic_, ~strike~, `mono`. Bold
+    // and monospace are precisely how a fragment is made to look like a system
+    // notice rather than a quote, so the markers are dropped and the text
+    // stays flat. Legitimate reasons lose nothing but punctuation.
+    .replace(/[*_~`]/g, "")
+    .trim();
+
+  if (flattened.length === 0) return NO_REASON;
+
+  // Sliced by code point, not by UTF-16 unit: a naive slice can cut an emoji
+  // in half and emit a lone surrogate. The ellipsis makes the truncation
+  // visible, so staff can tell a cut-off message from a terse one.
+  const points = Array.from(flattened);
+  if (points.length <= MAX_REASON_LEN) return flattened;
+  return points.slice(0, MAX_REASON_LEN - 1).join("") + "…";
+}
+
+/** Keep only what can legitimately appear in a WhatsApp number. */
+function sanitisePhone(raw: string | null | undefined): string {
+  return String(raw ?? "").replace(/[^\d+]/g, "").slice(0, 24);
+}
+
+function sanitiseUserId(raw: string): string {
+  const clean = raw.replace(/[^A-Za-z0-9_-]/g, "").slice(0, 64);
+  return clean.length > 0 ? clean : "identifiant illisible";
+}
+
+/**
+ * Build the alert a staff member reads. Exported so the flattening rules are
+ * testable on their own, without a database or an API client.
+ *
+ * `account` is informational, not a gate: it tells the reader how much to
+ * trust the sender instead of refusing to pass the message on. See the note
+ * on the verification gate in escalateHuman.
+ */
+export function buildEscalationMessage(
+  waPhone: string,
+  reason: string,
+  account?: { verified: boolean; userId: string | null }
+): string {
+  const phone = sanitisePhone(waPhone) || "inconnu";
+  const accountLine =
+    account?.verified && account.userId
+      ? `Compte: vérifié (${sanitiseUserId(account.userId)})`
+      : "Compte: non vérifié";
+
+  return [
+    "Escalade demandée",
+    `Client: ${phone}`,
+    accountLine,
+    "--- message du client (non vérifié) ---",
+    `« ${sanitiseClientText(reason)} »`,
+    "--- fin du message ---",
+  ].join("\n");
+}
+
+/**
+ * Push the alert to every configured admin phone. Returns how many were
+ * actually reached, so the caller can tell the customer the truth.
+ *
+ * Every step is guarded: a missing config row, malformed `admin_phones`, and a
+ * network error mid-loop must each cost at most one admin, never the whole
+ * escalation. `WhatsAppAPI.sendText` does not guard its own `fetch`, so an
+ * unhandled rejection there would otherwise abort the loop.
+ */
+async function notifyAdmins(db: D1Database, alertMsg: string): Promise<number> {
+  type ConfigRow = {
+    phone_number_id: string;
+    access_token: string;
+    admin_phones: string | null;
+  };
+
+  let config: ConfigRow | null;
+  try {
+    config = await db
+      .prepare("SELECT phone_number_id, access_token, admin_phones FROM whatsapp_config WHERE id = 1")
+      .first<ConfigRow>();
+  } catch (err) {
+    console.error("[escalation] Could not read whatsapp_config:", err);
+    return 0;
+  }
+
+  if (!config?.phone_number_id || !config.access_token) return 0;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(config.admin_phones ?? "[]");
+  } catch {
+    console.error("[escalation] Invalid admin_phones JSON in whatsapp_config");
+    return 0;
+  }
+
+  const adminPhones = Array.isArray(parsed)
+    ? parsed.filter((p): p is string => typeof p === "string" && p.trim().length > 0)
+    : [];
+  if (adminPhones.length === 0) return 0;
+
+  const api = new WhatsAppAPI(config.phone_number_id, config.access_token);
+  let notified = 0;
+  for (const phone of adminPhones) {
+    try {
+      const result = await api.sendText(phone, alertMsg);
+      if (result.success) notified++;
+      else console.error(`[escalation] Failed to notify admin ${phone}: ${result.error}`);
+    } catch (err) {
+      console.error(`[escalation] Failed to notify admin ${phone}:`, err);
+    }
+  }
+  return notified;
+}
 
 export async function escalateHuman(
   ctx: ToolContext,
   params: { reason: string }
 ): Promise<ToolResult> {
-  const { db, session } = ctx;
+  const { db, session, env } = ctx;
 
-  // Mark session as escalated
-  await db
-    .prepare("UPDATE whatsapp_sessions SET status = 'escalated', updated_at = datetime('now') WHERE id = ?")
-    .bind(session.id)
-    .run();
-
-  // Notify admin phones via WhatsApp
-  const config = await db
-    .prepare("SELECT phone_number_id, access_token, admin_phones FROM whatsapp_config WHERE id = 1")
-    .first<{ phone_number_id: string; access_token: string; admin_phones: string }>();
-
-  if (config) {
-    let adminPhones: string[] = [];
-    try {
-      adminPhones = JSON.parse(config.admin_phones) as string[];
-    } catch {
-      console.error("[escalation] Invalid admin_phones JSON in whatsapp_config");
-    }
-
-    if (adminPhones.length > 0) {
-      const api = new WhatsAppAPI(config.phone_number_id, config.access_token);
-      const alertMsg = `Escalade demandée\nClient: ${session.wa_phone}\nRaison: ${params.reason}`;
-      for (const phone of adminPhones) {
-        const result = await api.sendText(phone, alertMsg);
-        if (!result.success) {
-          console.error(`[escalation] Failed to notify admin ${phone}: ${result.error}`);
-        }
-      }
-    }
+  // Record the request before anything else, and keep it recorded even when no
+  // notification gets out. `status = 'escalated'` is a *record*, not a promise:
+  // nothing in the bot gates on it, it exists so the admin conversation list
+  // shows that this customer asked for a person. Rolling it back on a failed
+  // send would delete the only trace of the request — which is why there is no
+  // compensation here. What the earlier ordering actually got wrong is the
+  // reply, and that is fixed at the bottom of this function: the customer is
+  // told a conseiller is coming only when one was really notified.
+  try {
+    await db
+      .prepare("UPDATE whatsapp_sessions SET status = 'escalated', updated_at = datetime('now') WHERE id = ?")
+      .bind(session.id)
+      .run();
+  } catch (err) {
+    console.error("[escalation] Could not mark session escalated:", err);
   }
+
+  // No verification gate, deliberately. A customer who cannot link their
+  // account is exactly the one who most needs a human, so requiring
+  // verification to reach one would deny help precisely where it is needed —
+  // and would not stop abuse anyway, since anyone willing to register clears
+  // it. The abusable property is volume, not identity, so volume is what is
+  // capped here; identity is reported to the reader instead of enforced.
+  //
+  // Keyed on the WhatsApp number rather than the session id: a session row is
+  // trivial to churn, the number is what actually costs staff attention.
+  const throttleKey = sanitisePhone(session.wa_phone) || `session:${session.id}`;
+  let allowed = true;
+  try {
+    allowed = await checkKVRateLimit(env.KV, `wa:escalate:${throttleKey}`, {
+      max: ESCALATION_MAX_PER_WINDOW,
+      windowSeconds: ESCALATION_WINDOW_SECONDS,
+    });
+  } catch (err) {
+    // Fails open, on purpose and only here: KV being unavailable is a
+    // non-adversarial outage an abuser cannot induce, and closing this path
+    // would cut off the help channel for everyone during it. Contrast with the
+    // account guards, which fail closed because there the fallback grants
+    // access to data.
+    console.error("[escalation] Rate-limit check unavailable, letting the request through:", err);
+  }
+
+  if (!allowed) return { success: true, data: { message: THROTTLED_MESSAGE } };
+
+  const alertMsg = buildEscalationMessage(session.wa_phone, params.reason, {
+    verified: session.is_verified === 1 && Boolean(session.user_id),
+    userId: session.user_id,
+  });
+
+  const notified = await notifyAdmins(db, alertMsg);
 
   return {
     success: true,
-    data: { message: "Un conseiller va prendre le relais sous peu. Merci de votre patience." },
+    data: { message: notified > 0 ? ESCALATED_MESSAGE : UNREACHED_MESSAGE },
   };
 }

--- a/workers/whatsapp/src/tools/escalation.ts
+++ b/workers/whatsapp/src/tools/escalation.ts
@@ -174,9 +174,10 @@ export function buildEscalationMessage(
  * actually reached, so the caller can tell the customer the truth.
  *
  * Every step is guarded: a missing config row, malformed `admin_phones`, and a
- * network error mid-loop must each cost at most one admin, never the whole
- * escalation. `WhatsAppAPI.sendText` does not guard its own `fetch`, so an
- * unhandled rejection there would otherwise abort the loop.
+ * failed or timed-out send must each cost at most one admin, never the whole
+ * escalation. `WhatsAppAPI.sendText` still rejects rather than returning on a
+ * transport failure — deliberately — so each send is settled individually
+ * rather than awaited in a bare loop.
  */
 async function notifyAdmins(db: D1Database, alertMsg: string): Promise<number> {
   type ConfigRow = {
@@ -211,16 +212,39 @@ async function notifyAdmins(db: D1Database, alertMsg: string): Promise<number> {
   if (adminPhones.length === 0) return 0;
 
   const api = new WhatsAppAPI(config.phone_number_id, config.access_token);
-  let notified = 0;
-  for (const phone of adminPhones) {
-    try {
+
+  // Dispatched together rather than in sequence. There is no ordering
+  // requirement between administrators, and serial round trips multiply the
+  // exposure to a slow one: with four phones the worst case was four timeouts
+  // end to end, all of it charged to the deferred-work budget that also owes
+  // the rest of this message's processing. Fanned out, the worst case is one.
+  //
+  // `allSettled`, not `all`: one rejected send must not cancel the reporting
+  // of the others, and an unobserved rejection here would surface as an
+  // unhandled promise rejection in the Worker.
+  const settled = await Promise.allSettled(
+    adminPhones.map(async (phone) => {
       const result = await api.sendText(phone, alertMsg);
-      if (result.success) notified++;
-      else console.error(`[escalation] Failed to notify admin ${phone}: ${result.error}`);
-    } catch (err) {
-      console.error(`[escalation] Failed to notify admin ${phone}:`, err);
+      if (!result.success) {
+        console.error(`[escalation] Failed to notify admin ${phone}: ${result.error}`);
+      }
+      return result.success;
+    })
+  );
+
+  // The count keeps exactly the meaning it had when this was a loop: one
+  // administrator counts only if their own send came back successful. A
+  // rejection — network error, or the abort that bounds a hung request —
+  // counts as not notified, which is what makes the customer's message fall
+  // back to the alternative channel rather than promise a callback.
+  let notified = 0;
+  settled.forEach((outcome, i) => {
+    if (outcome.status === "rejected") {
+      console.error(`[escalation] Failed to notify admin ${adminPhones[i]}:`, outcome.reason);
+    } else if (outcome.value) {
+      notified++;
     }
-  }
+  });
   return notified;
 }
 

--- a/workers/whatsapp/src/tools/guards.ts
+++ b/workers/whatsapp/src/tools/guards.ts
@@ -1,0 +1,102 @@
+import type { ToolContext } from "../types";
+// Shared with the web guards on purpose: "is this ban in force?" has exactly
+// one implementation in this repo. lib/auth/guards.ts cannot be imported here
+// (it pulls in `next/navigation`), so the predicate itself lives in a pure
+// module both sides import. It has no imports of its own, so nothing extra
+// reaches the Worker bundle. See lib/auth/ban.ts.
+import { isActivelyBanned } from "../../../../lib/auth/ban";
+
+/** Refusals shown to the customer. Read by a human on WhatsApp, so: French. */
+export const ACCOUNT_SUSPENDED =
+  "Ce compte est suspendu et ne peut pas être utilisé ici. Contactez notre service client si vous pensez qu'il s'agit d'une erreur.";
+
+export const ACCOUNT_UNKNOWN =
+  "Ce compte est introuvable. Merci de lier à nouveau votre compte.";
+
+export const ACCOUNT_STATE_UNAVAILABLE =
+  "Nous n'avons pas pu vérifier votre compte. Merci de réessayer dans un instant.";
+
+interface BanRow {
+  banned: number | null;
+  banExpires: string | null;
+}
+
+/**
+ * `unavailable` is not the same as `active`: it means the read failed, so the
+ * caller must refuse rather than assume the best. A ban that cannot be read is
+ * not a ban that does not exist.
+ */
+export type AccountState = "active" | "banned" | "unknown" | "unavailable";
+
+/**
+ * Authoritative ban read, straight from the `user` row.
+ *
+ * The WhatsApp session row is not consulted and must not be: a session linked
+ * before the ban would otherwise stay usable forever, since nothing in this
+ * Worker ever revisits `whatsapp_sessions.is_verified`. The read is therefore
+ * repeated on every privileged call, with nothing cached in between — one
+ * indexed lookup by primary key.
+ */
+export async function readAccountState(
+  db: D1Database,
+  userId: string
+): Promise<AccountState> {
+  let row: BanRow | null;
+  try {
+    row = await db
+      .prepare("SELECT banned, banExpires FROM user WHERE id = ?")
+      .bind(userId)
+      .first<BanRow>();
+  } catch (err) {
+    console.error(`[guards] ban lookup failed for user ${userId}`, err);
+    return "unavailable";
+  }
+
+  if (!row) return "unknown";
+  return isActivelyBanned(row) ? "banned" : "active";
+}
+
+export type ActiveCustomer =
+  | { ok: true; userId: string }
+  | { ok: false; error: string };
+
+/**
+ * The gate in front of every tool that acts *as* a customer: placing an order,
+ * reading that customer's orders.
+ *
+ * It subsumes the `is_verified === 1 && user_id` check those tools used to do
+ * inline, and adds the ban read. An unverified session is refused first, with
+ * `notLinkedError` and without a database read: there is no account to check,
+ * because an unverified session has not proved it speaks for one. That also
+ * means this guard does *not* stop a banned person from starting over from a
+ * fresh, anonymous WhatsApp session — it stops them from acting on their
+ * account. Nothing on this channel binds a person to an account before the
+ * email OTP; the account is what carries the sanction.
+ *
+ * Browsing the catalogue, filling the WhatsApp cart and reaching a human agent
+ * stay open, which is what the web does too: a banned customer can still browse
+ * netereka.ci and fill a client-side cart, and only `requireAuth()`-gated pages
+ * — account, checkout — turn them away. A conversational channel that refused
+ * even a greeting would also leave the customer no way to be told why.
+ */
+export async function requireActiveCustomer(
+  ctx: ToolContext,
+  notLinkedError: string
+): Promise<ActiveCustomer> {
+  const userId = ctx.session.user_id;
+  if (ctx.session.is_verified !== 1 || !userId) {
+    return { ok: false, error: notLinkedError };
+  }
+
+  const state = await readAccountState(ctx.db, userId);
+  switch (state) {
+    case "active":
+      return { ok: true, userId };
+    case "banned":
+      return { ok: false, error: ACCOUNT_SUSPENDED };
+    case "unknown":
+      return { ok: false, error: ACCOUNT_UNKNOWN };
+    case "unavailable":
+      return { ok: false, error: ACCOUNT_STATE_UNAVAILABLE };
+  }
+}

--- a/workers/whatsapp/src/tools/line-issues.ts
+++ b/workers/whatsapp/src/tools/line-issues.ts
@@ -1,0 +1,30 @@
+/**
+ * Reasons a cart line cannot be ordered that `resolveOrderLine` does not
+ * cover — it decides pricing and stock, not whether the catalogue still
+ * carries the item.
+ *
+ * Both the cart view and the order path must say the same thing about the
+ * same line, so the wording lives here rather than inline in each file.
+ * These are deliberately NOT stock messages: the customer's remedy is to
+ * remove or change the line, not to reduce its quantity.
+ */
+
+export function productGoneFromCatalogue(productName: string): string {
+  return `« ${productName} » ne figure plus dans notre catalogue. Veuillez le retirer de votre panier.`;
+}
+
+export function variantGoneFromCatalogue(productName: string): string {
+  return `La variante choisie pour ${productName} n'est plus proposée. Veuillez en sélectionner une autre.`;
+}
+
+/**
+ * A product is orderable only while it is active and out of draft — the same
+ * predicate `add_to_cart` applies at entry and the web checkout applies at
+ * payment. D1 returns SQLite booleans as 0/1.
+ */
+export function isProductInCatalogue(row: {
+  product_is_active: number;
+  product_is_draft: number;
+}): boolean {
+  return row.product_is_active === 1 && row.product_is_draft === 0;
+}

--- a/workers/whatsapp/src/tools/orders.ts
+++ b/workers/whatsapp/src/tools/orders.ts
@@ -7,6 +7,13 @@ import {
   countActiveVariantsByProduct,
   calculateSubtotal,
 } from "../../../../lib/utils/checkout";
+// Same reason: the SQL that takes stock and the SQL that gives it back has one
+// implementation in this repo, shared with lib/db/orders.ts. Pure strings.
+import {
+  buildStockDecrement,
+  buildStockRestore,
+  stockUpdateApplied,
+} from "../../../../lib/utils/stock";
 import {
   isProductInCatalogue,
   productGoneFromCatalogue,
@@ -68,6 +75,124 @@ function generateOrderNumber(): string {
 
 function generateId(): string {
   return crypto.randomUUID();
+}
+
+// ─── Stock reservation ────────────────────────────────────────────────────────
+//
+// The stock check done while resolving the lines above is a read: between it
+// and the write, the web checkout, an admin, or another bot session can take
+// the same units. Reserving is therefore a compare-and-swap
+// (`AND stock_quantity >= ?`, see lib/utils/stock.ts) whose result is read
+// statement by statement.
+//
+// Reading the result is not optional. `D1Database.batch` is a single SQL
+// transaction, but an UPDATE that matches no row is not a failed statement:
+// D1 commits it with `changes: 0`, and every other statement in the batch
+// commits too. There is no rollback available afterwards. That is why the
+// reservation is a batch of its own, run before anything is written: when a
+// line is refused, no order row exists, no order line exists, and the
+// customer's cart is still there to retry from — the only thing left to undo
+// is the stock the earlier lines did take.
+//
+// The cost of that ordering is a window where stock is held with no order to
+// show for it, if the isolate dies between the two batches. That is the lesser
+// evil: leaked reservation is recoverable by an operator, whereas the reverse
+// ordering hands the customer a confirmed order the shop cannot fulfil.
+
+/** Refusal messages. Only the "…équipe…" ones need a human. */
+function outOfStockReleased(productName: string): string {
+  return `Stock insuffisant pour ${productName} : les derniers exemplaires viennent d'être commandés. Votre commande n'a pas été enregistrée et votre panier reste intact.`;
+}
+
+function outOfStockNotReleased(productName: string): string {
+  return `Stock insuffisant pour ${productName}. Votre commande n'a pas été enregistrée, mais le stock déjà réservé pour les autres articles n'a pas pu être libéré : notre équipe a été prévenue.`;
+}
+
+const RESERVATION_UNAVAILABLE =
+  "Nous n'avons pas pu réserver le stock de votre commande. Votre panier reste intact : merci de réessayer dans un instant.";
+
+const ORDER_WRITE_FAILED_RELEASED =
+  "L'enregistrement de votre commande a échoué. Le stock réservé a été libéré et votre panier reste intact : merci de réessayer.";
+
+const ORDER_WRITE_FAILED_NOT_RELEASED =
+  "L'enregistrement de votre commande a échoué et le stock réservé n'a pas pu être libéré : notre équipe a été prévenue.";
+
+/**
+ * Gives back stock that was reserved. Never throws — it is only ever called
+ * from a failure path, and an exception escaping here would replace a
+ * structured refusal with an unhandled rejection, leaving the caller with
+ * nothing to say to the customer.
+ *
+ * Returns false when any line could not be put back, including the silent
+ * case: a release matching no row means the product row moved on and the units
+ * are still missing. That is a different situation for the operator than a
+ * clean release, and the caller words it differently.
+ */
+async function releaseStock(ctx: ToolContext, taken: ResolvedOrderLine[]): Promise<boolean> {
+  if (taken.length === 0) return true;
+
+  try {
+    const results = await ctx.db.batch(
+      taken.map((line) => {
+        const { sql, params } = buildStockRestore(line);
+        return ctx.db.prepare(sql).bind(...params);
+      })
+    );
+
+    const missed = taken.filter((_, i) => !stockUpdateApplied(results[i]));
+    if (missed.length > 0) {
+      console.error(
+        "createOrder: stock release matched no row — units still reserved against no order",
+        missed.map((line) => ({
+          product_id: line.productId,
+          variant_id: line.variantId,
+          quantity: line.quantity,
+        }))
+      );
+      return false;
+    }
+    return true;
+  } catch (err) {
+    console.error("createOrder: stock release failed — units still reserved against no order", err);
+    return false;
+  }
+}
+
+/**
+ * Reserves every line, or nothing. On refusal, the lines that did reserve are
+ * released — and only those: crediting back a decrement that never applied
+ * would invent stock, which is how a compensation turns into a second bug.
+ */
+async function reserveStock(
+  ctx: ToolContext,
+  lines: ResolvedOrderLine[]
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  let results: D1Result[];
+  try {
+    results = await ctx.db.batch(
+      lines.map((line) => {
+        const { sql, params } = buildStockDecrement(line);
+        return ctx.db.prepare(sql).bind(...params);
+      })
+    );
+  } catch (err) {
+    // A statement that *fails* (as opposed to matching no row) rolls the whole
+    // sequence back, so nothing was taken and there is nothing to release.
+    console.error("createOrder: stock reservation batch failed, nothing reserved", err);
+    return { ok: false, error: RESERVATION_UNAVAILABLE };
+  }
+
+  const refusedIndex = lines.findIndex((_, i) => !stockUpdateApplied(results[i]));
+  if (refusedIndex === -1) return { ok: true };
+
+  const reserved = lines.filter((_, i) => stockUpdateApplied(results[i]));
+  const released = await releaseStock(ctx, reserved);
+  const productName = lines[refusedIndex].productName;
+
+  return {
+    ok: false,
+    error: released ? outOfStockReleased(productName) : outOfStockNotReleased(productName),
+  };
 }
 
 export async function createOrder(
@@ -194,6 +319,14 @@ export async function createOrder(
   const deliveryFee = zone.fee;
   const total = subtotal + deliveryFee;
 
+  // Reserve the stock first, in a batch of its own, and stop here if any line
+  // is refused — see the block comment above reserveStock for why this cannot
+  // ride in the same batch as the order write.
+  const reservation = await reserveStock(ctx, lines);
+  if (!reservation.ok) {
+    return { success: false, error: reservation.error };
+  }
+
   // Generate order number and id
   const orderId = generateId();
   const orderNumber = generateOrderNumber();
@@ -247,22 +380,24 @@ export async function createOrder(
       )
   );
 
-  // Decrement stock for each item
-  const stockDecrements = lines.map((line) =>
-    line.variantId
-      ? ctx.db
-          .prepare("UPDATE product_variants SET stock_quantity = stock_quantity - ? WHERE id = ?")
-          .bind(line.quantity, line.variantId)
-      : ctx.db
-          .prepare("UPDATE products SET stock_quantity = stock_quantity - ? WHERE id = ?")
-          .bind(line.quantity, line.productId)
-  );
-
   const clearCart = ctx.db
     .prepare(`DELETE FROM whatsapp_carts WHERE session_id = ?`)
     .bind(ctx.session.id);
 
-  await ctx.db.batch([insertOrder, ...insertItemStatements, ...stockDecrements, clearCart]);
+  // The stock is already held at this point. If this batch fails, D1 rolls the
+  // whole sequence back — no order, no lines, cart untouched — but the
+  // reservation was a separate, already-committed batch and has to be undone
+  // by hand, or those units stay held against an order that does not exist.
+  try {
+    await ctx.db.batch([insertOrder, ...insertItemStatements, clearCart]);
+  } catch (err) {
+    console.error(`createOrder: order write failed for ${orderNumber}, releasing reserved stock`, err);
+    const released = await releaseStock(ctx, lines);
+    return {
+      success: false,
+      error: released ? ORDER_WRITE_FAILED_RELEASED : ORDER_WRITE_FAILED_NOT_RELEASED,
+    };
+  }
 
   return {
     success: true,

--- a/workers/whatsapp/src/tools/orders.ts
+++ b/workers/whatsapp/src/tools/orders.ts
@@ -1,14 +1,38 @@
 import type { ToolContext, ToolResult } from "../types";
+// Shared with the web checkout on purpose: order-line pricing has exactly one
+// implementation in this repo. It is a pure module whose only import is an
+// `import type`, so nothing is pulled into the Worker bundle.
+import {
+  resolveOrderLine,
+  countActiveVariantsByProduct,
+  calculateSubtotal,
+} from "../../../../lib/utils/checkout";
 
 interface CartItemRow {
   cart_item_id: string;
   product_id: string;
   variant_id: string | null;
   product_name: string;
-  variant_name: string | null;
+  base_price: number;
+  product_stock: number;
   quantity: number;
-  unit_price: number;
+}
+
+interface ActiveVariantRow {
+  id: string;
+  product_id: string;
+  name: string;
+  price: number;
   stock_quantity: number;
+}
+
+interface ResolvedOrderLine {
+  productId: string;
+  variantId: string | null;
+  productName: string;
+  variantName: string | null;
+  unitPrice: number;
+  quantity: number;
 }
 
 interface DeliveryZoneRow {
@@ -50,17 +74,17 @@ export async function createOrder(
     };
   }
 
-  // Fetch cart items with product/variant info and stock
+  // Fetch cart items with the product's own figures. Prices are NOT read from
+  // this query: the unit price is decided by resolveOrderLine below, from the
+  // active variant when the product has any.
   const { results: cartItems } = await ctx.db
     .prepare(
       `SELECT wc.id as cart_item_id, p.id as product_id, wc.variant_id,
-              p.name as product_name, pv.name as variant_name,
-              wc.quantity,
-              COALESCE(pv.price, p.base_price) as unit_price,
-              COALESCE(pv.stock_quantity, p.stock_quantity) as stock_quantity
+              p.name as product_name, p.base_price,
+              p.stock_quantity as product_stock,
+              wc.quantity
        FROM whatsapp_carts wc
        JOIN products p ON wc.product_id = p.id
-       LEFT JOIN product_variants pv ON wc.variant_id = pv.id
        WHERE wc.session_id = ?`
     )
     .bind(ctx.session.id)
@@ -70,17 +94,68 @@ export async function createOrder(
     return { success: false, error: "Your cart is empty. Add items before placing an order." };
   }
 
-  // Validate stock for each item
+  // Fetch every ACTIVE variant of every product in the cart — not just the ones
+  // referenced by a variant_id. This yields each product's activeVariantCount
+  // without a second COUNT query, and guarantees a variant can only resolve for
+  // a product actually in this cart.
+  const productIds = [...new Set(cartItems.map((item) => item.product_id))];
+  const placeholders = productIds.map(() => "?").join(",");
+  const { results: activeVariantRows } = await ctx.db
+    .prepare(
+      `SELECT id, product_id, name, price, stock_quantity
+       FROM product_variants
+       WHERE product_id IN (${placeholders}) AND is_active = 1`
+    )
+    .bind(...productIds)
+    .all<ActiveVariantRow>();
+
+  const activeVariants = activeVariantRows ?? [];
+  const variantById = new Map(activeVariants.map((v) => [v.id, v]));
+  const activeVariantCountByProduct = countActiveVariantsByProduct(activeVariants);
+
+  // Resolve the price and stock of every line. base_price is a display figure
+  // for a product sold through variants, never a sellable price — a line with
+  // no variant on such a product stops the order here.
+  const lines: ResolvedOrderLine[] = [];
+
   for (const item of cartItems) {
-    if (item.stock_quantity < item.quantity) {
-      const name = item.variant_name
-        ? `${item.product_name} – ${item.variant_name}`
-        : item.product_name;
-      return {
-        success: false,
-        error: `Insufficient stock for "${name}". Only ${item.stock_quantity} unit(s) available.`,
-      };
+    let variant: ActiveVariantRow | null = null;
+    if (item.variant_id) {
+      const candidate = variantById.get(item.variant_id);
+      if (!candidate || candidate.product_id !== item.product_id) {
+        return {
+          success: false,
+          error: `La variante choisie pour ${item.product_name} n'est plus disponible. Veuillez en sélectionner une autre.`,
+        };
+      }
+      variant = candidate;
     }
+
+    const resolved = resolveOrderLine({
+      product: {
+        name: item.product_name,
+        base_price: item.base_price,
+        stock_quantity: item.product_stock,
+        activeVariantCount: activeVariantCountByProduct.get(item.product_id) ?? 0,
+      },
+      variant: variant
+        ? { name: variant.name, price: variant.price, stock_quantity: variant.stock_quantity }
+        : null,
+      quantity: item.quantity,
+    });
+
+    if (!resolved.ok) {
+      return { success: false, error: resolved.error };
+    }
+
+    lines.push({
+      productId: item.product_id,
+      variantId: variant?.id ?? null,
+      productName: item.product_name,
+      variantName: variant?.name ?? null,
+      unitPrice: resolved.unitPrice,
+      quantity: item.quantity,
+    });
   }
 
   // Look up delivery zone by commune
@@ -102,7 +177,7 @@ export async function createOrder(
   }
 
   // Calculate totals
-  const subtotal = cartItems.reduce((sum, item) => sum + item.quantity * item.unit_price, 0);
+  const subtotal = calculateSubtotal(lines);
   const deliveryFee = zone.fee;
   const total = subtotal + deliveryFee;
 
@@ -138,7 +213,7 @@ export async function createOrder(
       estimatedDelivery
     );
 
-  const insertItemStatements = cartItems.map((item) =>
+  const insertItemStatements = lines.map((line) =>
     ctx.db
       .prepare(
         `INSERT INTO order_items (
@@ -149,25 +224,25 @@ export async function createOrder(
       .bind(
         generateId(),
         orderId,
-        item.product_id,
-        item.variant_id ?? null,
-        item.product_name,
-        item.variant_name ?? null,
-        item.quantity,
-        item.unit_price,
-        item.quantity * item.unit_price
+        line.productId,
+        line.variantId,
+        line.productName,
+        line.variantName,
+        line.quantity,
+        line.unitPrice,
+        line.quantity * line.unitPrice
       )
   );
 
   // Decrement stock for each item
-  const stockDecrements = cartItems.map((item) =>
-    item.variant_id
+  const stockDecrements = lines.map((line) =>
+    line.variantId
       ? ctx.db
           .prepare("UPDATE product_variants SET stock_quantity = stock_quantity - ? WHERE id = ?")
-          .bind(item.quantity, item.variant_id)
+          .bind(line.quantity, line.variantId)
       : ctx.db
           .prepare("UPDATE products SET stock_quantity = stock_quantity - ? WHERE id = ?")
-          .bind(item.quantity, item.product_id)
+          .bind(line.quantity, line.productId)
   );
 
   const clearCart = ctx.db
@@ -184,7 +259,7 @@ export async function createOrder(
       delivery_fee: deliveryFee,
       total,
       estimated_delivery: estimatedDelivery,
-      item_count: cartItems.length,
+      item_count: lines.length,
     },
   };
 }

--- a/workers/whatsapp/src/tools/orders.ts
+++ b/workers/whatsapp/src/tools/orders.ts
@@ -19,6 +19,7 @@ import {
   productGoneFromCatalogue,
   variantGoneFromCatalogue,
 } from "./line-issues";
+import { requireActiveCustomer } from "./guards";
 
 interface CartItemRow {
   cart_item_id: string;
@@ -199,11 +200,15 @@ export async function createOrder(
   ctx: ToolContext,
   params: { address: string; commune: string; phone: string; instructions?: string }
 ): Promise<ToolResult & { data?: unknown }> {
-  if (ctx.session.is_verified !== 1 || !ctx.session.user_id) {
-    return {
-      success: false,
-      error: "Your account is not linked. Please link your account before placing an order.",
-    };
+  // Verified *and* not suspended, re-read from the user row on every call —
+  // `whatsapp_sessions.is_verified` is set once at OTP time and never revisited,
+  // so it cannot carry a ban decided afterwards. See ./guards.ts.
+  const customer = await requireActiveCustomer(
+    ctx,
+    "Your account is not linked. Please link your account before placing an order."
+  );
+  if (!customer.ok) {
+    return { success: false, error: customer.error };
   }
 
   // Fetch cart items with the product's own figures. Prices are NOT read from
@@ -347,7 +352,7 @@ export async function createOrder(
     )
     .bind(
       orderId,
-      ctx.session.user_id,
+      customer.userId,
       orderNumber,
       subtotal,
       deliveryFee,
@@ -416,11 +421,12 @@ export async function getOrderStatus(
   ctx: ToolContext,
   params: { order_number: string }
 ): Promise<ToolResult & { data?: unknown }> {
-  if (ctx.session.is_verified !== 1 || !ctx.session.user_id) {
-    return {
-      success: false,
-      error: "Your account is not linked. Please link your account to view orders.",
-    };
+  const customer = await requireActiveCustomer(
+    ctx,
+    "Your account is not linked. Please link your account to view orders."
+  );
+  if (!customer.ok) {
+    return { success: false, error: customer.error };
   }
 
   const order = await ctx.db
@@ -429,7 +435,7 @@ export async function getOrderStatus(
        FROM orders
        WHERE order_number = ? AND user_id = ?`
     )
-    .bind(params.order_number, ctx.session.user_id)
+    .bind(params.order_number, customer.userId)
     .first<OrderRow>();
 
   if (!order) {
@@ -455,11 +461,12 @@ export async function listOrders(
   ctx: ToolContext,
   params: { limit?: number }
 ): Promise<ToolResult & { data?: unknown }> {
-  if (ctx.session.is_verified !== 1 || !ctx.session.user_id) {
-    return {
-      success: false,
-      error: "Your account is not linked. Please link your account to view orders.",
-    };
+  const customer = await requireActiveCustomer(
+    ctx,
+    "Your account is not linked. Please link your account to view orders."
+  );
+  if (!customer.ok) {
+    return { success: false, error: customer.error };
   }
 
   const limit = Math.max(1, Math.min(params.limit ?? 5, 10));
@@ -472,7 +479,7 @@ export async function listOrders(
        ORDER BY created_at DESC
        LIMIT ?`
     )
-    .bind(ctx.session.user_id, limit)
+    .bind(customer.userId, limit)
     .all<Pick<OrderRow, "order_number" | "status" | "total" | "created_at">>();
 
   return {

--- a/workers/whatsapp/src/tools/orders.ts
+++ b/workers/whatsapp/src/tools/orders.ts
@@ -7,6 +7,11 @@ import {
   countActiveVariantsByProduct,
   calculateSubtotal,
 } from "../../../../lib/utils/checkout";
+import {
+  isProductInCatalogue,
+  productGoneFromCatalogue,
+  variantGoneFromCatalogue,
+} from "./line-issues";
 
 interface CartItemRow {
   cart_item_id: string;
@@ -15,6 +20,8 @@ interface CartItemRow {
   product_name: string;
   base_price: number;
   product_stock: number;
+  product_is_active: number;
+  product_is_draft: number;
   quantity: number;
 }
 
@@ -82,6 +89,7 @@ export async function createOrder(
       `SELECT wc.id as cart_item_id, p.id as product_id, wc.variant_id,
               p.name as product_name, p.base_price,
               p.stock_quantity as product_stock,
+              p.is_active as product_is_active, p.is_draft as product_is_draft,
               wc.quantity
        FROM whatsapp_carts wc
        JOIN products p ON wc.product_id = p.id
@@ -119,14 +127,19 @@ export async function createOrder(
   const lines: ResolvedOrderLine[] = [];
 
   for (const item of cartItems) {
+    // is_active / is_draft are read as columns rather than filtered in the
+    // JOIN on purpose: filtering would make the line vanish from the result
+    // set and the order would go through for the remaining items, at a
+    // quietly smaller total. The line must stop the order, not disappear.
+    if (!isProductInCatalogue(item)) {
+      return { success: false, error: productGoneFromCatalogue(item.product_name) };
+    }
+
     let variant: ActiveVariantRow | null = null;
     if (item.variant_id) {
       const candidate = variantById.get(item.variant_id);
       if (!candidate || candidate.product_id !== item.product_id) {
-        return {
-          success: false,
-          error: `La variante choisie pour ${item.product_name} n'est plus disponible. Veuillez en sélectionner une autre.`,
-        };
+        return { success: false, error: variantGoneFromCatalogue(item.product_name) };
       }
       variant = candidate;
     }

--- a/workers/whatsapp/src/tools/registry.ts
+++ b/workers/whatsapp/src/tools/registry.ts
@@ -88,7 +88,8 @@ export const TOOL_DEFINITIONS: ToolDefinition[] = [
     type: "function",
     function: {
       name: "cart_view",
-      description: "Show the current WhatsApp cart contents and subtotal.",
+      description:
+        "Show the current WhatsApp cart contents and subtotal. An item with unit_price null cannot be ordered as it stands — read its `issue` to the customer and never quote a price for it. The subtotal covers only orderable items, so do not present it as a final total when has_blocking_issues is true.",
       parameters: { type: "object", properties: {} },
     },
   },

--- a/workers/whatsapp/src/whatsapp-api.ts
+++ b/workers/whatsapp/src/whatsapp-api.ts
@@ -1,5 +1,25 @@
 const GRAPH_API_BASE = "https://graph.facebook.com/v21.0";
 
+/**
+ * Wall-clock ceiling on a single Graph API round trip.
+ *
+ * Nothing here runs on the webhook's acknowledgement path — `index.ts` returns
+ * 200 to Meta immediately and hands the work to `ctx.waitUntil`, so the 5s
+ * webhook budget is not what this protects. What it protects is the deferred
+ * budget: a request that never settles holds that work open until the runtime
+ * cancels it, taking every later step with it — the remaining admin phones on
+ * an escalation, the context save and the outbound log on a customer reply.
+ *
+ * Ten seconds is roughly an order of magnitude above a normal send, so a
+ * slow-but-working call is never recorded as a failure. That direction matters
+ * more than tightness here: a false failure would tell a customer nobody was
+ * reached, and would skip the acknowledgement marker, for a call that in fact
+ * succeeded. Cutting it to one or two seconds would buy nothing — the sends
+ * are dispatched concurrently, so the worst case is one timeout, not one per
+ * recipient.
+ */
+const REQUEST_TIMEOUT_MS = 10_000;
+
 export class WhatsAppAPI {
   private url: string;
   private headers: Record<string, string>;
@@ -35,16 +55,23 @@ export class WhatsAppAPI {
         status: "read",
         message_id: messageId,
       }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
   }
 
   private async send(
     payload: Record<string, unknown>
   ): Promise<{ success: boolean; messageId?: string; error?: string }> {
+    // A timeout surfaces as a rejection, exactly like any other network
+    // failure. The throw/return contract is left as it was on purpose: every
+    // caller already guards a rejected send, and turning failures into a
+    // returned `{ success: false }` here would silently change which branch
+    // the orchestrator takes on a failed customer reply.
     const response = await fetch(this.url, {
       method: "POST",
       headers: this.headers,
       body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
 
     const data = (await response.json()) as Record<string, unknown>;

--- a/workers/whatsapp/tsconfig.json
+++ b/workers/whatsapp/tsconfig.json
@@ -11,7 +11,11 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "paths": {
-      "@db/*": ["../../lib/db/*"]
+      "@db/*": ["../../lib/db/*"],
+      // Shared pure modules under lib/ (e.g. lib/utils/checkout.ts) are imported
+      // relatively from src/; this mapping only resolves the `@/...` type-only
+      // imports *inside* them. Nothing here reaches the Worker bundle.
+      "@/*": ["../../*"]
     }
   },
   "include": ["src/**/*.ts", "../../lib/db/schema.ts"],


### PR DESCRIPTION
Cinquième lot de la remédiation issue de l'audit de sécurité de juillet 2026. Fait hériter au Worker WhatsApp les garanties que le parcours web possède déjà.

Adresse `GHSA-wfww-7qvh-mpjh` (HIGH), `GHSA-3r6j-fwpf-p7mg` (MEDIUM), `GHSA-hp62-67jc-x6r4` (MEDIUM), `GHSA-7hm6-hwvj-j3rx` (LOW).

## ⚠️ À lire avant de merger

### Le bot WhatsApp n'est pas actif

Vérifié en production : `whatsapp_config.is_active = 0`, `phone_number_id` et `access_token` absents, **0 session, 0 message, 0 ligne de panier**. Seul `display_phone_number` est renseigné — c'est le numéro public qui alimente les boutons `wa.me` de la boutique, indépendant du bot conversationnel.

**Rien de ce lot ne ferme une faille exploitable aujourd'hui.** C'est du durcissement avant mise en service. Deux champs de configuration suffiraient à activer le canal, et ce jour-là personne ne relira ce code — d'où le même niveau d'exigence que sur les lots précédents.

### Trois commits touchent le parcours web, pas le bot

Chacun a été trouvé en tentant de **partager** une fonction avec le bot plutôt que de la copier. C'est l'élément le plus risqué de cette branche, et le plus utile.

| Commit | Ce qu'il corrige |
|---|---|
| `7090bc1` | **Perte définitive de stock au tunnel de commande.** Le rollback ne restituait que `items.slice(0, i)` — les lignes *après* celle refusée restaient décrémentées contre une commande supprimée, sans aucun chemin pour les libérer. Advisory `GHSA-9jf3-6g2m-xxpf` ouverte. |
| `6705ec1` | Le prédicat de bannissement **échouait en ouvert** : une date d'expiration illisible donnait `NaN > Date.now()`, donc `false` — un compte banni lu comme non banni. |
| `7f1fabd` | Le limiteur KV n'appliquait son plancher de 60 s qu'à l'incrément, pas à l'ouverture de fenêtre : toute fenêtre sous la minute aurait levé au premier appel. Latent, la plus courte livrée étant de 600 s. |

Les trois ont été vérifiés par mutation dans les deux sens, et la relecture de branche confirme que le web se comporte exactement comme avant.

## Ce que contient le lot

- **La tarification par variante ne peut plus retomber sur le prix de base.** Mesuré en production : 92 variantes ont un prix différent du prix de base, écart maximal **1 150 000 XOF**. Le bot réutilise `resolveOrderLine`, la fonction du web, plutôt qu'une quatrième copie.
- **Le bot ne vend plus ce que le catalogue ne porte plus** — asymétrie avec le web trouvée en chemin (66 produits inactifs ou brouillons sur 845).
- **Réservation atomique du stock** : décréments gardés, `meta.changes` vérifié, et libération de ce qui a réellement été réservé — jamais de la ligne refusée.
- **Les suspensions de compte s'appliquent au canal**, via un prédicat extrait dans un module partagé que `guards.ts` consomme aussi, donc sans copie qui dériverait.
- **Les alertes d'escalade vers le personnel sont encadrées et limitées.** Le texte du client est borné, débarrassé des contrôles invisibles (bidirectionnels, largeur nulle, BOM, C0/C1 dont le NEL que `\s` ne couvre pas en JavaScript) et enfermé dans un bloc délimité. Vérifié : la structure du message reste **invariante** — six lignes, un seul champ `Client:` — quelle que soit l'entrée.

## Vérifications

`tsc --noEmit` racine et Worker propres, ESLint propre, **1 385 tests**, aucune migration.

**Deux gardes de coût réécrits, et c'est une correction de ma part.** Ils asseyaient leur budget sur une durée absolue de 3 000 ms — confortable sur une machine à seize cœurs au repos, insuffisant sur un runner CI à deux cœurs partagés. Reproduit : sous trois suites concurrentes, les mêmes formes prennent 5,5 à 12 secondes, donc le garde aurait fait échouer le commit d'un tiers. Le budget est désormais un multiple d'une calibration mesurée dans le même processus, de durée comparable — le rapport tient entre 6,6 et 11,9 dans toutes les conditions pendant que le temps absolu varie d'un facteur six. Six suites complètes vertes, et la régression quadratique réintroduite le fait toujours échouer à 227 secondes.

**Un sixième test incapable d'échouer, trouvé et corrigé.** La garde refusant un `variant_id` devenu introuvable n'était épinglée par rien : supprimée, la suite complète de 1 380 tests restait verte. Deux tests vérifiaient `/variante/i`, motif que **les deux** messages de refus contiennent, donc ils passaient quelle que soit la règle déclenchée ; un troisième ne vérifiait que `success: false`. Corrigé en assertant le message propre à la garde, et en couvrant le cas `active_variant_count: 0` — celui où elle est la seule protection. La mutation fait désormais échouer 5 tests.

## Suites connues, non traitées ici

- `whatsapp_sessions.status = 'escalated'` est **inerte** : le bot continue de répondre à une session escaladée, donc un client et un conseiller peuvent se parler par-dessus. À fermer avant la mise en service.
- `cart_update` est le seul outil de panier non aligné : pas de contrôle catalogue. Ne peut pas survendre — le paiement revérifie — mais peut citer une ligne que le paiement refusera. La requête corrigée est écrite dans le rapport de tâche.
- Les URL du texte client restent cliquables dans l'alerte au personnel : délibéré, les neutraliser casserait du contenu légitime.
- Le limiteur reste au mieux-effort : KV n'a pas d'incrément atomique.
- La réservation en deux temps laisse une fenêtre où du stock est retenu sans commande — assumé, car l'alternative est une commande confirmée non honorable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
