### PR TITLE
docs: fix markdownlint and typography issues in plan files

### DIFF
--- a/docs/plans/2026-02-24-cloudflare-image-loader.md
+++ b/docs/plans/2026-02-24-cloudflare-image-loader.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1 : Branche de travail
+## Task 1 : Branche de travail
 
 **Files:**
 - Aucun
@@ -31,7 +31,7 @@ Expected output : `feat/cloudflare-image-loader`
 
 ---
 
-### Task 2 : Tests du loader
+## Task 2 : Tests du loader
 
 **Files:**
 - Create: `__tests__/unit/cloudflare-image-loader.test.ts`
@@ -143,7 +143,7 @@ Expected : FAIL — `Cannot find module '@/lib/utils/cloudflare-image-loader'`
 
 ---
 
-### Task 3 : Implémenter le loader
+## Task 3 : Implémenter le loader
 
 **Files:**
 - Create: `lib/utils/cloudflare-image-loader.ts`
@@ -186,7 +186,7 @@ git commit -m "feat(images): add Cloudflare Image Resizing custom loader"
 
 ---
 
-### Task 4 : Brancher le loader dans Next.js
+## Task 4 : Brancher le loader dans Next.js
 
 **Files:**
 - Modify: `next.config.ts`
@@ -242,7 +242,7 @@ git commit -m "feat(images): plug Cloudflare loader into next.config.ts"
 
 ---
 
-### Task 5 : PR et déploiement
+## Task 5 : PR et déploiement
 
 **Step 1 : Pousser la branche**
 
@@ -288,8 +288,11 @@ EOF
 **Step 3 : Merger**
 
 ```bash
-gh pr merge --squash --delete-branch --admin
+gh pr merge --squash --delete-branch
 ```
+
+> Ne pas ajouter `--admin` : ce flag contourne les protections de branche (CI et revues requises).
+> Attendre que la CI passe et que la PR soit approuvée.
 
 ---
 

--- a/docs/plans/2026-02-26-brand-filter-plan.md
+++ b/docs/plans/2026-02-26-brand-filter-plan.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Créer la branche
+## Task 1: Créer la branche
 
 **Files:**
 - (aucun fichier)
@@ -25,7 +25,7 @@ Expected: `Switched to a new branch 'feat/brand-filter-search'`
 
 ---
 
-### Task 2: Créer le composant `BrandFilter`
+## Task 2: Créer le composant `BrandFilter`
 
 **Files:**
 - Create: `app/(storefront)/search/brand-filter.tsx`
@@ -158,7 +158,7 @@ Expected: le fichier est listé.
 
 ---
 
-### Task 3: Intégrer `BrandFilter` dans `SearchFilters`
+## Task 3: Intégrer `BrandFilter` dans `SearchFilters`
 
 **Files:**
 - Modify: `app/(storefront)/search/search-filters.tsx`
@@ -215,7 +215,7 @@ Le remplacer par :
 
 ---
 
-### Task 4: Vérifier types, lint, et tests
+## Task 4: Vérifier types, lint, et tests
 
 **Step 1: Vérifier les types TypeScript**
 
