### PR TITLE
fix(admin): raise product-wizard step-variants buttons to the 44px touch target

### DIFF
--- a/__tests__/unit/components/product-wizard-touch-targets.test.ts
+++ b/__tests__/unit/components/product-wizard-touch-targets.test.ts
@@ -18,6 +18,24 @@ const SOURCE = readFileSync(
 const BUTTON_SIZE_RE = /<Button\b[^>]*?\bsize="([^"]+)"/g;
 const TOUCH_SIZES = ["touch", "icon-touch"];
 
+/**
+ * Vrai pour une classe de dimension non préfixée qui rendrait le bouton plus court
+ * que 44 px. Décide sur la valeur plutôt que sur une énumération : une liste figée
+ * (`h-0`…`h-10`) laissait passer `size-10` — la famille même qui pilote les boutons
+ * icônes — et les valeurs arbitraires comme `h-[40px]`.
+ */
+function isSubTouch(token: string): boolean {
+  const match = /^(?:h|size)-(.+)$/.exec(token);
+  if (!match) return false;
+  const value = match[1];
+  // Échelle Tailwind : 1 unité = 4 px, donc 44 px = 11.
+  if (/^\d+(?:\.\d+)?$/.test(value)) return parseFloat(value) * 4 < 44;
+  const arbitraryPx = /^\[(\d+(?:\.\d+)?)px\]$/.exec(value);
+  if (arbitraryPx) return parseFloat(arbitraryPx[1]) < 44;
+  // rem, %, calc()… non décidables statiquement : hors périmètre de ce garde.
+  return false;
+}
+
 describe("step-variants — cibles tactiles 44 px (#147)", () => {
   it("déclare une taille explicite sur chaque <Button>", () => {
     const buttonCount = (SOURCE.match(/<Button\b/g) ?? []).length;
@@ -39,7 +57,7 @@ describe("step-variants — cibles tactiles 44 px (#147)", () => {
     const classNames = [...SOURCE.matchAll(/className="([^"]*)"/g)].map((m) => m[1]);
     const subTouch = classNames
       .flatMap((cls) => cls.split(/\s+/))
-      .filter((token) => /^h-(?:[0-9]|10)$/.test(token));
+      .filter(isSubTouch);
     expect(subTouch).toEqual([]);
   });
 });

--- a/__tests__/unit/components/product-wizard-touch-targets.test.ts
+++ b/__tests__/unit/components/product-wizard-touch-targets.test.ts
@@ -1,0 +1,45 @@
+// __tests__/unit/components/product-wizard-touch-targets.test.ts
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Le design system NETEREKA impose une cible tactile minimale de 44 px (CLAUDE.md).
+ * Les tailles `touch` / `icon-touch` du composant Button valent h-11 / size-11 (44 px).
+ * Ce test verrouille la correction de l'issue #147 : tous les boutons de
+ * step-variants.tsx doivent partir d'une taille conforme, la densité desktop
+ * étant restaurée via les overrides `sm:` (motif de app/(admin)/products/page.tsx).
+ */
+const SOURCE = readFileSync(
+  resolve(__dirname, "../../..", "components/admin/product-wizard/step-variants.tsx"),
+  "utf8",
+);
+
+const BUTTON_SIZE_RE = /<Button\b[^>]*?\bsize="([^"]+)"/g;
+const TOUCH_SIZES = ["touch", "icon-touch"];
+
+describe("step-variants — cibles tactiles 44 px (#147)", () => {
+  it("déclare une taille explicite sur chaque <Button>", () => {
+    const buttonCount = (SOURCE.match(/<Button\b/g) ?? []).length;
+    const sized = [...SOURCE.matchAll(BUTTON_SIZE_RE)];
+    expect(buttonCount).toBeGreaterThan(0);
+    expect(sized).toHaveLength(buttonCount);
+  });
+
+  it("utilise uniquement des tailles conformes (touch / icon-touch)", () => {
+    const sizes = [...SOURCE.matchAll(BUTTON_SIZE_RE)].map((m) => m[1]);
+    expect(sizes.length).toBeGreaterThan(0);
+    for (const size of sizes) {
+      expect(TOUCH_SIZES).toContain(size);
+    }
+  });
+
+  it("ne réintroduit pas de hauteur sous 44 px en mobile", () => {
+    // Les overrides de hauteur ne sont tolérés que derrière un breakpoint (sm:, md:…)
+    const classNames = [...SOURCE.matchAll(/className="([^"]*)"/g)].map((m) => m[1]);
+    const subTouch = classNames
+      .flatMap((cls) => cls.split(/\s+/))
+      .filter((token) => /^h-(?:[0-9]|10)$/.test(token));
+    expect(subTouch).toEqual([]);
+  });
+});

