### PR TITLE
refactor(whatsapp): migrate admin config form to React Hook Form + Zod with fieldErrors

### DIFF
--- a/__tests__/unit/actions/admin-whatsapp.test.ts
+++ b/__tests__/unit/actions/admin-whatsapp.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockAdminSession, mockCustomerSession } from "../../helpers/mocks";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  redirect: vi.fn((url: string): never => {
+    const error = new Error(`NEXT_REDIRECT: ${url}`) as Error & { digest: string };
+    error.digest = `NEXT_REDIRECT;${url}`;
+    throw error;
+  }),
+  dbPrepare: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({ redirect: mocks.redirect }));
+vi.mock("next/headers", () => ({ headers: vi.fn().mockResolvedValue(new Headers()) }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/auth", () => ({
+  initAuth: vi.fn().mockResolvedValue({ api: { getSession: mocks.getSession } }),
+}));
+vi.mock("@/lib/cloudflare/context", () => ({
+  getDB: vi.fn().mockImplementation(() => Promise.resolve({ prepare: mocks.dbPrepare })),
+}));
+
+import { saveWhatsAppConfig } from "@/actions/admin/whatsapp";
+import type { WhatsAppConfigInput } from "@/lib/validations/whatsapp-config";
+
+// ─── D1 mock ────────────────────────────────────────────────────────────────
+
+interface DbCall {
+  sql: string;
+  bindings: unknown[];
+}
+
+interface ExistingRow {
+  id: number;
+  access_token: string | null;
+  webhook_secret: string | null;
+}
+
+/**
+ * Stubs `db.prepare(...)`:
+ *  - the SELECT (no .bind(), read via .first()) returns `existing`
+ *  - the UPDATE/INSERT (.bind(...).run()) records sql + bindings and reports `changes`
+ */
+function setupDb(existing: ExistingRow | null, changes = 1): DbCall[] {
+  const calls: DbCall[] = [];
+  mocks.dbPrepare.mockImplementation((sql: string) => ({
+    first: () => {
+      calls.push({ sql, bindings: [] });
+      return Promise.resolve(existing ?? undefined);
+    },
+    run: () => {
+      calls.push({ sql, bindings: [] });
+      return Promise.resolve({ meta: { changes } });
+    },
+    bind: (...bindings: unknown[]) => ({
+      run: () => {
+        calls.push({ sql, bindings });
+        return Promise.resolve({ meta: { changes } });
+      },
+      first: () => {
+        calls.push({ sql, bindings });
+        return Promise.resolve(existing ?? undefined);
+      },
+    }),
+  }));
+  return calls;
+}
+
+const writeCall = (calls: DbCall[]) =>
+  calls.find((c) => /^\s*(UPDATE|INSERT)/i.test(c.sql));
+
+function input(overrides: Partial<WhatsAppConfigInput> = {}): WhatsAppConfigInput {
+  return {
+    display_phone_number: "",
+    phone_number_id: "",
+    business_account_id: "",
+    access_token: "",
+    verify_token: "",
+    webhook_secret: "",
+    admin_phones: "[]",
+    is_active: false,
+    ...overrides,
+  };
+}
+
+const STORED_ACCESS_TOKEN = "EAAsecretaccesstoken1234";
+const STORED_WEBHOOK_SECRET = "hmac-webhook-secret-5678";
+// Masks getWhatsAppConfig() would have sent to the client for the values above.
+const ACCESS_TOKEN_MASK = "••••••••1234";
+const WEBHOOK_SECRET_MASK = "••••••••5678";
+
+const existingRow: ExistingRow = {
+  id: 1,
+  access_token: STORED_ACCESS_TOKEN,
+  webhook_secret: STORED_WEBHOOK_SECRET,
+};
+
+const activeApiFields = {
+  phone_number_id: "123456789012345",
+  business_account_id: "987654321098765",
+  verify_token: "verify-token",
+};
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("saveWhatsAppConfig — garde admin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue(mockAdminSession);
+  });
+
+  it("redirige si l'appelant n'est pas admin", async () => {
+    mocks.getSession.mockResolvedValue(mockCustomerSession);
+    await expect(saveWhatsAppConfig(input())).rejects.toThrow(/NEXT_REDIRECT/);
+  });
+});
+
+describe("saveWhatsAppConfig — config à deux étages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue(mockAdminSession);
+  });
+
+  it("accepte le numéro public seul avec is_active=0 (boutons wa.me sans bot)", async () => {
+    const calls = setupDb(null);
+
+    const result = await saveWhatsAppConfig(
+      input({ display_phone_number: "+225 07 00 00 00 01" })
+    );
+
+    expect(result.success).toBe(true);
+    const write = writeCall(calls);
+    expect(write?.sql).toMatch(/^INSERT/i);
+    // Numéro normalisé (chiffres uniquement) écrit en base, bot inactif.
+    expect(write?.bindings).toContain("2250700000001");
+    expect(write?.bindings).toContain(0);
+  });
+
+  it("refuse is_active=1 sans les champs API, erreurs ventilées par champ, sans écriture", async () => {
+    const calls = setupDb(null);
+
+    const result = await saveWhatsAppConfig(input({ is_active: true }));
+
+    expect(result.success).toBe(false);
+    expect(result.fieldErrors?.phone_number_id?.[0]).toBeTruthy();
+    expect(result.fieldErrors?.access_token?.[0]).toBeTruthy();
+    expect(result.fieldErrors?.verify_token?.[0]).toBeTruthy();
+    expect(result.fieldErrors?.webhook_secret?.[0]).toBeTruthy();
+    expect(result.fieldErrors?.business_account_id?.[0]).toBeTruthy();
+    expect(result.fieldErrors?.display_phone_number).toBeUndefined();
+    expect(writeCall(calls)).toBeUndefined();
+  });
+
+  it("ventile l'erreur de format du numéro public sur display_phone_number", async () => {
+    const calls = setupDb(null);
+
+    const result = await saveWhatsAppConfig(input({ display_phone_number: "12345" }));
+
+    expect(result.success).toBe(false);
+    expect(result.fieldErrors?.display_phone_number?.[0]).toContain("8 et 15 chiffres");
+    expect(writeCall(calls)).toBeUndefined();
+  });
+
+  it("ventile l'erreur admin_phones sur admin_phones", async () => {
+    const calls = setupDb(null);
+
+    const result = await saveWhatsAppConfig(input({ admin_phones: "{}" }));
+
+    expect(result.success).toBe(false);
+    expect(result.fieldErrors?.admin_phones?.[0]).toBe(
+      "admin_phones doit être un tableau JSON valide."
+    );
+    expect(writeCall(calls)).toBeUndefined();
+  });
+
+  it("active le bot quand les 5 champs API sont fournis", async () => {
+    const calls = setupDb(existingRow);
+
+    const result = await saveWhatsAppConfig(
+      input({
+        ...activeApiFields,
+        access_token: "EAAnewtoken",
+        webhook_secret: "new-hmac",
+        is_active: true,
+      })
+    );
+
+    expect(result.success).toBe(true);
+    const write = writeCall(calls);
+    expect(write?.bindings).toContain("EAAnewtoken");
+    expect(write?.bindings).toContain("new-hmac");
+    expect(write?.bindings).toContain(1);
+  });
+});
+
+describe("saveWhatsAppConfig — masquage des secrets", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue(mockAdminSession);
+  });
+
+  it("reconnaît le masque EXACT comme « inchangé » et préserve les secrets stockés", async () => {
+    const calls = setupDb(existingRow);
+
+    const result = await saveWhatsAppConfig(
+      input({
+        ...activeApiFields,
+        access_token: ACCESS_TOKEN_MASK,
+        webhook_secret: WEBHOOK_SECRET_MASK,
+        is_active: true,
+      })
+    );
+
+    expect(result.success).toBe(true);
+    const write = writeCall(calls);
+    // Les colonnes masquées ne sont pas réécrites → la valeur en base survit.
+    expect(write?.sql).not.toMatch(/access_token = \?/);
+    expect(write?.sql).not.toMatch(/webhook_secret = \?/);
+    expect(write?.bindings).not.toContain(ACCESS_TOKEN_MASK);
+    expect(write?.bindings).not.toContain(WEBHOOK_SECRET_MASK);
+  });
+
+  it("enregistre un secret RÉEL commençant par des puces (pas de startsWith(\"••\"))", async () => {
+    const calls = setupDb(existingRow);
+
+    // Même forme que le masque, mais 4 derniers caractères différents :
+    // c'est un vrai secret saisi par l'admin, il doit être écrit.
+    const realSecret = "••••••••9999";
+    const result = await saveWhatsAppConfig(
+      input({
+        ...activeApiFields,
+        access_token: realSecret,
+        webhook_secret: "••hmac-réel",
+        is_active: true,
+      })
+    );
+
+    expect(result.success).toBe(true);
+    const write = writeCall(calls);
+    expect(write?.sql).toMatch(/access_token = \?/);
+    expect(write?.sql).toMatch(/webhook_secret = \?/);
+    expect(write?.bindings).toContain(realSecret);
+    expect(write?.bindings).toContain("••hmac-réel");
+  });
+
+  it("ne confond pas le masque avec une valeur quand rien n'est stocké", async () => {
+    // Aucun secret en base → aucun masque n'a pu être envoyé au client :
+    // la saisie est prise au pied de la lettre.
+    const calls = setupDb({ id: 1, access_token: null, webhook_secret: null });
+
+    const result = await saveWhatsAppConfig(
+      input({
+        ...activeApiFields,
+        access_token: ACCESS_TOKEN_MASK,
+        webhook_secret: WEBHOOK_SECRET_MASK,
+        is_active: true,
+      })
+    );
+
+    expect(result.success).toBe(true);
+    const write = writeCall(calls);
+    expect(write?.bindings).toContain(ACCESS_TOKEN_MASK);
+    expect(write?.bindings).toContain(WEBHOOK_SECRET_MASK);
+  });
+
+  it("garde atomique : échoue si les identifiants masqués ont disparu entre-temps", async () => {
+    // changes = 0 → le WHERE ... IS NOT NULL n'a matché aucune ligne.
+    const calls = setupDb(existingRow, 0);
+
+    const result = await saveWhatsAppConfig(
+      input({
+        ...activeApiFields,
+        access_token: ACCESS_TOKEN_MASK,
+        webhook_secret: WEBHOOK_SECRET_MASK,
+        is_active: true,
+      })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("modifiés entre-temps");
+    expect(writeCall(calls)?.sql).toMatch(/access_token IS NOT NULL/);
+    expect(writeCall(calls)?.sql).toMatch(/webhook_secret IS NOT NULL/);
+  });
+
+  it("efface un secret quand le champ est vidé (bot inactif)", async () => {
+    const calls = setupDb(existingRow);
+
+    const result = await saveWhatsAppConfig(
+      input({ display_phone_number: "2250700000001", access_token: "" })
+    );
+
+    expect(result.success).toBe(true);
+    const write = writeCall(calls);
+    expect(write?.sql).toMatch(/access_token = \?/);
+    expect(write?.bindings).toContain(null);
+  });
+});

