### PR TITLE
refactor(admin): migrate products-ai server action to Drizzle ORM

### DIFF
--- a/__tests__/unit/actions/products-ai.test.ts
+++ b/__tests__/unit/actions/products-ai.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { mockAdminSession } from "../../helpers/mocks";
 
+/**
+ * The action builds its queries with Drizzle (`getDrizzle()`), so this suite mocks the
+ * D1 binding one level lower — `getDB()` — and lets the real Drizzle driver compile the
+ * statements. Assertions therefore run against the SQL/params Drizzle actually emits,
+ * which is what catches a column/type drift between `lib/db/schema.ts` and the action.
+ */
+
+interface BoundStatement { sql: string; params: unknown[] }
+
 const mocks = vi.hoisted(() => ({
   getSession: vi.fn(),
   redirect: vi.fn((url: string): never => {
@@ -8,27 +17,35 @@ const mocks = vi.hoisted(() => ({
     err.digest = `NEXT_REDIRECT;${url}`;
     throw err;
   }),
-  execute: vi.fn(),
-  queryFirst: vi.fn(),
-  query: vi.fn(),
+  /** Every prepare().bind() the driver issues, in order. */
+  bound: vi.fn(),
+  /** Single-statement execution (INSERT draft, compensating DELETE). */
+  run: vi.fn(),
+  /** Row-array reads backing `.get()` — return `[]` for "no row". */
+  raw: vi.fn(),
+  dbBatch: vi.fn(),
   fetchAndUploadImage: vi.fn(),
   revalidatePath: vi.fn(),
-  dbBatch: vi.fn(),
-  prepare: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({ redirect: mocks.redirect }));
 vi.mock("next/headers", () => ({ headers: vi.fn().mockResolvedValue(new Headers()) }));
 vi.mock("next/cache", () => ({ revalidatePath: mocks.revalidatePath }));
 vi.mock("@/lib/auth", () => ({ initAuth: vi.fn().mockResolvedValue({ api: { getSession: mocks.getSession } }) }));
-vi.mock("@/lib/db", () => ({
-  execute: mocks.execute,
-  queryFirst: mocks.queryFirst,
-  query: mocks.query,
-}));
 vi.mock("@/lib/cloudflare/context", () => ({
   getDB: async () => ({
-    prepare: (sql: string) => { mocks.prepare(sql); return { bind: (..._args: unknown[]) => ({ sql, args: _args }) }; },
+    prepare: (sql: string) => ({
+      bind: (...params: unknown[]) => {
+        const stmt = { sql, params };
+        mocks.bound(stmt);
+        return {
+          ...stmt,
+          run: () => mocks.run(stmt),
+          all: () => mocks.raw(stmt).then((rows: unknown[][]) => ({ results: rows })),
+          raw: () => mocks.raw(stmt),
+        };
+      },
+    }),
     batch: (stmts: unknown[]) => mocks.dbBatch(stmts),
   }),
 }));
@@ -73,13 +90,22 @@ const OUTPUT: AiProductOutput = {
   ],
 };
 
+/** Statements handed to `db.batch()` on the Nth call. */
+function batchStatements(call = 0): BoundStatement[] {
+  return mocks.dbBatch.mock.calls[call][0] as BoundStatement[];
+}
+
+function statementsMatching(pattern: RegExp, call = 0): BoundStatement[] {
+  return batchStatements(call).filter((s) => pattern.test(s.sql));
+}
+
 describe("importCandidateImages", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.getSession.mockResolvedValue(mockAdminSession);
-    mocks.execute.mockResolvedValue({ meta: { changes: 1 } });
-    mocks.queryFirst.mockResolvedValue(null);
-    mocks.query.mockResolvedValue([]);
+    mocks.run.mockResolvedValue({ success: true, meta: { changes: 1 }, results: [] });
+    // No category matches and no slug is taken, unless a test overrides it.
+    mocks.raw.mockResolvedValue([]);
     mocks.dbBatch.mockResolvedValue([]);
     mocks.fetchAndUploadImage.mockImplementation(async (_: string, url: string) =>
       ({ ok: true, key: `products/d1/${url.split("/").pop()}`, contentType: "image/jpeg", size: 10 }));
@@ -108,6 +134,60 @@ describe("importCandidateImages", () => {
     }
     expect(mocks.fetchAndUploadImage).toHaveBeenCalledTimes(2);
     expect(mocks.dbBatch).toHaveBeenCalled();
+
+    // The draft row is inserted on its own, before the batch.
+    const draftInsert = mocks.run.mock.calls
+      .map((call) => call[0] as BoundStatement)
+      .filter((s) => /insert into "products"/i.test(s.sql));
+    expect(draftInsert).toHaveLength(1);
+    expect(draftInsert[0].params).toContain(r.id);
+
+    // The batch leads with the UPDATE on the draft, then the attribute/image inserts.
+    const stmts = batchStatements();
+    expect(stmts[0].sql).toMatch(/^update "products" set/i);
+    // 1 colour + 1 dimension (length_mm) + 1 spec
+    expect(statementsMatching(/insert into "product_attributes"/i)).toHaveLength(3);
+    expect(statementsMatching(/insert into "product_images"/i)).toHaveLength(2);
+  });
+
+  it("résout la catégorie suggérée et la rattache au brouillon", async () => {
+    // First `.get()` is the category lookup; the following ones are slug-uniqueness probes.
+    mocks.raw.mockImplementation(async (stmt: BoundStatement) =>
+      /from "categories"/i.test(stmt.sql) ? [["cat-smartphones"]] : []);
+
+    const r = await importCandidateImages(OUTPUT, ["https://x.test/a.jpg"]);
+    expect(r.success).toBe(true);
+
+    const categoryLookup = mocks.bound.mock.calls
+      .map((call) => call[0] as BoundStatement)
+      .find((s) => /from "categories"/i.test(s.sql));
+    expect(categoryLookup).toBeDefined();
+    expect(categoryLookup!.sql).toMatch(/lower\("categories"\."slug"\) = lower\(\?\)/i);
+    expect(categoryLookup!.params).toEqual(["smartphones", 1]); // slug + limit
+
+    // The resolved category id is carried by the batch UPDATE.
+    expect(batchStatements()[0].params).toContain("cat-smartphones");
+  });
+
+  it("suffixe le slug tant qu'il est déjà pris", async () => {
+    const takenSlugs = new Set(["galaxy-a55", "galaxy-a55-2"]);
+    mocks.raw.mockImplementation(async (stmt: BoundStatement) => {
+      if (!/from "products"/i.test(stmt.sql)) return [];
+      return takenSlugs.has(stmt.params[0] as string) ? [["other-product"]] : [];
+    });
+
+    const r = await importCandidateImages(OUTPUT, ["https://x.test/a.jpg"]);
+    expect(r.success).toBe(true);
+    expect(batchStatements()[0].params).toContain("galaxy-a55-3");
+  });
+
+  it("garde le slug placeholder si les 20 candidats sont pris", async () => {
+    mocks.raw.mockImplementation(async (stmt: BoundStatement) =>
+      /from "products"/i.test(stmt.sql) ? [["other-product"]] : []);
+
+    const r = await importCandidateImages(OUTPUT, ["https://x.test/a.jpg"]);
+    expect(r.success).toBe(true);
+    expect(batchStatements()[0].params).toContain(`draft-${r.id}`);
   });
 
   it("renvoie warnings pour les images échouées mais crée quand même le draft", async () => {
@@ -144,25 +224,17 @@ describe("importCandidateImages", () => {
     ]);
     expect(r.success).toBe(true);
 
-    const imageInserts = mocks.prepare.mock.calls
-      .map((call) => call[0] as string)
-      .filter((sql) => sql.includes("INSERT INTO product_images"));
-    expect(imageInserts.length).toBe(2); // one prepare() call per image row
-    expect(imageInserts[0]).toContain("(id, product_id, url, alt, is_primary, sort_order, created_at)");
-
-    // Also verify the bind args carry the bare key and alt
-    const batchCall = mocks.dbBatch.mock.calls[0][0] as Array<{ sql: string; args: unknown[] }>;
-    const imageBinds = batchCall.filter((s) => s.sql.includes("INSERT INTO product_images"));
-    expect(imageBinds).toHaveLength(2);
-    expect(imageBinds[0].args[2]).toBe("products/d1/a.jpg"); // url = bare key, no "/images/" prefix
-    expect(imageBinds[0].args[3]).toBe("Face avant");        // alt
-    expect(imageBinds[1].args[2]).toBe("products/d1/b.jpg");
-    expect(imageBinds[1].args[3]).toBe("Profil");
+    const imageInserts = statementsMatching(/insert into "product_images"/i);
+    expect(imageInserts).toHaveLength(2); // one statement per image row
+    // url = bare R2 key, no "/images/" prefix — plus the alt text and the primary/order flags.
+    expect(imageInserts[0].params).toContain("products/d1/a.jpg");
+    expect(imageInserts[0].params).toContain("Face avant");
+    expect(imageInserts[1].params).toContain("products/d1/b.jpg");
+    expect(imageInserts[1].params).toContain("Profil");
   });
 
   it("nettoie les images R2 orphelines si le batch échoue", async () => {
     const { deleteFromR2: deleteFromR2Mock } = await import("@/lib/storage/images");
-    // deleteFromR2 was auto-mocked via vi.mock below — set up the mock.
     mocks.dbBatch.mockRejectedValueOnce(new Error("batch failed"));
     mocks.fetchAndUploadImage.mockImplementation(async (_: string, url: string) => ({
       ok: true,
@@ -192,12 +264,21 @@ describe("importCandidateImages", () => {
     expect(r.success).toBe(false);
 
     // The compensating DELETE should have been issued with the draft id.
-    const deleteCalls = mocks.execute.mock.calls.filter(
-      (call: unknown[]) => typeof call[0] === "string" && call[0].startsWith("DELETE FROM products"),
-    );
-    expect(deleteCalls).toHaveLength(1);
+    const deletes = mocks.run.mock.calls
+      .map((call) => call[0] as BoundStatement)
+      .filter((s) => /^delete from "products"/i.test(s.sql));
+    expect(deletes).toHaveLength(1);
     // The draft id is the one passed to fetchAndUploadImage as the first arg.
     const fetchCall = mocks.fetchAndUploadImage.mock.calls[0] as [string, string];
-    expect((deleteCalls[0] as unknown[])[1]).toEqual([fetchCall[0]]);
+    expect(deletes[0].params).toEqual([fetchCall[0]]);
+  });
+
+  it("échoue proprement si l'insertion du brouillon casse", async () => {
+    mocks.run.mockRejectedValueOnce(new Error("insert failed"));
+    const r = await importCandidateImages(OUTPUT, ["https://x.test/a.jpg"]);
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error).toMatch(/brouillon/i);
+    expect(mocks.dbBatch).not.toHaveBeenCalled();
+    expect(mocks.fetchAndUploadImage).not.toHaveBeenCalled();
   });
 });

--- a/actions/admin/products-ai.ts
+++ b/actions/admin/products-ai.ts
@@ -2,9 +2,11 @@
 
 import { revalidatePath } from "next/cache";
 import { nanoid } from "nanoid";
+import { and, eq, ne, sql } from "drizzle-orm";
+import type { BatchItem } from "drizzle-orm/batch";
 import { requireAdmin } from "@/lib/auth/guards";
-import { execute, queryFirst } from "@/lib/db";
-import { getDB } from "@/lib/cloudflare/context";
+import { getDrizzle } from "@/lib/db/drizzle";
+import { categories, productAttributes, productImages, products } from "@/lib/db/schema";
 import { slugify, type ActionResult } from "@/lib/utils";
 import { sanitizeDescriptionHtml } from "@/lib/utils/sanitize-html";
 import { fetchAndUploadImage, type FetchImageResult } from "@/lib/ai/image-fetch";
@@ -21,6 +23,9 @@ import {
 type ImportResult = ActionResult & { id?: string; warnings?: string[] };
 
 type FetchSuccess = Extract<FetchImageResult, { ok: true }>;
+
+/** Statements queued for the single D1 batch (one implicit transaction). */
+type Statement = BatchItem<"sqlite">;
 
 /** Create a draft + populate every AI-sourced field + attach selected images.
  *  Price, stock, SKU, visibility flags remain at their draft defaults; the admin
@@ -63,23 +68,33 @@ export async function importCandidateImages(
   const featureBlocks = storyFeatureBlocks.data;
   const faq = storyFaq.data;
 
+  const db = await getDrizzle();
+
   const draftId = nanoid();
   const placeholderSlug = `draft-${draftId}`;
   try {
-    await execute(
-      `INSERT INTO products (id, category_id, name, slug, base_price, is_active, is_draft, created_at, updated_at)
-       VALUES (?, NULL, '', ?, 0, 0, 1, datetime('now'), datetime('now'))`,
-      [draftId, placeholderSlug],
-    );
+    await db.insert(products).values({
+      id: draftId,
+      category_id: null,
+      name: "",
+      slug: placeholderSlug,
+      base_price: 0,
+      is_active: 0,
+      is_draft: 1,
+      created_at: sql`datetime('now')`,
+      updated_at: sql`datetime('now')`,
+    });
   } catch (err) {
     console.error("[admin/products-ai] draft insert failed", err);
     return { success: false, error: "Erreur lors de la création du brouillon" };
   }
 
-  const category = await queryFirst<{ id: string }>(
-    "SELECT id FROM categories WHERE LOWER(slug) = LOWER(?) LIMIT 1",
-    [output.category_suggestion],
-  );
+  const category = await db
+    .select({ id: categories.id })
+    .from(categories)
+    .where(sql`lower(${categories.slug}) = lower(${output.category_suggestion})`)
+    .limit(1)
+    .get();
   const categoryId = category?.id ?? null;
 
   const baseSlug = slugify(output.name);
@@ -89,10 +104,12 @@ export async function importCandidateImages(
   if (baseSlug) {
     let candidate = baseSlug;
     for (let suffix = 1; suffix <= 20; suffix++) {
-      const taken = await queryFirst<{ id: string }>(
-        "SELECT id FROM products WHERE slug = ? AND id != ? LIMIT 1",
-        [candidate, draftId],
-      );
+      const taken = await db
+        .select({ id: products.id })
+        .from(products)
+        .where(and(eq(products.slug, candidate), ne(products.id, draftId)))
+        .limit(1)
+        .get();
       if (!taken) { finalSlug = candidate; break; }
       candidate = `${baseSlug}-${suffix + 1}`;
     }
@@ -119,40 +136,37 @@ export async function importCandidateImages(
     ? sanitizeDescriptionHtml(output.description_html, draftId)
     : null;
 
-  const db = await getDB();
-  const stmts: ReturnType<typeof db.prepare>[] = [];
-
-  stmts.push(
-    db.prepare(
-      `UPDATE products SET
-         category_id = ?, name = ?, slug = ?, brand = ?,
-         description = ?, description_type = 'html', short_description = ?,
-         meta_title = ?, meta_description = ?,
-         tagline = ?, highlights = ?, feature_blocks = ?, faq = ?,
-         updated_at = datetime('now')
-       WHERE id = ? AND is_draft = 1`,
-    ).bind(
-      categoryId,
-      output.name,
-      finalSlug,
-      output.brand ?? null,
-      descriptionHtml,
-      output.short_description ?? null,
-      output.seo.meta_title ?? null,
-      output.seo.meta_description ?? null,
+  // The UPDATE always leads the batch, which keeps the array non-empty for db.batch().
+  const productUpdate: Statement = db
+    .update(products)
+    .set({
+      category_id: categoryId,
+      name: output.name,
+      slug: finalSlug,
+      brand: output.brand ?? null,
+      description: descriptionHtml,
+      description_type: "html",
+      short_description: output.short_description ?? null,
+      meta_title: output.seo.meta_title ?? null,
+      meta_description: output.seo.meta_description ?? null,
       tagline,
-      highlights ? JSON.stringify(highlights) : null,
-      featureBlocks ? JSON.stringify(featureBlocks) : null,
-      faq ? JSON.stringify(faq) : null,
-      draftId,
-    ),
-  );
+      highlights: highlights ? JSON.stringify(highlights) : null,
+      feature_blocks: featureBlocks ? JSON.stringify(featureBlocks) : null,
+      faq: faq ? JSON.stringify(faq) : null,
+      updated_at: sql`datetime('now')`,
+    })
+    .where(and(eq(products.id, draftId), eq(products.is_draft, 1)));
+
+  const stmts: Statement[] = [];
 
   for (const c of output.attributes.colors) {
     stmts.push(
-      db.prepare(
-        `INSERT INTO product_attributes (id, product_id, name, value) VALUES (?, ?, 'Couleur', ?)`,
-      ).bind(nanoid(), draftId, `${c.name}|${c.hex}`),
+      db.insert(productAttributes).values({
+        id: nanoid(),
+        product_id: draftId,
+        name: "Couleur",
+        value: `${c.name}|${c.hex}`,
+      }),
     );
   }
   const dims = output.attributes.dimensions;
@@ -165,30 +179,43 @@ export async function importCandidateImages(
   for (const [label, val] of dimFields) {
     if (val != null) {
       stmts.push(
-        db.prepare(`INSERT INTO product_attributes (id, product_id, name, value) VALUES (?, ?, ?, ?)`)
-          .bind(nanoid(), draftId, label, String(val)),
+        db.insert(productAttributes).values({
+          id: nanoid(),
+          product_id: draftId,
+          name: label,
+          value: String(val),
+        }),
       );
     }
   }
   for (const s of output.attributes.specs) {
     stmts.push(
-      db.prepare(`INSERT INTO product_attributes (id, product_id, name, value) VALUES (?, ?, ?, ?)`)
-        .bind(nanoid(), draftId, s.name, s.value),
+      db.insert(productAttributes).values({
+        id: nanoid(),
+        product_id: draftId,
+        name: s.name,
+        value: s.value,
+      }),
     );
   }
 
   succeeded.forEach(({ url, r }, idx) => {
     const alt = output.image_candidates.find((c) => c.url === url)?.alt ?? null;
     stmts.push(
-      db.prepare(
-        `INSERT INTO product_images (id, product_id, url, alt, is_primary, sort_order, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, datetime('now'))`,
-      ).bind(nanoid(), draftId, r.key, alt, idx === 0 ? 1 : 0, idx),
+      db.insert(productImages).values({
+        id: nanoid(),
+        product_id: draftId,
+        url: r.key,
+        alt,
+        is_primary: idx === 0 ? 1 : 0,
+        sort_order: idx,
+        created_at: sql`datetime('now')`,
+      }),
     );
   });
 
   try {
-    await db.batch(stmts);
+    await db.batch([productUpdate, ...stmts]);
   } catch (err) {
     console.error("[admin/products-ai] batch write failed", err);
     // Compensating cleanup — the draft row, any pending attribute/image inserts,
@@ -199,7 +226,7 @@ export async function importCandidateImages(
       ...succeeded.map(({ r }) => deleteFromR2(r.key).catch((e) => {
         console.warn("[admin/products-ai] orphan R2 cleanup failed for key", r.key, e);
       })),
-      execute("DELETE FROM products WHERE id = ?", [draftId]).catch((e) => {
+      db.delete(products).where(eq(products.id, draftId)).catch((e) => {
         console.warn("[admin/products-ai] orphan draft cleanup failed for id", draftId, e);
       }),
     ]);


### PR DESCRIPTION
## Contexte

`actions/admin/products-ai.ts` était l'un des ~29 fichiers encore sur les helpers SQL bruts (`execute`, `queryFirst`, `getDB().prepare(...).bind(...)`, `db.batch`). Cette PR le migre **entièrement** sur `getDrizzle()`, conformément à la section *Database* de `CLAUDE.md` (« ne mélange pas Drizzle et SQL brut dans un même fichier »).

Après cette PR, le fichier n'importe plus rien depuis `@/lib/db` ni depuis `@/lib/cloudflare/context`.

## Ce qui change

| Avant (SQL brut) | Après (Drizzle) |
| --- | --- |
| `execute("INSERT INTO products ...")` | `db.insert(products).values({...})` |
| `queryFirst("... LOWER(slug) = LOWER(?)")` | `db.select({id}).from(categories).where(sql\`lower(...) = lower(...)\`).limit(1).get()` |
| `queryFirst("... slug = ? AND id != ?")` | `db.select({id}).from(products).where(and(eq(...), ne(...))).limit(1).get()` |
| `db.prepare(...).bind(...)` × N puis `db.batch(stmts)` | query builders Drizzle passés à `db.batch([...])` |
| `execute("DELETE FROM products WHERE id = ?")` | `db.delete(products).where(eq(products.id, draftId))` |

### Le `batch`

Drizzle expose `db.batch()` nativement sur D1 (`drizzle-orm/d1`), donc l'écriture reste **une seule transaction implicite**, exactement comme avant. La signature exige un tuple non vide (`Readonly<[U, ...U[]]>`) : l'`UPDATE` du brouillon est extrait dans une variable et le batch est construit `[productUpdate, ...stmts]`, ce qui satisfait le typage **sans cast**.

## Refactor pur — parité de comportement vérifiée

Le point sensible était l'`INSERT` du brouillon : le SQL brut listait explicitement 9 colonnes et laissait la DB appliquer ses `DEFAULT` sur le reste. Drizzle liste toutes les colonnes et **matérialise les défauts de `schema.ts` en paramètres**. J'ai vérifié le SQL généré :

```
insert into "products" ("id", "category_id", ..., "created_at", "updated_at")
values (?, ?, ?, ?, null, ?, null, ?, null, null, null, ?, ?, ?, ?, ?, null, ..., datetime('now'), datetime('now'))
params: ["<id>", null, "", "draft-<id>", "richtext", 0, 0, 0, 1, 0, 5]
```

`richtext / 0 / 0 / 5` correspondent bien aux `DEFAULT` de `description_type`, `is_featured`, `stock_quantity`, `low_stock_threshold` — comportement identique, avec en prime `schema.ts` comme source de vérité.

## Colonnes nullable

Aucun mensonge de type révélé sur ce fichier : les deux lectures portaient sur `categories.id` et `products.id`, tous deux `notNull` (clés primaires), et le typage Drizzle inféré (`{ id: string } | undefined`) correspond exactement aux anciens `queryFirst<{ id: string }>`. Les colonnes nullable écrites (`brand`, `description`, `tagline`, `product_images.alt`, …) recevaient déjà `?? null` explicitement.

## Tests

L'ancienne suite (`__tests__/unit/actions/products-ai.test.ts`) assertait sur **des chaînes SQL brutes et la forme des appels `prepare()`** — des détails d'implémentation qui n'existent plus. Elle est réécrite en mockant le binding D1 un cran plus bas (`getDB()`) et en laissant le **vrai driver Drizzle** compiler les requêtes : les assertions portent désormais sur le SQL et les params que Drizzle émet réellement, ce qui attrape une dérive de colonne entre `schema.ts` et l'action.

Aucune assertion comportementale n'a été affaiblie, et 4 cas ont été ajoutés :
- résolution de la catégorie suggérée (`lower(slug) = lower(?)` + rattachement à l'`UPDATE`)
- suffixage du slug tant qu'il est pris (`galaxy-a55` → `galaxy-a55-3`)
- conservation du slug placeholder quand les 20 candidats collisionnent
- échec propre si l'`INSERT` du brouillon casse (pas de batch, pas de fetch d'images)

`1394 tests` verts (contre 1390 avant), `tsc --noEmit` et `eslint` verts.

## Hors périmètre

L'issue #190 suggérait de migrer `actions/admin/products.ts` « en lockstep ». Ce n'est pas fait ici : c'est un fichier nettement plus gros, et `CLAUDE.md` demande explicitement un suivi fichier par fichier. Il reste dans le backlog de #234.

Closes #190
Fait avancer #234 (migration graduelle vers Drizzle) — sans le fermer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGMDCzf2UnxoR71tws5wRS