--- a/components/admin/product-wizard/step-variants.tsx
+++ b/components/admin/product-wizard/step-variants.tsx
@@ -115,7 +115,8 @@ export function StepVariants({ product, formRef }: StepVariantsProps) {
         <Button
           type="button"
           variant="outline"
-          size="sm"
+          size="touch"
+          className="sm:size-auto sm:h-8 sm:px-3 sm:text-xs"
           disabled={isPending}
           onClick={() => setShowCreate(true)}
         >
@@ -179,9 +180,9 @@ function VariantCard({
       <div className="flex items-center gap-1 shrink-0">
         <Button
           type="button"
-          size="sm"
+          size="touch"
           variant="ghost"
-          className="h-8 text-xs"
+          className="sm:size-auto sm:h-8 sm:px-3 sm:text-xs"
           disabled={isPending}
           onClick={onEdit}
         >
@@ -189,9 +190,9 @@ function VariantCard({
         </Button>
         <Button
           type="button"
-          size="sm"
+          size="touch"
           variant="ghost"
-          className="h-8 text-xs text-destructive hover:text-destructive"
+          className="text-destructive hover:text-destructive sm:size-auto sm:h-8 sm:px-3 sm:text-xs"
           disabled={isPending}
           onClick={onDelete}
         >
@@ -300,13 +301,20 @@ function InlineVariantForm({
         <input type="hidden" name="sort_order" value={variant?.sort_order ?? 0} />
 
         <div className="flex items-center gap-2 pt-1">
-          <Button type="button" size="sm" disabled={isPending} onClick={handleSubmit}>
+          <Button
+            type="button"
+            size="touch"
+            className="sm:size-auto sm:h-8 sm:px-3 sm:text-xs"
+            disabled={isPending}
+            onClick={handleSubmit}
+          >
             {isPending ? "Enregistrement..." : isEdit ? "Mettre à jour" : "Ajouter"}
           </Button>
           <Button
             type="button"
-            size="sm"
+            size="touch"
             variant="ghost"
+            className="sm:size-auto sm:h-8 sm:px-3 sm:text-xs"
             disabled={isPending}
             onClick={onCancel}
           >


### PR DESCRIPTION
## Contexte

`CLAUDE.md`, section **Design System**, impose : *« Accessibility: Min 44px touch targets, mobile-first »*. Les boutons de `components/admin/product-wizard/step-variants.tsx` (étape 5 du wizard produit) étaient tous en dessous.

## ⚠️ L'issue sous-estimait le problème

L'issue #147 décrivait des boutons à **32 px**. Le fichier a évolué depuis sa rédaction : les boutons du formulaire inline (`InlineVariantForm`) n'ont plus d'override de hauteur du tout, la CVA leur applique donc `h-6` — soit **24 px**, moins de la moitié de la cible requise. Les numéros de ligne cités dans l'issue (199, 303-314) sont également périmés. La correction porte sur l'état réel du code, pas sur la description de l'issue.

## Ce qui est corrigé

| Bouton | Avant | Après (mobile) | Après (≥ sm) |
| --- | --- | --- | --- |
| « + Ajouter une variante » | `size="sm"` → **24 px** | `size="touch"` → **44 px** | 32 px |
| « Modifier » (VariantCard) | `size="sm"` + `h-8` → **32 px** | `size="touch"` → **44 px** | 32 px |
| « Supprimer » (VariantCard) | `size="sm"` + `h-8` → **32 px** | `size="touch"` → **44 px** | 32 px |
| Soumission (`InlineVariantForm`) | `size="sm"` → **24 px** | `size="touch"` → **44 px** | 32 px |
| « Annuler » (`InlineVariantForm`) | `size="sm"` → **24 px** | `size="touch"` → **44 px** | 32 px |

Les cinq (et seuls) `<Button>` du fichier sont couverts.

## Approche

Le motif « 44 px en mobile, densité conservée en desktop » existe déjà dans le dépôt — `app/(admin)/products/page.tsx` lignes 153 et 165 :

```tsx
<Button variant="outline" size="touch" asChild className="sm:size-auto sm:h-8 sm:px-3">
```

Il est repris tel quel ici, avec un `sm:text-xs` supplémentaire pour préserver la typographie d'origine du fichier sur grand écran. Aucune nouvelle taille n'a été ajoutée à `components/ui/button.tsx` : `touch` (`h-11`) et `icon-touch` (`size-11`) y existaient déjà depuis la refonte mobile admin.

## Test de non-régression

`__tests__/unit/components/product-wizard-touch-targets.test.ts` (3 assertions) lit la source du composant et vérifie que chaque `<Button>` déclare une taille explicite, que cette taille est `touch` ou `icon-touch`, et qu'aucune classe `h-0`…`h-10` non préfixée par un breakpoint ne réintroduit une hauteur sous-dimensionnée en mobile.

Le harnais Vitest est en `environment: "node"` sans `@testing-library/react` et n'inclut que les `*.test.ts` — un test de rendu n'était pas possible. Le test suit donc le motif d'inspection de source déjà utilisé par `__tests__/unit/admin-page-guards.test.ts`.

Vérifié : le test échoue (2 assertions sur 3) sur le code d'avant le correctif, et passe après.

## Vérifications

- `npx tsc --noEmit` ✅
- `npm run lint` ✅
- `npx vitest run` ✅ — 84 fichiers, 1393 tests

## Non vérifié

Le rendu réel en navigateur (mesure des hauteurs effectives sur un vrai viewport mobile) n'a pas pu être contrôlé dans cet environnement — la validation repose sur les classes Tailwind et la CVA de `Button`.

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGMDCzf2UnxoR71tws5wRS