--- a/__tests__/unit/components/whatsapp-config-form-a11y.test.ts
+++ b/__tests__/unit/components/whatsapp-config-form-a11y.test.ts
@@ -1,0 +1,47 @@
+// __tests__/unit/components/whatsapp-config-form-a11y.test.ts
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * `aria-invalid` fait annoncer « champ invalide » par un lecteur d'écran, mais pas
+ * le motif : sans relation explicite, le message d'erreur et l'indication de format
+ * restent inaudibles. Ce test verrouille le câblage `aria-describedby` du formulaire
+ * de configuration WhatsApp — l'oubli sur un champ ajouté plus tard serait invisible
+ * à la relecture comme à l'exécution.
+ *
+ * L'inspection porte sur la source : la suite tourne en environnement `node`, sans
+ * jsdom ni Testing Library (voir vitest.config.ts). Même motif que
+ * __tests__/unit/admin-page-guards.test.ts.
+ */
+const SOURCE = readFileSync(
+  resolve(__dirname, "../../..", "components/admin/whatsapp/whatsapp-config-form.tsx"),
+  "utf8",
+);
+
+/** Tout champ qui se déclare invalide doit dire pourquoi. */
+const INVALID_RE = /aria-invalid=\{!!errors\.(\w+)\}/g;
+
+describe("whatsapp-config-form — accessibilité des messages de validation", () => {
+  const fields = [...SOURCE.matchAll(INVALID_RE)].map((m) => m[1]);
+
+  it("déclare au moins un champ validé", () => {
+    expect(fields.length).toBeGreaterThan(0);
+  });
+
+  it.each(fields)("%s associe son message d'erreur à l'input", (field) => {
+    expect(SOURCE).toContain(`aria-describedby={fieldDescribedBy("${field}", errors.${field},`);
+    expect(SOURCE).toContain(`<p id="${field}-error"`);
+  });
+
+  it("associe chaque indication de format déclarée à son input", () => {
+    // Un id `-hint` n'est annoncé que si le champ passe `true` à fieldDescribedBy.
+    const hintIds = [...SOURCE.matchAll(/<p id="(\w+)-hint"/g)].map((m) => m[1]);
+    for (const field of hintIds) {
+      expect(SOURCE).toContain(`fieldDescribedBy("${field}", errors.${field}, true)`);
+    }
+    // Réciproquement, aucun champ ne doit promettre une aide qui n'existe pas.
+    const promised = [...SOURCE.matchAll(/fieldDescribedBy\("(\w+)", errors\.\w+, true\)/g)].map((m) => m[1]);
+    expect(promised.sort()).toEqual(hintIds.sort());
+  });
+});

