### PR TITLE
fix(storefront): route descriptions on their real format, not description_type

### DIFF
--- a/__tests__/unit/description-to-html.test.ts
+++ b/__tests__/unit/description-to-html.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { descriptionToHtml } from "@/lib/utils/description-to-html";
 
 describe("descriptionToHtml", () => {
@@ -115,8 +115,70 @@ describe("descriptionToHtml with description_type", () => {
     expect(descriptionToHtml("", "richtext")).toBe("");
   });
 
-  it("returns empty for non-JSON content with richtext type", () => {
-    expect(descriptionToHtml("plain text product description", "richtext")).toBe("");
+  // ── description_type lies about the content (issue #145) ───────────────────
+  //
+  // `description_type` records what the admin editor MEANT to store, not what
+  // the column actually holds. Rows written before the rich-text editor shipped
+  // — or repaired by hand in D1 — carry type "richtext" over plain text or
+  // legacy HTML. Those must render on their real format, not be swallowed.
+
+  it("renders plain text stored under richtext type", () => {
+    expect(descriptionToHtml("L'iPhone 17 Pro est le dernier modele.", "richtext")).toBe(
+      "<p>L&#39;iPhone 17 Pro est le dernier modele.</p>",
+    );
+  });
+
+  it("paragraphs multi-line plain text stored under richtext type", () => {
+    expect(descriptionToHtml("Para one\n\nPara two\nsuite", "richtext")).toBe(
+      "<p>Para one</p><p>Para two<br>suite</p>",
+    );
+  });
+
+  it("escapes HTML-special characters in plain text stored under richtext type", () => {
+    expect(descriptionToHtml('Ecran 6" & <promo>', "richtext")).toBe(
+      "<p>Ecran 6&quot; &amp; &lt;promo&gt;</p>",
+    );
+  });
+
+  it("sanitizes legacy HTML stored under richtext type", () => {
+    const result = descriptionToHtml(
+      '<p>Hello <strong>world</strong></p><script>alert("xss")</script>',
+      "richtext",
+    );
+    expect(result).not.toContain("<script>");
+    expect(result).toContain("<p>Hello <strong>world</strong></p>");
+  });
+
+  it("does not log when plain text is stored under richtext type", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      descriptionToHtml("plain text product description", "richtext");
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  // ── Non-regression: genuine data anomalies must still be reported ──────────
+
+  it("still logs and returns empty for malformed JSON under richtext type", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(descriptionToHtml('{"root": {broken}', "richtext")).toBe("");
+      expect(spy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("still logs and returns empty for JSON without a root key under richtext type", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(descriptionToHtml('{"foo":"bar"}', "richtext")).toBe("");
+      expect(spy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("sanitizes HTML at read time for defense-in-depth", () => {

--- a/lib/utils/description-to-html.ts
+++ b/lib/utils/description-to-html.ts
@@ -13,6 +13,19 @@ import { sanitizeDescriptionHtml } from "./sanitize-html";
  * All three paths produce sanitized HTML safe for `dangerouslySetInnerHTML`.
  * Legacy HTML sanitization uses an allowlist-based regex pass; this is
  * intentionally limited to admin-authored content (not end-user input).
+ *
+ * `type` (the `description_type` column) selects the editor that OWNS the
+ * content, and only `"html"` — whose payload is by definition raw markup that
+ * must not be re-detected — routes on it alone. `"richtext"` is a claim about
+ * the writer, not a guarantee about the bytes: rows predating the rich-text
+ * editor, and rows patched by hand in D1, carry that type over plain text or
+ * legacy HTML. Trusting the claim sent those through `JSON.parse`, which threw,
+ * logged, and returned "" — the description simply vanished from the product
+ * page (issue #145). So the Lexical branch is entered on the content's actual
+ * shape instead. A serialized Lexical state is always a JSON object, so
+ * `{`-prefixed content is exactly the set that branch should claim, and content
+ * that both starts with `{` and fails to parse stays a reported anomaly rather
+ * than being quietly rendered as prose.
  */
 export function descriptionToHtml(raw: string, type?: string): string {
   if (!raw) return "";
@@ -24,7 +37,7 @@ export function descriptionToHtml(raw: string, type?: string): string {
     return sanitizeDescriptionHtml(trimmed);
   }
 
-  if (type === "richtext" || trimmed.startsWith("{")) {
+  if (trimmed.startsWith("{")) {
     let state: unknown;
     try {
       state = JSON.parse(trimmed);


### PR DESCRIPTION
## Le cas reproduit

Un produit dont la colonne `description_type` vaut `"richtext"` mais dont la colonne `description` contient du **texte brut** (pas du JSON Lexical).

`lib/utils/description-to-html.ts` routait sur `type === "richtext" || trimmed.startsWith("{")`. Le premier terme suffisait : le texte brut partait dans `JSON.parse`, qui levait une `SyntaxError`, la journalisait et renvoyait `""`.

Conséquence : **la description ne s'affichait pas** sur la fiche produit, et chaque requête re-journalisait l'erreur.

Sortie réelle du test rouge avant correctif :

```
FAIL  does not log when plain text is stored under richtext type
AssertionError: expected "error" to not be called at all, but actually been called 1 times
  1st error call:
    "[description-to-html] JSON.parse failed — returning empty",
    [SyntaxError: Unexpected token 'p', "plain text"... is not valid JSON],
    { "prefix": "plain text product description" }
```

## Ce qui change

`description_type` dit quel **éditeur** possède le contenu, pas ce que les octets **sont** réellement. Les lignes antérieures à l'éditeur rich-text, et celles corrigées à la main dans D1, portent `"richtext"` sur du texte brut ou du HTML legacy.

La branche Lexical s'appuie désormais sur la forme réelle du contenu (préfixe `{`) plutôt que sur cette déclaration. Ces lignes retombent donc sur les branches HTML-legacy et texte-brut existantes — celles qui les traitaient déjà correctement quand `type` était absent.

Un état Lexical sérialisé est toujours un objet JSON, donc le contenu préfixé par `{` est exactement l'ensemble que cette branche doit revendiquer : le terme `type === "richtext"` était redondant dans le cas nominal, et faux positif dans tous les autres.

## Non-régressions vérifiées (tests ajoutés)

- `type === "html"` passe toujours par `sanitizeDescriptionHtml`.
- Contenu commençant par `{` mais dont le `JSON.parse` échoue → journalise **toujours** et renvoie `""` (vraie anomalie de données, pas un faux positif).
- JSON valide sans clé `root` → journalise toujours et renvoie `""`.

## Sécurité

Aucun nouveau chemin de sortie n'a été créé. Les trois sorties restent assainies (`escapeHtml` + paragraphage, `sanitizeLegacyHtml`, `sanitizeDescriptionHtml`). Le correctif ne fait que **rediriger** vers des branches déjà assainies — il ne contourne rien. Un test couvre explicitement le HTML legacy sous `type="richtext"` avec une balise `<script>` : elle est bien retirée.

## Vérification

TDD strict : les 5 nouveaux tests ont d'abord échoué pour la bonne raison (`SyntaxError` journalisée, `""` renvoyé), puis passent après le correctif.

```
npx tsc --noEmit     # OK
npm run lint         # OK
npx vitest run       # Test Files 83 passed (83) | Tests 1396 passed (1396)
```

Le hook pre-commit (tsc + eslint + vitest) est passé sans `--no-verify`.

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGMDCzf2UnxoR71tws5wRS