@@ -243,7 +243,7 @@ Expected: tous les tests passent (les tests existants ne couvrent pas les compos
 
 ---
 
-### Task 5: Commit et PR
+## Task 5: Commit et PR
 
 **Step 1: Stager les fichiers**
 

--- a/docs/plans/2026-02-26-price-filter-plan.md
+++ b/docs/plans/2026-02-26-price-filter-plan.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Créer la branche
+## Task 1: Créer la branche
 
 **Files:** (aucun fichier)
 
@@ -24,7 +24,7 @@ Expected: `Switched to a new branch 'feat/price-filter-slider'`
 
 ---
 
-### Task 2: Installer le composant shadcn Slider
+## Task 2: Installer le composant shadcn Slider
 
 **Files:**
 - Create: `components/ui/slider.tsx` (généré par shadcn)
@@ -55,7 +55,7 @@ Expected: aucune erreur.
 
 ---
 
-### Task 3: Créer le composant `PriceFilter`
+## Task 3: Créer le composant `PriceFilter`
 
 **Files:**
 - Create: `app/(storefront)/search/price-filter.tsx`
@@ -195,7 +195,7 @@ Expected: aucune erreur.
 
 ---
 
-### Task 4: Intégrer `PriceFilter` dans `SearchFilters`
+## Task 4: Intégrer `PriceFilter` dans `SearchFilters`
 
 **Files:**
 - Modify: `app/(storefront)/search/search-filters.tsx`
@@ -296,14 +296,14 @@ export function SearchFilters() {
 ```
 
 Ce qui change par rapport à l'actuel :
-- **Supprimé** : `useState`, `useRef` imports, `Input` import, `formatPrice` import
-- **Supprimé** : `priceState`, `priceTimerRef` state
-- **Supprimé** : le bloc de sync externe prix (lignes 24-29 actuel)
-- **Supprimé** : `handlePriceChange` function
-- **Supprimé** : le `<fieldset>` Prix avec ses deux `<Input>`
-- **Ajouté** : import `PriceFilter`
-- **Ajouté** : `<PriceFilter>` avec les props
-- **Ajouté** : `type="button"` sur le bouton reset (bonne pratique)
+- **Supprimé:** `useState`, `useRef` imports, `Input` import, `formatPrice` import
+- **Supprimé:** `priceState`, `priceTimerRef` state
+- **Supprimé:** le bloc de sync externe prix (lignes 24-29 actuel)
+- **Supprimé:** `handlePriceChange` function
+- **Supprimé:** le `<fieldset>` Prix avec ses deux `<Input>`
+- **Ajouté:** import `PriceFilter`
+- **Ajouté:** `<PriceFilter>` avec les props
+- **Ajouté:** `type="button"` sur le bouton reset (bonne pratique)
 
 **Step 2: Vérifier tsc**
 
@@ -315,7 +315,7 @@ Expected: aucune erreur.
 
 ---
 
-### Task 5: Vérifier types, lint, et tests
+## Task 5: Vérifier types, lint, et tests
 
 **Step 1: TypeScript**
 
@@ -343,7 +343,7 @@ Expected: tous les tests passent (422 tests, composants React non couverts par l
 
 ---
 
-### Task 6: Commit et PR
+## Task 6: Commit et PR
 
 **Step 1: Stager les fichiers**
 

--- a/docs/plans/2026-02-27-product-card-actions.md
+++ b/docs/plans/2026-02-27-product-card-actions.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Create `actions/variants.ts`
+## Task 1: Create `actions/variants.ts`
 
 **Files:**
 - Create: `actions/variants.ts`
@@ -116,7 +116,7 @@ git commit -m "feat(variants): add getProductVariants server action"
 
 ---
 
-### Task 2: Create `components/storefront/variant-picker-dialog.tsx`
+## Task 2: Create `components/storefront/variant-picker-dialog.tsx`
 
 This dialog is opened by `ProductCardActions` when a multi-variant product's cart button is clicked. It fetches variants lazily, lets the user pick one, then adds to cart and closes.
 
@@ -256,7 +256,7 @@ git commit -m "feat(product-card): add VariantPickerDialog for multi-variant pro
 
 ---
 
-### Task 3: Create `components/storefront/product-card-actions.tsx`
+## Task 3: Create `components/storefront/product-card-actions.tsx`
 
 Client component that renders the two action buttons at the bottom of the card.
 
@@ -367,7 +367,7 @@ git commit -m "feat(product-card): add ProductCardActions with cart and wishlist
 
 ---
 
-### Task 4: Integrate `ProductCardActions` into `ProductCard`
+## Task 4: Integrate `ProductCardActions` into `ProductCard`
 
 **Files:**
 - Modify: `components/storefront/product-card.tsx`
@@ -387,7 +387,7 @@ import { ProductCardActions } from "@/components/storefront/product-card-actions
 ```
 
 Final structure inside `<Link>`:
-```
+```tsx
 <Link>
   {/* Image */}
   <div>...</div>
@@ -422,7 +422,7 @@ git commit -m "feat(product-card): integrate cart and wishlist action buttons"
 
 ---
 
-### Task 5: Create branch and open PR
+## Task 5: Create branch and open PR
 
 **Step 1: Create branch (at start of implementation — do this first)**
 

--- a/docs/plans/2026-03-02-lcp-optimization.md
+++ b/docs/plans/2026-03-02-lcp-optimization.md
@@ -223,12 +223,12 @@ git commit -m "perf: add 750w and 1200w to hero preload Link header srcset"
 The fix: extract only the scroll/drag logic into a new `ScrollContainer` client component. `HorizontalSection` becomes a server component and passes `<ProductCard>` children to `ScrollContainer`. In Next.js App Router, server component children passed to a client component are serialized as RSC payload — they are NOT bundled as client JS. `ProductCard` itself has no `"use client"` directive, so it remains a server component. Only `ProductCardActions` (already a client component, small) stays in the client bundle.
 
 **Before:**
-```
+```text
 HorizontalSection (client) → ProductCard (bundled as client) → ProductCardActions (client)
 ```
 
 **After:**
-```
+```text
 HorizontalSection (server) → ScrollContainer (client, just scroll logic) → children (RSC payload)
 ProductCard stays server-rendered, not bundled as client JS
 ```


### PR DESCRIPTION
Nettoyage **strictement documentaire** des fichiers de plan signalés par CodeRabbit sur la PR #146. Aucun fichier de code n'est touché.

## MD001 — sauts de niveau de titre

Les quatre fichiers passaient d'un `#` (titre) directement à `### Task 1`. Chacun de ces documents est une **suite plate de tâches** sous le titre — il n'y a pas de niveau intermédiaire à représenter. Plutôt que d'injecter un `##` artificiel isolé, toute la série `### Task N` est promue en `## Task N`, ce qui rend la hiérarchie cohérente de bout en bout et aligne ces fichiers sur `2026-03-02-lcp-optimization.md`, qui utilise déjà `## Task N` / `### Step N`.

Aucun sous-titre à décaler : ces plans utilisent du gras (`**Step 1: …**`) et non des titres pour leurs étapes.

- `docs/plans/2026-02-24-cloudflare-image-loader.md` — Tasks 1–5
- `docs/plans/2026-02-26-brand-filter-plan.md` — Tasks 1–5
- `docs/plans/2026-02-26-price-filter-plan.md` — Tasks 1–6
- `docs/plans/2026-02-27-product-card-actions.md` — Tasks 1–5

## MD040 — blocs de code sans langage

Taggés selon le **contenu réel** du bloc :

| Fichier | Ligne | Contenu | Tag |
|---|---|---|---|
| `2026-02-27-product-card-actions.md` | 390 | Croquis d'arbre JSX (`<Link>` / `<div>` / `<ProductCardActions>`) | `tsx` |
| `2026-03-02-lcp-optimization.md` | 226 | Diagramme ASCII « Before » (flèches `→`) | `text` |
| `2026-03-02-lcp-optimization.md` | 231 | Diagramme ASCII « After » | `text` |

L'occurrence signalée en `2026-02-24-cloudflare-image-loader.md:292` n'était **pas** une violation : c'est la fence *fermante* d'un bloc ` ```bash ` déjà taggé. Rien à corriger.

## Typographie française — `2026-02-26-price-filter-plan.md`

Convention vérifiée avant de trancher, pas imposée :

- **Apostrophes** — le fichier n'utilise que des apostrophes droites `'`. Le dépôt entier fait de même (0 occurrence de `’` U+2019 dans `docs/`). Le fichier était déjà conforme : **aucune modification**.
- **Deux-points / libellés en gras** — le fichier mélangeait deux styles : `**Label:**` (8 occurrences, lignes 3/5/7/9/15/…) et `**Label** :` (8 occurrences, lignes 299-306). C'était la vraie incohérence. Harmonisation sur `**Label:**`, largement dominant dans `docs/plans` (195 contre 16) et déjà le style des 8 autres libellés du même fichier.

Les remontées LanguageTool sur les lignes 3, 7 et 9 (`**For Claude:**`, `**Architecture:**`, `**Tech Stack:**`) sont des faux positifs : le `:` y est suivi des `**` de la syntaxe Markdown, pas d'un caractère manquant. Non touchées.

## Point de documentation — `--admin`

`gh pr merge --squash --delete-branch --admin` → **`--admin` retiré**, avec une note courte à la place :

> Ne pas ajouter `--admin` : ce flag contourne les protections de branche (CI et revues requises).
> Attendre que la CI passe et que la PR soit approuvée.

Choix motivé : ces plans sont écrits pour être **copiés-collés** (par un humain ou par un agent qui exécute le plan). Garder le flag en le commentant laisserait quand même la commande dangereuse comme valeur par défaut. Le retirer rend la commande sûre par défaut, et la note conserve l'information pour qui aurait un jour un motif légitime de l'ajouter.

## Vérification

- `npx markdownlint-cli2` (v0.23.2 / markdownlint v0.41.1) exécuté via `npx` avec une config limitée à `MD001` + `MD040` : **les 5 fichiers du périmètre sont propres**. Le dépôt n'a **aucune configuration markdownlint** (`.markdownlint*`, `.mdlrc`, dépendance npm ou hook) — le linter a été apporté ponctuellement pour valider ce travail.
- D'autres fichiers de `docs/plans/` ont encore des MD001/MD040 (`2026-02-18-*`, `2026-02-25-otp-auth-design.md`, `2026-03-02-banner-dnd*`, …). Hors périmètre de l'issue, laissés en l'état.
- Le ruleset markdownlint par défaut remonte aussi beaucoup de MD013 (longueur de ligne), MD031, MD036… préexistants sur tout `docs/plans`. Hors périmètre également.
- `npx tsc --noEmit` ✅ · `npm run lint` ✅ · `npx vitest run` ✅ (83 fichiers, 1390 tests). Hook pre-commit passé sans `--no-verify`.

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGMDCzf2UnxoR71tws5wRS