--- a/__tests__/unit/validations/whatsapp-config.test.ts
+++ b/__tests__/unit/validations/whatsapp-config.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import { whatsappConfigSchema } from "@/lib/validations/whatsapp-config";
+
+// Base payload: every field present and empty, bot off.
+// Mirrors what the form submits when nothing has been filled in.
+function base(overrides: Record<string, unknown> = {}) {
+  return {
+    display_phone_number: "",
+    phone_number_id: "",
+    business_account_id: "",
+    access_token: "",
+    verify_token: "",
+    webhook_secret: "",
+    admin_phones: "",
+    is_active: false,
+    ...overrides,
+  };
+}
+
+function fieldErrors(input: Record<string, unknown>) {
+  const parsed = whatsappConfigSchema.safeParse(input);
+  if (parsed.success) return null;
+  return parsed.error.flatten().fieldErrors;
+}
+
+describe("whatsappConfigSchema — numéro public (étage public)", () => {
+  it("accepte le numéro public seul, bot inactif (config à deux étages)", () => {
+    const parsed = whatsappConfigSchema.safeParse(
+      base({ display_phone_number: "2250700000001" })
+    );
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.display_phone_number).toBe("2250700000001");
+      expect(parsed.data.is_active).toBe(false);
+    }
+  });
+
+  it("normalise le numéro public en ne gardant que les chiffres", () => {
+    const parsed = whatsappConfigSchema.safeParse(
+      base({ display_phone_number: " +225 07-00.00 00 01 " })
+    );
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data.display_phone_number).toBe("2250700000001");
+  });
+
+  it("accepte un numéro public vide (aucun bouton wa.me)", () => {
+    expect(whatsappConfigSchema.safeParse(base()).success).toBe(true);
+  });
+
+  it("rejette un numéro trop court, erreur ventilée sur display_phone_number", () => {
+    const errors = fieldErrors(base({ display_phone_number: "1234567" }));
+    expect(errors?.display_phone_number?.[0]).toContain("8 et 15 chiffres");
+    expect(errors?.phone_number_id).toBeUndefined();
+  });
+
+  it("rejette un numéro trop long (> 15 chiffres, E.164)", () => {
+    const errors = fieldErrors(base({ display_phone_number: "1234567890123456" }));
+    expect(errors?.display_phone_number?.[0]).toContain("8 et 15 chiffres");
+  });
+});
+
+describe("whatsappConfigSchema — admin_phones", () => {
+  it("normalise une valeur vide en tableau JSON vide", () => {
+    const parsed = whatsappConfigSchema.safeParse(base({ admin_phones: "   " }));
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data.admin_phones).toBe("[]");
+  });
+
+  it("ré-encode un tableau JSON valide", () => {
+    const parsed = whatsappConfigSchema.safeParse(
+      base({ admin_phones: '[ "2250700000001" , "2250700000002" ]' })
+    );
+    expect(parsed.success).toBe(true);
+    if (parsed.success)
+      expect(parsed.data.admin_phones).toBe('["2250700000001","2250700000002"]');
+  });
+
+  it("rejette un JSON qui n'est pas un tableau, ventilé sur admin_phones", () => {
+    const errors = fieldErrors(base({ admin_phones: '{"a":1}' }));
+    expect(errors?.admin_phones?.[0]).toBe("admin_phones doit être un tableau JSON valide.");
+  });
+
+  it("rejette un JSON malformé, ventilé sur admin_phones", () => {
+    const errors = fieldErrors(base({ admin_phones: "pas du json" }));
+    expect(errors?.admin_phones?.[0]).toBe("admin_phones doit être un tableau JSON valide.");
+  });
+});
+
+describe("whatsappConfigSchema — activation du bot (étage API)", () => {
+  const fullApi = {
+    phone_number_id: "123456789012345",
+    business_account_id: "987654321098765",
+    access_token: "EAAtoken",
+    verify_token: "verify",
+    webhook_secret: "secret",
+  };
+
+  it("refuse is_active=1 sans les champs API, avec une erreur sur CHAQUE champ manquant", () => {
+    const errors = fieldErrors(base({ is_active: true }));
+    expect(errors?.phone_number_id?.[0]).toBeTruthy();
+    expect(errors?.business_account_id?.[0]).toBeTruthy();
+    expect(errors?.access_token?.[0]).toBeTruthy();
+    expect(errors?.verify_token?.[0]).toBeTruthy();
+    expect(errors?.webhook_secret?.[0]).toBeTruthy();
+    // Le numéro public n'est PAS requis pour activer le bot.
+    expect(errors?.display_phone_number).toBeUndefined();
+  });
+
+  it("ne ventile que le champ API réellement manquant", () => {
+    const errors = fieldErrors(base({ is_active: true, ...fullApi, webhook_secret: "" }));
+    expect(errors?.webhook_secret?.[0]).toBeTruthy();
+    expect(errors?.phone_number_id).toBeUndefined();
+    expect(errors?.access_token).toBeUndefined();
+    expect(errors?.verify_token).toBeUndefined();
+    expect(errors?.business_account_id).toBeUndefined();
+  });
+
+  it("accepte is_active=1 avec les 5 champs API, sans numéro public", () => {
+    const parsed = whatsappConfigSchema.safeParse(base({ is_active: true, ...fullApi }));
+    expect(parsed.success).toBe(true);
+  });
+
+  it("n'exige aucun champ API quand is_active=0", () => {
+    expect(whatsappConfigSchema.safeParse(base({ is_active: false })).success).toBe(true);
+  });
+});
+
+describe("whatsappConfigSchema — secrets", () => {
+  it("laisse passer un secret réel qui commence par des puces (pas de rejet de forme)", () => {
+    const parsed = whatsappConfigSchema.safeParse(
+      base({ access_token: "••••••••wxyz", webhook_secret: "••hmac-réel" })
+    );
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.access_token).toBe("••••••••wxyz");
+      expect(parsed.data.webhook_secret).toBe("••hmac-réel");
+    }
+  });
+});

--- a/actions/admin/whatsapp.ts
+++ b/actions/admin/whatsapp.ts
@@ -3,6 +3,10 @@
 import { revalidatePath } from "next/cache";
 import { requireAdmin } from "@/lib/auth/guards";
 import { getDB } from "@/lib/cloudflare/context";
+import {
+  whatsappConfigSchema,
+  type WhatsAppConfigInput,
+} from "@/lib/validations/whatsapp-config";
 import type { ActionResult } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
@@ -97,53 +101,34 @@ export async function getWhatsAppConfig(): Promise<WhatsAppConfig | null> {
 }
 
 export async function saveWhatsAppConfig(
-  formData: FormData
+  input: WhatsAppConfigInput
 ): Promise<ActionResult> {
   await requireAdmin();
 
-  const phone_number_id_raw = String(formData.get("phone_number_id") ?? "").trim();
+  // Field formats, admin_phones JSON shape and the "API fields required when the
+  // bot is activated" rule all live in the schema — see lib/validations/whatsapp-config.ts.
+  // Note the activation rule can be checked on the raw submission: an API field's
+  // effective value is non-null exactly when its submitted value is non-empty
+  // (a submitted mask preserves a stored — therefore non-null — secret).
+  const parsed = whatsappConfigSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, fieldErrors: parsed.error.flatten().fieldErrors };
+  }
+
+  const {
+    display_phone_number: display_phone_number_normalized,
+    phone_number_id: phone_number_id_raw,
+    business_account_id: business_account_id_raw,
+    access_token: access_token_raw,
+    verify_token: verify_token_raw,
+    webhook_secret: webhook_secret_raw,
+    admin_phones,
+  } = parsed.data;
+
   const phone_number_id = phone_number_id_raw || null;
-
-  const display_phone_number_raw = String(formData.get("display_phone_number") ?? "").trim();
-  // Normalize: keep digits only (strips +, spaces, dashes, dots)
-  const display_phone_number_normalized = display_phone_number_raw.replace(/\D/g, "");
   const display_phone_number = display_phone_number_normalized || null;
-
-  // Validate E.164-ish format: 8-15 digits (ITU-T E.164 max is 15)
-  if (display_phone_number && !/^\d{8,15}$/.test(display_phone_number)) {
-    return {
-      success: false,
-      error: "Le numéro public doit contenir entre 8 et 15 chiffres (format international, ex: 2250700000001).",
-    };
-  }
-
-  const access_token_raw = String(formData.get("access_token") ?? "").trim();
-  const verify_token_raw = String(formData.get("verify_token") ?? "").trim();
-  const webhook_secret_raw = String(formData.get("webhook_secret") ?? "").trim();
-  const business_account_id_raw = String(formData.get("business_account_id") ?? "").trim();
   const business_account_id = business_account_id_raw || null;
-  const admin_phones_raw = String(formData.get("admin_phones") ?? "").trim();
-  const is_active = formData.get("is_active") === "1" ? 1 : 0;
-
-  // Validate admin_phones is a valid JSON array (if provided)
-  let admin_phones = "[]";
-  if (admin_phones_raw) {
-    try {
-      const parsed = JSON.parse(admin_phones_raw);
-      if (!Array.isArray(parsed)) {
-        return {
-          success: false,
-          error: "admin_phones doit être un tableau JSON valide.",
-        };
-      }
-      admin_phones = JSON.stringify(parsed);
-    } catch {
-      return {
-        success: false,
-        error: "admin_phones doit être un tableau JSON valide.",
-      };
-    }
-  }
+  const is_active = parsed.data.is_active ? 1 : 0;
 
   try {
     const db = await getDB();
@@ -165,20 +150,6 @@ export async function saveWhatsAppConfig(
     const access_token = accessTokenMasked ? undefined : (access_token_raw || null);
     const verify_token = verify_token_raw || null;
     const webhook_secret = webhookSecretMasked ? undefined : (webhook_secret_raw || null);
-
-    // If bot is being activated, require full API credentials (check effective values against DB).
-    if (is_active === 1) {
-      const effectiveAccessToken = accessTokenMasked ? existingRow?.access_token ?? null : access_token;
-      const effectiveWebhookSecret = webhookSecretMasked ? existingRow?.webhook_secret ?? null : webhook_secret;
-
-      if (!phone_number_id || !effectiveAccessToken || !verify_token || !effectiveWebhookSecret || !business_account_id) {
-        return {
-          success: false,
-          error:
-            "Pour activer le bot, renseignez phone_number_id, access_token, verify_token, webhook_secret et business_account_id.",
-        };
-      }
-    }
 
     const existing = existingRow ? { id: existingRow.id } : null;
 

--- a/components/admin/whatsapp/whatsapp-config-form.tsx
+++ b/components/admin/whatsapp/whatsapp-config-form.tsx
@@ -35,6 +35,19 @@ function isFieldName(value: string): value is (typeof FIELD_NAMES)[number] {
   return (FIELD_NAMES as readonly string[]).includes(value);
 }
 
+/**
+ * Construit la valeur `aria-describedby` d'un champ : le message d'erreur quand il
+ * est affiché, plus l'indication de format quand le champ en porte une. `aria-invalid`
+ * seul fait annoncer « champ invalide » par un lecteur d'écran sans jamais dire
+ * pourquoi — la relation doit être explicite pour que le message soit lu.
+ */
+function fieldDescribedBy(name: string, error: unknown, hasHint: boolean): string | undefined {
+  const ids: string[] = [];
+  if (error) ids.push(`${name}-error`);
+  if (hasHint) ids.push(`${name}-hint`);
+  return ids.length > 0 ? ids.join(" ") : undefined;
+}
+
 export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
   const [isPending, startTransition] = useTransition();
   const [showAccessToken, setShowAccessToken] = useState(false);
@@ -108,14 +121,15 @@ export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
                 id="display_phone_number"
                 {...register("display_phone_number")}
                 aria-invalid={!!errors.display_phone_number}
+                aria-describedby={fieldDescribedBy("display_phone_number", errors.display_phone_number, true)}
                 placeholder="Ex: 2250700000001"
               />
               {errors.display_phone_number && (
-                <p className="text-sm text-destructive">
+                <p id="display_phone_number-error" className="text-sm text-destructive">
                   {errors.display_phone_number.message}
                 </p>
               )}
-              <p className="text-xs text-muted-foreground">
+              <p id="display_phone_number-hint" className="text-xs text-muted-foreground">
                 Format international sans « + », entre 8 et 15 chiffres. Utilisé pour les liens wa.me.
               </p>
             </div>
@@ -138,14 +152,15 @@ export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
                 id="phone_number_id"
                 {...register("phone_number_id")}
                 aria-invalid={!!errors.phone_number_id}
+                aria-describedby={fieldDescribedBy("phone_number_id", errors.phone_number_id, true)}
                 placeholder="Ex: 123456789012345"
               />
               {errors.phone_number_id && (
-                <p className="text-sm text-destructive">
+                <p id="phone_number_id-error" className="text-sm text-destructive">
                   {errors.phone_number_id.message}
                 </p>
               )}
-              <p className="text-xs text-muted-foreground">
+              <p id="phone_number_id-hint" className="text-xs text-muted-foreground">
                 ID opaque fourni par Meta (différent du numéro public).
               </p>
             </div>
@@ -156,10 +171,11 @@ export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
                 id="business_account_id"
                 {...register("business_account_id")}
                 aria-invalid={!!errors.business_account_id}
+                aria-describedby={fieldDescribedBy("business_account_id", errors.business_account_id, false)}
                 placeholder="Ex: 123456789012345"
               />
               {errors.business_account_id && (
-                <p className="text-sm text-destructive">
+                <p id="business_account_id-error" className="text-sm text-destructive">
                   {errors.business_account_id.message}
                 </p>
               )}
@@ -173,6 +189,7 @@ export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
                   type={showAccessToken ? "text" : "password"}
                   {...register("access_token")}
                   aria-invalid={!!errors.access_token}
+                  aria-describedby={fieldDescribedBy("access_token", errors.access_token, false)}
                   placeholder="EAAxxxxxxxx..."
                   className="flex-1"
                 />
@@ -187,7 +204,7 @@ export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
                 </Button>
               </div>
               {errors.access_token && (
-                <p className="text-sm text-destructive">
+                <p id="access_token-error" className="text-sm text-destructive">
                   {errors.access_token.message}
                 </p>
               )}
@@ -199,10 +216,11 @@ export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
                 id="verify_token"
                 {...register("verify_token")}
                 aria-invalid={!!errors.verify_token}
+                aria-describedby={fieldDescribedBy("verify_token", errors.verify_token, false)}
                 placeholder="Token de vérification du webhook"
               />
               {errors.verify_token && (
-                <p className="text-sm text-destructive">
+                <p id="verify_token-error" className="text-sm text-destructive">
                   {errors.verify_token.message}
                 </p>
               )}
@@ -216,6 +234,7 @@ export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
                   type={showWebhookSecret ? "text" : "password"}
                   {...register("webhook_secret")}
                   aria-invalid={!!errors.webhook_secret}
+                  aria-describedby={fieldDescribedBy("webhook_secret", errors.webhook_secret, false)}
                   placeholder="Secret HMAC pour valider les webhooks"
                   className="flex-1"
                 />
@@ -230,7 +249,7 @@ export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
                 </Button>
               </div>
               {errors.webhook_secret && (
-                <p className="text-sm text-destructive">
+                <p id="webhook_secret-error" className="text-sm text-destructive">
                   {errors.webhook_secret.message}
                 </p>
               )}
@@ -251,14 +270,15 @@ export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
                 rows={3}
                 {...register("admin_phones")}
                 aria-invalid={!!errors.admin_phones}
+                aria-describedby={fieldDescribedBy("admin_phones", errors.admin_phones, true)}
                 placeholder='["2250700000001", "2250700000002"]'
               />
               {errors.admin_phones && (
-                <p className="text-sm text-destructive">
+                <p id="admin_phones-error" className="text-sm text-destructive">
                   {errors.admin_phones.message}
                 </p>
               )}
-              <p className="text-muted-foreground text-xs">
+              <p id="admin_phones-hint" className="text-muted-foreground text-xs">
                 Tableau JSON des numéros WhatsApp qui recevront les alertes d&apos;escalade
                 (avec indicatif pays, sans « + »). Ex&nbsp;: <code>[&quot;2250700000001&quot;]</code>
               </p>

--- a/components/admin/whatsapp/whatsapp-config-form.tsx
+++ b/components/admin/whatsapp/whatsapp-config-form.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useRef, useState, useTransition } from "react";
+import { useState, useTransition } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -8,27 +10,79 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  whatsappConfigSchema,
+  type WhatsAppConfigInput,
+} from "@/lib/validations/whatsapp-config";
 import { saveWhatsAppConfig, type WhatsAppConfig } from "@/actions/admin/whatsapp";
 
 interface WhatsAppConfigFormProps {
   config: WhatsAppConfig | null;
 }
 
+const FIELD_NAMES = [
+  "display_phone_number",
+  "phone_number_id",
+  "business_account_id",
+  "access_token",
+  "verify_token",
+  "webhook_secret",
+  "admin_phones",
+  "is_active",
+] as const;
+
+function isFieldName(value: string): value is (typeof FIELD_NAMES)[number] {
+  return (FIELD_NAMES as readonly string[]).includes(value);
+}
+
 export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
   const [isPending, startTransition] = useTransition();
   const [showAccessToken, setShowAccessToken] = useState(false);
   const [showWebhookSecret, setShowWebhookSecret] = useState(false);
-  const isActiveRef = useRef<HTMLInputElement>(null);
 
-  function handleSubmit(formData: FormData) {
+  const {
+    register,
+    handleSubmit,
+    control,
+    setError,
+    formState: { errors },
+  } = useForm<WhatsAppConfigInput>({
+    resolver: zodResolver(whatsappConfigSchema),
+    defaultValues: {
+      display_phone_number: config?.display_phone_number ?? "",
+      phone_number_id: config?.phone_number_id ?? "",
+      business_account_id: config?.business_account_id ?? "",
+      // Secrets arrive masked (•••••••• + last 4) — submitting them unchanged
+      // preserves the stored value server-side.
+      access_token: config?.access_token ?? "",
+      verify_token: config?.verify_token ?? "",
+      webhook_secret: config?.webhook_secret ?? "",
+      admin_phones: config?.admin_phones ?? "[]",
+      is_active: config?.is_active === 1,
+    },
+  });
+
+  function onSubmit(values: WhatsAppConfigInput) {
     startTransition(async () => {
       try {
-        const result = await saveWhatsAppConfig(formData);
+        const result = await saveWhatsAppConfig(values);
         if (result.success) {
           toast.success("Configuration WhatsApp sauvegardée");
-        } else {
-          toast.error(result.error ?? "Une erreur est survenue");
+          return;
         }
+        if (result.fieldErrors) {
+          for (const [field, messages] of Object.entries(result.fieldErrors)) {
+            const message = messages?.[0];
+            if (message && isFieldName(field)) {
+              setError(field, { type: "server", message });
+            }
+          }
+          toast.error(
+            Object.values(result.fieldErrors).flat()[0] ?? "Erreur de validation"
+          );
+          return;
+        }
+        toast.error(result.error ?? "Une erreur est survenue");
       } catch {
         toast.error("Erreur de connexion au serveur. Veuillez réessayer.");
       }
@@ -36,7 +90,7 @@ export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
   }
 
   return (
-    <form action={handleSubmit}>
+    <form onSubmit={handleSubmit(onSubmit)}>
       <div className="space-y-6">
         {/* Public display — minimal config for storefront buttons */}
         <Card>
@@ -52,10 +106,15 @@ export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
               <Label htmlFor="display_phone_number">Numéro public</Label>
               <Input
                 id="display_phone_number"
-                name="display_phone_number"
-                defaultValue={config?.display_phone_number ?? ""}
+                {...register("display_phone_number")}
+                aria-invalid={!!errors.display_phone_number}
                 placeholder="Ex: 2250700000001"
               />
+              {errors.display_phone_number && (
+                <p className="text-sm text-destructive">
+                  {errors.display_phone_number.message}
+                </p>
+              )}
               <p className="text-xs text-muted-foreground">
                 Format international sans « + », entre 8 et 15 chiffres. Utilisé pour les liens wa.me.
               </p>
@@ -77,10 +136,15 @@ export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
               <Label htmlFor="phone_number_id">Phone Number ID</Label>
               <Input
                 id="phone_number_id"
-                name="phone_number_id"
-                defaultValue={config?.phone_number_id ?? ""}
+                {...register("phone_number_id")}
+                aria-invalid={!!errors.phone_number_id}
                 placeholder="Ex: 123456789012345"
               />
+              {errors.phone_number_id && (
+                <p className="text-sm text-destructive">
+                  {errors.phone_number_id.message}
+                </p>
+              )}
               <p className="text-xs text-muted-foreground">
                 ID opaque fourni par Meta (différent du numéro public).
               </p>
@@ -90,10 +154,15 @@ export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
               <Label htmlFor="business_account_id">Business Account ID</Label>
               <Input
                 id="business_account_id"
-                name="business_account_id"
-                defaultValue={config?.business_account_id ?? ""}
+                {...register("business_account_id")}
+                aria-invalid={!!errors.business_account_id}
                 placeholder="Ex: 123456789012345"
               />
+              {errors.business_account_id && (
+                <p className="text-sm text-destructive">
+                  {errors.business_account_id.message}
+                </p>
+              )}
             </div>
 
             <div className="space-y-2">
@@ -101,9 +170,9 @@ export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
               <div className="flex gap-2">
                 <Input
                   id="access_token"
-                  name="access_token"
                   type={showAccessToken ? "text" : "password"}
-                  defaultValue={config?.access_token ?? ""}
+                  {...register("access_token")}
+                  aria-invalid={!!errors.access_token}
                   placeholder="EAAxxxxxxxx..."
                   className="flex-1"
                 />
@@ -117,16 +186,26 @@ export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
                   {showAccessToken ? "Masquer" : "Afficher"}
                 </Button>
               </div>
+              {errors.access_token && (
+                <p className="text-sm text-destructive">
+                  {errors.access_token.message}
+                </p>
+              )}
             </div>
 
             <div className="space-y-2">
               <Label htmlFor="verify_token">Verify Token (webhook)</Label>
               <Input
                 id="verify_token"
-                name="verify_token"
-                defaultValue={config?.verify_token ?? ""}
+                {...register("verify_token")}
+                aria-invalid={!!errors.verify_token}
                 placeholder="Token de vérification du webhook"
               />
+              {errors.verify_token && (
+                <p className="text-sm text-destructive">
+                  {errors.verify_token.message}
+                </p>
+              )}
             </div>
 
             <div className="space-y-2">
@@ -134,9 +213,9 @@ export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
               <div className="flex gap-2">
                 <Input
                   id="webhook_secret"
-                  name="webhook_secret"
                   type={showWebhookSecret ? "text" : "password"}
-                  defaultValue={config?.webhook_secret ?? ""}
+                  {...register("webhook_secret")}
+                  aria-invalid={!!errors.webhook_secret}
                   placeholder="Secret HMAC pour valider les webhooks"
                   className="flex-1"
                 />
@@ -150,6 +229,11 @@ export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
                   {showWebhookSecret ? "Masquer" : "Afficher"}
                 </Button>
               </div>
+              {errors.webhook_secret && (
+                <p className="text-sm text-destructive">
+                  {errors.webhook_secret.message}
+                </p>
+              )}
             </div>
           </CardContent>
         </Card>
@@ -164,11 +248,16 @@ export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
               <Label htmlFor="admin_phones">Numéros WhatsApp (JSON)</Label>
               <Textarea
                 id="admin_phones"
-                name="admin_phones"
                 rows={3}
-                defaultValue={config?.admin_phones ?? "[]"}
+                {...register("admin_phones")}
+                aria-invalid={!!errors.admin_phones}
                 placeholder='["2250700000001", "2250700000002"]'
               />
+              {errors.admin_phones && (
+                <p className="text-sm text-destructive">
+                  {errors.admin_phones.message}
+                </p>
+              )}
               <p className="text-muted-foreground text-xs">
                 Tableau JSON des numéros WhatsApp qui recevront les alertes d&apos;escalade
                 (avec indicatif pays, sans « + »). Ex&nbsp;: <code>[&quot;2250700000001&quot;]</code>
@@ -185,24 +274,23 @@ export function WhatsAppConfigForm({ config }: WhatsAppConfigFormProps) {
           <CardContent>
             <div className="flex items-center justify-between">
               <div>
-                <Label>Bot WhatsApp actif</Label>
+                <Label htmlFor="is_active">Bot WhatsApp actif</Label>
                 <p className="text-muted-foreground text-sm">
                   Active le bot conversationnel (nécessite l&apos;intégration API complète).
                 </p>
               </div>
-              <input
-                type="hidden"
+              <Controller
+                control={control}
                 name="is_active"
-                ref={isActiveRef}
-                defaultValue={config?.is_active ?? 0}
-              />
-              <Switch
-                defaultChecked={config ? config.is_active === 1 : false}
-                onCheckedChange={(checked) => {
-                  if (isActiveRef.current) {
-                    isActiveRef.current.value = checked ? "1" : "0";
-                  }
-                }}
+                render={({ field }) => (
+                  <Switch
+                    id="is_active"
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                    onBlur={field.onBlur}
+                    ref={field.ref}
+                  />
+                )}
               />
             </div>
           </CardContent>

--- a/lib/validations/whatsapp-config.ts
+++ b/lib/validations/whatsapp-config.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+
+// Two-tier config (see CLAUDE.md § WhatsApp Integration):
+//   - display_phone_number is PUBLIC: it drives the storefront wa.me buttons and
+//     works independently of is_active. It is never required.
+//   - the five API fields are required ONLY when is_active is true, to switch the
+//     conversational bot on.
+export const WHATSAPP_API_FIELDS = [
+  "phone_number_id",
+  "access_token",
+  "verify_token",
+  "webhook_secret",
+  "business_account_id",
+] as const;
+
+const API_FIELD_LABELS: Record<(typeof WHATSAPP_API_FIELDS)[number], string> = {
+  phone_number_id: "Le Phone Number ID",
+  access_token: "L'Access Token",
+  verify_token: "Le Verify Token",
+  webhook_secret: "Le Webhook Secret",
+  business_account_id: "Le Business Account ID",
+};
+
+export const DISPLAY_PHONE_ERROR =
+  "Le numéro public doit contenir entre 8 et 15 chiffres (format international, ex: 2250700000001).";
+export const ADMIN_PHONES_ERROR = "admin_phones doit être un tableau JSON valide.";
+
+function isJsonArray(value: string): boolean {
+  if (value === "") return true;
+  try {
+    return Array.isArray(JSON.parse(value));
+  } catch {
+    return false;
+  }
+}
+
+// Secrets are deliberately unconstrained in shape: the form pre-fills them with
+// the mask (•••••••• + last 4), and a real secret may legitimately start with
+// bullets too. Distinguishing "unchanged" from "new value" needs the stored
+// value, so it happens server-side in saveWhatsAppConfig via an EXACT mask
+// comparison — never a startsWith("••") guess.
+export const whatsappConfigSchema = z
+  .object({
+    display_phone_number: z
+      .string()
+      // Normalize: keep digits only (strips +, spaces, dashes, dots)
+      .transform((v) => v.trim().replace(/\D/g, ""))
+      // E.164-ish: 8-15 digits (ITU-T E.164 max is 15)
+      .refine((v) => v === "" || /^\d{8,15}$/.test(v), DISPLAY_PHONE_ERROR),
+    phone_number_id: z.string().trim(),
+    business_account_id: z.string().trim(),
+    access_token: z.string().trim(),
+    verify_token: z.string().trim(),
+    webhook_secret: z.string().trim(),
+    admin_phones: z
+      .string()
+      .transform((v) => v.trim())
+      .refine(isJsonArray, ADMIN_PHONES_ERROR)
+      .transform((v) => (v === "" ? "[]" : JSON.stringify(JSON.parse(v) as unknown[]))),
+    is_active: z.boolean(),
+  })
+  .superRefine((data, ctx) => {
+    if (!data.is_active) return;
+    for (const field of WHATSAPP_API_FIELDS) {
+      if (data[field] === "") {
+        ctx.addIssue({
+          code: "custom",
+          path: [field],
+          message: `${API_FIELD_LABELS[field]} est requis pour activer le bot.`,
+        });
+      }
+    }
+  });
+
+export type WhatsAppConfigInput = z.input<typeof whatsappConfigSchema>;
+export type WhatsAppConfigValues = z.infer<typeof whatsappConfigSchema>;


### PR DESCRIPTION
## Contexte

La configuration WhatsApp de l'admin était la dernière poche de validation ad-hoc du dépôt : `saveWhatsAppConfig` lisait un `FormData` brut champ par champ, enchaînait des `if` de validation manuels, et ne renvoyait qu'un `error: string` **global** — une seule erreur à la fois, jamais rattachée au champ fautif. Côté formulaire, `<form action={...}>` non contrôlé, aucun affichage d'erreur par champ, et un contournement à base de `ref` caché pour convertir le `Switch` en `"0"` / `"1"`.

Elle suit désormais le motif documenté dans `CLAUDE.md` et utilisé partout ailleurs (checkout, compte, adresse, avis, ai-config) : schéma Zod dans `lib/validations/`, `safeParse` + `fieldErrors` côté Server Action, React Hook Form + `zodResolver` côté formulaire.

**Refonte de la forme, pas du fond** : mêmes règles de validation, mêmes effets en base, mêmes messages — désormais ventilés par champ.

## Ce qui change

| Fichier | Changement |
|---|---|
| `lib/validations/whatsapp-config.ts` | **Nouveau.** `whatsappConfigSchema` : normalisation du numéro public, format E.164-ish, `admin_phones` en tableau JSON, `superRefine` pour l'activation du bot. |
| `actions/admin/whatsapp.ts` | `saveWhatsAppConfig(formData: FormData)` → `saveWhatsAppConfig(input: WhatsAppConfigInput)`. Validation déléguée au schéma, retour en `fieldErrors`. Le reste (détection de masque, écriture, garde atomique) est inchangé. |
| `components/admin/whatsapp/whatsapp-config-form.tsx` | RHF + `zodResolver`, `register()` sur chaque champ, `Controller` pour le `Switch` (le `ref` caché disparaît), erreurs affichées sous chaque champ + `aria-invalid`, erreurs serveur réinjectées via `setError`. |

Le SQL brut du fichier d'actions est **laissé tel quel** : `CLAUDE.md` interdit de mélanger Drizzle et SQL brut dans un même fichier au sein d'une même PR. Cette PR porte sur la validation ; la migration Drizzle reste au backlog.

## Les deux invariants métier — comment ils tiennent

### 1. Masque des secrets (égalité exacte, jamais `startsWith("••")`)

La détection « champ inchangé » **reste dans l'action**, car elle a besoin de la valeur stockée en base :

```ts
const expectedMaskedAccessToken = existingRow?.access_token ? maskSecret(existingRow.access_token) : null;
const accessTokenMasked = expectedMaskedAccessToken !== null && access_token_raw === expectedMaskedAccessToken;
```

Le schéma Zod ne contraint **volontairement pas** la forme des secrets : aucun rejet ni transformation basée sur les puces. Un vrai secret commençant par `••` traverse la validation intact et arrive à la comparaison d'égalité exacte, où il est reconnu comme une nouvelle valeur.

Verrouillé par :
- `__tests__/unit/actions/admin-whatsapp.test.ts` › *« enregistre un secret RÉEL commençant par des puces »* — soumet `••••••••9999` alors que le masque attendu est `••••••••1234` : le SQL contient bien `access_token = ?` et la valeur est dans les bindings.
- › *« reconnaît le masque EXACT comme « inchangé » »* — soumet `••••••••1234` : la colonne n'est pas réécrite du tout et le masque n'apparaît nulle part dans les bindings.
- › *« ne confond pas le masque avec une valeur quand rien n'est stocké »* — aucun secret en base ⇒ aucun masque n'a pu être envoyé au client, la saisie est prise au pied de la lettre.
- › *« garde atomique »* — `changes === 0` sur un `UPDATE ... WHERE access_token IS NOT NULL` renvoie toujours l'erreur de course.
- `__tests__/unit/validations/whatsapp-config.test.ts` › *« laisse passer un secret réel qui commence par des puces »* — le schéma ne les touche pas.

### 2. Configuration à deux étages

`display_phone_number` reste **public et facultatif**, indépendant de `is_active`. Les cinq champs API ne sont exigés que lorsque `is_active` est vrai, via un `superRefine` qui ajoute une issue **sur chaque champ manquant** (`path: [field]`), donc une entrée `fieldErrors` par champ.

Équivalence avec l'ancienne règle : l'ancien code vérifiait les valeurs « effectives » (masque ⇒ valeur en base). Or une valeur effective est non nulle **exactement** quand la valeur soumise est non vide — un masque soumis ne peut correspondre qu'à un secret stocké, donc non nul ; une saisie non vide non-masque est écrite telle quelle ; une saisie vide efface. La règle est donc décidable sur la soumission brute, et l'ancien bloc redondant a été retiré. La garde atomique en base (`WHERE ... IS NOT NULL`), qui couvre la course entre le `SELECT` et l'`UPDATE`, est conservée intacte.

Verrouillé par :
- `whatsapp-config.test.ts` › *« accepte le numéro public seul, bot inactif »*, *« n'exige aucun champ API quand is_active=0 »*.
- › *« refuse is_active=1 sans les champs API, avec une erreur sur CHAQUE champ manquant »* — vérifie aussi que `display_phone_number` **n'est pas** dans les erreurs.
- › *« ne ventile que le champ API réellement manquant »*.
- `admin-whatsapp.test.ts` › *« accepte le numéro public seul avec is_active=0 »* (INSERT avec le numéro normalisé et `is_active = 0`), › *« refuse is_active=1 sans les champs API »* (fieldErrors ventilés **et aucune écriture en base**), › *« active le bot quand les 5 champs API sont fournis »*.

## Tests

25 tests ajoutés (14 sur le schéma, 11 sur l'action), aucun test existant modifié.

```
tsc --noEmit  ✅
eslint        ✅
vitest run    ✅  85 fichiers / 1415 tests
```

## Seul écart assumé au « aucun changement fonctionnel »

Le message global unique d'activation — *« Pour activer le bot, renseignez phone_number_id, access_token, verify_token, webhook_secret et business_account_id. »* — n'existe plus tel quel : c'est précisément la chaîne globale que l'issue demande de ventiler. Il est remplacé par un message par champ manquant (*« L'Access Token est requis pour activer le bot. »*, etc.), affiché sous le champ concerné. Les autres messages (numéro public, `admin_phones`, course sur les identifiants, erreur de sauvegarde) sont repris **mot pour mot**.

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGMDCzf2UnxoR71tws5wRS
