### PR TITLE
feat(admin): remote MCP server for AI-driven product drafts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,17 @@ Public number flow: `getPublicWhatsAppNumber()` (server, React-cached) → `What
 
 Masked secret pattern: admin config form shows secrets as `••••••••` + last 4 chars. Detect "unchanged" on save by exact equality against the expected mask (not `startsWith("••")`), otherwise a real secret starting with bullets gets silently discarded.
 
+## Admin MCP Server
+
+Remote MCP endpoint at `POST /api/mcp` (Streamable HTTP, stateless) for AI clients (claude.ai, Claude Desktop, Claude Code, ChatGPT, Cursor…). Spec: `docs/superpowers/specs/2026-09-02-admin-mcp-server-design.md`.
+
+- **Auth:** OAuth 2.1 via better-auth's `mcp` plugin (`lib/auth/index.ts`). Dynamic client registration is open, so `lib/auth/mcp-consent-hook.ts` forces `prompt=consent` on every `/mcp/authorize` and `/admin/mcp/consent` requires a human click — without it a signed-in admin could be phished into issuing a token silently. Do not remove the hook.
+- **Authorization:** `lib/mcp/context.ts` re-reads the user from D1 on every request; only `admin`/`super_admin`, not banned. A `customer` can finish the OAuth flow but every call gets 403.
+- **Tools:** `lib/mcp/tools/*.ts`, registered by `lib/mcp/server.ts`. All product writes go through `lib/db/product-drafts.ts`, whose every UPDATE/DELETE carries `is_draft = 1`. No tool can publish; that stays in the wizard.
+- **Audit:** each write tool records `product.draft_*` in `audit_log` with `details.via = "mcp"`.
+- **Local test:** `claude mcp add --transport http netereka-local http://localhost:3000/api/mcp`, then `/mcp` in Claude Code. Discovery documents: `/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource`.
+- **Adding a tool:** `defineTool({ name, description, inputSchema: <zod raw shape>, handler })` in a `lib/mcp/tools/*.ts` file, add it to `ALL_TOOLS`, map domain errors to `fail(code, message)`; never let a stack trace reach the client.
+
 ## Release Pipeline
 
 Full reference : **[`docs/RELEASE_PIPELINE.md`](./docs/RELEASE_PIPELINE.md)**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,7 @@ Remote MCP endpoint at `POST /api/mcp` (Streamable HTTP, stateless) for AI clien
 - **Audit:** each write tool records `product.draft_*` in `audit_log` with `details.via = "mcp"`.
 - **Local test:** `claude mcp add --transport http netereka-local http://localhost:3000/api/mcp`, then `/mcp` in Claude Code. Discovery documents: `/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource`.
 - **Adding a tool:** `defineTool({ name, description, inputSchema: <zod raw shape>, handler })` in a `lib/mcp/tools/*.ts` file, add it to `ALL_TOOLS`, map domain errors to `fail(code, message)`; never let a stack trace reach the client.
+- **Consent page:** `/admin/mcp/consent` must keep showing the redirect host and posting the `consent_code` it displayed — `/mcp/token` does not check `requireConsent`, so the consent code must never leave the admin's browser (page is `no-referrer`).
 
 ## Release Pipeline
 

--- a/__tests__/helpers/d1-mock.ts
+++ b/__tests__/helpers/d1-mock.ts
@@ -1,0 +1,53 @@
+import { vi } from "vitest";
+
+/**
+ * Mocks the D1 binding one level below Drizzle so the real driver compiles the
+ * statements. Assertions run against the SQL/params Drizzle emits, which is
+ * what catches schema/column drift. Same technique as products-ai.test.ts.
+ *
+ * `raw` feeds `.get()`/`.all()` with POSITIONAL row arrays in select order
+ * (Drizzle's D1 driver reads `stmt.raw()` when a field selection exists).
+ * Return `[]` for "no row".
+ *
+ * Usage:
+ *   const d1 = createD1Mock();
+ *   vi.mock("@/lib/cloudflare/context", () => ({ getDB: async () => d1.binding }));
+ */
+export interface BoundStatement { sql: string; params: unknown[] }
+
+export function createD1Mock() {
+  const bound = vi.fn<(stmt: BoundStatement) => void>();
+  const run = vi.fn<(stmt: BoundStatement) => Promise<unknown>>();
+  const raw = vi.fn<(stmt: BoundStatement) => Promise<unknown[][]>>();
+  const batch = vi.fn<(stmts: BoundStatement[]) => Promise<unknown[]>>();
+
+  const binding = {
+    prepare: (sql: string) => ({
+      bind: (...params: unknown[]) => {
+        const stmt = { sql, params };
+        bound(stmt);
+        return {
+          ...stmt,
+          run: () => run(stmt),
+          all: () => raw(stmt).then((rows) => ({ results: rows })),
+          raw: () => raw(stmt),
+        };
+      },
+    }),
+    batch: (stmts: BoundStatement[]) => batch(stmts),
+  };
+
+  function reset() {
+    bound.mockReset();
+    run.mockReset().mockResolvedValue({ success: true, meta: { changes: 1 }, results: [] });
+    raw.mockReset().mockResolvedValue([]);
+    batch.mockReset().mockResolvedValue([]);
+  }
+  reset();
+
+  /** Statements handed to the Nth `db.batch()` call. */
+  const batchStatements = (call = 0) => batch.mock.calls[call][0];
+  const boundMatching = (re: RegExp) => bound.mock.calls.map((c) => c[0]).filter((s) => re.test(s.sql));
+
+  return { binding, bound, run, raw, batch, reset, batchStatements, boundMatching };
+}

--- a/__tests__/unit/api/mcp-route.test.ts
+++ b/__tests__/unit/api/mcp-route.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getMcpSession: vi.fn(),
+  buildMcpContext: vi.fn(),
+}));
+
+// withMcpAuth (real, from better-auth) calls auth.api.getMcpSession and needs auth.options.
+vi.mock("@/lib/auth", () => ({
+  initAuth: vi.fn().mockResolvedValue({
+    options: { baseURL: "https://netereka.ci", basePath: "/api/auth" },
+    api: { getMcpSession: mocks.getMcpSession },
+  }),
+}));
+vi.mock("@/lib/mcp/context", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/mcp/context")>("@/lib/mcp/context");
+  return { ...actual, buildMcpContext: mocks.buildMcpContext };
+});
+vi.mock("@/lib/cloudflare/context", () => ({ getDB: async () => { throw new Error("no DB"); } }));
+
+import { McpAuthError } from "@/lib/mcp/context";
+import { POST, GET, DELETE } from "@/app/api/mcp/route";
+
+function rpc(body: unknown, token = "tok") {
+  return new Request("https://netereka.ci/api/mcp", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+const INIT = {
+  jsonrpc: "2.0", id: 1, method: "initialize",
+  params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "test", version: "0" } },
+};
+const LIST = { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getMcpSession.mockResolvedValue({ userId: "u1", clientId: "c1", scopes: "openid" });
+  mocks.buildMcpContext.mockResolvedValue({ user: { id: "u1", name: "Admin", role: "admin" }, clientId: "c1" });
+});
+
+describe("POST /api/mcp", () => {
+  it("répond 401 avec WWW-Authenticate sans jeton valide", async () => {
+    mocks.getMcpSession.mockResolvedValue(null);
+    const res = await POST(rpc(LIST));
+    expect(res.status).toBe(401);
+    expect(res.headers.get("www-authenticate")).toMatch(/resource_metadata=/);
+    expect(mocks.buildMcpContext).not.toHaveBeenCalled();
+  });
+
+  it("répond 403 JSON-RPC quand le porteur du jeton n'est pas admin", async () => {
+    mocks.buildMcpContext.mockRejectedValue(new McpAuthError("Accès réservé aux administrateurs"));
+    const res = await POST(rpc(LIST));
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toBe("Accès réservé aux administrateurs");
+  });
+
+  it("sert tools/list à un admin", async () => {
+    const res = await POST(rpc(LIST));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { result: { tools: { name: string }[] } };
+    const names = body.result.tools.map((t: { name: string }) => t.name);
+    expect(names).toContain("create_product_draft");
+    expect(names).toContain("list_categories");
+    expect(names).toHaveLength(9);
+  });
+
+  it("accepte initialize sans identifiant de session (stateless)", async () => {
+    const res = await POST(rpc(INIT));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("mcp-session-id")).toBeNull();
+    const body = (await res.json()) as { result: { serverInfo: { name: string } } };
+    expect(body.result.serverInfo.name).toBe("netereka-admin");
+  });
+});
+
+describe("GET/DELETE /api/mcp", () => {
+  it("répondent 405", async () => {
+    expect((await GET()).status).toBe(405);
+    expect((await DELETE()).status).toBe(405);
+  });
+});

--- a/__tests__/unit/auth-config.test.ts
+++ b/__tests__/unit/auth-config.test.ts
@@ -101,3 +101,31 @@ describe("auth configuration — captcha coverage", () => {
     expect(endpoints).toEqual([...CAPTCHA_ENDPOINTS]);
   });
 });
+
+describe("auth configuration — MCP OAuth provider", () => {
+  function mcpPlugin() {
+    const opts = buildAuthOptions(env);
+    return opts.plugins.find((p) => p.id === "mcp") as
+      | { id: string; options?: { loginPage?: string; resource?: string; oidcConfig?: { consentPage?: string; requirePKCE?: boolean } } }
+      | undefined;
+  }
+
+  it("registers the mcp plugin against the admin login page", () => {
+    expect(mcpPlugin()).toBeDefined();
+    expect(mcpPlugin()?.options?.loginPage).toBe("/admin/login");
+  });
+
+  it("declares /api/mcp as the protected resource", () => {
+    expect(mcpPlugin()?.options?.resource).toBe("https://netereka.ci/api/mcp");
+  });
+
+  it("routes consent through the admin consent page and requires PKCE", () => {
+    expect(mcpPlugin()?.options?.oidcConfig?.consentPage).toBe("/admin/mcp/consent");
+    expect(mcpPlugin()?.options?.oidcConfig?.requirePKCE).toBe(true);
+  });
+
+  it("installs a before hook (the forced-consent guard)", () => {
+    const opts = buildAuthOptions(env);
+    expect(typeof opts.hooks?.before).toBe("function");
+  });
+});

--- a/__tests__/unit/constants.test.ts
+++ b/__tests__/unit/constants.test.ts
@@ -123,3 +123,13 @@ describe("AUDIT_ACTION_OPTIONS", () => {
     }
   });
 });
+
+describe("audit actions — product drafts (MCP)", () => {
+  it.each(["product.draft_created", "product.draft_updated", "product.draft_deleted"] as const)(
+    "%s a un libellé et une option de filtre",
+    (action) => {
+      expect(AUDIT_ACTION_LABELS[action]).toBeTruthy();
+      expect(AUDIT_ACTION_OPTIONS.some((o) => o.value === action)).toBe(true);
+    },
+  );
+});

--- a/__tests__/unit/lib/auth/mcp-consent-client.test.ts
+++ b/__tests__/unit/lib/auth/mcp-consent-client.test.ts
@@ -19,7 +19,33 @@ vi.mock("@/lib/cloudflare/context", () => ({
   }),
 }));
 
-import { findOAuthClientName } from "@/lib/auth/mcp-consent-client";
+import { findOAuthClientName, findConsentRequest } from "@/lib/auth/mcp-consent-client";
+
+/** Routes the mocked D1 driver by table name so a test can queue rows for the
+ * `verification` select and, separately, for the `oauthApplication` select
+ * that `findConsentRequest` issues afterwards to resolve the client name. */
+function mockRowsFor(verificationRows: unknown[], clientRows: unknown[]) {
+  mocks.raw.mockImplementation(async (stmt: { sql: string }) => {
+    if (/from "verification"/i.test(stmt.sql)) return verificationRows;
+    if (/from "oauthApplication"/i.test(stmt.sql)) return clientRows;
+    throw new Error(`unexpected query: ${stmt.sql}`);
+  });
+}
+
+function verificationValue(overrides: Partial<Record<string, unknown>> = {}) {
+  return JSON.stringify({
+    clientId: "client-1",
+    redirectURI: "http://localhost:9999/callback",
+    scope: ["mcp:products:draft"],
+    userId: "user-1",
+    authTime: 0,
+    requireConsent: true,
+    state: null,
+    codeChallenge: "challenge",
+    codeChallengeMethod: "S256",
+    ...overrides,
+  });
+}
 
 describe("findOAuthClientName", () => {
   beforeEach(() => { vi.clearAllMocks(); });
@@ -35,5 +61,48 @@ describe("findOAuthClientName", () => {
   it("retourne null pour un client inconnu", async () => {
     mocks.raw.mockResolvedValue([]);
     await expect(findOAuthClientName("nope")).resolves.toBeNull();
+  });
+});
+
+describe("findConsentRequest", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("résout la demande de consentement à partir du code", async () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    mockRowsFor([[verificationValue(), future]], [["Claude Desktop"]]);
+
+    await expect(findConsentRequest("code-1")).resolves.toEqual({
+      clientId: "client-1",
+      clientName: "Claude Desktop",
+      redirectHost: "localhost:9999",
+      scopes: ["mcp:products:draft"],
+    });
+  });
+
+  it("retourne null quand le code a expiré", async () => {
+    const past = new Date(Date.now() - 60_000).toISOString();
+    mockRowsFor([[verificationValue(), past]], [["Claude Desktop"]]);
+
+    await expect(findConsentRequest("code-1")).resolves.toBeNull();
+  });
+
+  it("retourne null quand requireConsent est faux", async () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    mockRowsFor([[verificationValue({ requireConsent: false }), future]], [["Claude Desktop"]]);
+
+    await expect(findConsentRequest("code-1")).resolves.toBeNull();
+  });
+
+  it("retourne null quand le code est introuvable", async () => {
+    mockRowsFor([], [["Claude Desktop"]]);
+
+    await expect(findConsentRequest("missing")).resolves.toBeNull();
+  });
+
+  it("retourne null quand la valeur stockée est du JSON invalide", async () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    mockRowsFor([["not-json", future]], [["Claude Desktop"]]);
+
+    await expect(findConsentRequest("code-1")).resolves.toBeNull();
   });
 });

--- a/__tests__/unit/lib/auth/mcp-consent-client.test.ts
+++ b/__tests__/unit/lib/auth/mcp-consent-client.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({ raw: vi.fn(), bound: vi.fn() }));
+
+vi.mock("@/lib/cloudflare/context", () => ({
+  getDB: async () => ({
+    prepare: (sql: string) => ({
+      bind: (...params: unknown[]) => {
+        const stmt = { sql, params };
+        mocks.bound(stmt);
+        return {
+          run: async () => ({ success: true, meta: {}, results: [] }),
+          all: async () => ({ results: await mocks.raw(stmt) }),
+          raw: () => mocks.raw(stmt),
+        };
+      },
+    }),
+    batch: async () => [],
+  }),
+}));
+
+import { findOAuthClientName } from "@/lib/auth/mcp-consent-client";
+
+describe("findOAuthClientName", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("retourne le nom du client enregistré", async () => {
+    mocks.raw.mockResolvedValue([["Claude Desktop"]]);
+    await expect(findOAuthClientName("client-1")).resolves.toBe("Claude Desktop");
+    const stmt = mocks.bound.mock.calls[0][0] as { sql: string; params: unknown[] };
+    expect(stmt.sql).toMatch(/from "oauthApplication"/i);
+    expect(stmt.params).toEqual(["client-1"]);
+  });
+
+  it("retourne null pour un client inconnu", async () => {
+    mocks.raw.mockResolvedValue([]);
+    await expect(findOAuthClientName("nope")).resolves.toBeNull();
+  });
+});

--- a/__tests__/unit/lib/auth/mcp-consent-hook.test.ts
+++ b/__tests__/unit/lib/auth/mcp-consent-hook.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { forceConsentQuery, MCP_AUTHORIZE_PATH } from "@/lib/auth/mcp-consent-hook";
+
+describe("forceConsentQuery", () => {
+  it("ignore les autres endpoints", () => {
+    expect(forceConsentQuery("/sign-in/email", { prompt: "none" })).toBeUndefined();
+    expect(forceConsentQuery(undefined, { prompt: "none" })).toBeUndefined();
+  });
+
+  it("force prompt=consent quand le client n'envoie rien", () => {
+    expect(forceConsentQuery(MCP_AUTHORIZE_PATH, { client_id: "c1" }))
+      .toEqual({ client_id: "c1", prompt: "consent" });
+  });
+
+  it("écrase prompt=none et prompt=login", () => {
+    expect(forceConsentQuery(MCP_AUTHORIZE_PATH, { prompt: "none" })?.prompt).toBe("consent");
+    expect(forceConsentQuery(MCP_AUTHORIZE_PATH, { prompt: "login" })?.prompt).toBe("consent");
+  });
+
+  it("tolère une query absente", () => {
+    expect(forceConsentQuery(MCP_AUTHORIZE_PATH, undefined)).toEqual({ prompt: "consent" });
+  });
+});

--- a/__tests__/unit/lib/auth/oauth-resume.test.ts
+++ b/__tests__/unit/lib/auth/oauth-resume.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { getOAuthResumeUrl } from "@/lib/auth/oauth-resume";
+
+describe("getOAuthResumeUrl", () => {
+  it("retourne null sans paramètres OAuth", () => {
+    expect(getOAuthResumeUrl(new URLSearchParams(""))).toBeNull();
+    expect(getOAuthResumeUrl(new URLSearchParams("redirect=/dashboard"))).toBeNull();
+  });
+
+  it("exige client_id, redirect_uri et response_type", () => {
+    expect(getOAuthResumeUrl(new URLSearchParams("client_id=c&redirect_uri=http://x"))).toBeNull();
+  });
+
+  it("reconstruit l'URL d'autorisation avec la query intacte", () => {
+    const params = new URLSearchParams(
+      "client_id=c1&redirect_uri=http%3A%2F%2Flocalhost%3A6274%2Fcb&response_type=code&state=s1&code_challenge=abc&code_challenge_method=S256",
+    );
+    expect(getOAuthResumeUrl(params)).toBe(`/api/auth/mcp/authorize?${params.toString()}`);
+  });
+});

--- a/__tests__/unit/lib/db/product-drafts-media.test.ts
+++ b/__tests__/unit/lib/db/product-drafts-media.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createD1Mock, type BoundStatement } from "../../../helpers/d1-mock";
+
+const d1 = vi.hoisted(() => ({
+  current: null as null | ReturnType<typeof import("../../../helpers/d1-mock").createD1Mock>,
+}));
+const mocks = vi.hoisted(() => ({ deleteFromR2: vi.fn(), fetchAndUploadImage: vi.fn() }));
+
+vi.mock("@/lib/cloudflare/context", () => ({ getDB: async () => d1.current!.binding }));
+vi.mock("@/lib/storage/images", () => ({ deleteFromR2: mocks.deleteFromR2, uploadToR2: vi.fn() }));
+vi.mock("@/lib/ai/image-fetch", () => ({ fetchAndUploadImage: mocks.fetchAndUploadImage }));
+
+import { addImagesFromUrls, removeImage, setColorVariants } from "@/lib/db/product-drafts";
+
+const sqlOf = (s: BoundStatement) => s.sql.replace(/\s+/g, " ");
+const DRAFT_ROW = [["p1", "slug"]];
+
+beforeEach(() => {
+  d1.current = createD1Mock();
+  mocks.deleteFromR2.mockReset().mockResolvedValue(undefined);
+  mocks.fetchAndUploadImage.mockReset().mockImplementation(async (_id: string, url: string) =>
+    ({ ok: true, key: `products/p1/${url.split("/").pop()}`, contentType: "image/jpeg", size: 10 }));
+});
+
+describe("addImagesFromUrls", () => {
+  it("refuse au-delà de 12 images au total, avant tout téléchargement", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) => {
+      if (/"is_draft" = \?/i.test(stmt.sql)) return DRAFT_ROW;
+      if (/from "product_images"/i.test(stmt.sql)) return Array.from({ length: 11 }, (_, i) => [`img-${i}`, i === 0 ? 1 : 0, i]);
+      return [];
+    });
+    await expect(addImagesFromUrls("p1", [{ url: "https://x/a.jpg" }, { url: "https://x/b.jpg" }]))
+      .rejects.toMatchObject({ code: "limit_exceeded" });
+    expect(mocks.fetchAndUploadImage).not.toHaveBeenCalled();
+  });
+
+  it("insère les images réussies, marque la première primaire, rapporte les échecs", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) => (/"is_draft" = \?/i.test(stmt.sql) ? DRAFT_ROW : []));
+    mocks.fetchAndUploadImage.mockImplementation(async (_id: string, url: string) =>
+      url.endsWith("bad.jpg") ? { ok: false, reason: "bad_status", status: 404 }
+        : { ok: true, key: `products/p1/${url.split("/").pop()}`, contentType: "image/jpeg", size: 1 });
+
+    const r = await addImagesFromUrls("p1", [{ url: "https://x/bad.jpg" }, { url: "https://x/a.jpg", alt: "A" }, { url: "https://x/b.jpg" }]);
+
+    expect(r.results).toEqual([
+      { url: "https://x/bad.jpg", ok: false, reason: "bad_status" },
+      { url: "https://x/a.jpg", ok: true, image_id: expect.any(String) },
+      { url: "https://x/b.jpg", ok: true, image_id: expect.any(String) },
+    ]);
+    expect(r.primary_image_id).toBe(r.results[1].image_id);
+    const inserts = d1.current!.batchStatements().filter((s) => /insert into "product_images"/i.test(s.sql));
+    expect(inserts).toHaveLength(2);
+    expect(inserts[0].params).toEqual(expect.arrayContaining(["products/p1/a.jpg", "A", 1, 0]));  // is_primary 1, sort 0
+    expect(inserts[1].params).toEqual(expect.arrayContaining(["products/p1/b.jpg", 0, 1]));
+  });
+
+  it("garde la primaire existante et poursuit le sort_order", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) => {
+      if (/"is_draft" = \?/i.test(stmt.sql)) return DRAFT_ROW;
+      if (/from "product_images"/i.test(stmt.sql)) return [["img-0", 1, 0], ["img-1", 0, 4]];
+      return [];
+    });
+    const r = await addImagesFromUrls("p1", [{ url: "https://x/c.jpg" }]);
+    expect(r.primary_image_id).toBe("img-0");
+    const insert = d1.current!.batchStatements()[0];
+    expect(insert.params).toEqual(expect.arrayContaining([0, 5]));
+  });
+
+  it("nettoie R2 si le batch échoue", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) => (/"is_draft" = \?/i.test(stmt.sql) ? DRAFT_ROW : []));
+    d1.current!.batch.mockRejectedValue(new Error("D1 down"));
+    await expect(addImagesFromUrls("p1", [{ url: "https://x/a.jpg" }])).rejects.toThrow("D1 down");
+    expect(mocks.deleteFromR2).toHaveBeenCalledWith("products/p1/a.jpg");
+  });
+});
+
+describe("removeImage", () => {
+  it("supprime la ligne, promeut la suivante en primaire et efface l'objet R2", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) => {
+      if (/"is_draft" = \?/i.test(stmt.sql)) return DRAFT_ROW;
+      if (/from "product_images"/i.test(stmt.sql) && /"id" = \?/i.test(stmt.sql)) return [["img-0", "products/p1/a.jpg", 1]];
+      if (/from "product_images"/i.test(stmt.sql)) return [["img-1"]];
+      return [];
+    });
+    await removeImage("p1", "img-0");
+    const stmts = d1.current!.batchStatements().map(sqlOf);
+    expect(stmts[0]).toMatch(/delete from "product_images"/i);
+    expect(stmts[1]).toMatch(/update "product_images" set "is_primary" = \?/i);
+    expect(mocks.deleteFromR2).toHaveBeenCalledWith("products/p1/a.jpg");
+  });
+
+  it("lève not_found pour une image d'un autre produit", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) => (/"is_draft" = \?/i.test(stmt.sql) ? DRAFT_ROW : []));
+    await expect(removeImage("p1", "img-x")).rejects.toMatchObject({ code: "not_found" });
+  });
+});
+
+describe("setColorVariants", () => {
+  // select({ id, slug, base_price, compare_price }) → positional row
+  const PRODUCT_ROW = [["p1", "slug", 100000, 120000]];
+
+  it("crée, met à jour et supprime les variantes couleur, et recalcule le stock", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) => {
+      if (/from "products"/i.test(stmt.sql)) return PRODUCT_ROW;
+      if (/from "product_variants"/i.test(stmt.sql) && /"attributes"/i.test(stmt.sql)) {
+        return [["v-noir", JSON.stringify({ color: "Noir:#000000" })], ["v-bleu", JSON.stringify({ color: "Bleu:#0000ff" })]];
+      }
+      return [];
+    });
+
+    const r = await setColorVariants("p1", {
+      uniform_price: false,
+      variants: [
+        { color_name: "Noir", color_hex: "#000000", stock: 2, price: 90000 },
+        { color_name: "Rouge", color_hex: "#ff0000", stock: 3 },
+      ],
+    });
+
+    expect(r.stock_quantity).toBe(5);
+    const stmts = d1.current!.batchStatements().map(sqlOf);
+    expect(stmts.some((s) => /update "product_variants" set/i.test(s))).toBe(true);        // Noir
+    expect(stmts.some((s) => /insert into "product_variants"/i.test(s))).toBe(true);      // Rouge
+    expect(stmts.some((s) => /update "product_images" set "variant_id" = \?/i.test(s))).toBe(true); // Bleu images detached
+    expect(stmts.some((s) => /delete from "product_variants" where "product_variants"."id" = \?/i.test(s))).toBe(true); // Bleu
+    expect(stmts[stmts.length - 1]).toMatch(/update "products" set "stock_quantity" = \?.*"is_draft" = \?/i);
+    const rougeInsert = d1.current!.batchStatements().find((s) => /insert into "product_variants"/i.test(s.sql))!;
+    expect(rougeInsert.params).toEqual(expect.arrayContaining(["Rouge", 100000, JSON.stringify({ color: "Rouge:#ff0000" })])); // price → base_price
+  });
+
+  it("applique le prix de base à toutes les variantes en uniform_price", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) => (/from "products"/i.test(stmt.sql) ? PRODUCT_ROW : []));
+    await setColorVariants("p1", { uniform_price: true, variants: [{ color_name: "Noir", color_hex: "#000000", stock: 1, price: 5 }] });
+    const insert = d1.current!.batchStatements().find((s) => /insert into "product_variants"/i.test(s.sql))!;
+    expect(insert.params).toEqual(expect.arrayContaining([100000, 120000]));
+    expect(insert.params).not.toContain(5);
+  });
+
+  it("refuse un produit publié", async () => {
+    await expect(setColorVariants("p1", { uniform_price: true, variants: [] })).rejects.toMatchObject({ code: "not_found" });
+  });
+});

--- a/__tests__/unit/lib/db/product-drafts-media.test.ts
+++ b/__tests__/unit/lib/db/product-drafts-media.test.ts
@@ -72,6 +72,30 @@ describe("addImagesFromUrls", () => {
     await expect(addImagesFromUrls("p1", [{ url: "https://x/a.jpg" }])).rejects.toThrow("D1 down");
     expect(mocks.deleteFromR2).toHaveBeenCalledWith("products/p1/a.jpg");
   });
+
+  it("journalise les échecs de nettoyage R2 après un batch en échec", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) => (/"is_draft" = \?/i.test(stmt.sql) ? DRAFT_ROW : []));
+    d1.current!.batch.mockRejectedValue(new Error("D1 down"));
+    mocks.deleteFromR2.mockImplementation(async (key: string) => {
+      if (key === "products/p1/a.jpg") throw new Error("R2 unreachable");
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(addImagesFromUrls("p1", [{ url: "https://x/a.jpg" }, { url: "https://x/b.jpg" }]))
+      .rejects.toThrow("D1 down");
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[product-drafts] orphan R2 object after failed image batch",
+      "products/p1/a.jpg",
+      expect.any(Error),
+    );
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.anything(),
+      "products/p1/b.jpg",
+      expect.anything(),
+    );
+    warnSpy.mockRestore();
+  });
 });
 
 describe("removeImage", () => {

--- a/__tests__/unit/lib/db/product-drafts.test.ts
+++ b/__tests__/unit/lib/db/product-drafts.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createD1Mock, type BoundStatement } from "../../../helpers/d1-mock";
+
+const d1 = vi.hoisted(() => {
+  // createD1Mock is imported above but hoisting needs a lazy reference.
+  return { current: null as null | ReturnType<typeof import("../../../helpers/d1-mock").createD1Mock> };
+});
+const mocks = vi.hoisted(() => ({ deleteFromR2: vi.fn() }));
+
+vi.mock("@/lib/cloudflare/context", () => ({ getDB: async () => d1.current!.binding }));
+vi.mock("@/lib/storage/images", () => ({ deleteFromR2: mocks.deleteFromR2, uploadToR2: vi.fn() }));
+vi.mock("@/lib/ai/image-fetch", () => ({ fetchAndUploadImage: vi.fn() }));
+
+import {
+  attributesToRows,
+  createDraft,
+  updateDraft,
+  getDraft,
+  searchProducts,
+  deleteDraft,
+  DraftError,
+} from "@/lib/db/product-drafts";
+
+beforeEach(() => {
+  d1.current = createD1Mock();
+  mocks.deleteFromR2.mockReset().mockResolvedValue(undefined);
+});
+
+const sqlOf = (s: BoundStatement) => s.sql.replace(/\s+/g, " ");
+
+describe("attributesToRows", () => {
+  it("encode couleurs, dimensions et specs avec les conventions du wizard", () => {
+    expect(attributesToRows({
+      colors: [{ name: "Noir", hex: "#000000" }],
+      dimensions: { length_mm: 160, weight_g: 190 },
+      specs: [{ name: "Écran", value: "6.1\"" }],
+    })).toEqual([
+      { name: "Couleur", value: "Noir|#000000" },
+      { name: "Longueur", value: "160" },
+      { name: "Poids", value: "190" },
+      { name: "Écran", value: "6.1\"" },
+    ]);
+  });
+
+  it("retourne [] sans attributs", () => {
+    expect(attributesToRows(undefined)).toEqual([]);
+  });
+});
+
+describe("createDraft", () => {
+  it("refuse une catégorie inconnue", async () => {
+    await expect(createDraft({ name: "Galaxy A55", category_id: "nope" }))
+      .rejects.toMatchObject({ code: "not_found" });
+  });
+
+  it("insère un brouillon inactif avec un slug dérivé du nom, en un seul batch", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) =>
+      /from "categories"/i.test(stmt.sql) ? [["cat-1"]] : []);
+
+    const r = await createDraft({
+      name: "Galaxy A55",
+      category_id: "cat-1",
+      description_html: "<p>Hi</p><script>x()</script>",
+      attributes: { colors: [{ name: "Noir", hex: "#000000" }], dimensions: {}, specs: [] },
+      pricing: { base_price: 150000, sku: "GA55" },
+    });
+
+    expect(r.slug).toBe("galaxy-a55");
+    const stmts = d1.current!.batchStatements();
+    const insert = stmts.find((s) => /insert into "products"/i.test(s.sql))!;
+    expect(insert.params).toContain("galaxy-a55");
+    const strings = insert.params.filter((p): p is string => typeof p === "string");
+    expect(strings.some((s) => s.includes("<p>Hi</p>"))).toBe(true);   // sanitized HTML kept
+    expect(strings.some((s) => s.includes("<script>"))).toBe(false);   // script stripped
+    expect(stmts.filter((s) => /insert into "product_attributes"/i.test(s.sql))).toHaveLength(1);
+    // is_draft = 1, is_active = 0 are bound values of the products insert
+    expect(insert.params).toEqual(expect.arrayContaining([1, 0]));
+  });
+
+  it("suffixe le slug quand il est pris", async () => {
+    const taken = new Set(["galaxy-a55", "galaxy-a55-2"]);
+    d1.current!.raw.mockImplementation(async (stmt) => {
+      if (/from "categories"/i.test(stmt.sql)) return [["cat-1"]];
+      if (/from "products"/i.test(stmt.sql) && /"slug" =/i.test(stmt.sql)) {
+        return taken.has(stmt.params[0] as string) ? [["other"]] : [];
+      }
+      return [];
+    });
+    const r = await createDraft({ name: "Galaxy A55", category_id: "cat-1" });
+    expect(r.slug).toBe("galaxy-a55-3");
+  });
+
+  it("refuse un SKU déjà utilisé", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) => {
+      if (/from "categories"/i.test(stmt.sql)) return [["cat-1"]];
+      if (/"sku" =/i.test(stmt.sql)) return [["p-other"]];
+      return [];
+    });
+    await expect(createDraft({ name: "X", category_id: "cat-1", pricing: { sku: "DUP" } }))
+      .rejects.toMatchObject({ code: "conflict" });
+  });
+});
+
+describe("updateDraft", () => {
+  it("refuse un produit qui n'est pas un brouillon", async () => {
+    await expect(updateDraft("p1", { name: "Y" })).rejects.toMatchObject({ code: "not_found" });
+    const probe = d1.current!.boundMatching(/from "products"/i)[0];
+    expect(sqlOf(probe)).toMatch(/"is_draft" = \?/);
+    expect(probe.params).toContain(1);
+  });
+
+  it("met à jour uniquement les champs fournis et remplace les attributs quand présents", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) =>
+      /from "products"/i.test(stmt.sql) ? [["p1", "old-slug"]] : []);
+
+    const r = await updateDraft("p1", {
+      brand: null,
+      attributes: { colors: [], dimensions: {}, specs: [{ name: "RAM", value: "8 Go" }] },
+    });
+
+    expect(r).toEqual({ id: "p1", slug: "old-slug" });
+    const stmts = d1.current!.batchStatements();
+    const update = stmts.find((s) => /update "products"/i.test(s.sql))!;
+    expect(sqlOf(update)).toMatch(/"brand" = \?/);
+    expect(sqlOf(update)).not.toMatch(/"name" = \?/);
+    expect(sqlOf(update)).toMatch(/where .*"is_draft" = \?/i);
+    expect(stmts.some((s) => /delete from "product_attributes"/i.test(s.sql))).toBe(true);
+    expect(stmts.filter((s) => /insert into "product_attributes"/i.test(s.sql))).toHaveLength(1);
+  });
+
+  it("refuse un slug explicite déjà pris", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) => {
+      if (/"is_draft" = \?/i.test(stmt.sql)) return [["p1", "old-slug"]];
+      if (/"slug" = \?/i.test(stmt.sql)) return [["p2"]];
+      return [];
+    });
+    await expect(updateDraft("p1", { slug: "taken" })).rejects.toMatchObject({ code: "conflict" });
+  });
+});
+
+describe("getDraft", () => {
+  it("lève not_found si le brouillon n'existe pas", async () => {
+    await expect(getDraft("p1")).rejects.toBeInstanceOf(DraftError);
+  });
+});
+
+describe("searchProducts", () => {
+  it("cherche sur nom, slug et SKU avec la limite", async () => {
+    await searchProducts("galaxy", 5);
+    const stmt = d1.current!.boundMatching(/from "products"/i)[0];
+    expect(sqlOf(stmt)).toMatch(/"name" like \?/i);
+    expect(sqlOf(stmt)).toMatch(/"slug" like \?/i);
+    expect(sqlOf(stmt)).toMatch(/"sku" like \?/i);
+    expect(stmt.params).toContain("%galaxy%");
+    expect(stmt.params).toContain(5);
+  });
+
+  it("échappe % et _ dans la requête", async () => {
+    await searchProducts("100%_x", 5);
+    const stmt = d1.current!.boundMatching(/from "products"/i)[0];
+    expect(stmt.params).toContain("%100\\%\\_x%");
+  });
+});
+
+describe("deleteDraft", () => {
+  it("supprime enfants puis produit, puis les objets R2, uniquement pour un brouillon", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) => {
+      if (/"is_draft" = \?/i.test(stmt.sql)) return [["p1", "slug"]];
+      if (/from "product_images"/i.test(stmt.sql)) return [["products/p1/a.jpg"], ["/images/legacy.jpg"]];
+      return [];
+    });
+    await deleteDraft("p1");
+    const stmts = d1.current!.batchStatements().map(sqlOf);
+    expect(stmts[stmts.length - 1]).toMatch(/delete from "products" where .*"is_draft" = \?/i);
+    expect(stmts.some((s) => /delete from "product_images"/i.test(s))).toBe(true);
+    expect(stmts.some((s) => /delete from "product_variants"/i.test(s))).toBe(true);
+    expect(stmts.some((s) => /delete from "product_attributes"/i.test(s))).toBe(true);
+    expect(mocks.deleteFromR2).toHaveBeenCalledWith("products/p1/a.jpg");
+    expect(mocks.deleteFromR2).toHaveBeenCalledWith("legacy.jpg");
+  });
+});

--- a/__tests__/unit/lib/mcp/context.test.ts
+++ b/__tests__/unit/lib/mcp/context.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const d1 = vi.hoisted(() => ({
+  current: null as null | ReturnType<typeof import("../../../helpers/d1-mock").createD1Mock>,
+}));
+vi.mock("@/lib/cloudflare/context", () => ({ getDB: async () => d1.current!.binding }));
+
+import { createD1Mock } from "../../../helpers/d1-mock";
+import { buildMcpContext, McpAuthError } from "@/lib/mcp/context";
+
+// select({ id, name, role, banned, banExpires }) → positional row
+const row = (role: string, banned = 0, banExpires: string | null = null) => [["u1", "Admin", role, banned, banExpires]];
+
+beforeEach(() => { d1.current = createD1Mock(); });
+
+describe("buildMcpContext", () => {
+  it("accepte admin et super_admin", async () => {
+    d1.current!.raw.mockResolvedValue(row("admin"));
+    await expect(buildMcpContext({ userId: "u1", clientId: "c1" })).resolves.toEqual({
+      user: { id: "u1", name: "Admin", role: "admin" }, clientId: "c1",
+    });
+    d1.current!.raw.mockResolvedValue(row("super_admin"));
+    await expect(buildMcpContext({ userId: "u1", clientId: "c1" })).resolves.toMatchObject({ user: { role: "super_admin" } });
+  });
+
+  it("refuse customer et agent", async () => {
+    d1.current!.raw.mockResolvedValue(row("customer"));
+    await expect(buildMcpContext({ userId: "u1", clientId: "c1" })).rejects.toBeInstanceOf(McpAuthError);
+    d1.current!.raw.mockResolvedValue(row("agent"));
+    await expect(buildMcpContext({ userId: "u1", clientId: "c1" })).rejects.toBeInstanceOf(McpAuthError);
+  });
+
+  it("refuse un admin banni, accepte un ban expiré", async () => {
+    d1.current!.raw.mockResolvedValue(row("admin", 1, null));
+    await expect(buildMcpContext({ userId: "u1", clientId: "c1" })).rejects.toBeInstanceOf(McpAuthError);
+    d1.current!.raw.mockResolvedValue(row("admin", 1, "2000-01-01T00:00:00.000Z"));
+    await expect(buildMcpContext({ userId: "u1", clientId: "c1" })).resolves.toBeDefined();
+  });
+
+  it("refuse un jeton sans utilisateur ou un utilisateur supprimé", async () => {
+    await expect(buildMcpContext({ userId: null, clientId: "c1" })).rejects.toBeInstanceOf(McpAuthError);
+    d1.current!.raw.mockResolvedValue([]);
+    await expect(buildMcpContext({ userId: "gone", clientId: "c1" })).rejects.toBeInstanceOf(McpAuthError);
+  });
+});

--- a/__tests__/unit/lib/mcp/result.test.ts
+++ b/__tests__/unit/lib/mcp/result.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { ok, fail } from "@/lib/mcp/result";
+
+describe("mcp result helpers", () => {
+  it("ok sérialise la donnée en texte JSON", () => {
+    const r = ok({ id: "p1" });
+    expect(r.isError).toBeUndefined();
+    expect(JSON.parse(r.content[0].text)).toEqual({ id: "p1" });
+  });
+
+  it("fail porte code, message et fieldErrors", () => {
+    const r = fail("validation_error", "Nom requis", { name: ["Requis"] });
+    expect(r.isError).toBe(true);
+    expect(JSON.parse(r.content[0].text)).toEqual({ code: "validation_error", message: "Nom requis", fieldErrors: { name: ["Requis"] } });
+  });
+});

--- a/__tests__/unit/lib/mcp/server.test.ts
+++ b/__tests__/unit/lib/mcp/server.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 
 vi.mock("@/lib/cloudflare/context", () => ({ getDB: async () => { throw new Error("no DB"); } }));
 
-import { ALL_TOOLS, createMcpServer } from "@/lib/mcp/server";
+import { ALL_TOOLS, createMcpServer, MCP_SERVER_NAME } from "@/lib/mcp/server";
 
 describe("createMcpServer", () => {
   it("enregistre tous les outils avec description et schéma", () => {
@@ -12,6 +14,30 @@ describe("createMcpServer", () => {
     for (const t of ALL_TOOLS) {
       expect(t.description.length).toBeGreaterThan(20);
       expect(typeof t.inputSchema).toBe("object");
+    }
+  });
+
+  it("expose les 9 outils à un vrai client MCP via un transport en mémoire", async () => {
+    const server = createMcpServer({ user: { id: "u", name: "n", role: "admin" }, clientId: "c" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    const client = new Client({ name: "test-client", version: "0" });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    try {
+      expect(client.getServerVersion()?.name).toBe(MCP_SERVER_NAME);
+
+      const { tools } = await client.listTools();
+      expect(tools.map((t) => t.name).sort()).toEqual([
+        "add_product_images", "create_product_draft", "delete_product_draft", "get_product_draft",
+        "list_categories", "remove_product_image", "search_products", "set_product_variants", "update_product_draft",
+      ]);
+      for (const tool of tools) {
+        expect(tool.description?.length ?? 0).toBeGreaterThan(0);
+        expect(typeof tool.inputSchema).toBe("object");
+      }
+    } finally {
+      await client.close();
     }
   });
 });

--- a/__tests__/unit/lib/mcp/server.test.ts
+++ b/__tests__/unit/lib/mcp/server.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/lib/cloudflare/context", () => ({ getDB: async () => { throw new Error("no DB"); } }));
+
+import { ALL_TOOLS, createMcpServer } from "@/lib/mcp/server";
+
+describe("createMcpServer", () => {
+  it("enregistre tous les outils avec description et schéma", () => {
+    const server = createMcpServer({ user: { id: "u", name: "n", role: "admin" }, clientId: "c" });
+    expect(server).toBeDefined();
+    expect(ALL_TOOLS.length).toBe(9);
+    for (const t of ALL_TOOLS) {
+      expect(t.description.length).toBeGreaterThan(20);
+      expect(typeof t.inputSchema).toBe("object");
+    }
+  });
+});

--- a/__tests__/unit/lib/mcp/tools-products.test.ts
+++ b/__tests__/unit/lib/mcp/tools-products.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { McpContext } from "@/lib/mcp/context";
+
+const mocks = vi.hoisted(() => ({
+  createDraft: vi.fn(), updateDraft: vi.fn(), getDraft: vi.fn(), searchProducts: vi.fn(), deleteDraft: vi.fn(),
+  addImagesFromUrls: vi.fn(), removeImage: vi.fn(), setColorVariants: vi.fn(),
+  createAuditLog: vi.fn(),
+}));
+
+vi.mock("@/lib/db/product-drafts", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/db/product-drafts")>("@/lib/db/product-drafts");
+  return { ...actual, ...mocks };
+});
+vi.mock("@/lib/db/admin/audit-log", () => ({ createAuditLog: mocks.createAuditLog }));
+vi.mock("@/lib/cloudflare/context", () => ({ getDB: async () => { throw new Error("no DB in this test"); } }));
+
+import { DraftError } from "@/lib/db/product-drafts";
+import { productTools } from "@/lib/mcp/tools/products";
+
+const ctx: McpContext = { user: { id: "admin-1", name: "Admin", role: "admin" }, clientId: "client-1" };
+// productTools is typed ToolDefinition[] (base shape), so handler accepts any object literal here.
+const tool = (name: string) => productTools.find((t) => t.name === name)!;
+const parse = (r: { content: { text: string }[] }) => JSON.parse(r.content[0].text);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.createAuditLog.mockResolvedValue(undefined);
+});
+
+describe("productTools", () => {
+  it("expose exactement les outils du contrat", () => {
+    expect(productTools.map((t) => t.name).sort()).toEqual([
+      "add_product_images", "create_product_draft", "delete_product_draft", "get_product_draft",
+      "remove_product_image", "search_products", "set_product_variants", "update_product_draft",
+    ]);
+  });
+
+  it("create_product_draft renvoie id, slug, edit_url et écrit l'audit", async () => {
+    mocks.createDraft.mockResolvedValue({ id: "p1", slug: "galaxy-a55" });
+    const r = await tool("create_product_draft").handler(ctx, { name: "Galaxy A55", category_id: "cat-1" });
+    expect(r.isError).toBeUndefined();
+    expect(parse(r)).toEqual({ id: "p1", slug: "galaxy-a55", edit_url: "/products/p1/edit" });
+    expect(mocks.createAuditLog).toHaveBeenCalledWith(expect.objectContaining({
+      actorId: "admin-1", actorName: "Admin", action: "product.draft_created", targetType: "product", targetId: "p1",
+      details: JSON.stringify({ via: "mcp", tool: "create_product_draft", client_id: "client-1" }),
+    }));
+  });
+
+  it("mappe DraftError vers un résultat isError avec le code", async () => {
+    mocks.updateDraft.mockRejectedValue(new DraftError("not_found", "Brouillon introuvable"));
+    const r = await tool("update_product_draft").handler(ctx, { id: "p1", name: "X" });
+    expect(r.isError).toBe(true);
+    expect(parse(r)).toEqual({ code: "not_found", message: "Brouillon introuvable" });
+    expect(mocks.createAuditLog).not.toHaveBeenCalled();
+  });
+
+  it("mappe une erreur inattendue vers internal_error sans détail", async () => {
+    mocks.getDraft.mockRejectedValue(new Error("D1 exploded with secret details"));
+    const r = await tool("get_product_draft").handler(ctx, { id: "p1" });
+    expect(r.isError).toBe(true);
+    expect(parse(r).code).toBe("internal_error");
+    expect(parse(r).message).not.toContain("secret");
+  });
+
+  it("add_product_images rapporte un succès partiel sans isError", async () => {
+    mocks.addImagesFromUrls.mockResolvedValue({
+      results: [{ url: "https://x/a.jpg", ok: true, image_id: "img-1" }, { url: "https://x/b.jpg", ok: false, reason: "too_large" }],
+      primary_image_id: "img-1",
+    });
+    const r = await tool("add_product_images").handler(ctx, { id: "p1", images: [{ url: "https://x/a.jpg" }, { url: "https://x/b.jpg" }] });
+    expect(r.isError).toBeUndefined();
+    expect(parse(r).results[1]).toEqual({ url: "https://x/b.jpg", ok: false, reason: "too_large" });
+    expect(mocks.createAuditLog).toHaveBeenCalledWith(expect.objectContaining({ action: "product.draft_updated" }));
+  });
+
+  it("delete_product_draft audite la suppression", async () => {
+    mocks.deleteDraft.mockResolvedValue(undefined);
+    const r = await tool("delete_product_draft").handler(ctx, { id: "p1" });
+    expect(parse(r)).toEqual({ deleted: true });
+    expect(mocks.createAuditLog).toHaveBeenCalledWith(expect.objectContaining({ action: "product.draft_deleted", targetId: "p1" }));
+  });
+
+  it("search_products délègue avec la limite", async () => {
+    mocks.searchProducts.mockResolvedValue([]);
+    await tool("search_products").handler(ctx, { query: "galaxy", limit: 7 });
+    expect(mocks.searchProducts).toHaveBeenCalledWith("galaxy", 7);
+  });
+});

--- a/__tests__/unit/lib/validations/mcp-product.test.ts
+++ b/__tests__/unit/lib/validations/mcp-product.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import {
+  createDraftSchema,
+  updateDraftSchema,
+  addImagesSchema,
+  setVariantsSchema,
+  searchProductsSchema,
+} from "@/lib/validations/mcp-product";
+
+describe("createDraftSchema", () => {
+  it("exige name et category_id", () => {
+    expect(createDraftSchema.safeParse({}).success).toBe(false);
+    expect(createDraftSchema.safeParse({ name: "X", category_id: "cat-1" }).success).toBe(true);
+  });
+
+  it("borne name à 150 et short_description à 120", () => {
+    expect(createDraftSchema.safeParse({ name: "a".repeat(151), category_id: "c" }).success).toBe(false);
+    expect(createDraftSchema.safeParse({ name: "a", category_id: "c", short_description: "b".repeat(121) }).success).toBe(false);
+  });
+
+  it("valide la story avec les règles de product-story", () => {
+    const base = { name: "a", category_id: "c" };
+    expect(createDraftSchema.safeParse({ ...base, story: { highlights: [{ icon: "camera", label: "x" }] } }).success).toBe(false);
+    expect(createDraftSchema.safeParse({
+      ...base,
+      story: { tagline: "  t  ", highlights: [
+        { icon: "camera", label: "a" }, { icon: "battery", label: "b" }, { icon: "display", label: "c" },
+      ] },
+    }).data?.story?.tagline).toBe("t");
+  });
+
+  it("refuse une couleur hex invalide et plus de 12 couleurs", () => {
+    const base = { name: "a", category_id: "c" };
+    expect(createDraftSchema.safeParse({ ...base, attributes: { colors: [{ name: "Noir", hex: "black" }] } }).success).toBe(false);
+    const colors = Array.from({ length: 13 }, (_, i) => ({ name: `c${i}`, hex: "#000000" }));
+    expect(createDraftSchema.safeParse({ ...base, attributes: { colors } }).success).toBe(false);
+  });
+
+  it("refuse un prix négatif ou décimal", () => {
+    const base = { name: "a", category_id: "c" };
+    expect(createDraftSchema.safeParse({ ...base, pricing: { base_price: -1 } }).success).toBe(false);
+    expect(createDraftSchema.safeParse({ ...base, pricing: { base_price: 10.5 } }).success).toBe(false);
+    expect(createDraftSchema.safeParse({ ...base, pricing: { base_price: 15000, compare_price: null } }).success).toBe(true);
+  });
+});
+
+describe("updateDraftSchema", () => {
+  it("accepte un patch vide et distingue null d'absent", () => {
+    const r = updateDraftSchema.safeParse({ brand: null });
+    expect(r.success).toBe(true);
+    expect(r.data).toEqual({ brand: null });
+    expect(updateDraftSchema.safeParse({}).success).toBe(true);
+  });
+
+  it("valide le format du slug", () => {
+    expect(updateDraftSchema.safeParse({ slug: "iphone-15-pro" }).success).toBe(true);
+    expect(updateDraftSchema.safeParse({ slug: "IPhone 15" }).success).toBe(false);
+    expect(updateDraftSchema.safeParse({ slug: "-bad" }).success).toBe(false);
+  });
+});
+
+describe("addImagesSchema", () => {
+  it("exige 1 à 8 URLs http(s)", () => {
+    expect(addImagesSchema.safeParse({ images: [] }).success).toBe(false);
+    expect(addImagesSchema.safeParse({ images: [{ url: "ftp://x/a.jpg" }] }).success).toBe(false);
+    const nine = Array.from({ length: 9 }, (_, i) => ({ url: `https://x.test/${i}.jpg` }));
+    expect(addImagesSchema.safeParse({ images: nine }).success).toBe(false);
+    expect(addImagesSchema.safeParse({ images: nine.slice(0, 8) }).success).toBe(true);
+  });
+});
+
+describe("setVariantsSchema", () => {
+  it("uniform_price vaut true par défaut", () => {
+    const r = setVariantsSchema.safeParse({ variants: [{ color_name: "Noir", color_hex: "#000000", stock: 3 }] });
+    expect(r.success).toBe(true);
+    expect(r.data?.uniform_price).toBe(true);
+  });
+
+  it("refuse un stock négatif", () => {
+    expect(setVariantsSchema.safeParse({ variants: [{ color_name: "Noir", color_hex: "#000000", stock: -1 }] }).success).toBe(false);
+  });
+});
+
+describe("searchProductsSchema", () => {
+  it("borne la requête et la limite", () => {
+    expect(searchProductsSchema.safeParse({ query: "ab" }).success).toBe(false);
+    expect(searchProductsSchema.safeParse({ query: "abc" }).data?.limit).toBe(20);
+    expect(searchProductsSchema.safeParse({ query: "abc", limit: 51 }).success).toBe(false);
+  });
+});

--- a/app/(admin-auth)/admin/login/page.tsx
+++ b/app/(admin-auth)/admin/login/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import dynamic from "next/dynamic";
 import Image from "next/image";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -20,6 +20,7 @@ import {
 import { PasswordInput } from "@/components/storefront/auth/password-input";
 import { authClient } from "@/lib/auth/client";
 import { verifyAdminRole } from "@/actions/admin/auth";
+import { getOAuthResumeUrl } from "@/lib/auth/oauth-resume";
 
 const TurnstileCaptcha = dynamic(
   () =>
@@ -50,6 +51,8 @@ const errorTextMessages: Record<string, string> = {
 
 export default function AdminLoginPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const resumeUrl = getOAuthResumeUrl(searchParams);
   const [captchaKey, setCaptchaKey] = useState(0);
   const [captchaToken, setCaptchaToken] = useState("");
   const [serverError, setServerError] = useState("");
@@ -86,6 +89,17 @@ export default function AdminLoginPage() {
       });
 
       if (error) {
+        // OAuth resume: the mcp plugin's after-hook turns a successful sign-in
+        // into a 302 that fetch follows to an HTML page, so the client lib can
+        // report an error although the session cookie was set. Trust the
+        // server-side role check instead of the parse failure.
+        if (resumeUrl) {
+          const check = await verifyAdminRole();
+          if (check.success) {
+            window.location.assign(resumeUrl);
+            return;
+          }
+        }
         resetCaptcha();
         setServerError(
           errorCodeMessages[error.code ?? ""] ??
@@ -99,6 +113,12 @@ export default function AdminLoginPage() {
       const result = await verifyAdminRole();
       if (!result.success) {
         setServerError(result.error ?? "Accès refusé.");
+        return;
+      }
+
+      if (resumeUrl) {
+        // Full navigation, not router.push: the target is an API route.
+        window.location.assign(resumeUrl);
         return;
       }
 

--- a/app/(admin-auth)/admin/mcp/consent/consent-form.tsx
+++ b/app/(admin-auth)/admin/mcp/consent/consent-form.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 
-export function ConsentForm({ disabled }: { disabled: boolean }) {
+export function ConsentForm({ disabled, consentCode }: { disabled: boolean; consentCode: string | null }) {
   const [pending, setPending] = useState<"accept" | "deny" | null>(null);
   const [error, setError] = useState("");
 
@@ -11,13 +11,18 @@ export function ConsentForm({ disabled }: { disabled: boolean }) {
     setPending(accept ? "accept" : "deny");
     setError("");
     try {
-      // Same-origin POST: better-auth validates the Origin header, and the
-      // consent code travels in the signed `oidc_consent_prompt` cookie.
+      // Same-origin POST: better-auth validates the Origin header. We post
+      // the exact consent_code shown on this page — the body code takes
+      // precedence over the signed `oidc_consent_prompt` cookie
+      // (node_modules/better-auth/dist/plugins/oidc-provider/index.mjs:300-306)
+      // so the server can never approve a different request than the one the
+      // admin reviewed. Omit the key entirely when null (unknown/expired
+      // request) so the deny path still falls back to the cookie.
       const res = await fetch("/api/auth/oauth2/consent", {
         method: "POST",
         headers: { "content-type": "application/json" },
         credentials: "include",
-        body: JSON.stringify({ accept }),
+        body: JSON.stringify(consentCode ? { accept, consent_code: consentCode } : { accept }),
       });
       const body = (await res.json().catch(() => null)) as { redirectURI?: string } | null;
       if (!res.ok || !body?.redirectURI) {

--- a/app/(admin-auth)/admin/mcp/consent/consent-form.tsx
+++ b/app/(admin-auth)/admin/mcp/consent/consent-form.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+
+export function ConsentForm({ disabled }: { disabled: boolean }) {
+  const [pending, setPending] = useState<"accept" | "deny" | null>(null);
+  const [error, setError] = useState("");
+
+  async function submit(accept: boolean) {
+    setPending(accept ? "accept" : "deny");
+    setError("");
+    try {
+      // Same-origin POST: better-auth validates the Origin header, and the
+      // consent code travels in the signed `oidc_consent_prompt` cookie.
+      const res = await fetch("/api/auth/oauth2/consent", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ accept }),
+      });
+      const body = (await res.json().catch(() => null)) as { redirectURI?: string } | null;
+      if (!res.ok || !body?.redirectURI) {
+        setError("La demande a expiré. Relancez la connexion depuis votre assistant.");
+        setPending(null);
+        return;
+      }
+      window.location.assign(body.redirectURI);
+    } catch {
+      setError("Une erreur réseau est survenue. Réessayez.");
+      setPending(null);
+    }
+  }
+
+  return (
+    <div className="grid gap-3">
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+      <Button className="h-11 w-full" disabled={disabled || pending !== null} onClick={() => submit(true)}>
+        {pending === "accept" ? "Autorisation…" : "Autoriser"}
+      </Button>
+      <Button variant="outline" className="h-11 w-full" disabled={pending !== null} onClick={() => submit(false)}>
+        {pending === "deny" ? "Refus…" : "Refuser"}
+      </Button>
+    </div>
+  );
+}

--- a/app/(admin-auth)/admin/mcp/consent/page.tsx
+++ b/app/(admin-auth)/admin/mcp/consent/page.tsx
@@ -2,12 +2,14 @@ import { redirect } from "next/navigation";
 import Image from "next/image";
 import type { Metadata } from "next";
 import { getOptionalSession } from "@/lib/auth/guards";
-import { findOAuthClientName } from "@/lib/auth/mcp-consent-client";
+import { findConsentRequest } from "@/lib/auth/mcp-consent-client";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { ConsentForm } from "./consent-form";
 
 export const dynamic = "force-dynamic";
-export const metadata: Metadata = { robots: { index: false, follow: false } };
+// The consent code rides in this page's own URL (?consent_code=...); never
+// let it leak to a third party via the Referer header of an outbound link.
+export const metadata: Metadata = { robots: { index: false, follow: false }, referrer: "no-referrer" };
 
 type SearchParams = Promise<Record<string, string | string[] | undefined>>;
 
@@ -17,18 +19,21 @@ function first(v: string | string[] | undefined): string | null {
 
 /**
  * Landing page of the forced OAuth consent step (lib/auth/mcp-consent-hook.ts).
- * better-auth redirected here with `consent_code` in a signed cookie plus
- * `client_id` and `scope` in the query. The form posts to
- * /api/auth/oauth2/consent, which answers with the redirect URI to follow.
+ * better-auth redirected here with `consent_code` in both a signed cookie and
+ * the query string (node_modules/better-auth/dist/plugins/mcp/authorize.mjs:130-136).
+ * The displayed client name and redirect host are resolved from the code
+ * itself via `findConsentRequest` — never from the query's `client_id`, which
+ * an attacker fully controls — and the form posts that same code back so the
+ * server (`/api/auth/oauth2/consent`) consumes exactly the request shown here
+ * instead of falling back to whatever cookie happens to be set.
  */
 export default async function McpConsentPage({ searchParams }: { searchParams: SearchParams }) {
   const session = await getOptionalSession();
   if (!session) redirect("/admin/login");
 
   const params = await searchParams;
-  const clientId = first(params.client_id);
-  const scopes = (first(params.scope) ?? "").split(" ").filter(Boolean);
-  const clientName = clientId ? await findOAuthClientName(clientId) : null;
+  const consentCode = first(params.consent_code);
+  const request = consentCode ? await findConsentRequest(consentCode) : null;
 
   return (
     <div className="flex min-h-dvh items-center justify-center bg-muted/30 p-4">
@@ -45,21 +50,32 @@ export default async function McpConsentPage({ searchParams }: { searchParams: S
             </CardDescription>
           </CardHeader>
           <CardContent className="grid gap-4">
-            {clientName ? (
-              <p className="text-sm">
-                <span className="font-semibold">{clientName}</span> demande l&apos;accès à
-                l&apos;administration NETEREKA en votre nom. Il pourra créer et modifier des
-                brouillons produits, mais jamais les publier.
-              </p>
+            {request ? (
+              <>
+                <p className="text-sm">
+                  <span className="font-semibold">{request.clientName ?? "Un client OAuth inconnu"}</span>{" "}
+                  demande l&apos;accès à l&apos;administration NETEREKA en votre nom. Il pourra créer et
+                  modifier des brouillons produits, mais jamais les publier.
+                </p>
+                <p className="text-sm font-semibold">
+                  Redirection vers : <span className="font-mono">{request.redirectHost}</span>
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Vérifiez que ce nom de domaine correspond bien à l&apos;assistant que vous venez
+                  d&apos;autoriser avant de continuer.
+                </p>
+                {request.scopes.length > 0 ? (
+                  <p className="text-xs text-muted-foreground">
+                    Portées demandées : {request.scopes.join(", ")}
+                  </p>
+                ) : null}
+              </>
             ) : (
               <p className="text-sm text-destructive">
-                Client OAuth inconnu. Relancez la connexion depuis votre assistant.
+                Client OAuth inconnu ou demande expirée. Relancez la connexion depuis votre assistant.
               </p>
             )}
-            {scopes.length > 0 ? (
-              <p className="text-xs text-muted-foreground">Portées demandées : {scopes.join(", ")}</p>
-            ) : null}
-            <ConsentForm disabled={!clientName} />
+            <ConsentForm disabled={!request} consentCode={consentCode} />
           </CardContent>
         </Card>
       </div>

--- a/app/(admin-auth)/admin/mcp/consent/page.tsx
+++ b/app/(admin-auth)/admin/mcp/consent/page.tsx
@@ -1,0 +1,68 @@
+import { redirect } from "next/navigation";
+import Image from "next/image";
+import type { Metadata } from "next";
+import { getOptionalSession } from "@/lib/auth/guards";
+import { findOAuthClientName } from "@/lib/auth/mcp-consent-client";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ConsentForm } from "./consent-form";
+
+export const dynamic = "force-dynamic";
+export const metadata: Metadata = { robots: { index: false, follow: false } };
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+function first(v: string | string[] | undefined): string | null {
+  return typeof v === "string" ? v : Array.isArray(v) ? (v[0] ?? null) : null;
+}
+
+/**
+ * Landing page of the forced OAuth consent step (lib/auth/mcp-consent-hook.ts).
+ * better-auth redirected here with `consent_code` in a signed cookie plus
+ * `client_id` and `scope` in the query. The form posts to
+ * /api/auth/oauth2/consent, which answers with the redirect URI to follow.
+ */
+export default async function McpConsentPage({ searchParams }: { searchParams: SearchParams }) {
+  const session = await getOptionalSession();
+  if (!session) redirect("/admin/login");
+
+  const params = await searchParams;
+  const clientId = first(params.client_id);
+  const scopes = (first(params.scope) ?? "").split(" ").filter(Boolean);
+  const clientName = clientId ? await findOAuthClientName(clientId) : null;
+
+  return (
+    <div className="flex min-h-dvh items-center justify-center bg-muted/30 p-4">
+      <div className="w-full max-w-md">
+        <div className="mb-8 text-center">
+          <Image src="/logo.png" alt="NETEREKA" width={180} height={64} className="mx-auto h-14 w-auto" priority />
+          <p className="mt-2 text-sm text-muted-foreground">Espace Administration</p>
+        </div>
+        <Card>
+          <CardHeader className="text-center">
+            <CardTitle className="text-xl">Autoriser un assistant IA</CardTitle>
+            <CardDescription>
+              Connecté en tant que {session.user.name} ({session.user.email})
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-4">
+            {clientName ? (
+              <p className="text-sm">
+                <span className="font-semibold">{clientName}</span> demande l&apos;accès à
+                l&apos;administration NETEREKA en votre nom. Il pourra créer et modifier des
+                brouillons produits, mais jamais les publier.
+              </p>
+            ) : (
+              <p className="text-sm text-destructive">
+                Client OAuth inconnu. Relancez la connexion depuis votre assistant.
+              </p>
+            )}
+            {scopes.length > 0 ? (
+              <p className="text-xs text-muted-foreground">Portées demandées : {scopes.join(", ")}</p>
+            ) : null}
+            <ConsentForm disabled={!clientName} />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/app/.well-known/oauth-authorization-server/route.ts
+++ b/app/.well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,11 @@
+import { oAuthDiscoveryMetadata } from "better-auth/plugins";
+import { initAuth } from "@/lib/auth";
+
+// better-auth serves this document under /api/auth/.well-known/… ; several MCP
+// clients probe the site root first (RFC 8414 default), so mirror it here.
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  const auth = await initAuth();
+  return oAuthDiscoveryMetadata(auth)(request);
+}

--- a/app/.well-known/oauth-protected-resource/route.ts
+++ b/app/.well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,9 @@
+import { oAuthProtectedResourceMetadata } from "better-auth/plugins";
+import { initAuth } from "@/lib/auth";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  const auth = await initAuth();
+  return oAuthProtectedResourceMetadata(auth)(request);
+}

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -1,0 +1,59 @@
+import { withMcpAuth } from "better-auth/plugins";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { initAuth } from "@/lib/auth";
+import { buildMcpContext, McpAuthError } from "@/lib/mcp/context";
+import { createMcpServer } from "@/lib/mcp/server";
+
+/**
+ * Remote MCP endpoint (Streamable HTTP, stateless).
+ *
+ * withMcpAuth validates the OAuth bearer token (401 + WWW-Authenticate
+ * otherwise, which is how clients discover the OAuth flow). buildMcpContext
+ * then enforces the business rule — active admin — before any server exists.
+ * A fresh McpServer + transport per request: nothing to share between Workers
+ * isolates, no session id to store.
+ */
+export const dynamic = "force-dynamic";
+
+function jsonRpcError(status: number, code: number, message: string): Response {
+  return Response.json({ jsonrpc: "2.0", error: { code, message }, id: null }, { status });
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const auth = await initAuth();
+  const handler = withMcpAuth(auth, async (req, session) => {
+    let ctx;
+    try {
+      ctx = await buildMcpContext({ userId: session.userId, clientId: session.clientId });
+    } catch (err) {
+      if (err instanceof McpAuthError) return jsonRpcError(403, -32000, err.message);
+      console.error("[mcp] context build failed", err);
+      return jsonRpcError(500, -32603, "Erreur interne");
+    }
+
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      // Plain JSON responses: tools answer in one shot, no server-push needed,
+      // and it keeps the response cacheable-by-nobody and easy to test.
+      enableJsonResponse: true,
+    });
+    const server = createMcpServer(ctx);
+    await server.connect(transport);
+    try {
+      return await transport.handleRequest(req);
+    } finally {
+      // Stateless: release the per-request server once the response is built.
+      void transport.close().catch(() => {});
+    }
+  });
+  return handler(request);
+}
+
+// Stateless mode has no standalone SSE stream and no session to delete.
+export async function GET(): Promise<Response> {
+  return new Response("Method Not Allowed", { status: 405, headers: { allow: "POST" } });
+}
+
+export async function DELETE(): Promise<Response> {
+  return new Response("Method Not Allowed", { status: 405, headers: { allow: "POST" } });
+}

--- a/docs/superpowers/plans/2026-09-02-admin-mcp-server.md
+++ b/docs/superpowers/plans/2026-09-02-admin-mcp-server.md
@@ -1,0 +1,3080 @@
+# Admin MCP Server (phase 1, product drafts) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose a remote, OAuth-protected MCP server inside the Next.js app so any MCP client can create and edit product drafts on behalf of an admin.
+
+**Architecture:** `POST /api/mcp` is guarded by better-auth's `mcp` plugin (OAuth 2.1, dynamic client registration, forced consent page). Each request builds a fresh stateless `McpServer` from the official SDK, checks the token's user is an active admin, and serves tools that delegate to a new Drizzle module `lib/db/product-drafts.ts` whose every write carries `is_draft = 1`. Existing helpers (`fetchAndUploadImage`, `sanitizeDescriptionHtml`, `slugify`, `getCategoryTree`, `createAuditLog`) are reused, not modified.
+
+**Tech Stack:** Next.js 16 App Router on Cloudflare Workers (OpenNext), better-auth 1.6.25 (`mcp` plugin), `@modelcontextprotocol/sdk` 1.30 (`WebStandardStreamableHTTPServerTransport`), Drizzle ORM on D1, R2, Zod 4, Vitest 4.
+
+**Spec:** `docs/superpowers/specs/2026-09-02-admin-mcp-server-design.md`
+
+## Global Constraints
+
+- All new DB code uses `getDrizzle()` from `lib/db/drizzle.ts`. No new raw SQL. `lib/db/admin/audit-log.ts` is a legacy raw-SQL file: reuse `createAuditLog()` from it, do not edit it.
+- Every `UPDATE`/`DELETE` on `products` in `lib/db/product-drafts.ts` includes `eq(products.is_draft, 1)` in its `WHERE`. No tool accepts or writes `is_draft`, `is_active`, `is_featured`.
+- Tool error codes: `validation_error | not_found | conflict | limit_exceeded | internal_error`. Messages in French.
+- Image limits: ≤ 8 URLs per `add_product_images` call, ≤ 12 images per product.
+- Token lifetimes stay at plugin defaults (access 3600 s, refresh 604800 s, code 600 s).
+- Attribute conventions: colors stored as `name = "Couleur"`, `value = "<name>|<#hex>"`; dimensions as `Longueur`, `Hauteur`, `Largeur`, `Poids`; variant `attributes` JSON is `{ "color": "<name>:<#hex>" }` (matches `components/admin/product-wizard/step-pricing.tsx`).
+- Commit scopes allowed by commitlint: `storefront | admin | whatsapp | auth | db | seo | claude | ci | deps | release`.
+- Pre-commit runs `tsc --noEmit`, `eslint`, `vitest run`, migration-safety check. Every commit must pass them.
+- Quote route-group paths in bash: `"app/(admin-auth)/..."`.
+- Work on branch `feat/admin-mcp-server` (already created, holds the spec).
+
+---
+
+### Task 1: SDK dependency, OAuth tables, migration
+
+**Files:**
+- Modify: `package.json` (dependency)
+- Modify: `lib/db/schema.ts` (after the `rateLimit` table, ~line 100)
+- Create: `drizzle/0017_*.sql` + `drizzle/meta/*` (generated)
+
+**Interfaces:**
+- Produces: Drizzle tables `oauthApplication`, `oauthAccessToken`, `oauthConsent` exported from `@/lib/db/schema` (used by Task 3 for the client-name lookup).
+
+- [ ] **Step 1: Install the MCP SDK**
+
+```bash
+npm install @modelcontextprotocol/sdk@^1.30.0
+```
+
+Expected: `package.json` gains `"@modelcontextprotocol/sdk": "^1.30.0"` under `dependencies`. Verify the transport file exists:
+
+```bash
+ls node_modules/@modelcontextprotocol/sdk/dist/esm/server/webStandardStreamableHttp.js
+```
+
+- [ ] **Step 2: Add the three OAuth tables to the Drizzle schema**
+
+Insert right after the `rateLimit` table definition in `lib/db/schema.ts`:
+
+```ts
+// better-auth `mcp` plugin (OAuth 2.1 provider for MCP clients). Column names
+// mirror node_modules/better-auth/dist/plugins/oidc-provider/schema.mjs exactly:
+// better-auth reaches these tables through its own Kysely adapter, so a
+// mismatch here fails at request time, not at compile time. Dates are ISO
+// strings (the adapter runs with supportsDates: false on sqlite), booleans 0/1.
+export const oauthApplication = sqliteTable("oauthApplication", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  icon: text("icon"),
+  metadata: text("metadata"),
+  clientId: text("clientId").unique().notNull(),
+  clientSecret: text("clientSecret"),
+  redirectUrls: text("redirectUrls").notNull(),
+  type: text("type").notNull(),
+  disabled: integer("disabled").notNull().default(0),
+  userId: text("userId").references(() => user.id, { onDelete: "cascade" }),
+  createdAt: text("createdAt").notNull().default(sql`(datetime('now'))`),
+  updatedAt: text("updatedAt").notNull().default(sql`(datetime('now'))`),
+}, (table) => [
+  index("idx_oauthApplication_userId").on(table.userId),
+]);
+
+export const oauthAccessToken = sqliteTable("oauthAccessToken", {
+  id: text("id").primaryKey(),
+  accessToken: text("accessToken").unique().notNull(),
+  refreshToken: text("refreshToken").unique().notNull(),
+  accessTokenExpiresAt: text("accessTokenExpiresAt").notNull(),
+  refreshTokenExpiresAt: text("refreshTokenExpiresAt").notNull(),
+  clientId: text("clientId").notNull().references(() => oauthApplication.clientId, { onDelete: "cascade" }),
+  userId: text("userId").references(() => user.id, { onDelete: "cascade" }),
+  scopes: text("scopes").notNull(),
+  createdAt: text("createdAt").notNull().default(sql`(datetime('now'))`),
+  updatedAt: text("updatedAt").notNull().default(sql`(datetime('now'))`),
+}, (table) => [
+  index("idx_oauthAccessToken_clientId").on(table.clientId),
+  index("idx_oauthAccessToken_userId").on(table.userId),
+]);
+
+export const oauthConsent = sqliteTable("oauthConsent", {
+  id: text("id").primaryKey(),
+  clientId: text("clientId").notNull().references(() => oauthApplication.clientId, { onDelete: "cascade" }),
+  userId: text("userId").notNull().references(() => user.id, { onDelete: "cascade" }),
+  scopes: text("scopes").notNull(),
+  consentGiven: integer("consentGiven").notNull().default(0),
+  createdAt: text("createdAt").notNull().default(sql`(datetime('now'))`),
+  updatedAt: text("updatedAt").notNull().default(sql`(datetime('now'))`),
+}, (table) => [
+  index("idx_oauthConsent_clientId").on(table.clientId),
+  index("idx_oauthConsent_userId").on(table.userId),
+]);
+```
+
+- [ ] **Step 3: Generate and review the migration**
+
+```bash
+npx wrangler d1 execute netereka-db --local --command "SELECT 1" >/dev/null
+npm run db:generate
+ls drizzle | tail -3
+```
+
+Open the new `drizzle/0017_*.sql`. Expected content: three `CREATE TABLE` statements (`oauthApplication`, `oauthAccessToken`, `oauthConsent`) with the FKs above and five `CREATE INDEX` statements. Nothing else (no `DROP`, no `ALTER`). If drizzle-kit emits changes to other tables, stop: the local schema drifted, run `npm run db:migrate` first and regenerate.
+
+- [ ] **Step 4: Apply locally and run the safety check**
+
+```bash
+npm run db:migrate
+npm run check:migrations
+npx tsc --noEmit
+```
+
+Expected: migration applied, `[migration-safety]` reports no violation, tsc clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json package-lock.json lib/db/schema.ts drizzle/
+git commit -m "feat(db): add better-auth OAuth tables for the MCP plugin"
+```
+
+---
+
+### Task 2: better-auth `mcp` plugin, forced consent, discovery routes
+
+**Files:**
+- Create: `lib/auth/mcp-consent-hook.ts`
+- Modify: `lib/auth/index.ts` (imports at top; `plugins` array and `hooks` inside `buildAuthOptions`)
+- Create: `app/.well-known/oauth-authorization-server/route.ts`
+- Create: `app/.well-known/oauth-protected-resource/route.ts`
+- Test: `__tests__/unit/lib/auth/mcp-consent-hook.test.ts`
+- Test: `__tests__/unit/auth-config.test.ts` (append a `describe`)
+
+**Interfaces:**
+- Produces: `forceConsentQuery(path, query)` in `lib/auth/mcp-consent-hook.ts`; `MCP_AUTHORIZE_PATH = "/mcp/authorize"`; the auth instance from `initAuth()` now exposes `auth.api.getMcpSession` (used by Task 11 via `withMcpAuth`).
+
+- [ ] **Step 1: Write the failing hook test**
+
+`__tests__/unit/lib/auth/mcp-consent-hook.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { forceConsentQuery, MCP_AUTHORIZE_PATH } from "@/lib/auth/mcp-consent-hook";
+
+describe("forceConsentQuery", () => {
+  it("ignore les autres endpoints", () => {
+    expect(forceConsentQuery("/sign-in/email", { prompt: "none" })).toBeUndefined();
+    expect(forceConsentQuery(undefined, { prompt: "none" })).toBeUndefined();
+  });
+
+  it("force prompt=consent quand le client n'envoie rien", () => {
+    expect(forceConsentQuery(MCP_AUTHORIZE_PATH, { client_id: "c1" }))
+      .toEqual({ client_id: "c1", prompt: "consent" });
+  });
+
+  it("écrase prompt=none et prompt=login", () => {
+    expect(forceConsentQuery(MCP_AUTHORIZE_PATH, { prompt: "none" })?.prompt).toBe("consent");
+    expect(forceConsentQuery(MCP_AUTHORIZE_PATH, { prompt: "login" })?.prompt).toBe("consent");
+  });
+
+  it("tolère une query absente", () => {
+    expect(forceConsentQuery(MCP_AUTHORIZE_PATH, undefined)).toEqual({ prompt: "consent" });
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+```bash
+npx vitest run __tests__/unit/lib/auth/mcp-consent-hook.test.ts
+```
+
+Expected: FAIL, module `@/lib/auth/mcp-consent-hook` not found.
+
+- [ ] **Step 3: Implement the hook helper**
+
+`lib/auth/mcp-consent-hook.ts`:
+
+```ts
+/**
+ * better-auth's `mcp` plugin (1.6.25) issues an authorization code without any
+ * consent screen as soon as the user has a session, unless the client sends
+ * `prompt=consent` (node_modules/better-auth/dist/plugins/mcp/authorize.mjs,
+ * `if (query.prompt !== "consent")`). Dynamic client registration is open — it
+ * has to be, claude.ai and ChatGPT register themselves — so without this hook a
+ * malicious site could register a client with its own redirect URI, send a
+ * signed-in admin to the authorize URL, and collect an admin token silently.
+ *
+ * Forcing `prompt=consent` on every /mcp/authorize request routes the flow
+ * through `oidcConfig.consentPage`, where a human must click "Autoriser".
+ *
+ * Pure function so the rule is unit-testable without a better-auth context.
+ */
+export const MCP_AUTHORIZE_PATH = "/mcp/authorize";
+
+export function forceConsentQuery(
+  path: string | undefined,
+  query: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (path !== MCP_AUTHORIZE_PATH) return undefined;
+  return { ...(query ?? {}), prompt: "consent" };
+}
+```
+
+- [ ] **Step 4: Run the hook test to verify it passes**
+
+```bash
+npx vitest run __tests__/unit/lib/auth/mcp-consent-hook.test.ts
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 5: Write the failing auth-config tests**
+
+Append to `__tests__/unit/auth-config.test.ts`:
+
+```ts
+describe("auth configuration — MCP OAuth provider", () => {
+  function mcpPlugin() {
+    const opts = buildAuthOptions(env);
+    return opts.plugins.find((p) => p.id === "mcp") as
+      | { id: string; options?: { loginPage?: string; resource?: string; oidcConfig?: { consentPage?: string; requirePKCE?: boolean } } }
+      | undefined;
+  }
+
+  it("registers the mcp plugin against the admin login page", () => {
+    expect(mcpPlugin()).toBeDefined();
+    expect(mcpPlugin()?.options?.loginPage).toBe("/admin/login");
+  });
+
+  it("declares /api/mcp as the protected resource", () => {
+    expect(mcpPlugin()?.options?.resource).toBe("https://netereka.ci/api/mcp");
+  });
+
+  it("routes consent through the admin consent page and requires PKCE", () => {
+    expect(mcpPlugin()?.options?.oidcConfig?.consentPage).toBe("/admin/mcp/consent");
+    expect(mcpPlugin()?.options?.oidcConfig?.requirePKCE).toBe(true);
+  });
+
+  it("installs a before hook (the forced-consent guard)", () => {
+    const opts = buildAuthOptions(env);
+    expect(typeof opts.hooks?.before).toBe("function");
+  });
+});
+```
+
+- [ ] **Step 6: Run to verify they fail**
+
+```bash
+npx vitest run __tests__/unit/auth-config.test.ts
+```
+
+Expected: the 4 new tests FAIL (`mcpPlugin()` undefined, `hooks` undefined).
+
+- [ ] **Step 7: Wire the plugin and hook into `buildAuthOptions`**
+
+In `lib/auth/index.ts`, extend the imports:
+
+```ts
+import { captcha, emailOTP, admin, mcp } from "better-auth/plugins";
+import { createAuthMiddleware } from "better-auth/api";
+import { forceConsentQuery } from "@/lib/auth/mcp-consent-hook";
+```
+
+Inside the returned options object of `buildAuthOptions`, add `hooks` next to `session` (before `plugins`):
+
+```ts
+    hooks: {
+      before: createAuthMiddleware(async (ctx) => {
+        // See lib/auth/mcp-consent-hook.ts — every /mcp/authorize must show
+        // the consent page. Returning { context } merges into the endpoint
+        // context (better-auth/dist/api/dispatch.mjs, defuReplaceArrays).
+        const query = forceConsentQuery(ctx.path, ctx.query as Record<string, unknown> | undefined);
+        if (!query) return;
+        return { context: { query } };
+      }),
+    },
+```
+
+Append to the `plugins` array, after `emailOTP({...})`:
+
+```ts
+      mcp({
+        loginPage: "/admin/login",
+        // Advertised in the protected-resource metadata; MCP clients bind
+        // their token request to it.
+        resource: `${cfEnv.SITE_URL}/api/mcp`,
+        oidcConfig: {
+          consentPage: "/admin/mcp/consent",
+          requirePKCE: true,
+        },
+      }),
+```
+
+- [ ] **Step 8: Run the auth-config tests and tsc**
+
+```bash
+npx vitest run __tests__/unit/auth-config.test.ts
+npx tsc --noEmit
+```
+
+Expected: all pass. If tsc rejects `p.id` on the plugin union, cast in the test: `(opts.plugins as Array<{ id: string; options?: unknown }>)`.
+
+- [ ] **Step 9: Add the root discovery routes**
+
+`app/.well-known/oauth-authorization-server/route.ts`:
+
+```ts
+import { oAuthDiscoveryMetadata } from "better-auth/plugins";
+import { initAuth } from "@/lib/auth";
+
+// better-auth serves this document under /api/auth/.well-known/… ; several MCP
+// clients probe the site root first (RFC 8414 default), so mirror it here.
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  const auth = await initAuth();
+  return oAuthDiscoveryMetadata(auth)(request);
+}
+```
+
+`app/.well-known/oauth-protected-resource/route.ts`:
+
+```ts
+import { oAuthProtectedResourceMetadata } from "better-auth/plugins";
+import { initAuth } from "@/lib/auth";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  const auth = await initAuth();
+  return oAuthProtectedResourceMetadata(auth)(request);
+}
+```
+
+- [ ] **Step 10: Smoke-test discovery locally**
+
+```bash
+npm run dev &
+sleep 8
+curl -s http://localhost:3000/.well-known/oauth-authorization-server | head -c 400; echo
+curl -s http://localhost:3000/api/auth/.well-known/oauth-protected-resource; echo
+kill %1
+```
+
+Expected: first JSON contains `"authorization_endpoint":"http://localhost:3000/api/auth/mcp/authorize"` and `"registration_endpoint"`; second contains `"resource":"http://localhost:3000/api/mcp"`.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add lib/auth/index.ts lib/auth/mcp-consent-hook.ts "app/.well-known" __tests__/unit/lib/auth/mcp-consent-hook.test.ts __tests__/unit/auth-config.test.ts
+git commit -m "feat(auth): turn better-auth into an OAuth provider for MCP clients with forced consent"
+```
+
+---
+
+### Task 3: Consent page `/admin/mcp/consent`
+
+**Files:**
+- Create: `app/(admin-auth)/admin/mcp/consent/page.tsx`
+- Create: `app/(admin-auth)/admin/mcp/consent/consent-form.tsx`
+- Create: `lib/auth/mcp-consent-client.ts`
+- Test: `__tests__/unit/lib/auth/mcp-consent-client.test.ts`
+
+**Interfaces:**
+- Consumes: `oauthApplication` table (Task 1), `getOptionalSession()` from `@/lib/auth/guards`.
+- Produces: `findOAuthClientName(clientId): Promise<string | null>` in `lib/auth/mcp-consent-client.ts`.
+
+- [ ] **Step 1: Write the failing test for the client lookup**
+
+`__tests__/unit/lib/auth/mcp-consent-client.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({ raw: vi.fn(), bound: vi.fn() }));
+
+vi.mock("@/lib/cloudflare/context", () => ({
+  getDB: async () => ({
+    prepare: (sql: string) => ({
+      bind: (...params: unknown[]) => {
+        const stmt = { sql, params };
+        mocks.bound(stmt);
+        return {
+          run: async () => ({ success: true, meta: {}, results: [] }),
+          all: async () => ({ results: await mocks.raw(stmt) }),
+          raw: () => mocks.raw(stmt),
+        };
+      },
+    }),
+    batch: async () => [],
+  }),
+}));
+
+import { findOAuthClientName } from "@/lib/auth/mcp-consent-client";
+
+describe("findOAuthClientName", () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it("retourne le nom du client enregistré", async () => {
+    mocks.raw.mockResolvedValue([["Claude Desktop"]]);
+    await expect(findOAuthClientName("client-1")).resolves.toBe("Claude Desktop");
+    const stmt = mocks.bound.mock.calls[0][0] as { sql: string; params: unknown[] };
+    expect(stmt.sql).toMatch(/from "oauthApplication"/i);
+    expect(stmt.params).toEqual(["client-1"]);
+  });
+
+  it("retourne null pour un client inconnu", async () => {
+    mocks.raw.mockResolvedValue([]);
+    await expect(findOAuthClientName("nope")).resolves.toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+npx vitest run __tests__/unit/lib/auth/mcp-consent-client.test.ts
+```
+
+Expected: FAIL, module not found.
+
+- [ ] **Step 3: Implement the lookup**
+
+`lib/auth/mcp-consent-client.ts`:
+
+```ts
+import { eq } from "drizzle-orm";
+import { getDrizzle } from "@/lib/db/drizzle";
+import { oauthApplication } from "@/lib/db/schema";
+
+/** Name a dynamically-registered MCP client gave itself. Untrusted: render escaped. */
+export async function findOAuthClientName(clientId: string): Promise<string | null> {
+  const db = await getDrizzle();
+  const row = await db
+    .select({ name: oauthApplication.name })
+    .from(oauthApplication)
+    .where(eq(oauthApplication.clientId, clientId))
+    .limit(1)
+    .get();
+  return row?.name ?? null;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+npx vitest run __tests__/unit/lib/auth/mcp-consent-client.test.ts
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 5: Create the server page**
+
+`app/(admin-auth)/admin/mcp/consent/page.tsx`:
+
+```tsx
+import { redirect } from "next/navigation";
+import Image from "next/image";
+import type { Metadata } from "next";
+import { getOptionalSession } from "@/lib/auth/guards";
+import { findOAuthClientName } from "@/lib/auth/mcp-consent-client";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ConsentForm } from "./consent-form";
+
+export const dynamic = "force-dynamic";
+export const metadata: Metadata = { robots: { index: false, follow: false } };
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+function first(v: string | string[] | undefined): string | null {
+  return typeof v === "string" ? v : Array.isArray(v) ? (v[0] ?? null) : null;
+}
+
+/**
+ * Landing page of the forced OAuth consent step (lib/auth/mcp-consent-hook.ts).
+ * better-auth redirected here with `consent_code` in a signed cookie plus
+ * `client_id` and `scope` in the query. The form posts to
+ * /api/auth/oauth2/consent, which answers with the redirect URI to follow.
+ */
+export default async function McpConsentPage({ searchParams }: { searchParams: SearchParams }) {
+  const session = await getOptionalSession();
+  if (!session) redirect("/admin/login");
+
+  const params = await searchParams;
+  const clientId = first(params.client_id);
+  const scopes = (first(params.scope) ?? "").split(" ").filter(Boolean);
+  const clientName = clientId ? await findOAuthClientName(clientId) : null;
+
+  return (
+    <div className="flex min-h-dvh items-center justify-center bg-muted/30 p-4">
+      <div className="w-full max-w-md">
+        <div className="mb-8 text-center">
+          <Image src="/logo.png" alt="NETEREKA" width={180} height={64} className="mx-auto h-14 w-auto" priority />
+          <p className="mt-2 text-sm text-muted-foreground">Espace Administration</p>
+        </div>
+        <Card>
+          <CardHeader className="text-center">
+            <CardTitle className="text-xl">Autoriser un assistant IA</CardTitle>
+            <CardDescription>
+              Connecté en tant que {session.user.name} ({session.user.email})
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-4">
+            {clientName ? (
+              <p className="text-sm">
+                <span className="font-semibold">{clientName}</span> demande l&apos;accès à
+                l&apos;administration NETEREKA en votre nom. Il pourra créer et modifier des
+                brouillons produits, mais jamais les publier.
+              </p>
+            ) : (
+              <p className="text-sm text-destructive">
+                Client OAuth inconnu. Relancez la connexion depuis votre assistant.
+              </p>
+            )}
+            {scopes.length > 0 ? (
+              <p className="text-xs text-muted-foreground">Portées demandées : {scopes.join(", ")}</p>
+            ) : null}
+            <ConsentForm disabled={!clientName} />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: Create the client form**
+
+`app/(admin-auth)/admin/mcp/consent/consent-form.tsx`:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+
+export function ConsentForm({ disabled }: { disabled: boolean }) {
+  const [pending, setPending] = useState<"accept" | "deny" | null>(null);
+  const [error, setError] = useState("");
+
+  async function submit(accept: boolean) {
+    setPending(accept ? "accept" : "deny");
+    setError("");
+    try {
+      // Same-origin POST: better-auth validates the Origin header, and the
+      // consent code travels in the signed `oidc_consent_prompt` cookie.
+      const res = await fetch("/api/auth/oauth2/consent", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ accept }),
+      });
+      const body = (await res.json().catch(() => null)) as { redirectURI?: string } | null;
+      if (!res.ok || !body?.redirectURI) {
+        setError("La demande a expiré. Relancez la connexion depuis votre assistant.");
+        setPending(null);
+        return;
+      }
+      window.location.assign(body.redirectURI);
+    } catch {
+      setError("Une erreur réseau est survenue. Réessayez.");
+      setPending(null);
+    }
+  }
+
+  return (
+    <div className="grid gap-3">
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+      <Button className="h-11 w-full" disabled={disabled || pending !== null} onClick={() => submit(true)}>
+        {pending === "accept" ? "Autorisation…" : "Autoriser"}
+      </Button>
+      <Button variant="outline" className="h-11 w-full" disabled={pending !== null} onClick={() => submit(false)}>
+        {pending === "deny" ? "Refus…" : "Refuser"}
+      </Button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 7: Type-check and lint**
+
+```bash
+npx tsc --noEmit && npx eslint "app/(admin-auth)/admin/mcp" lib/auth/mcp-consent-client.ts
+```
+
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add "app/(admin-auth)/admin/mcp" lib/auth/mcp-consent-client.ts __tests__/unit/lib/auth/mcp-consent-client.test.ts
+git commit -m "feat(auth): admin consent page for MCP OAuth clients"
+```
+
+---
+
+### Task 4: Resume the OAuth flow after admin login
+
+**Files:**
+- Create: `lib/auth/oauth-resume.ts`
+- Modify: `app/(admin-auth)/admin/login/page.tsx` (imports, `onSubmit`)
+- Test: `__tests__/unit/lib/auth/oauth-resume.test.ts`
+
+**Interfaces:**
+- Produces: `getOAuthResumeUrl(params: URLSearchParams): string | null`.
+
+- [ ] **Step 1: Write the failing test**
+
+`__tests__/unit/lib/auth/oauth-resume.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { getOAuthResumeUrl } from "@/lib/auth/oauth-resume";
+
+describe("getOAuthResumeUrl", () => {
+  it("retourne null sans paramètres OAuth", () => {
+    expect(getOAuthResumeUrl(new URLSearchParams(""))).toBeNull();
+    expect(getOAuthResumeUrl(new URLSearchParams("redirect=/dashboard"))).toBeNull();
+  });
+
+  it("exige client_id, redirect_uri et response_type", () => {
+    expect(getOAuthResumeUrl(new URLSearchParams("client_id=c&redirect_uri=http://x"))).toBeNull();
+  });
+
+  it("reconstruit l'URL d'autorisation avec la query intacte", () => {
+    const params = new URLSearchParams(
+      "client_id=c1&redirect_uri=http%3A%2F%2Flocalhost%3A6274%2Fcb&response_type=code&state=s1&code_challenge=abc&code_challenge_method=S256",
+    );
+    expect(getOAuthResumeUrl(params)).toBe(`/api/auth/mcp/authorize?${params.toString()}`);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+npx vitest run __tests__/unit/lib/auth/oauth-resume.test.ts
+```
+
+Expected: FAIL, module not found.
+
+- [ ] **Step 3: Implement**
+
+`lib/auth/oauth-resume.ts`:
+
+```ts
+const REQUIRED_PARAMS = ["client_id", "redirect_uri", "response_type"] as const;
+
+/**
+ * The better-auth `mcp` plugin sends an unauthenticated /mcp/authorize caller
+ * to `/admin/login?<original OAuth query>`. After sign-in the browser must go
+ * back to the authorize endpoint with that same query so the flow continues
+ * (and lands on the consent page). Same-origin path, hardcoded on purpose.
+ */
+export function getOAuthResumeUrl(params: URLSearchParams): string | null {
+  for (const key of REQUIRED_PARAMS) {
+    if (!params.get(key)) return null;
+  }
+  return `/api/auth/mcp/authorize?${params.toString()}`;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+npx vitest run __tests__/unit/lib/auth/oauth-resume.test.ts
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 5: Use it in the admin login page**
+
+In `app/(admin-auth)/admin/login/page.tsx`:
+
+Add imports:
+
+```ts
+import { useRouter, useSearchParams } from "next/navigation";
+import { getOAuthResumeUrl } from "@/lib/auth/oauth-resume";
+```
+
+(replace the existing `import { useRouter } from "next/navigation";`).
+
+Inside the component, right after `const router = useRouter();`:
+
+```ts
+  const searchParams = useSearchParams();
+  const resumeUrl = getOAuthResumeUrl(searchParams);
+```
+
+Replace the body of `onSubmit` from `const { error } = await authClient.signIn.email({` through `router.refresh();` with:
+
+```ts
+      const { error } = await authClient.signIn.email({
+        email: data.email,
+        password: data.password,
+        callbackURL: "/dashboard",
+        fetchOptions: {
+          headers: { "x-captcha-response": captchaToken },
+        },
+      });
+
+      if (error) {
+        // OAuth resume: the mcp plugin's after-hook turns a successful sign-in
+        // into a 302 that fetch follows to an HTML page, so the client lib can
+        // report an error although the session cookie was set. Trust the
+        // server-side role check instead of the parse failure.
+        if (resumeUrl) {
+          const check = await verifyAdminRole();
+          if (check.success) {
+            window.location.assign(resumeUrl);
+            return;
+          }
+        }
+        resetCaptcha();
+        setServerError(
+          errorCodeMessages[error.code ?? ""] ??
+            errorTextMessages[error.message ?? ""] ??
+            "Une erreur est survenue."
+        );
+        return;
+      }
+
+      // Verify admin role server-side
+      const result = await verifyAdminRole();
+      if (!result.success) {
+        setServerError(result.error ?? "Accès refusé.");
+        return;
+      }
+
+      if (resumeUrl) {
+        // Full navigation, not router.push: the target is an API route.
+        window.location.assign(resumeUrl);
+        return;
+      }
+
+      router.push("/dashboard");
+      router.refresh();
+```
+
+- [ ] **Step 6: Type-check, lint, full test run**
+
+```bash
+npx tsc --noEmit && npx eslint "app/(admin-auth)/admin/login/page.tsx" && npx vitest run
+```
+
+Expected: clean, all tests pass. `useSearchParams` needs no Suspense boundary here: `app/(admin-auth)/layout.tsx` already sets `dynamic = "force-dynamic"`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/auth/oauth-resume.ts "app/(admin-auth)/admin/login/page.tsx" __tests__/unit/lib/auth/oauth-resume.test.ts
+git commit -m "feat(auth): resume the MCP OAuth authorize flow after admin login"
+```
+
+---
+
+### Task 5: Product audit actions
+
+**Files:**
+- Modify: `lib/db/types.ts` (`AuditAction` union, ~line 347)
+- Modify: `lib/constants/audit.ts`
+- Test: `__tests__/unit/constants.test.ts` (append)
+
+**Interfaces:**
+- Produces: `AuditAction` gains `"product.draft_created" | "product.draft_updated" | "product.draft_deleted"`; used by Task 10 through `createAuditLog` from `@/lib/db/admin/audit-log`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `__tests__/unit/constants.test.ts`:
+
+```ts
+import { AUDIT_ACTION_LABELS, AUDIT_ACTION_OPTIONS } from "@/lib/constants/audit";
+
+describe("audit actions — product drafts (MCP)", () => {
+  it.each(["product.draft_created", "product.draft_updated", "product.draft_deleted"] as const)(
+    "%s a un libellé et une option de filtre",
+    (action) => {
+      expect(AUDIT_ACTION_LABELS[action]).toBeTruthy();
+      expect(AUDIT_ACTION_OPTIONS.some((o) => o.value === action)).toBe(true);
+    },
+  );
+});
+```
+
+(If the file already imports from `@/lib/constants/audit`, merge the import.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+npx vitest run __tests__/unit/constants.test.ts
+```
+
+Expected: FAIL (tsc type error on the key, or undefined label).
+
+- [ ] **Step 3: Extend the type and labels**
+
+`lib/db/types.ts`:
+
+```ts
+export type AuditAction =
+  | "user.created"
+  | "user.role_changed"
+  | "user.banned"
+  | "user.unbanned"
+  | "product.draft_created"
+  | "product.draft_updated"
+  | "product.draft_deleted";
+```
+
+`lib/constants/audit.ts`:
+
+```ts
+import type { AuditAction } from "@/lib/db/types";
+
+export const AUDIT_ACTION_LABELS: Record<AuditAction, string> = {
+  "user.created": "Création de compte",
+  "user.role_changed": "Changement de rôle",
+  "user.banned": "Bannissement",
+  "user.unbanned": "Débannissement",
+  "product.draft_created": "Brouillon produit créé",
+  "product.draft_updated": "Brouillon produit modifié",
+  "product.draft_deleted": "Brouillon produit supprimé",
+};
+
+export const AUDIT_ACTION_OPTIONS: { value: string; label: string }[] = [
+  { value: "all", label: "Toutes les actions" },
+  ...(Object.entries(AUDIT_ACTION_LABELS) as [AuditAction, string][]).map(([value, label]) => ({ value, label })),
+];
+```
+
+- [ ] **Step 4: Run tests and tsc**
+
+```bash
+npx vitest run __tests__/unit/constants.test.ts && npx tsc --noEmit
+```
+
+Expected: pass, clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/db/types.ts lib/constants/audit.ts __tests__/unit/constants.test.ts
+git commit -m "feat(admin): audit actions for product drafts"
+```
+
+---
+
+### Task 6: MCP input validation schemas
+
+**Files:**
+- Modify: `lib/validations/product-ai.ts` (export `colorSchema`, `dimensionsSchema`, `specSchema`)
+- Create: `lib/validations/mcp-product.ts`
+- Test: `__tests__/unit/lib/validations/mcp-product.test.ts`
+
+**Interfaces:**
+- Produces (all from `@/lib/validations/mcp-product`): `idSchema`, `createDraftSchema`, `updateDraftSchema`, `addImagesSchema`, `setVariantsSchema`, `searchProductsSchema`, and types `CreateDraftInput`, `UpdateDraftInput`, `AddImagesInput`, `SetVariantsInput`, `DraftAttributesInput`.
+
+- [ ] **Step 1: Export the attribute sub-schemas**
+
+In `lib/validations/product-ai.ts`, change `const colorSchema`, `const dimensionsSchema`, `const specSchema` to `export const …`. No other change.
+
+- [ ] **Step 2: Write the failing tests**
+
+`__tests__/unit/lib/validations/mcp-product.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  createDraftSchema,
+  updateDraftSchema,
+  addImagesSchema,
+  setVariantsSchema,
+  searchProductsSchema,
+} from "@/lib/validations/mcp-product";
+
+describe("createDraftSchema", () => {
+  it("exige name et category_id", () => {
+    expect(createDraftSchema.safeParse({}).success).toBe(false);
+    expect(createDraftSchema.safeParse({ name: "X", category_id: "cat-1" }).success).toBe(true);
+  });
+
+  it("borne name à 150 et short_description à 120", () => {
+    expect(createDraftSchema.safeParse({ name: "a".repeat(151), category_id: "c" }).success).toBe(false);
+    expect(createDraftSchema.safeParse({ name: "a", category_id: "c", short_description: "b".repeat(121) }).success).toBe(false);
+  });
+
+  it("valide la story avec les règles de product-story", () => {
+    const base = { name: "a", category_id: "c" };
+    expect(createDraftSchema.safeParse({ ...base, story: { highlights: [{ icon: "camera", label: "x" }] } }).success).toBe(false);
+    expect(createDraftSchema.safeParse({
+      ...base,
+      story: { tagline: "  t  ", highlights: [
+        { icon: "camera", label: "a" }, { icon: "battery", label: "b" }, { icon: "display", label: "c" },
+      ] },
+    }).data?.story?.tagline).toBe("t");
+  });
+
+  it("refuse une couleur hex invalide et plus de 12 couleurs", () => {
+    const base = { name: "a", category_id: "c" };
+    expect(createDraftSchema.safeParse({ ...base, attributes: { colors: [{ name: "Noir", hex: "black" }] } }).success).toBe(false);
+    const colors = Array.from({ length: 13 }, (_, i) => ({ name: `c${i}`, hex: "#000000" }));
+    expect(createDraftSchema.safeParse({ ...base, attributes: { colors } }).success).toBe(false);
+  });
+
+  it("refuse un prix négatif ou décimal", () => {
+    const base = { name: "a", category_id: "c" };
+    expect(createDraftSchema.safeParse({ ...base, pricing: { base_price: -1 } }).success).toBe(false);
+    expect(createDraftSchema.safeParse({ ...base, pricing: { base_price: 10.5 } }).success).toBe(false);
+    expect(createDraftSchema.safeParse({ ...base, pricing: { base_price: 15000, compare_price: null } }).success).toBe(true);
+  });
+});
+
+describe("updateDraftSchema", () => {
+  it("accepte un patch vide et distingue null d'absent", () => {
+    const r = updateDraftSchema.safeParse({ brand: null });
+    expect(r.success).toBe(true);
+    expect(r.data).toEqual({ brand: null });
+    expect(updateDraftSchema.safeParse({}).success).toBe(true);
+  });
+
+  it("valide le format du slug", () => {
+    expect(updateDraftSchema.safeParse({ slug: "iphone-15-pro" }).success).toBe(true);
+    expect(updateDraftSchema.safeParse({ slug: "IPhone 15" }).success).toBe(false);
+    expect(updateDraftSchema.safeParse({ slug: "-bad" }).success).toBe(false);
+  });
+});
+
+describe("addImagesSchema", () => {
+  it("exige 1 à 8 URLs http(s)", () => {
+    expect(addImagesSchema.safeParse({ images: [] }).success).toBe(false);
+    expect(addImagesSchema.safeParse({ images: [{ url: "ftp://x/a.jpg" }] }).success).toBe(false);
+    const nine = Array.from({ length: 9 }, (_, i) => ({ url: `https://x.test/${i}.jpg` }));
+    expect(addImagesSchema.safeParse({ images: nine }).success).toBe(false);
+    expect(addImagesSchema.safeParse({ images: nine.slice(0, 8) }).success).toBe(true);
+  });
+});
+
+describe("setVariantsSchema", () => {
+  it("uniform_price vaut true par défaut", () => {
+    const r = setVariantsSchema.safeParse({ variants: [{ color_name: "Noir", color_hex: "#000000", stock: 3 }] });
+    expect(r.success).toBe(true);
+    expect(r.data?.uniform_price).toBe(true);
+  });
+
+  it("refuse un stock négatif", () => {
+    expect(setVariantsSchema.safeParse({ variants: [{ color_name: "Noir", color_hex: "#000000", stock: -1 }] }).success).toBe(false);
+  });
+});
+
+describe("searchProductsSchema", () => {
+  it("borne la requête et la limite", () => {
+    expect(searchProductsSchema.safeParse({ query: "ab" }).success).toBe(false);
+    expect(searchProductsSchema.safeParse({ query: "abc" }).data?.limit).toBe(20);
+    expect(searchProductsSchema.safeParse({ query: "abc", limit: 51 }).success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run to verify they fail**
+
+```bash
+npx vitest run __tests__/unit/lib/validations/mcp-product.test.ts
+```
+
+Expected: FAIL, module not found.
+
+- [ ] **Step 4: Implement the schemas**
+
+`lib/validations/mcp-product.ts`:
+
+```ts
+import { z } from "zod";
+import { colorSchema, dimensionsSchema, specSchema } from "@/lib/validations/product-ai";
+import { taglineSchema, highlightsSchema, featureBlocksSchema, faqSchema } from "@/lib/validations/product-story";
+
+/**
+ * Input contracts of the MCP product tools (lib/mcp/tools/products.ts).
+ * Story and attribute rules are the wizard's own schemas, reused so the MCP
+ * cannot write a product the admin UI would reject.
+ */
+
+export const idSchema = z.string().trim().min(1).max(64);
+
+const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/** Upper bound of sanitizeDescriptionHtml's input (lib/utils/sanitize-html.ts). */
+const DESCRIPTION_MAX_BYTES = 512_000;
+
+export const draftAttributesSchema = z.object({
+  colors: z.array(colorSchema).max(12).default([]),
+  dimensions: dimensionsSchema.default({}),
+  specs: z.array(specSchema).max(20).default([]),
+});
+
+const storyInputSchema = z.object({
+  tagline: taglineSchema.optional(),
+  highlights: highlightsSchema.optional(),
+  feature_blocks: featureBlocksSchema.optional(),
+  faq: faqSchema.optional(),
+});
+
+const seoSchema = z.object({
+  meta_title: z.string().trim().max(60).nullable().optional(),
+  meta_description: z.string().trim().max(160).nullable().optional(),
+});
+
+const pricingSchema = z.object({
+  base_price: z.number().int().min(0).optional(),
+  compare_price: z.number().int().min(0).nullable().optional(),
+  sku: z.string().trim().min(1).max(64).nullable().optional(),
+  stock_quantity: z.number().int().min(0).optional(),
+  low_stock_threshold: z.number().int().min(0).optional(),
+  weight_grams: z.number().int().positive().nullable().optional(),
+});
+
+export const createDraftSchema = z.object({
+  name: z.string().trim().min(1).max(150),
+  category_id: idSchema,
+  brand: z.string().trim().max(80).nullable().optional(),
+  short_description: z.string().trim().max(120).nullable().optional(),
+  description_html: z.string().max(DESCRIPTION_MAX_BYTES).nullable().optional(),
+  story: storyInputSchema.optional(),
+  seo: seoSchema.optional(),
+  attributes: draftAttributesSchema.optional(),
+  pricing: pricingSchema.optional(),
+});
+
+export const updateDraftSchema = createDraftSchema.partial().extend({
+  slug: z.string().trim().max(160).regex(SLUG_RE, "Slug invalide (minuscules, chiffres, tirets)").optional(),
+});
+
+export const addImagesSchema = z.object({
+  images: z
+    .array(z.object({
+      url: z.string().url().max(2048).refine((u) => /^https?:\/\//i.test(u), "URL http(s) requise"),
+      alt: z.string().trim().max(200).nullable().optional(),
+    }))
+    .min(1)
+    .max(8),
+});
+
+export const setVariantsSchema = z.object({
+  variants: z
+    .array(z.object({
+      color_name: z.string().trim().min(1).max(40),
+      color_hex: z.string().regex(/^#[0-9a-fA-F]{6}$/, "Couleur hex invalide (format #rrggbb)"),
+      stock: z.number().int().min(0),
+      price: z.number().int().min(0).nullable().optional(),
+    }))
+    .max(12),
+  uniform_price: z.boolean().default(true),
+});
+
+export const searchProductsSchema = z.object({
+  query: z.string().trim().min(3).max(100),
+  limit: z.number().int().min(1).max(50).default(20),
+});
+
+export type DraftAttributesInput = z.infer<typeof draftAttributesSchema>;
+export type CreateDraftInput = z.infer<typeof createDraftSchema>;
+export type UpdateDraftInput = z.infer<typeof updateDraftSchema>;
+export type AddImagesInput = z.infer<typeof addImagesSchema>;
+export type SetVariantsInput = z.infer<typeof setVariantsSchema>;
+export type SearchProductsInput = z.infer<typeof searchProductsSchema>;
+```
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+npx vitest run __tests__/unit/lib/validations/mcp-product.test.ts && npx tsc --noEmit
+```
+
+Expected: all pass, tsc clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/validations/product-ai.ts lib/validations/mcp-product.ts __tests__/unit/lib/validations/mcp-product.test.ts
+git commit -m "feat(admin): zod contracts for the MCP product tools"
+```
+
+---
+
+### Task 7: `product-drafts` — create, read, update, search, delete
+
+**Files:**
+- Create: `__tests__/helpers/d1-mock.ts`
+- Create: `lib/db/product-drafts.ts`
+- Test: `__tests__/unit/lib/db/product-drafts.test.ts`
+
+**Interfaces:**
+- Consumes: schemas/types from Task 6; `slugify` from `@/lib/utils`; `sanitizeDescriptionHtml` from `@/lib/utils/sanitize-html`; `getImageUrl` from `@/lib/utils/images`; `deleteFromR2` from `@/lib/storage/images`.
+- Produces (from `@/lib/db/product-drafts`):
+  - `class DraftError extends Error { code: "not_found" | "conflict" | "limit_exceeded" }`
+  - `attributesToRows(attrs: DraftAttributesInput | undefined): { name: string; value: string }[]`
+  - `createDraft(input: CreateDraftInput): Promise<{ id: string; slug: string }>`
+  - `updateDraft(id: string, patch: UpdateDraftInput): Promise<{ id: string; slug: string }>`
+  - `getDraft(id: string): Promise<DraftDetail>`
+  - `searchProducts(query: string, limit: number): Promise<ProductSearchRow[]>`
+  - `deleteDraft(id: string): Promise<void>`
+  - types `DraftDetail`, `ProductSearchRow`
+
+- [ ] **Step 1: Create the shared D1 mock helper**
+
+`__tests__/helpers/d1-mock.ts`:
+
+```ts
+import { vi } from "vitest";
+
+/**
+ * Mocks the D1 binding one level below Drizzle so the real driver compiles the
+ * statements. Assertions run against the SQL/params Drizzle emits, which is
+ * what catches schema/column drift. Same technique as products-ai.test.ts.
+ *
+ * `raw` feeds `.get()`/`.all()` with POSITIONAL row arrays in select order
+ * (Drizzle's D1 driver reads `stmt.raw()` when a field selection exists).
+ * Return `[]` for "no row".
+ *
+ * Usage:
+ *   const d1 = createD1Mock();
+ *   vi.mock("@/lib/cloudflare/context", () => ({ getDB: async () => d1.binding }));
+ */
+export interface BoundStatement { sql: string; params: unknown[] }
+
+export function createD1Mock() {
+  const bound = vi.fn<(stmt: BoundStatement) => void>();
+  const run = vi.fn<(stmt: BoundStatement) => Promise<unknown>>();
+  const raw = vi.fn<(stmt: BoundStatement) => Promise<unknown[][]>>();
+  const batch = vi.fn<(stmts: BoundStatement[]) => Promise<unknown[]>>();
+
+  const binding = {
+    prepare: (sql: string) => ({
+      bind: (...params: unknown[]) => {
+        const stmt = { sql, params };
+        bound(stmt);
+        return {
+          ...stmt,
+          run: () => run(stmt),
+          all: () => raw(stmt).then((rows) => ({ results: rows })),
+          raw: () => raw(stmt),
+        };
+      },
+    }),
+    batch: (stmts: BoundStatement[]) => batch(stmts),
+  };
+
+  function reset() {
+    bound.mockReset();
+    run.mockReset().mockResolvedValue({ success: true, meta: { changes: 1 }, results: [] });
+    raw.mockReset().mockResolvedValue([]);
+    batch.mockReset().mockResolvedValue([]);
+  }
+  reset();
+
+  /** Statements handed to the Nth `db.batch()` call. */
+  const batchStatements = (call = 0) => batch.mock.calls[call][0];
+  const boundMatching = (re: RegExp) => bound.mock.calls.map((c) => c[0]).filter((s) => re.test(s.sql));
+
+  return { binding, bound, run, raw, batch, reset, batchStatements, boundMatching };
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+`__tests__/unit/lib/db/product-drafts.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createD1Mock, type BoundStatement } from "../../../helpers/d1-mock";
+
+const d1 = vi.hoisted(() => {
+  // createD1Mock is imported above but hoisting needs a lazy reference.
+  return { current: null as null | ReturnType<typeof import("../../../helpers/d1-mock").createD1Mock> };
+});
+const mocks = vi.hoisted(() => ({ deleteFromR2: vi.fn() }));
+
+vi.mock("@/lib/cloudflare/context", () => ({ getDB: async () => d1.current!.binding }));
+vi.mock("@/lib/storage/images", () => ({ deleteFromR2: mocks.deleteFromR2, uploadToR2: vi.fn() }));
+vi.mock("@/lib/ai/image-fetch", () => ({ fetchAndUploadImage: vi.fn() }));
+
+import {
+  attributesToRows,
+  createDraft,
+  updateDraft,
+  getDraft,
+  searchProducts,
+  deleteDraft,
+  DraftError,
+} from "@/lib/db/product-drafts";
+
+beforeEach(() => {
+  d1.current = createD1Mock();
+  mocks.deleteFromR2.mockReset().mockResolvedValue(undefined);
+});
+
+const sqlOf = (s: BoundStatement) => s.sql.replace(/\s+/g, " ");
+
+describe("attributesToRows", () => {
+  it("encode couleurs, dimensions et specs avec les conventions du wizard", () => {
+    expect(attributesToRows({
+      colors: [{ name: "Noir", hex: "#000000" }],
+      dimensions: { length_mm: 160, weight_g: 190 },
+      specs: [{ name: "Écran", value: "6.1\"" }],
+    })).toEqual([
+      { name: "Couleur", value: "Noir|#000000" },
+      { name: "Longueur", value: "160" },
+      { name: "Poids", value: "190" },
+      { name: "Écran", value: "6.1\"" },
+    ]);
+  });
+
+  it("retourne [] sans attributs", () => {
+    expect(attributesToRows(undefined)).toEqual([]);
+  });
+});
+
+describe("createDraft", () => {
+  it("refuse une catégorie inconnue", async () => {
+    await expect(createDraft({ name: "Galaxy A55", category_id: "nope" }))
+      .rejects.toMatchObject({ code: "not_found" });
+  });
+
+  it("insère un brouillon inactif avec un slug dérivé du nom, en un seul batch", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) =>
+      /from "categories"/i.test(stmt.sql) ? [["cat-1"]] : []);
+
+    const r = await createDraft({
+      name: "Galaxy A55",
+      category_id: "cat-1",
+      description_html: "<p>Hi</p><script>x()</script>",
+      attributes: { colors: [{ name: "Noir", hex: "#000000" }], dimensions: {}, specs: [] },
+      pricing: { base_price: 150000, sku: "GA55" },
+    });
+
+    expect(r.slug).toBe("galaxy-a55");
+    const stmts = d1.current!.batchStatements();
+    const insert = stmts.find((s) => /insert into "products"/i.test(s.sql))!;
+    expect(insert.params).toContain("galaxy-a55");
+    const strings = insert.params.filter((p): p is string => typeof p === "string");
+    expect(strings.some((s) => s.includes("<p>Hi</p>"))).toBe(true);   // sanitized HTML kept
+    expect(strings.some((s) => s.includes("<script>"))).toBe(false);   // script stripped
+    expect(stmts.filter((s) => /insert into "product_attributes"/i.test(s.sql))).toHaveLength(1);
+    // is_draft = 1, is_active = 0 are bound values of the products insert
+    expect(insert.params).toEqual(expect.arrayContaining([1, 0]));
+  });
+
+  it("suffixe le slug quand il est pris", async () => {
+    const taken = new Set(["galaxy-a55", "galaxy-a55-2"]);
+    d1.current!.raw.mockImplementation(async (stmt) => {
+      if (/from "categories"/i.test(stmt.sql)) return [["cat-1"]];
+      if (/from "products"/i.test(stmt.sql) && /"slug" =/i.test(stmt.sql)) {
+        return taken.has(stmt.params[0] as string) ? [["other"]] : [];
+      }
+      return [];
+    });
+    const r = await createDraft({ name: "Galaxy A55", category_id: "cat-1" });
+    expect(r.slug).toBe("galaxy-a55-3");
+  });
+
+  it("refuse un SKU déjà utilisé", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) => {
+      if (/from "categories"/i.test(stmt.sql)) return [["cat-1"]];
+      if (/"sku" =/i.test(stmt.sql)) return [["p-other"]];
+      return [];
+    });
+    await expect(createDraft({ name: "X", category_id: "cat-1", pricing: { sku: "DUP" } }))
+      .rejects.toMatchObject({ code: "conflict" });
+  });
+});
+
+describe("updateDraft", () => {
+  it("refuse un produit qui n'est pas un brouillon", async () => {
+    await expect(updateDraft("p1", { name: "Y" })).rejects.toMatchObject({ code: "not_found" });
+    const probe = d1.current!.boundMatching(/from "products"/i)[0];
+    expect(sqlOf(probe)).toMatch(/"is_draft" = \?/);
+    expect(probe.params).toContain(1);
+  });
+
+  it("met à jour uniquement les champs fournis et remplace les attributs quand présents", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) =>
+      /from "products"/i.test(stmt.sql) ? [["p1", "old-slug"]] : []);
+
+    const r = await updateDraft("p1", {
+      brand: null,
+      attributes: { colors: [], dimensions: {}, specs: [{ name: "RAM", value: "8 Go" }] },
+    });
+
+    expect(r).toEqual({ id: "p1", slug: "old-slug" });
+    const stmts = d1.current!.batchStatements();
+    const update = stmts.find((s) => /update "products"/i.test(s.sql))!;
+    expect(sqlOf(update)).toMatch(/"brand" = \?/);
+    expect(sqlOf(update)).not.toMatch(/"name" = \?/);
+    expect(sqlOf(update)).toMatch(/where .*"is_draft" = \?/i);
+    expect(stmts.some((s) => /delete from "product_attributes"/i.test(s.sql))).toBe(true);
+    expect(stmts.filter((s) => /insert into "product_attributes"/i.test(s.sql))).toHaveLength(1);
+  });
+
+  it("refuse un slug explicite déjà pris", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) => {
+      if (/"is_draft" = \?/i.test(stmt.sql)) return [["p1", "old-slug"]];
+      if (/"slug" = \?/i.test(stmt.sql)) return [["p2"]];
+      return [];
+    });
+    await expect(updateDraft("p1", { slug: "taken" })).rejects.toMatchObject({ code: "conflict" });
+  });
+});
+
+describe("getDraft", () => {
+  it("lève not_found si le brouillon n'existe pas", async () => {
+    await expect(getDraft("p1")).rejects.toBeInstanceOf(DraftError);
+  });
+});
+
+describe("searchProducts", () => {
+  it("cherche sur nom, slug et SKU avec la limite", async () => {
+    await searchProducts("galaxy", 5);
+    const stmt = d1.current!.boundMatching(/from "products"/i)[0];
+    expect(sqlOf(stmt)).toMatch(/"name" like \?/i);
+    expect(sqlOf(stmt)).toMatch(/"slug" like \?/i);
+    expect(sqlOf(stmt)).toMatch(/"sku" like \?/i);
+    expect(stmt.params).toContain("%galaxy%");
+    expect(stmt.params).toContain(5);
+  });
+
+  it("échappe % et _ dans la requête", async () => {
+    await searchProducts("100%_x", 5);
+    const stmt = d1.current!.boundMatching(/from "products"/i)[0];
+    expect(stmt.params).toContain("%100\\%\\_x%");
+  });
+});
+
+describe("deleteDraft", () => {
+  it("supprime enfants puis produit, puis les objets R2, uniquement pour un brouillon", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) => {
+      if (/"is_draft" = \?/i.test(stmt.sql)) return [["p1", "slug"]];
+      if (/from "product_images"/i.test(stmt.sql)) return [["products/p1/a.jpg"], ["/images/legacy.jpg"]];
+      return [];
+    });
+    await deleteDraft("p1");
+    const stmts = d1.current!.batchStatements().map(sqlOf);
+    expect(stmts[stmts.length - 1]).toMatch(/delete from "products" where .*"is_draft" = \?/i);
+    expect(stmts.some((s) => /delete from "product_images"/i.test(s))).toBe(true);
+    expect(stmts.some((s) => /delete from "product_variants"/i.test(s))).toBe(true);
+    expect(stmts.some((s) => /delete from "product_attributes"/i.test(s))).toBe(true);
+    expect(mocks.deleteFromR2).toHaveBeenCalledWith("products/p1/a.jpg");
+    expect(mocks.deleteFromR2).toHaveBeenCalledWith("legacy.jpg");
+  });
+});
+```
+
+- [ ] **Step 3: Run to verify they fail**
+
+```bash
+npx vitest run __tests__/unit/lib/db/product-drafts.test.ts
+```
+
+Expected: FAIL, module `@/lib/db/product-drafts` not found.
+
+- [ ] **Step 4: Implement the module (part 1)**
+
+`lib/db/product-drafts.ts`:
+
+```ts
+import { and, asc, eq, ne, or, sql } from "drizzle-orm";
+import type { BatchItem } from "drizzle-orm/batch";
+import { nanoid } from "nanoid";
+import { getDrizzle, type DrizzleDB } from "@/lib/db/drizzle";
+import { categories, productAttributes, productImages, productVariants, products } from "@/lib/db/schema";
+import { slugify } from "@/lib/utils";
+import { sanitizeDescriptionHtml } from "@/lib/utils/sanitize-html";
+import { getImageUrl } from "@/lib/utils/images";
+import { deleteFromR2 } from "@/lib/storage/images";
+import { fetchAndUploadImage, type FetchImageResult } from "@/lib/ai/image-fetch";
+import type {
+  AddImagesInput,
+  CreateDraftInput,
+  DraftAttributesInput,
+  SetVariantsInput,
+  UpdateDraftInput,
+} from "@/lib/validations/mcp-product";
+
+/**
+ * Draft-only product persistence for the MCP tools (lib/mcp/tools/products.ts).
+ *
+ * Invariant: every UPDATE/DELETE on `products` filters on `is_draft = 1`. A
+ * published product is unreachable from here by construction — that is the
+ * mechanical form of the "drafts only" decision in the spec.
+ */
+
+export type DraftErrorCode = "not_found" | "conflict" | "limit_exceeded";
+
+export class DraftError extends Error {
+  constructor(public readonly code: DraftErrorCode, message: string) {
+    super(message);
+    this.name = "DraftError";
+  }
+}
+
+export const MAX_IMAGES_PER_PRODUCT = 12;
+
+type Statement = BatchItem<"sqlite">;
+type Batch = [Statement, ...Statement[]];
+
+// ─── Pure helpers ───
+
+const DIMENSION_LABELS: Array<[keyof DraftAttributesInput["dimensions"], string]> = [
+  ["length_mm", "Longueur"],
+  ["height_mm", "Hauteur"],
+  ["width_mm", "Largeur"],
+  ["weight_g", "Poids"],
+];
+
+/** Same encoding as the wizard's step 2 and products-ai.ts. */
+export function attributesToRows(attrs: DraftAttributesInput | undefined): { name: string; value: string }[] {
+  if (!attrs) return [];
+  const rows: { name: string; value: string }[] = [];
+  for (const c of attrs.colors) rows.push({ name: "Couleur", value: `${c.name}|${c.hex}` });
+  for (const [key, label] of DIMENSION_LABELS) {
+    const v = attrs.dimensions[key];
+    if (v != null) rows.push({ name: label, value: String(v) });
+  }
+  for (const s of attrs.specs) rows.push({ name: s.name, value: s.value });
+  return rows;
+}
+
+type ProductColumns = Partial<typeof products.$inferInsert>;
+
+/** Only keys the caller provided end up in the statement; `null` clears. */
+function buildProductColumns(input: UpdateDraftInput, productId: string): ProductColumns {
+  const cols: ProductColumns = {};
+  if (input.name !== undefined) cols.name = input.name;
+  if (input.category_id !== undefined) cols.category_id = input.category_id;
+  if (input.brand !== undefined) cols.brand = input.brand;
+  if (input.short_description !== undefined) cols.short_description = input.short_description;
+  if (input.description_html !== undefined) {
+    cols.description = input.description_html ? sanitizeDescriptionHtml(input.description_html, productId) : null;
+    cols.description_type = "html";
+  }
+  if (input.seo) {
+    if (input.seo.meta_title !== undefined) cols.meta_title = input.seo.meta_title;
+    if (input.seo.meta_description !== undefined) cols.meta_description = input.seo.meta_description;
+  }
+  if (input.story) {
+    const s = input.story;
+    if (s.tagline !== undefined) cols.tagline = s.tagline;
+    if (s.highlights !== undefined) cols.highlights = s.highlights ? JSON.stringify(s.highlights) : null;
+    if (s.feature_blocks !== undefined) cols.feature_blocks = s.feature_blocks ? JSON.stringify(s.feature_blocks) : null;
+    if (s.faq !== undefined) cols.faq = s.faq ? JSON.stringify(s.faq) : null;
+  }
+  if (input.pricing) {
+    const p = input.pricing;
+    if (p.base_price !== undefined) cols.base_price = p.base_price;
+    if (p.compare_price !== undefined) cols.compare_price = p.compare_price;
+    if (p.sku !== undefined) cols.sku = p.sku;
+    if (p.stock_quantity !== undefined) cols.stock_quantity = p.stock_quantity;
+    if (p.low_stock_threshold !== undefined) cols.low_stock_threshold = p.low_stock_threshold;
+    if (p.weight_grams !== undefined) cols.weight_grams = p.weight_grams;
+  }
+  return cols;
+}
+
+function escapeLike(q: string): string {
+  return q.replace(/[\\%_]/g, (m) => `\\${m}`);
+}
+
+function r2KeyFromImageUrl(url: string): string {
+  return url.replace(/^\/images\//, "");
+}
+
+// ─── DB probes ───
+
+async function requireDraft(db: DrizzleDB, id: string): Promise<{ id: string; slug: string }> {
+  const row = await db
+    .select({ id: products.id, slug: products.slug })
+    .from(products)
+    .where(and(eq(products.id, id), eq(products.is_draft, 1)))
+    .limit(1)
+    .get();
+  if (!row) throw new DraftError("not_found", "Brouillon introuvable (ou produit déjà publié)");
+  return row;
+}
+
+async function requireCategory(db: DrizzleDB, categoryId: string): Promise<void> {
+  const row = await db
+    .select({ id: categories.id })
+    .from(categories)
+    .where(and(eq(categories.id, categoryId), eq(categories.is_active, 1)))
+    .limit(1)
+    .get();
+  if (!row) throw new DraftError("not_found", "Catégorie introuvable");
+}
+
+async function requireSkuFree(db: DrizzleDB, sku: string, excludeId: string | null): Promise<void> {
+  const cond = excludeId ? and(eq(products.sku, sku), ne(products.id, excludeId)) : eq(products.sku, sku);
+  const row = await db.select({ id: products.id }).from(products).where(cond).limit(1).get();
+  if (row) throw new DraftError("conflict", `Le SKU "${sku}" est déjà utilisé`);
+}
+
+async function isSlugTaken(db: DrizzleDB, slug: string, excludeId: string): Promise<boolean> {
+  const row = await db
+    .select({ id: products.id })
+    .from(products)
+    .where(and(eq(products.slug, slug), ne(products.id, excludeId)))
+    .limit(1)
+    .get();
+  return Boolean(row);
+}
+
+/** `base`, then `base-2` … `base-20`; null when everything collides (caller uses a placeholder). */
+async function ensureUniqueSlug(db: DrizzleDB, base: string, excludeId: string): Promise<string | null> {
+  if (!base) return null;
+  let candidate = base;
+  for (let suffix = 1; suffix <= 20; suffix++) {
+    if (!(await isSlugTaken(db, candidate, excludeId))) return candidate;
+    candidate = `${base}-${suffix + 1}`;
+  }
+  return null;
+}
+
+// ─── Create / update / read / search / delete ───
+
+export async function createDraft(input: CreateDraftInput): Promise<{ id: string; slug: string }> {
+  const db = await getDrizzle();
+  await requireCategory(db, input.category_id);
+  if (input.pricing?.sku) await requireSkuFree(db, input.pricing.sku, null);
+
+  const id = nanoid();
+  const slug = (await ensureUniqueSlug(db, slugify(input.name), id)) ?? `draft-${id}`;
+  const cols = buildProductColumns(input, id);
+
+  const stmts: Batch = [
+    db.insert(products).values({
+      ...cols,
+      id,
+      name: input.name,
+      category_id: input.category_id,
+      slug,
+      base_price: cols.base_price ?? 0,
+      is_active: 0,
+      is_draft: 1,
+      created_at: sql`datetime('now')`,
+      updated_at: sql`datetime('now')`,
+    }),
+  ];
+  for (const row of attributesToRows(input.attributes)) {
+    stmts.push(db.insert(productAttributes).values({ id: nanoid(), product_id: id, ...row }));
+  }
+  await db.batch(stmts);
+  return { id, slug };
+}
+
+export async function updateDraft(id: string, patch: UpdateDraftInput): Promise<{ id: string; slug: string }> {
+  const db = await getDrizzle();
+  const current = await requireDraft(db, id);
+  if (patch.category_id !== undefined) await requireCategory(db, patch.category_id);
+  if (patch.pricing?.sku) await requireSkuFree(db, patch.pricing.sku, id);
+
+  let slug = current.slug;
+  if (patch.slug !== undefined) {
+    if (await isSlugTaken(db, patch.slug, id)) throw new DraftError("conflict", `Le slug "${patch.slug}" est déjà utilisé`);
+    slug = patch.slug;
+  }
+
+  const stmts: Batch = [
+    db
+      .update(products)
+      .set({ ...buildProductColumns(patch, id), slug, updated_at: sql`datetime('now')` })
+      .where(and(eq(products.id, id), eq(products.is_draft, 1))),
+  ];
+  if (patch.attributes !== undefined) {
+    stmts.push(db.delete(productAttributes).where(eq(productAttributes.product_id, id)));
+    for (const row of attributesToRows(patch.attributes)) {
+      stmts.push(db.insert(productAttributes).values({ id: nanoid(), product_id: id, ...row }));
+    }
+  }
+  await db.batch(stmts);
+  return { id, slug };
+}
+
+export interface DraftDetail {
+  id: string;
+  name: string;
+  slug: string;
+  edit_url: string;
+  category_id: string | null;
+  brand: string | null;
+  short_description: string | null;
+  description_html: string | null;
+  base_price: number;
+  compare_price: number | null;
+  sku: string | null;
+  stock_quantity: number;
+  low_stock_threshold: number;
+  weight_grams: number | null;
+  seo: { meta_title: string | null; meta_description: string | null };
+  story: { tagline: string | null; highlights: unknown; feature_blocks: unknown; faq: unknown };
+  attributes: { id: string; name: string; value: string }[];
+  images: { id: string; url: string; alt: string | null; is_primary: boolean; sort_order: number; variant_id: string | null }[];
+  variants: { id: string; name: string; price: number; compare_price: number | null; stock_quantity: number; attributes: unknown }[];
+  created_at: string;
+  updated_at: string;
+}
+
+function parseJson(v: string | null): unknown {
+  if (!v) return null;
+  try { return JSON.parse(v); } catch { return null; }
+}
+
+export async function getDraft(id: string): Promise<DraftDetail> {
+  const db = await getDrizzle();
+  const p = await db
+    .select()
+    .from(products)
+    .where(and(eq(products.id, id), eq(products.is_draft, 1)))
+    .limit(1)
+    .get();
+  if (!p) throw new DraftError("not_found", "Brouillon introuvable (ou produit déjà publié)");
+
+  const [attrs, imgs, vars] = await Promise.all([
+    db.select({ id: productAttributes.id, name: productAttributes.name, value: productAttributes.value })
+      .from(productAttributes).where(eq(productAttributes.product_id, id)).all(),
+    db.select({
+      id: productImages.id, url: productImages.url, alt: productImages.alt,
+      is_primary: productImages.is_primary, sort_order: productImages.sort_order, variant_id: productImages.variant_id,
+    }).from(productImages).where(eq(productImages.product_id, id)).orderBy(asc(productImages.sort_order)).all(),
+    db.select({
+      id: productVariants.id, name: productVariants.name, price: productVariants.price,
+      compare_price: productVariants.compare_price, stock_quantity: productVariants.stock_quantity, attributes: productVariants.attributes,
+    }).from(productVariants).where(eq(productVariants.product_id, id)).orderBy(asc(productVariants.sort_order)).all(),
+  ]);
+
+  return {
+    id: p.id,
+    name: p.name,
+    slug: p.slug,
+    edit_url: `/products/${p.id}/edit`,
+    category_id: p.category_id,
+    brand: p.brand,
+    short_description: p.short_description,
+    description_html: p.description,
+    base_price: p.base_price,
+    compare_price: p.compare_price,
+    sku: p.sku,
+    stock_quantity: p.stock_quantity,
+    low_stock_threshold: p.low_stock_threshold,
+    weight_grams: p.weight_grams,
+    seo: { meta_title: p.meta_title, meta_description: p.meta_description },
+    story: {
+      tagline: p.tagline,
+      highlights: parseJson(p.highlights),
+      feature_blocks: parseJson(p.feature_blocks),
+      faq: parseJson(p.faq),
+    },
+    attributes: attrs,
+    images: imgs.map((i) => ({ ...i, url: getImageUrl(i.url), is_primary: i.is_primary === 1 })),
+    variants: vars.map((v) => ({ ...v, attributes: parseJson(v.attributes) })),
+    created_at: p.created_at,
+    updated_at: p.updated_at,
+  };
+}
+
+export interface ProductSearchRow {
+  id: string;
+  name: string;
+  slug: string;
+  brand: string | null;
+  sku: string | null;
+  base_price: number;
+  is_draft: boolean;
+  is_active: boolean;
+}
+
+/** Drafts and published products alike: this is the duplicate detector. */
+export async function searchProducts(query: string, limit: number): Promise<ProductSearchRow[]> {
+  const db = await getDrizzle();
+  const pattern = `%${escapeLike(query)}%`;
+  const rows = await db
+    .select({
+      id: products.id, name: products.name, slug: products.slug, brand: products.brand,
+      sku: products.sku, base_price: products.base_price, is_draft: products.is_draft, is_active: products.is_active,
+    })
+    .from(products)
+    .where(or(
+      sql`${products.name} like ${pattern} escape '\\'`,
+      sql`${products.slug} like ${pattern} escape '\\'`,
+      sql`${products.sku} like ${pattern} escape '\\'`,
+    ))
+    .orderBy(asc(products.name))
+    .limit(limit)
+    .all();
+  return rows.map((r) => ({ ...r, is_draft: r.is_draft === 1, is_active: r.is_active === 1 }));
+}
+
+export async function deleteDraft(id: string): Promise<void> {
+  const db = await getDrizzle();
+  await requireDraft(db, id);
+  const imgs = await db.select({ url: productImages.url }).from(productImages).where(eq(productImages.product_id, id)).all();
+
+  // Children explicitly, like actions/admin/products.ts deleteProduct — do not
+  // rely on FK cascade being enabled on the D1 connection.
+  await db.batch([
+    db.delete(productImages).where(eq(productImages.product_id, id)),
+    db.delete(productVariants).where(eq(productVariants.product_id, id)),
+    db.delete(productAttributes).where(eq(productAttributes.product_id, id)),
+    db.delete(products).where(and(eq(products.id, id), eq(products.is_draft, 1))),
+  ]);
+
+  const cleanup = await Promise.allSettled(imgs.map((i) => deleteFromR2(r2KeyFromImageUrl(i.url))));
+  for (const c of cleanup) {
+    if (c.status === "rejected") console.warn("[product-drafts] orphan R2 object after deleteDraft", id, c.reason);
+  }
+}
+
+// ─── Images and variants: see Task 8 ───
+export { fetchAndUploadImage as _fetchAndUploadImage };
+export type { FetchImageResult as _FetchImageResult, AddImagesInput as _AddImagesInput, SetVariantsInput as _SetVariantsInput };
+```
+
+The last two `export` lines exist only so the not-yet-used imports do not fail lint before Task 8; Task 8 removes them.
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+npx vitest run __tests__/unit/lib/db/product-drafts.test.ts
+```
+
+Expected: all pass. If the `like` assertion in `searchProducts` fails because Drizzle renders the raw `sql` template with different quoting, adjust the regex to `/"name" like \?/i` on `sqlOf(stmt)` (whitespace-normalised) — the parameter assertions are the important ones.
+
+- [ ] **Step 6: Lint and type-check**
+
+```bash
+npx tsc --noEmit && npx eslint lib/db/product-drafts.ts __tests__/helpers/d1-mock.ts __tests__/unit/lib/db/product-drafts.test.ts
+```
+
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/db/product-drafts.ts __tests__/helpers/d1-mock.ts __tests__/unit/lib/db/product-drafts.test.ts
+git commit -m "feat(db): draft-only product persistence for the MCP tools"
+```
+
+---
+
+### Task 8: `product-drafts` — images and colour variants
+
+**Files:**
+- Modify: `lib/db/product-drafts.ts` (replace the Task 7 trailing exports)
+- Test: `__tests__/unit/lib/db/product-drafts-media.test.ts`
+
+**Interfaces:**
+- Consumes: `fetchAndUploadImage(draftId, url): Promise<FetchImageResult>` from `@/lib/ai/image-fetch` (returns `{ ok: true, key }` or `{ ok: false, reason }`).
+- Produces (from `@/lib/db/product-drafts`):
+  - `addImagesFromUrls(id: string, images: AddImagesInput["images"]): Promise<{ results: ImageImportResult[]; primary_image_id: string | null }>`
+  - `removeImage(id: string, imageId: string): Promise<void>`
+  - `setColorVariants(id: string, input: SetVariantsInput): Promise<{ variants: VariantRow[]; stock_quantity: number }>`
+  - types `ImageImportResult = { url: string; ok: boolean; image_id?: string; reason?: string }`, `VariantRow = { id: string; color_name: string; color_hex: string; price: number; stock: number }`
+
+- [ ] **Step 1: Write the failing tests**
+
+`__tests__/unit/lib/db/product-drafts-media.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createD1Mock, type BoundStatement } from "../../../helpers/d1-mock";
+
+const d1 = vi.hoisted(() => ({
+  current: null as null | ReturnType<typeof import("../../../helpers/d1-mock").createD1Mock>,
+}));
+const mocks = vi.hoisted(() => ({ deleteFromR2: vi.fn(), fetchAndUploadImage: vi.fn() }));
+
+vi.mock("@/lib/cloudflare/context", () => ({ getDB: async () => d1.current!.binding }));
+vi.mock("@/lib/storage/images", () => ({ deleteFromR2: mocks.deleteFromR2, uploadToR2: vi.fn() }));
+vi.mock("@/lib/ai/image-fetch", () => ({ fetchAndUploadImage: mocks.fetchAndUploadImage }));
+
+import { addImagesFromUrls, removeImage, setColorVariants } from "@/lib/db/product-drafts";
+
+const sqlOf = (s: BoundStatement) => s.sql.replace(/\s+/g, " ");
+const DRAFT_ROW = [["p1", "slug"]];
+
+beforeEach(() => {
+  d1.current = createD1Mock();
+  mocks.deleteFromR2.mockReset().mockResolvedValue(undefined);
+  mocks.fetchAndUploadImage.mockReset().mockImplementation(async (_id: string, url: string) =>
+    ({ ok: true, key: `products/p1/${url.split("/").pop()}`, contentType: "image/jpeg", size: 10 }));
+});
+
+describe("addImagesFromUrls", () => {
+  it("refuse au-delà de 12 images au total, avant tout téléchargement", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) => {
+      if (/"is_draft" = \?/i.test(stmt.sql)) return DRAFT_ROW;
+      if (/from "product_images"/i.test(stmt.sql)) return Array.from({ length: 11 }, (_, i) => [`img-${i}`, i === 0 ? 1 : 0, i]);
+      return [];
+    });
+    await expect(addImagesFromUrls("p1", [{ url: "https://x/a.jpg" }, { url: "https://x/b.jpg" }]))
+      .rejects.toMatchObject({ code: "limit_exceeded" });
+    expect(mocks.fetchAndUploadImage).not.toHaveBeenCalled();
+  });
+
+  it("insère les images réussies, marque la première primaire, rapporte les échecs", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) => (/"is_draft" = \?/i.test(stmt.sql) ? DRAFT_ROW : []));
+    mocks.fetchAndUploadImage.mockImplementation(async (_id: string, url: string) =>
+      url.endsWith("bad.jpg") ? { ok: false, reason: "bad_status", status: 404 }
+        : { ok: true, key: `products/p1/${url.split("/").pop()}`, contentType: "image/jpeg", size: 1 });
+
+    const r = await addImagesFromUrls("p1", [{ url: "https://x/bad.jpg" }, { url: "https://x/a.jpg", alt: "A" }, { url: "https://x/b.jpg" }]);
+
+    expect(r.results).toEqual([
+      { url: "https://x/bad.jpg", ok: false, reason: "bad_status" },
+      { url: "https://x/a.jpg", ok: true, image_id: expect.any(String) },
+      { url: "https://x/b.jpg", ok: true, image_id: expect.any(String) },
+    ]);
+    expect(r.primary_image_id).toBe(r.results[1].image_id);
+    const inserts = d1.current!.batchStatements().filter((s) => /insert into "product_images"/i.test(s.sql));
+    expect(inserts).toHaveLength(2);
+    expect(inserts[0].params).toEqual(expect.arrayContaining(["products/p1/a.jpg", "A", 1, 0]));  // is_primary 1, sort 0
+    expect(inserts[1].params).toEqual(expect.arrayContaining(["products/p1/b.jpg", 0, 1]));
+  });
+
+  it("garde la primaire existante et poursuit le sort_order", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) => {
+      if (/"is_draft" = \?/i.test(stmt.sql)) return DRAFT_ROW;
+      if (/from "product_images"/i.test(stmt.sql)) return [["img-0", 1, 0], ["img-1", 0, 4]];
+      return [];
+    });
+    const r = await addImagesFromUrls("p1", [{ url: "https://x/c.jpg" }]);
+    expect(r.primary_image_id).toBe("img-0");
+    const insert = d1.current!.batchStatements()[0];
+    expect(insert.params).toEqual(expect.arrayContaining([0, 5]));
+  });
+
+  it("nettoie R2 si le batch échoue", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) => (/"is_draft" = \?/i.test(stmt.sql) ? DRAFT_ROW : []));
+    d1.current!.batch.mockRejectedValue(new Error("D1 down"));
+    await expect(addImagesFromUrls("p1", [{ url: "https://x/a.jpg" }])).rejects.toThrow("D1 down");
+    expect(mocks.deleteFromR2).toHaveBeenCalledWith("products/p1/a.jpg");
+  });
+});
+
+describe("removeImage", () => {
+  it("supprime la ligne, promeut la suivante en primaire et efface l'objet R2", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) => {
+      if (/"is_draft" = \?/i.test(stmt.sql)) return DRAFT_ROW;
+      if (/from "product_images"/i.test(stmt.sql) && /"id" = \?/i.test(stmt.sql)) return [["img-0", "products/p1/a.jpg", 1]];
+      if (/from "product_images"/i.test(stmt.sql)) return [["img-1"]];
+      return [];
+    });
+    await removeImage("p1", "img-0");
+    const stmts = d1.current!.batchStatements().map(sqlOf);
+    expect(stmts[0]).toMatch(/delete from "product_images"/i);
+    expect(stmts[1]).toMatch(/update "product_images" set "is_primary" = \?/i);
+    expect(mocks.deleteFromR2).toHaveBeenCalledWith("products/p1/a.jpg");
+  });
+
+  it("lève not_found pour une image d'un autre produit", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) => (/"is_draft" = \?/i.test(stmt.sql) ? DRAFT_ROW : []));
+    await expect(removeImage("p1", "img-x")).rejects.toMatchObject({ code: "not_found" });
+  });
+});
+
+describe("setColorVariants", () => {
+  // select({ id, slug, base_price, compare_price }) → positional row
+  const PRODUCT_ROW = [["p1", "slug", 100000, 120000]];
+
+  it("crée, met à jour et supprime les variantes couleur, et recalcule le stock", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) => {
+      if (/from "products"/i.test(stmt.sql)) return PRODUCT_ROW;
+      if (/from "product_variants"/i.test(stmt.sql) && /"attributes"/i.test(stmt.sql)) {
+        return [["v-noir", JSON.stringify({ color: "Noir:#000000" })], ["v-bleu", JSON.stringify({ color: "Bleu:#0000ff" })]];
+      }
+      return [];
+    });
+
+    const r = await setColorVariants("p1", {
+      uniform_price: false,
+      variants: [
+        { color_name: "Noir", color_hex: "#000000", stock: 2, price: 90000 },
+        { color_name: "Rouge", color_hex: "#ff0000", stock: 3 },
+      ],
+    });
+
+    expect(r.stock_quantity).toBe(5);
+    const stmts = d1.current!.batchStatements().map(sqlOf);
+    expect(stmts.some((s) => /update "product_variants" set/i.test(s))).toBe(true);        // Noir
+    expect(stmts.some((s) => /insert into "product_variants"/i.test(s))).toBe(true);      // Rouge
+    expect(stmts.some((s) => /update "product_images" set "variant_id" = \?/i.test(s))).toBe(true); // Bleu images detached
+    expect(stmts.some((s) => /delete from "product_variants" where "product_variants"."id" = \?/i.test(s))).toBe(true); // Bleu
+    expect(stmts[stmts.length - 1]).toMatch(/update "products" set "stock_quantity" = \?.*"is_draft" = \?/i);
+    const rougeInsert = d1.current!.batchStatements().find((s) => /insert into "product_variants"/i.test(s.sql))!;
+    expect(rougeInsert.params).toEqual(expect.arrayContaining(["Rouge", 100000, JSON.stringify({ color: "Rouge:#ff0000" })])); // price → base_price
+  });
+
+  it("applique le prix de base à toutes les variantes en uniform_price", async () => {
+    d1.current!.raw.mockImplementation(async (stmt) => (/from "products"/i.test(stmt.sql) ? PRODUCT_ROW : []));
+    await setColorVariants("p1", { uniform_price: true, variants: [{ color_name: "Noir", color_hex: "#000000", stock: 1, price: 5 }] });
+    const insert = d1.current!.batchStatements().find((s) => /insert into "product_variants"/i.test(s.sql))!;
+    expect(insert.params).toEqual(expect.arrayContaining([100000, 120000]));
+    expect(insert.params).not.toContain(5);
+  });
+
+  it("refuse un produit publié", async () => {
+    await expect(setColorVariants("p1", { uniform_price: true, variants: [] })).rejects.toMatchObject({ code: "not_found" });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+npx vitest run __tests__/unit/lib/db/product-drafts-media.test.ts
+```
+
+Expected: FAIL, `addImagesFromUrls` is not exported.
+
+- [ ] **Step 3: Implement (replace the trailing placeholder exports of Task 7)**
+
+Delete the two lines after `// ─── Images and variants: see Task 8 ───` in `lib/db/product-drafts.ts` and append:
+
+```ts
+// ─── Images ───
+
+export interface ImageImportResult {
+  url: string;
+  ok: boolean;
+  image_id?: string;
+  reason?: string;
+}
+
+type FetchSuccess = Extract<FetchImageResult, { ok: true }>;
+
+export async function addImagesFromUrls(
+  id: string,
+  images: AddImagesInput["images"],
+): Promise<{ results: ImageImportResult[]; primary_image_id: string | null }> {
+  const db = await getDrizzle();
+  await requireDraft(db, id);
+
+  const existing = await db
+    .select({ id: productImages.id, is_primary: productImages.is_primary, sort_order: productImages.sort_order })
+    .from(productImages)
+    .where(eq(productImages.product_id, id))
+    .all();
+
+  if (existing.length + images.length > MAX_IMAGES_PER_PRODUCT) {
+    throw new DraftError(
+      "limit_exceeded",
+      `Au plus ${MAX_IMAGES_PER_PRODUCT} images par produit (${existing.length} déjà présentes)`,
+    );
+  }
+
+  const fetched = await Promise.all(
+    images.map(async (img) => ({ img, r: await fetchAndUploadImage(id, img.url) })),
+  );
+  const succeeded = fetched.filter((x): x is { img: typeof x.img; r: FetchSuccess } => x.r.ok);
+
+  let primaryId: string | null = existing.find((e) => e.is_primary === 1)?.id ?? null;
+  let nextSort = existing.reduce((max, e) => Math.max(max, e.sort_order + 1), 0);
+
+  const idByUrl = new Map<string, string>();
+  const stmts: Statement[] = [];
+  for (const { img, r } of succeeded) {
+    const imageId = nanoid();
+    idByUrl.set(img.url, imageId);
+    const isPrimary = primaryId === null ? 1 : 0;
+    if (isPrimary) primaryId = imageId;
+    stmts.push(
+      db.insert(productImages).values({
+        id: imageId,
+        product_id: id,
+        url: r.key,
+        alt: img.alt ?? null,
+        is_primary: isPrimary,
+        sort_order: nextSort++,
+        created_at: sql`datetime('now')`,
+      }),
+    );
+  }
+
+  if (stmts.length > 0) {
+    try {
+      await db.batch(stmts as Batch);
+    } catch (err) {
+      console.error("[product-drafts] image batch failed, cleaning R2", { id }, err);
+      await Promise.allSettled(succeeded.map(({ r }) => deleteFromR2(r.key)));
+      throw err;
+    }
+  }
+
+  const results: ImageImportResult[] = fetched.map(({ img, r }) =>
+    r.ok ? { url: img.url, ok: true, image_id: idByUrl.get(img.url) } : { url: img.url, ok: false, reason: r.reason },
+  );
+  if (fetched.some((f) => !f.r.ok)) {
+    console.error("[product-drafts] image fetch failures", { id }, results.filter((x) => !x.ok));
+  }
+  return { results, primary_image_id: primaryId };
+}
+
+export async function removeImage(id: string, imageId: string): Promise<void> {
+  const db = await getDrizzle();
+  await requireDraft(db, id);
+
+  const img = await db
+    .select({ id: productImages.id, url: productImages.url, is_primary: productImages.is_primary })
+    .from(productImages)
+    .where(and(eq(productImages.id, imageId), eq(productImages.product_id, id)))
+    .limit(1)
+    .get();
+  if (!img) throw new DraftError("not_found", "Image introuvable sur ce brouillon");
+
+  const stmts: Batch = [db.delete(productImages).where(eq(productImages.id, imageId))];
+  if (img.is_primary === 1) {
+    const next = await db
+      .select({ id: productImages.id })
+      .from(productImages)
+      .where(and(eq(productImages.product_id, id), ne(productImages.id, imageId)))
+      .orderBy(asc(productImages.sort_order))
+      .limit(1)
+      .get();
+    if (next) stmts.push(db.update(productImages).set({ is_primary: 1 }).where(eq(productImages.id, next.id)));
+  }
+  await db.batch(stmts);
+
+  await deleteFromR2(r2KeyFromImageUrl(img.url)).catch((e) => {
+    console.warn("[product-drafts] orphan R2 object after removeImage", img.url, e);
+  });
+}
+
+// ─── Colour variants ───
+
+export interface VariantRow {
+  id: string;
+  color_name: string;
+  color_hex: string;
+  price: number;
+  stock: number;
+}
+
+/** Wizard convention (step-pricing.tsx): `{ color: "<name>:<#hex>" }`. */
+function colorKey(name: string, hex: string): string {
+  return `${name}:${hex}`;
+}
+
+/** Port of actions/admin/products.ts saveColorVariants, Drizzle + draft-only. */
+export async function setColorVariants(
+  id: string,
+  input: SetVariantsInput,
+): Promise<{ variants: VariantRow[]; stock_quantity: number }> {
+  const db = await getDrizzle();
+  const product = await db
+    .select({ id: products.id, slug: products.slug, base_price: products.base_price, compare_price: products.compare_price })
+    .from(products)
+    .where(and(eq(products.id, id), eq(products.is_draft, 1)))
+    .limit(1)
+    .get();
+  if (!product) throw new DraftError("not_found", "Brouillon introuvable (ou produit déjà publié)");
+
+  const existing = await db
+    .select({ id: productVariants.id, attributes: productVariants.attributes })
+    .from(productVariants)
+    .where(eq(productVariants.product_id, id))
+    .all();
+
+  // Only colour-only variants (single "color" key) are managed here.
+  const existingByColor = new Map<string, string>();
+  for (const v of existing) {
+    try {
+      const attrs = JSON.parse(v.attributes) as Record<string, unknown>;
+      const keys = Object.keys(attrs);
+      if (keys.length === 1 && keys[0] === "color" && typeof attrs.color === "string") existingByColor.set(attrs.color, v.id);
+    } catch (e) {
+      console.error("[product-drafts] malformed variant attributes", v.id, e);
+    }
+  }
+
+  const stmts: Statement[] = [];
+  const out: VariantRow[] = [];
+  const seen = new Set<string>();
+  let total = 0;
+
+  input.variants.forEach((entry, index) => {
+    const key = colorKey(entry.color_name, entry.color_hex);
+    seen.add(key);
+    const price = input.uniform_price || entry.price == null ? product.base_price : entry.price;
+    const comparePrice = input.uniform_price ? product.compare_price : null;
+    const attrs = JSON.stringify({ color: key });
+    total += entry.stock;
+
+    const existingId = existingByColor.get(key);
+    const variantId = existingId ?? nanoid();
+    if (existingId) {
+      stmts.push(
+        db.update(productVariants)
+          .set({ name: entry.color_name, price, compare_price: comparePrice, stock_quantity: entry.stock, attributes: attrs })
+          .where(eq(productVariants.id, existingId)),
+      );
+    } else {
+      stmts.push(
+        db.insert(productVariants).values({
+          id: variantId, product_id: id, name: entry.color_name, price, compare_price: comparePrice,
+          stock_quantity: entry.stock, attributes: attrs, is_active: 1, sort_order: index,
+          created_at: sql`datetime('now')`,
+        }),
+      );
+    }
+    out.push({ id: variantId, color_name: entry.color_name, color_hex: entry.color_hex, price, stock: entry.stock });
+  });
+
+  for (const [key, variantId] of existingByColor) {
+    if (seen.has(key)) continue;
+    stmts.push(db.update(productImages).set({ variant_id: null }).where(eq(productImages.variant_id, variantId)));
+    stmts.push(db.delete(productVariants).where(eq(productVariants.id, variantId)));
+  }
+
+  stmts.push(
+    db.update(products)
+      .set({ stock_quantity: total, updated_at: sql`datetime('now')` })
+      .where(and(eq(products.id, id), eq(products.is_draft, 1))),
+  );
+
+  await db.batch(stmts as Batch);
+  return { variants: out, stock_quantity: total };
+}
+```
+
+- [ ] **Step 4: Run both draft test files**
+
+```bash
+npx vitest run __tests__/unit/lib/db/product-drafts.test.ts __tests__/unit/lib/db/product-drafts-media.test.ts
+```
+
+Expected: all pass. If a positional-row assertion fails, print `d1.current!.bound.mock.calls` and align the mocked row with the `select({...})` column order in the implementation; the column order is the contract.
+
+- [ ] **Step 5: Lint, type-check, commit**
+
+```bash
+npx tsc --noEmit && npx eslint lib/db/product-drafts.ts __tests__/unit/lib/db/product-drafts-media.test.ts
+git add lib/db/product-drafts.ts __tests__/unit/lib/db/product-drafts-media.test.ts
+git commit -m "feat(db): draft images and colour variants for the MCP tools"
+```
+
+---
+
+### Task 9: MCP result helpers and admin context
+
+**Files:**
+- Create: `lib/mcp/result.ts`
+- Create: `lib/mcp/context.ts`
+- Test: `__tests__/unit/lib/mcp/result.test.ts`
+- Test: `__tests__/unit/lib/mcp/context.test.ts`
+
+**Interfaces:**
+- Consumes: `isActivelyBanned` from `@/lib/auth/ban`; `user` table.
+- Produces:
+  - `lib/mcp/result.ts`: `type McpErrorCode`, `type ToolResult = { content: { type: "text"; text: string }[]; isError?: boolean }`, `ok(data: unknown): ToolResult`, `fail(code, message, fieldErrors?): ToolResult`
+  - `lib/mcp/context.ts`: `interface McpContext { user: { id: string; name: string; role: "admin" | "super_admin" }; clientId: string }`, `class McpAuthError extends Error { status: 403 }`, `buildMcpContext(session: { userId?: string | null; clientId: string }): Promise<McpContext>`
+
+- [ ] **Step 1: Write the failing tests**
+
+`__tests__/unit/lib/mcp/result.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { ok, fail } from "@/lib/mcp/result";
+
+describe("mcp result helpers", () => {
+  it("ok sérialise la donnée en texte JSON", () => {
+    const r = ok({ id: "p1" });
+    expect(r.isError).toBeUndefined();
+    expect(JSON.parse(r.content[0].text)).toEqual({ id: "p1" });
+  });
+
+  it("fail porte code, message et fieldErrors", () => {
+    const r = fail("validation_error", "Nom requis", { name: ["Requis"] });
+    expect(r.isError).toBe(true);
+    expect(JSON.parse(r.content[0].text)).toEqual({ code: "validation_error", message: "Nom requis", fieldErrors: { name: ["Requis"] } });
+  });
+});
+```
+
+`__tests__/unit/lib/mcp/context.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const d1 = vi.hoisted(() => ({
+  current: null as null | ReturnType<typeof import("../../../helpers/d1-mock").createD1Mock>,
+}));
+vi.mock("@/lib/cloudflare/context", () => ({ getDB: async () => d1.current!.binding }));
+
+import { createD1Mock } from "../../../helpers/d1-mock";
+import { buildMcpContext, McpAuthError } from "@/lib/mcp/context";
+
+// select({ id, name, role, banned, banExpires }) → positional row
+const row = (role: string, banned = 0, banExpires: string | null = null) => [["u1", "Admin", role, banned, banExpires]];
+
+beforeEach(() => { d1.current = createD1Mock(); });
+
+describe("buildMcpContext", () => {
+  it("accepte admin et super_admin", async () => {
+    d1.current!.raw.mockResolvedValue(row("admin"));
+    await expect(buildMcpContext({ userId: "u1", clientId: "c1" })).resolves.toEqual({
+      user: { id: "u1", name: "Admin", role: "admin" }, clientId: "c1",
+    });
+    d1.current!.raw.mockResolvedValue(row("super_admin"));
+    await expect(buildMcpContext({ userId: "u1", clientId: "c1" })).resolves.toMatchObject({ user: { role: "super_admin" } });
+  });
+
+  it("refuse customer et agent", async () => {
+    d1.current!.raw.mockResolvedValue(row("customer"));
+    await expect(buildMcpContext({ userId: "u1", clientId: "c1" })).rejects.toBeInstanceOf(McpAuthError);
+    d1.current!.raw.mockResolvedValue(row("agent"));
+    await expect(buildMcpContext({ userId: "u1", clientId: "c1" })).rejects.toBeInstanceOf(McpAuthError);
+  });
+
+  it("refuse un admin banni, accepte un ban expiré", async () => {
+    d1.current!.raw.mockResolvedValue(row("admin", 1, null));
+    await expect(buildMcpContext({ userId: "u1", clientId: "c1" })).rejects.toBeInstanceOf(McpAuthError);
+    d1.current!.raw.mockResolvedValue(row("admin", 1, "2000-01-01T00:00:00.000Z"));
+    await expect(buildMcpContext({ userId: "u1", clientId: "c1" })).resolves.toBeDefined();
+  });
+
+  it("refuse un jeton sans utilisateur ou un utilisateur supprimé", async () => {
+    await expect(buildMcpContext({ userId: null, clientId: "c1" })).rejects.toBeInstanceOf(McpAuthError);
+    d1.current!.raw.mockResolvedValue([]);
+    await expect(buildMcpContext({ userId: "gone", clientId: "c1" })).rejects.toBeInstanceOf(McpAuthError);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+npx vitest run __tests__/unit/lib/mcp
+```
+
+Expected: FAIL, modules not found.
+
+- [ ] **Step 3: Implement `result.ts`**
+
+`lib/mcp/result.ts`:
+
+```ts
+export type McpErrorCode = "validation_error" | "not_found" | "conflict" | "limit_exceeded" | "internal_error";
+
+/** Shape the MCP SDK expects back from a tool handler (text content only in phase 1). */
+export interface ToolResult {
+  content: { type: "text"; text: string }[];
+  isError?: boolean;
+  [key: string]: unknown;
+}
+
+export function ok(data: unknown): ToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(data) }] };
+}
+
+export function fail(code: McpErrorCode, message: string, fieldErrors?: Record<string, string[]>): ToolResult {
+  const body: Record<string, unknown> = { code, message };
+  if (fieldErrors) body.fieldErrors = fieldErrors;
+  return { content: [{ type: "text", text: JSON.stringify(body) }], isError: true };
+}
+```
+
+- [ ] **Step 4: Implement `context.ts`**
+
+`lib/mcp/context.ts`:
+
+```ts
+import { eq } from "drizzle-orm";
+import { getDrizzle } from "@/lib/db/drizzle";
+import { user } from "@/lib/db/schema";
+import { isActivelyBanned } from "@/lib/auth/ban";
+
+export interface McpContext {
+  user: { id: string; name: string; role: "admin" | "super_admin" };
+  clientId: string;
+}
+
+/** Thrown before any tool runs; the route turns it into a JSON-RPC 403. */
+export class McpAuthError extends Error {
+  readonly status = 403;
+  constructor(message: string) {
+    super(message);
+    this.name = "McpAuthError";
+  }
+}
+
+/**
+ * The OAuth token proves "some user consented"; this is the authorization
+ * boundary. Fresh D1 read on every request (same spirit as requireAdmin's
+ * disableCookieCache) so a role change or ban applies immediately.
+ */
+export async function buildMcpContext(session: { userId?: string | null; clientId: string }): Promise<McpContext> {
+  if (!session.userId) throw new McpAuthError("Jeton sans utilisateur");
+  const db = await getDrizzle();
+  const row = await db
+    .select({ id: user.id, name: user.name, role: user.role, banned: user.banned, banExpires: user.banExpires })
+    .from(user)
+    .where(eq(user.id, session.userId))
+    .limit(1)
+    .get();
+  if (!row) throw new McpAuthError("Utilisateur introuvable");
+  if (isActivelyBanned(row)) throw new McpAuthError("Compte suspendu");
+  if (row.role !== "admin" && row.role !== "super_admin") throw new McpAuthError("Accès réservé aux administrateurs");
+  return { user: { id: row.id, name: row.name, role: row.role }, clientId: session.clientId };
+}
+```
+
+- [ ] **Step 5: Run the tests, lint, type-check**
+
+```bash
+npx vitest run __tests__/unit/lib/mcp && npx tsc --noEmit && npx eslint lib/mcp
+```
+
+Expected: all pass, clean. If `isActivelyBanned(row)` fails typing, pass `{ banned: row.banned, banExpires: row.banExpires }` — its parameter type accepts `BanFlag`/`BanExpiry` (lib/auth/ban.ts).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/mcp/result.ts lib/mcp/context.ts __tests__/unit/lib/mcp
+git commit -m "feat(admin): MCP tool result helpers and admin context guard"
+```
+
+---
+
+### Task 10: Tool definitions and server factory
+
+**Files:**
+- Create: `lib/mcp/tools/types.ts`
+- Create: `lib/mcp/tools/categories.ts`
+- Create: `lib/mcp/tools/products.ts`
+- Create: `lib/mcp/server.ts`
+- Test: `__tests__/unit/lib/mcp/tools-products.test.ts`
+- Test: `__tests__/unit/lib/mcp/server.test.ts`
+
+**Interfaces:**
+- Consumes: everything from Tasks 5–9; `getCategoryTree` from `@/lib/db/categories`; `createAuditLog` from `@/lib/db/admin/audit-log`.
+- Produces:
+  - `lib/mcp/tools/types.ts`: `interface ToolDefinition<Shape extends ZodRawShape> { name: string; description: string; inputSchema: Shape; handler: (ctx: McpContext, input: z.infer<z.ZodObject<Shape>>) => Promise<ToolResult> }` and `defineTool()`
+  - `lib/mcp/tools/products.ts`: `productTools: ToolDefinition<any>[]`; `lib/mcp/tools/categories.ts`: `categoryTools`
+  - `lib/mcp/server.ts`: `createMcpServer(ctx: McpContext): McpServer`, `ALL_TOOLS`
+
+- [ ] **Step 1: Write the failing tool tests**
+
+`__tests__/unit/lib/mcp/tools-products.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { McpContext } from "@/lib/mcp/context";
+
+const mocks = vi.hoisted(() => ({
+  createDraft: vi.fn(), updateDraft: vi.fn(), getDraft: vi.fn(), searchProducts: vi.fn(), deleteDraft: vi.fn(),
+  addImagesFromUrls: vi.fn(), removeImage: vi.fn(), setColorVariants: vi.fn(),
+  createAuditLog: vi.fn(),
+}));
+
+vi.mock("@/lib/db/product-drafts", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/db/product-drafts")>("@/lib/db/product-drafts");
+  return { ...actual, ...mocks };
+});
+vi.mock("@/lib/db/admin/audit-log", () => ({ createAuditLog: mocks.createAuditLog }));
+vi.mock("@/lib/cloudflare/context", () => ({ getDB: async () => { throw new Error("no DB in this test"); } }));
+
+import { DraftError } from "@/lib/db/product-drafts";
+import { productTools } from "@/lib/mcp/tools/products";
+
+const ctx: McpContext = { user: { id: "admin-1", name: "Admin", role: "admin" }, clientId: "client-1" };
+// productTools is typed ToolDefinition[] (base shape), so handler accepts any object literal here.
+const tool = (name: string) => productTools.find((t) => t.name === name)!;
+const parse = (r: { content: { text: string }[] }) => JSON.parse(r.content[0].text);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.createAuditLog.mockResolvedValue(undefined);
+});
+
+describe("productTools", () => {
+  it("expose exactement les outils du contrat", () => {
+    expect(productTools.map((t) => t.name).sort()).toEqual([
+      "add_product_images", "create_product_draft", "delete_product_draft", "get_product_draft",
+      "remove_product_image", "search_products", "set_product_variants", "update_product_draft",
+    ]);
+  });
+
+  it("create_product_draft renvoie id, slug, edit_url et écrit l'audit", async () => {
+    mocks.createDraft.mockResolvedValue({ id: "p1", slug: "galaxy-a55" });
+    const r = await tool("create_product_draft").handler(ctx, { name: "Galaxy A55", category_id: "cat-1" });
+    expect(r.isError).toBeUndefined();
+    expect(parse(r)).toEqual({ id: "p1", slug: "galaxy-a55", edit_url: "/products/p1/edit" });
+    expect(mocks.createAuditLog).toHaveBeenCalledWith(expect.objectContaining({
+      actorId: "admin-1", actorName: "Admin", action: "product.draft_created", targetType: "product", targetId: "p1",
+      details: JSON.stringify({ via: "mcp", tool: "create_product_draft", client_id: "client-1" }),
+    }));
+  });
+
+  it("mappe DraftError vers un résultat isError avec le code", async () => {
+    mocks.updateDraft.mockRejectedValue(new DraftError("not_found", "Brouillon introuvable"));
+    const r = await tool("update_product_draft").handler(ctx, { id: "p1", name: "X" });
+    expect(r.isError).toBe(true);
+    expect(parse(r)).toEqual({ code: "not_found", message: "Brouillon introuvable" });
+    expect(mocks.createAuditLog).not.toHaveBeenCalled();
+  });
+
+  it("mappe une erreur inattendue vers internal_error sans détail", async () => {
+    mocks.getDraft.mockRejectedValue(new Error("D1 exploded with secret details"));
+    const r = await tool("get_product_draft").handler(ctx, { id: "p1" });
+    expect(r.isError).toBe(true);
+    expect(parse(r).code).toBe("internal_error");
+    expect(parse(r).message).not.toContain("secret");
+  });
+
+  it("add_product_images rapporte un succès partiel sans isError", async () => {
+    mocks.addImagesFromUrls.mockResolvedValue({
+      results: [{ url: "https://x/a.jpg", ok: true, image_id: "img-1" }, { url: "https://x/b.jpg", ok: false, reason: "too_large" }],
+      primary_image_id: "img-1",
+    });
+    const r = await tool("add_product_images").handler(ctx, { id: "p1", images: [{ url: "https://x/a.jpg" }, { url: "https://x/b.jpg" }] });
+    expect(r.isError).toBeUndefined();
+    expect(parse(r).results[1]).toEqual({ url: "https://x/b.jpg", ok: false, reason: "too_large" });
+    expect(mocks.createAuditLog).toHaveBeenCalledWith(expect.objectContaining({ action: "product.draft_updated" }));
+  });
+
+  it("delete_product_draft audite la suppression", async () => {
+    mocks.deleteDraft.mockResolvedValue(undefined);
+    const r = await tool("delete_product_draft").handler(ctx, { id: "p1" });
+    expect(parse(r)).toEqual({ deleted: true });
+    expect(mocks.createAuditLog).toHaveBeenCalledWith(expect.objectContaining({ action: "product.draft_deleted", targetId: "p1" }));
+  });
+
+  it("search_products délègue avec la limite", async () => {
+    mocks.searchProducts.mockResolvedValue([]);
+    await tool("search_products").handler(ctx, { query: "galaxy", limit: 7 });
+    expect(mocks.searchProducts).toHaveBeenCalledWith("galaxy", 7);
+  });
+});
+```
+
+`__tests__/unit/lib/mcp/server.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/lib/cloudflare/context", () => ({ getDB: async () => { throw new Error("no DB"); } }));
+
+import { ALL_TOOLS, createMcpServer } from "@/lib/mcp/server";
+
+describe("createMcpServer", () => {
+  it("enregistre tous les outils avec description et schéma", () => {
+    const server = createMcpServer({ user: { id: "u", name: "n", role: "admin" }, clientId: "c" });
+    expect(server).toBeDefined();
+    expect(ALL_TOOLS.length).toBe(9);
+    for (const t of ALL_TOOLS) {
+      expect(t.description.length).toBeGreaterThan(20);
+      expect(typeof t.inputSchema).toBe("object");
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+npx vitest run __tests__/unit/lib/mcp/tools-products.test.ts __tests__/unit/lib/mcp/server.test.ts
+```
+
+Expected: FAIL, modules not found.
+
+- [ ] **Step 3: Implement `tools/types.ts`**
+
+`lib/mcp/tools/types.ts`:
+
+```ts
+import type { z, ZodRawShape } from "zod";
+import type { McpContext } from "@/lib/mcp/context";
+import type { ToolResult } from "@/lib/mcp/result";
+
+/**
+ * One MCP tool. `inputSchema` is a raw Zod shape (what the SDK's registerTool
+ * takes); the SDK validates and rejects invalid params with JSON-RPC -32602
+ * before `handler` runs.
+ */
+export interface ToolDefinition<Shape extends ZodRawShape = ZodRawShape> {
+  name: string;
+  description: string;
+  inputSchema: Shape;
+  handler: (ctx: McpContext, input: z.infer<z.ZodObject<Shape>>) => Promise<ToolResult>;
+}
+
+/**
+ * Infers the handler's input type from the shape, then widens to the base
+ * ToolDefinition so heterogeneous tools can live in one array. The widening
+ * is a cast because handler parameters are contravariant under
+ * strictFunctionTypes; the SDK re-validates the input at runtime anyway.
+ */
+export function defineTool<Shape extends ZodRawShape>(def: ToolDefinition<Shape>): ToolDefinition {
+  return def as unknown as ToolDefinition;
+}
+```
+
+- [ ] **Step 4: Implement `tools/categories.ts`**
+
+`lib/mcp/tools/categories.ts`:
+
+```ts
+import { getCategoryTree } from "@/lib/db/categories";
+import type { CategoryNode } from "@/lib/db/types";
+import { ok, fail } from "@/lib/mcp/result";
+import { defineTool, type ToolDefinition } from "./types";
+
+interface CategoryOut { id: string; name: string; slug: string; children: CategoryOut[] }
+
+function strip(nodes: readonly CategoryNode[]): CategoryOut[] {
+  return nodes.map((n) => ({ id: n.id, name: n.name, slug: n.slug, children: strip(n.children) }));
+}
+
+export const categoryTools: ToolDefinition[] = [
+  defineTool({
+    name: "list_categories",
+    description:
+      "Liste l'arbre des catégories actives de la boutique (2 niveaux max). Utilise l'id retourné comme category_id pour create_product_draft.",
+    inputSchema: {},
+    handler: async () => {
+      try {
+        return ok(strip(await getCategoryTree()));
+      } catch (err) {
+        console.error("[mcp/list_categories]", err);
+        return fail("internal_error", "Impossible de lire les catégories");
+      }
+    },
+  }),
+];
+```
+
+- [ ] **Step 5: Implement `tools/products.ts`**
+
+`lib/mcp/tools/products.ts`:
+
+```ts
+import { createAuditLog } from "@/lib/db/admin/audit-log";
+import type { AuditAction } from "@/lib/db/types";
+import {
+  DraftError,
+  addImagesFromUrls,
+  createDraft,
+  deleteDraft,
+  getDraft,
+  removeImage,
+  searchProducts,
+  setColorVariants,
+  updateDraft,
+} from "@/lib/db/product-drafts";
+import type { McpContext } from "@/lib/mcp/context";
+import { ok, fail, type ToolResult } from "@/lib/mcp/result";
+import {
+  addImagesSchema,
+  createDraftSchema,
+  idSchema,
+  searchProductsSchema,
+  setVariantsSchema,
+  updateDraftSchema,
+} from "@/lib/validations/mcp-product";
+import { defineTool, type ToolDefinition } from "./types";
+
+/**
+ * Product-draft tools. Every write goes through lib/db/product-drafts.ts,
+ * which refuses anything that is not `is_draft = 1`. Publishing stays in the
+ * admin wizard (/products/<id>/edit) — no tool here can flip is_draft/is_active.
+ */
+
+function toolError(toolName: string, err: unknown): ToolResult {
+  if (err instanceof DraftError) return fail(err.code, err.message);
+  console.error(`[mcp/${toolName}]`, err);
+  return fail("internal_error", "Erreur interne, réessayez ou contactez un administrateur");
+}
+
+async function audit(ctx: McpContext, tool: string, action: AuditAction, productId: string): Promise<void> {
+  try {
+    await createAuditLog({
+      actorId: ctx.user.id,
+      actorName: ctx.user.name,
+      action,
+      targetType: "product",
+      targetId: productId,
+      details: JSON.stringify({ via: "mcp", tool, client_id: ctx.clientId }),
+    });
+  } catch (err) {
+    // The write already succeeded; losing the audit row must not fail the tool.
+    console.error(`[mcp/${tool}] audit log failed`, { productId }, err);
+  }
+}
+
+const DESCRIPTION_RULES =
+  "Champs : name (requis), category_id (requis, voir list_categories), brand, short_description (≤120), description_html (HTML, assaini côté serveur), story {tagline, highlights[3-6] {icon,label}, feature_blocks[2-4] {title,body}, faq[≤5] {question,answer}}, seo {meta_title ≤60, meta_description ≤160}, attributes {colors[{name,hex}], dimensions {length_mm,height_mm,width_mm,weight_g}, specs[{name,value}]}, pricing {base_price, compare_price, sku, stock_quantity, low_stock_threshold, weight_grams} (prix en XOF entiers).";
+
+export const productTools: ToolDefinition[] = [
+  defineTool({
+    name: "search_products",
+    description:
+      "Recherche des produits (brouillons et publiés) par nom, slug ou SKU. À appeler avant create_product_draft pour éviter les doublons.",
+    inputSchema: searchProductsSchema.shape,
+    handler: async (_ctx, input) => {
+      try {
+        return ok(await searchProducts(input.query, input.limit));
+      } catch (err) {
+        return toolError("search_products", err);
+      }
+    },
+  }),
+
+  defineTool({
+    name: "get_product_draft",
+    description: "Relit un brouillon complet : champs, attributs, images (URL publiques), variantes. Échoue sur un produit publié.",
+    inputSchema: { id: idSchema },
+    handler: async (_ctx, input) => {
+      try {
+        return ok(await getDraft(input.id));
+      } catch (err) {
+        return toolError("get_product_draft", err);
+      }
+    },
+  }),
+
+  defineTool({
+    name: "create_product_draft",
+    description:
+      `Crée un brouillon produit (non publié, invisible en boutique). Retourne {id, slug, edit_url}. ${DESCRIPTION_RULES} Les couleurs déclarées ici doivent correspondre à celles de set_product_variants.`,
+    inputSchema: createDraftSchema.shape,
+    handler: async (ctx, input) => {
+      try {
+        const { id, slug } = await createDraft(input);
+        await audit(ctx, "create_product_draft", "product.draft_created", id);
+        return ok({ id, slug, edit_url: `/products/${id}/edit` });
+      } catch (err) {
+        return toolError("create_product_draft", err);
+      }
+    },
+  }),
+
+  defineTool({
+    name: "update_product_draft",
+    description:
+      `Met à jour un brouillon. Champs absents ignorés, null efface. attributes fourni remplace tous les attributs. slug optionnel (unique). ${DESCRIPTION_RULES}`,
+    inputSchema: { id: idSchema, ...updateDraftSchema.shape },
+    handler: async (ctx, input) => {
+      try {
+        const { id, ...patch } = input;
+        const result = await updateDraft(id, patch);
+        await audit(ctx, "update_product_draft", "product.draft_updated", id);
+        return ok(result);
+      } catch (err) {
+        return toolError("update_product_draft", err);
+      }
+    },
+  }),
+
+  defineTool({
+    name: "add_product_images",
+    description:
+      "Télécharge 1 à 8 images depuis des URL http(s) (≤5 Mo chacune, 12 max par produit) vers le stockage de la boutique et les attache au brouillon. Succès partiel possible : vérifier results[].ok. La première image du produit devient l'image principale.",
+    inputSchema: { id: idSchema, ...addImagesSchema.shape },
+    handler: async (ctx, input) => {
+      try {
+        const result = await addImagesFromUrls(input.id, input.images);
+        if (result.results.some((r) => r.ok)) await audit(ctx, "add_product_images", "product.draft_updated", input.id);
+        return ok(result);
+      } catch (err) {
+        return toolError("add_product_images", err);
+      }
+    },
+  }),
+
+  defineTool({
+    name: "remove_product_image",
+    description: "Retire une image d'un brouillon (ligne et fichier). Si elle était principale, la suivante le devient.",
+    inputSchema: { id: idSchema, image_id: idSchema },
+    handler: async (ctx, input) => {
+      try {
+        await removeImage(input.id, input.image_id);
+        await audit(ctx, "remove_product_image", "product.draft_updated", input.id);
+        return ok({ removed: true });
+      } catch (err) {
+        return toolError("remove_product_image", err);
+      }
+    },
+  }),
+
+  defineTool({
+    name: "set_product_variants",
+    description:
+      "Définit les variantes couleur d'un brouillon (remplace l'ensemble). price absent ou uniform_price=true → prix de base du produit. Les variantes retirées sont supprimées. Le stock du produit devient la somme des stocks. Déclarer les mêmes couleurs dans attributes.colors.",
+    inputSchema: { id: idSchema, ...setVariantsSchema.shape },
+    handler: async (ctx, input) => {
+      try {
+        const { id, ...rest } = input;
+        const result = await setColorVariants(id, rest);
+        await audit(ctx, "set_product_variants", "product.draft_updated", id);
+        return ok(result);
+      } catch (err) {
+        return toolError("set_product_variants", err);
+      }
+    },
+  }),
+
+  defineTool({
+    name: "delete_product_draft",
+    description: "Supprime définitivement un brouillon et ses images. Impossible sur un produit publié.",
+    inputSchema: { id: idSchema },
+    handler: async (ctx, input) => {
+      try {
+        await deleteDraft(input.id);
+        await audit(ctx, "delete_product_draft", "product.draft_deleted", input.id);
+        return ok({ deleted: true });
+      } catch (err) {
+        return toolError("delete_product_draft", err);
+      }
+    },
+  }),
+];
+```
+
+- [ ] **Step 6: Implement `server.ts`**
+
+`lib/mcp/server.ts`:
+
+```ts
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpContext } from "@/lib/mcp/context";
+import { categoryTools } from "@/lib/mcp/tools/categories";
+import { productTools } from "@/lib/mcp/tools/products";
+import type { ToolDefinition } from "@/lib/mcp/tools/types";
+
+export const MCP_SERVER_NAME = "netereka-admin";
+export const MCP_SERVER_VERSION = "1.0.0";
+
+export const ALL_TOOLS: ToolDefinition[] = [...categoryTools, ...productTools];
+
+/**
+ * One server per request (stateless transport) bound to the admin who owns
+ * the OAuth token. Tools never see the token, only the resolved context.
+ */
+export function createMcpServer(ctx: McpContext): McpServer {
+  const server = new McpServer({ name: MCP_SERVER_NAME, version: MCP_SERVER_VERSION });
+  for (const tool of ALL_TOOLS) {
+    server.registerTool(
+      tool.name,
+      { description: tool.description, inputSchema: tool.inputSchema },
+      async (input) => tool.handler(ctx, input),
+    );
+  }
+  return server;
+}
+```
+
+- [ ] **Step 7: Run the tests, lint, type-check**
+
+```bash
+npx vitest run __tests__/unit/lib/mcp && npx tsc --noEmit && npx eslint lib/mcp
+```
+
+Expected: all pass. Known typing friction point and its fix:
+- If `registerTool` rejects `tool.inputSchema` (generic `ZodRawShape` vs the SDK's `ZodRawShapeCompat`) or the handler's `input` type, cast at the call site only: `inputSchema: tool.inputSchema as never` and `tool.handler(ctx, input as never)` — the runtime shape is what matters and the SDK validates it.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/mcp/tools lib/mcp/server.ts __tests__/unit/lib/mcp/tools-products.test.ts __tests__/unit/lib/mcp/server.test.ts
+git commit -m "feat(admin): MCP product-draft tools and server factory"
+```
+
+---
+
+### Task 11: `POST /api/mcp` route
+
+**Files:**
+- Create: `app/api/mcp/route.ts`
+- Test: `__tests__/unit/api/mcp-route.test.ts`
+
+**Interfaces:**
+- Consumes: `withMcpAuth` from `better-auth/plugins`; `initAuth` from `@/lib/auth`; `buildMcpContext`, `McpAuthError` (Task 9); `createMcpServer` (Task 10); `WebStandardStreamableHTTPServerTransport` from `@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js`.
+
+- [ ] **Step 1: Write the failing route test**
+
+`__tests__/unit/api/mcp-route.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getMcpSession: vi.fn(),
+  buildMcpContext: vi.fn(),
+}));
+
+// withMcpAuth (real, from better-auth) calls auth.api.getMcpSession and needs auth.options.
+vi.mock("@/lib/auth", () => ({
+  initAuth: vi.fn().mockResolvedValue({
+    options: { baseURL: "https://netereka.ci", basePath: "/api/auth" },
+    api: { getMcpSession: mocks.getMcpSession },
+  }),
+}));
+vi.mock("@/lib/mcp/context", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/mcp/context")>("@/lib/mcp/context");
+  return { ...actual, buildMcpContext: mocks.buildMcpContext };
+});
+vi.mock("@/lib/cloudflare/context", () => ({ getDB: async () => { throw new Error("no DB"); } }));
+
+import { McpAuthError } from "@/lib/mcp/context";
+import { POST, GET, DELETE } from "@/app/api/mcp/route";
+
+function rpc(body: unknown, token = "tok") {
+  return new Request("https://netereka.ci/api/mcp", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+const INIT = {
+  jsonrpc: "2.0", id: 1, method: "initialize",
+  params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "test", version: "0" } },
+};
+const LIST = { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getMcpSession.mockResolvedValue({ userId: "u1", clientId: "c1", scopes: "openid" });
+  mocks.buildMcpContext.mockResolvedValue({ user: { id: "u1", name: "Admin", role: "admin" }, clientId: "c1" });
+});
+
+describe("POST /api/mcp", () => {
+  it("répond 401 avec WWW-Authenticate sans jeton valide", async () => {
+    mocks.getMcpSession.mockResolvedValue(null);
+    const res = await POST(rpc(LIST));
+    expect(res.status).toBe(401);
+    expect(res.headers.get("www-authenticate")).toMatch(/resource_metadata=/);
+    expect(mocks.buildMcpContext).not.toHaveBeenCalled();
+  });
+
+  it("répond 403 JSON-RPC quand le porteur du jeton n'est pas admin", async () => {
+    mocks.buildMcpContext.mockRejectedValue(new McpAuthError("Accès réservé aux administrateurs"));
+    const res = await POST(rpc(LIST));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error.message).toBe("Accès réservé aux administrateurs");
+  });
+
+  it("sert tools/list à un admin", async () => {
+    const res = await POST(rpc(LIST));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const names = body.result.tools.map((t: { name: string }) => t.name);
+    expect(names).toContain("create_product_draft");
+    expect(names).toContain("list_categories");
+    expect(names).toHaveLength(9);
+  });
+
+  it("accepte initialize sans identifiant de session (stateless)", async () => {
+    const res = await POST(rpc(INIT));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("mcp-session-id")).toBeNull();
+    const body = await res.json();
+    expect(body.result.serverInfo.name).toBe("netereka-admin");
+  });
+});
+
+describe("GET/DELETE /api/mcp", () => {
+  it("répondent 405", async () => {
+    expect((await GET()).status).toBe(405);
+    expect((await DELETE()).status).toBe(405);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+npx vitest run __tests__/unit/api/mcp-route.test.ts
+```
+
+Expected: FAIL, route module not found.
+
+- [ ] **Step 3: Implement the route**
+
+`app/api/mcp/route.ts`:
+
+```ts
+import { withMcpAuth } from "better-auth/plugins";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { initAuth } from "@/lib/auth";
+import { buildMcpContext, McpAuthError } from "@/lib/mcp/context";
+import { createMcpServer } from "@/lib/mcp/server";
+
+/**
+ * Remote MCP endpoint (Streamable HTTP, stateless).
+ *
+ * withMcpAuth validates the OAuth bearer token (401 + WWW-Authenticate
+ * otherwise, which is how clients discover the OAuth flow). buildMcpContext
+ * then enforces the business rule — active admin — before any server exists.
+ * A fresh McpServer + transport per request: nothing to share between Workers
+ * isolates, no session id to store.
+ */
+export const dynamic = "force-dynamic";
+
+function jsonRpcError(status: number, code: number, message: string): Response {
+  return Response.json({ jsonrpc: "2.0", error: { code, message }, id: null }, { status });
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const auth = await initAuth();
+  const handler = withMcpAuth(auth, async (req, session) => {
+    let ctx;
+    try {
+      ctx = await buildMcpContext({ userId: session.userId, clientId: session.clientId });
+    } catch (err) {
+      if (err instanceof McpAuthError) return jsonRpcError(403, -32000, err.message);
+      console.error("[mcp] context build failed", err);
+      return jsonRpcError(500, -32603, "Erreur interne");
+    }
+
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      // Plain JSON responses: tools answer in one shot, no server-push needed,
+      // and it keeps the response cacheable-by-nobody and easy to test.
+      enableJsonResponse: true,
+    });
+    const server = createMcpServer(ctx);
+    await server.connect(transport);
+    try {
+      return await transport.handleRequest(req);
+    } finally {
+      // Stateless: release the per-request server once the response is built.
+      void transport.close().catch(() => {});
+    }
+  });
+  return handler(request);
+}
+
+// Stateless mode has no standalone SSE stream and no session to delete.
+export async function GET(): Promise<Response> {
+  return new Response("Method Not Allowed", { status: 405, headers: { allow: "POST" } });
+}
+
+export async function DELETE(): Promise<Response> {
+  return new Response("Method Not Allowed", { status: 405, headers: { allow: "POST" } });
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+```bash
+npx vitest run __tests__/unit/api/mcp-route.test.ts
+```
+
+Expected: all pass. If `withMcpAuth`'s type rejects the mocked `auth` in the test, that is test-only: cast the resolved value `as never`. If the `initialize` test returns 406, add `accept: "application/json, text/event-stream"` (already in `rpc()`) — the transport requires both.
+
+- [ ] **Step 5: Type-check, lint, full suite**
+
+```bash
+npx tsc --noEmit && npx eslint app/api/mcp && npx vitest run
+```
+
+Expected: clean, everything green.
+
+- [ ] **Step 6: Local end-to-end with Claude Code as the first client**
+
+```bash
+npm run dev
+```
+
+In another terminal:
+
+```bash
+claude mcp add --transport http netereka-local http://localhost:3000/api/mcp
+claude
+```
+
+Inside Claude Code run `/mcp`, pick `netereka-local`, authenticate. Expected sequence:
+
+1. Browser opens `/admin/login?client_id=…&redirect_uri=…&response_type=code&…` (or the consent page directly if already signed in as admin).
+2. After login, `/admin/mcp/consent?client_id=…&scope=…` shows the client name (Claude Code registers as "Claude Code" or similar) with **Autoriser** / **Refuser**.
+3. **Autoriser** → browser lands on the client's localhost callback ("You can close this window"), Claude Code reports the server connected.
+4. Ask Claude Code: "liste les catégories" → `list_categories` returns the tree.
+5. Ask it to create a full draft (name, category, story, SEO, attributes, pricing) then `add_product_images` with two real image URLs and `set_product_variants` with two colours. Open `http://localhost:3000/products/<id>/edit`: every wizard step shows the data; publish from step 5.
+6. Ask it to `update_product_draft` on the now-published id → error `not_found`. Same for `delete_product_draft`.
+7. Sign out, sign in as `customer` (seed account), re-authenticate the MCP → tool calls return the 403 message.
+
+If step 2 is skipped (code issued without consent page), the before hook is not merging the query: check `lib/auth/index.ts` returns `{ context: { query } }` and that `ctx.path` is `/mcp/authorize` (log it once). If step 1's login page shows "Une erreur est survenue" and stays, the `resumeUrl` branch in Task 4 is not reached: verify `getOAuthResumeUrl` sees the params (they must all be present in the URL better-auth redirected to).
+
+Record the actual outcome of steps 1–7 in the commit message of Step 7.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/api/mcp/route.ts __tests__/unit/api/mcp-route.test.ts
+git commit -m "feat(admin): remote MCP endpoint at /api/mcp (OAuth, stateless, draft-only tools)"
+```
+
+---
+
+### Task 12: Documentation, PR
+
+**Files:**
+- Modify: `CLAUDE.md` (new section after "## WhatsApp Integration")
+- Modify: `docs/superpowers/specs/2026-09-02-admin-mcp-server-design.md` (status line)
+
+- [ ] **Step 1: Document the MCP server in CLAUDE.md**
+
+Insert after the WhatsApp section:
+
+```markdown
+## Admin MCP Server
+
+Remote MCP endpoint at `POST /api/mcp` (Streamable HTTP, stateless) for AI clients (claude.ai, Claude Desktop, Claude Code, ChatGPT, Cursor…). Spec: `docs/superpowers/specs/2026-09-02-admin-mcp-server-design.md`.
+
+- **Auth:** OAuth 2.1 via better-auth's `mcp` plugin (`lib/auth/index.ts`). Dynamic client registration is open, so `lib/auth/mcp-consent-hook.ts` forces `prompt=consent` on every `/mcp/authorize` and `/admin/mcp/consent` requires a human click — without it a signed-in admin could be phished into issuing a token silently. Do not remove the hook.
+- **Authorization:** `lib/mcp/context.ts` re-reads the user from D1 on every request; only `admin`/`super_admin`, not banned. A `customer` can finish the OAuth flow but every call gets 403.
+- **Tools:** `lib/mcp/tools/*.ts`, registered by `lib/mcp/server.ts`. All product writes go through `lib/db/product-drafts.ts`, whose every UPDATE/DELETE carries `is_draft = 1`. No tool can publish; that stays in the wizard.
+- **Audit:** each write tool records `product.draft_*` in `audit_log` with `details.via = "mcp"`.
+- **Local test:** `claude mcp add --transport http netereka-local http://localhost:3000/api/mcp`, then `/mcp` in Claude Code. Discovery documents: `/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource`.
+- **Adding a tool:** `defineTool({ name, description, inputSchema: <zod raw shape>, handler })` in a `lib/mcp/tools/*.ts` file, add it to `ALL_TOOLS`, map domain errors to `fail(code, message)`; never let a stack trace reach the client.
+```
+
+- [ ] **Step 2: Update the spec status**
+
+In the spec header change `**Statut :** Design validé, à implémenter` to `**Statut :** Implémenté (2026-09-02)`.
+
+- [ ] **Step 3: Commit and open the PR**
+
+```bash
+git add CLAUDE.md docs/superpowers/specs/2026-09-02-admin-mcp-server-design.md
+git commit -m "docs(claude): document the admin MCP server"
+git push -u origin feat/admin-mcp-server
+gh pr create --title "feat(admin): remote MCP server for AI-driven product drafts" --body-file - <<'EOF'
+## Summary
+
+- Remote MCP endpoint `POST /api/mcp` (Streamable HTTP, stateless) so any MCP client (claude.ai, Claude Desktop, Claude Code, ChatGPT, Cursor…) can administer product drafts.
+- OAuth 2.1 provider via better-auth's `mcp` plugin, with a forced consent page (`/admin/mcp/consent`) — required because dynamic client registration is open.
+- 9 tools: `list_categories`, `search_products`, `get_product_draft`, `create_product_draft`, `update_product_draft`, `add_product_images`, `remove_product_image`, `set_product_variants`, `delete_product_draft`. All writes are draft-only by construction (`lib/db/product-drafts.ts`).
+- Three additive OAuth tables (migration 0017). Existing in-app AI product creation is untouched.
+
+Spec: `docs/superpowers/specs/2026-09-02-admin-mcp-server-design.md`
+Plan: `docs/superpowers/plans/2026-09-02-admin-mcp-server.md`
+
+## Test plan
+
+- [ ] `npm run test` green (unit: schemas, drafts module, context guard, tools, route, auth config)
+- [ ] Local e2e with Claude Code (Task 11 step 6): login → consent → draft with images and variants → visible in wizard → publish from wizard → MCP refuses the published product
+- [ ] `customer` account gets 403 on every tool
+- [ ] After canary: connect a claude.ai custom connector to `https://netereka.ci/api/mcp`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_015x8NA9A7Rc3sNLBSeUkC9g
+EOF
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** §1 architecture → Tasks 9–11; §2 auth (plugin, forced consent, consent page, business authorization, login resume) → Tasks 2, 3, 4, 9, 11; §3 data → Task 1; §4 tool contract → Tasks 6, 7, 8, 10; §5 errors → Tasks 7, 8, 10, 11; §6 tests → every task plus Task 11 step 6. Audit rows: the spec named a new `lib/db/audit.ts`; the repo already has `lib/db/admin/audit-log.ts` with `createAuditLog()`, so the plan reuses it (Task 10) instead of adding a second writer.
+- **Deviation from spec file list:** `lib/validations/product-ai.ts` gets three `export` keywords (Task 6) so the attribute schemas can be reused without duplication.
+- **Type consistency:** `DraftError.code` ⊂ `McpErrorCode`; `ToolDefinition.handler(ctx, input)` signature used identically in Tasks 10 and 11; `buildMcpContext({ userId, clientId })` matches the `getMcpSession` row fields (`userId`, `clientId`) used by `withMcpAuth`.

--- a/docs/superpowers/specs/2026-09-02-admin-mcp-server-design.md
+++ b/docs/superpowers/specs/2026-09-02-admin-mcp-server-design.md
@@ -25,7 +25,7 @@ Le MCP est **généraliste** : serveur distant, transport standard, authentifica
 
 ```
 Client MCP ──POST /api/mcp (Authorization: Bearer)──▶ withMcpAuth (better-auth)
-   ▶ buildMcpContext : lecture fraîche de l'utilisateur en D1, rôle admin|super_admin, non banni
+   ▶ buildMcpContext() : lecture fraîche de l'utilisateur en D1, rôle admin|super_admin, non banni
    ▶ McpServer (SDK officiel, instance par requête, mode stateless)
    ▶ handler d'outil ──▶ lib/db/product-drafts.ts (Drizzle) ──▶ D1 / R2
    ▶ audit_log (details.via = "mcp")
@@ -41,14 +41,19 @@ Mode stateless : un `McpServer` et un transport sont créés par requête, sans 
 | `app/.well-known/oauth-authorization-server/route.ts` | `oAuthDiscoveryMetadata(auth)` — exposé à la racine car certains clients cherchent là plutôt que sous `/api/auth`. |
 | `app/.well-known/oauth-protected-resource/route.ts` | `oAuthProtectedResourceMetadata(auth)`. |
 | `lib/mcp/server.ts` | Construit le `McpServer`, enregistre les outils depuis le registre. |
-| `lib/mcp/context.ts` | `McpContext { user: { id, name, role }, clientId, clientName }` et `assertAdminContext()`. |
+| `lib/mcp/context.ts` | `McpContext { user: { id, name, role }, clientId }` et `buildMcpContext()`. |
 | `lib/mcp/result.ts` | Helpers `ok(data)` / `fail(code, message, fieldErrors?)` — format de réponse uniforme. |
 | `lib/mcp/tools/categories.ts` | `list_categories`. |
 | `lib/mcp/tools/products.ts` | Outils produits (section 4). |
+| `lib/mcp/tools/types.ts` | `ToolDefinition` et `defineTool()` — le type commun d'un outil MCP (nom, description, schéma d'entrée, handler typé sur `McpContext`). |
 | `lib/validations/mcp-product.ts` | Schémas Zod d'entrée des outils, composés à partir de `product-story.ts` et `product-ai.ts`. Aucune règle métier dupliquée. |
 | `lib/db/product-drafts.ts` | Module Drizzle portant toute la logique brouillon : création, mise à jour partielle, slug unique, images, variantes, suppression. Chaque `UPDATE`/`DELETE` porte `is_draft = 1` dans son `WHERE`. |
-| `lib/db/audit.ts` | `recordAudit()` en Drizzle. |
+| audit via `createAuditLog()` de `lib/db/admin/audit-log.ts` (existant) | Aucun nouveau module d'audit : les outils MCP réutilisent la fonction existante. |
 | `app/(admin-auth)/admin/mcp/consent/page.tsx` | Page de consentement OAuth (section 2). |
+| `app/(admin-auth)/admin/mcp/consent/consent-form.tsx` | Formulaire client du consentement : POST `{ accept, consent_code }` vers `/api/auth/oauth2/consent`. |
+| `lib/auth/mcp-consent-hook.ts` | `forceConsentQuery()` — force `prompt=consent` sur `/mcp/authorize`, fonction pure testable sans contexte better-auth. |
+| `lib/auth/mcp-consent-client.ts` | `findOAuthClientName()` et `findConsentRequest()` — résolution de la demande de consentement depuis `verification.identifier` (section 2). |
+| `lib/auth/oauth-resume.ts` | `getOAuthResumeUrl()` — reconstruit l'URL `/api/auth/mcp/authorize?...` après connexion (section 2, « Reprise après login »). |
 
 ### Fichiers modifiés
 
@@ -83,14 +88,14 @@ En 1.6.25, `authorizeMCPOAuth` émet le code **sans écran de consentement** dè
 Mitigation :
 
 - Un hook `before` sur `/mcp/authorize` force `prompt=consent` sur toute requête, quelle que soit la valeur envoyée par le client.
-- `oidcConfig.consentPage = "/admin/mcp/consent"`. La page lit `client_id` et `scope` dans ses paramètres, charge le nom du client dans `oauthApplication` (nom fourni par le client, donc affiché échappé), et propose « Autoriser » / « Refuser ». Elle appelle l'endpoint de consentement du plugin (`/api/auth/oauth2/consent`, cookie signé `oidc_consent_prompt`), qui redirige vers le client avec le code et le `state`.
-- Résultat : aucun jeton n'est émis sans un clic humain explicite sur une page du domaine.
+- `oidcConfig.consentPage = "/admin/mcp/consent"`. La page lit `consent_code` dans ses paramètres (pas `client_id`, contrôlé par l'attaquant à l'enregistrement dynamique) et résout la demande depuis `verification` (`findConsentRequest()`) : nom du client (`oauthApplication`, nom fourni par le client, donc affiché échappé) **et** hôte de redirection (`new URL(redirectURI).host`), affichés ensemble. Le formulaire poste `consent_code` à l'endpoint de consentement du plugin (`/api/auth/oauth2/consent`), qui consomme le code du corps de préférence au cookie signé `oidc_consent_prompt`, puis redirige vers le client avec le code et le `state`.
+- Résultat : aucun jeton n'est émis sans un clic humain explicite sur une page du domaine, et ce clic porte sur la même demande que celle affichée — le nom du client seul ne suffisant pas (l'attaquant peut s'enregistrer sous n'importe quel nom), l'hôte de redirection est le signal fiable.
 
-La page de consentement vit dans `(admin-auth)` (layout sans sidebar) et exige une session : sans session elle redirige vers `/admin/login` en conservant ses paramètres.
+La page de consentement vit dans `(admin-auth)` (layout sans sidebar) et exige une session : sans session elle redirige vers `/admin/login` en conservant ses paramètres. `/mcp/token` ne vérifie pas `requireConsent` : le code de consentement ne doit jamais quitter le navigateur de l'admin, d'où le `no-referrer` sur la page.
 
 ### Autorisation métier
 
-Un compte `customer` peut techniquement terminer le flux OAuth. La frontière de sécurité est `assertAdminContext()`, appelée dans `app/api/mcp/route.ts` avant toute instanciation du serveur MCP :
+Un compte `customer` peut techniquement terminer le flux OAuth. La frontière de sécurité est `buildMcpContext()`, appelée dans `app/api/mcp/route.ts` avant toute instanciation du serveur MCP :
 
 - lecture fraîche de l'utilisateur en D1 à partir de `session.userId` (pas de cache cookie, même principe que `requireAdmin()`) ;
 - rôle `admin` ou `super_admin` ;
@@ -159,7 +164,7 @@ Toutes refusent une cible qui n'est pas un brouillon (`not_found`).
 
 - Obligatoires : `name` (1–150), `category_id` (doit exister).
 - Optionnels : `brand` (≤80), `short_description` (≤120), `description_html` (passé par `sanitizeDescriptionHtml`, stocké avec `description_type = "html"`), `story { tagline, highlights[3–6], feature_blocks[2–4], faq[≤5] }`, `seo { meta_title ≤60, meta_description ≤160 }`, `attributes { colors[≤12], dimensions { length_mm, height_mm, width_mm, weight_g }, specs[≤20] }`, `pricing { base_price, compare_price, sku, stock_quantity, low_stock_threshold, weight_grams }`.
-- Les schémas `story` et `attributes` sont ceux de `lib/validations/product-story.ts` et `lib/validations/product-ai.ts`, réutilisés tels quels.
+- Les schémas `story` et `attributes` sont ceux de `lib/validations/product-story.ts` et `lib/validations/product-ai.ts`, réutilisés tels quels. `product-ai.ts` exporte désormais ses trois sous-schémas d'attributs (`colorSchema`, `dimensionsSchema`, `specSchema`) pour cette réutilisation.
 - Les couleurs s'écrivent en attributs `Couleur` = `nom|#hex`, les dimensions en `Longueur`, `Hauteur`, `Largeur`, `Poids` (convention du wizard et de `products-ai.ts`).
 - Slug généré depuis le nom via `slugify`, suffixe anti-collision (`-2`, `-3`, … jusqu'à 20 essais, puis slug placeholder `draft-<id>`), même logique que `products-ai.ts`.
 - `base_price` par défaut 0 si absent : le brouillon peut être créé avant la tarification et complété ensuite.
@@ -197,11 +202,11 @@ Toutes refusent une cible qui n'est pas un brouillon (`not_found`).
 
 - Aucun outil n'accepte ni n'écrit `is_draft`, `is_active`, `is_featured`.
 - Chaque `UPDATE`/`DELETE` porte `is_draft = 1` dans son `WHERE`.
-- Chaque outil d'écriture enregistre une ligne `audit_log` : `actor_id`/`actor_name` = admin porteur du jeton, `target_type = "product"`, `details = { via: "mcp", tool, client_id, client_name }`.
+- Chaque outil d'écriture enregistre une ligne `audit_log` : `actor_id`/`actor_name` = admin porteur du jeton, `target_type = "product"`, `details = { via: "mcp", tool, client_id }`.
 
 ## 5. Gestion d'erreurs
 
-- **Avant les outils** : 401 par `withMcpAuth` (jeton absent, invalide ou expiré), 403 par `assertAdminContext` (rôle insuffisant, ban, utilisateur supprimé). Réponses JSON-RPC ; le serveur MCP n'est jamais instancié.
+- **Avant les outils** : 401 par `withMcpAuth` (jeton absent, invalide ou expiré), 403 par `buildMcpContext` (rôle insuffisant, ban, utilisateur supprimé). Réponses JSON-RPC ; le serveur MCP n'est jamais instancié.
 - **Codes d'erreur d'outil** : `validation_error` (avec `fieldErrors`), `not_found`, `conflict` (slug ou SKU déjà pris), `limit_exceeded`, `internal_error`. Messages en français, destinés à être relayés à l'admin par l'IA.
 - **Atomicité** : écritures multi-tables via `db.batch` (une transaction D1 implicite), comme `importCandidateImages`. Pour les images : upload R2 d'abord, puis batch d'insertion ; en cas d'échec du batch, suppression compensatoire des objets R2 uploadés, échecs de nettoyage journalisés mais non propagés.
 - **Journalisation** : `console.error("[mcp/<outil>] …")` avec l'id du produit et de l'utilisateur, jamais le jeton. Workers Logs retient 7 jours.
@@ -212,7 +217,7 @@ Toutes refusent une cible qui n'est pas un brouillon (`not_found`).
 ### Unitaires (Vitest, `__tests__/unit/`)
 
 - `lib/validations/mcp-product.ts` : bornes, hex, tailles de listes, `null` vs absent.
-- `assertAdminContext` : `customer` → 403, banni → 403, `admin`/`super_admin` → ok, utilisateur inexistant → 403.
+- `buildMcpContext` : `customer` → 403, banni → 403, `admin`/`super_admin` → ok, utilisateur inexistant → 403.
 - Hook `before` sur `/mcp/authorize` : `prompt=consent` forcé quelle que soit l'entrée (absent, `none`, `login`).
 - Handlers d'outils avec `product-drafts` mocké : mapping des erreurs, forme des résultats, succès partiel des images, refus d'un produit publié, audit enregistré.
 - `product-drafts.ts` : génération de slug avec collisions, calcul de `stock_quantity` des variantes, réattribution de l'image primaire, sur le pattern de mock DB des tests existants.

--- a/docs/superpowers/specs/2026-09-02-admin-mcp-server-design.md
+++ b/docs/superpowers/specs/2026-09-02-admin-mcp-server-design.md
@@ -1,7 +1,7 @@
 # Spec — Serveur MCP d'administration (phase 1 : brouillons produits)
 
 **Date :** 2026-09-02
-**Statut :** Design validé, à implémenter
+**Statut :** Implémenté (2026-09-02)
 **Périmètre :** Phase 1 — création et édition de brouillons produits par une IA externe
 
 ---

--- a/docs/superpowers/specs/2026-09-02-admin-mcp-server-design.md
+++ b/docs/superpowers/specs/2026-09-02-admin-mcp-server-design.md
@@ -1,0 +1,236 @@
+# Spec — Serveur MCP d'administration (phase 1 : brouillons produits)
+
+**Date :** 2026-09-02
+**Statut :** Design validé, à implémenter
+**Périmètre :** Phase 1 — création et édition de brouillons produits par une IA externe
+
+---
+
+## Objectif
+
+Exposer l'administration de NETEREKA à une IA externe via le protocole MCP (Model Context Protocol), pour que la recherche et la rédaction d'une fiche produit soient faites par le client IA (Claude Desktop, claude.ai, Claude Code, ChatGPT, Cursor, agent maison…) et non plus par le pipeline Anthropic embarqué dans l'application (`/products/ai-new`).
+
+Le MCP est **généraliste** : serveur distant, transport standard, authentification standard. N'importe quel client conforme peut s'y connecter.
+
+## Décisions prises
+
+1. **Client cible** : tous (claude.ai, Claude Desktop, Claude Code, ChatGPT, Cursor…). Conséquences : transport Streamable HTTP, authentification OAuth 2.1 avec enregistrement dynamique des clients. Un simple bearer token est exclu : les connecteurs claude.ai et ChatGPT ne permettent pas d'ajouter un en-tête manuel.
+2. **Fonctionnalité IA existante** : conservée telle quelle (`/products/ai-new`, clés Anthropic/Brave, page AI settings). Son retrait est un chantier séparé, après validation du MCP en usage réel.
+3. **Niveau de confiance** : brouillon complet uniquement (fiche, attributs, story, SEO, images, prix, stock, SKU, variantes). La publication (`is_draft = 0`) reste un geste humain dans le wizard admin.
+4. **Hébergement** : route dans l'application Next.js (`app/api/mcp/`), pas de Worker séparé ni de serveur stdio local. Motifs : réutilisation directe de tout le code métier (`getDrizzle`, validations Zod, `fetchAndUploadImage`, `sanitizeDescriptionHtml`, `slugify`), déploiement par le pipeline canary existant, fournisseur OAuth (better-auth) et audit-log dans le même processus.
+
+## 1. Architecture
+
+### Flux d'un appel d'outil
+
+```
+Client MCP ──POST /api/mcp (Authorization: Bearer)──▶ withMcpAuth (better-auth)
+   ▶ buildMcpContext : lecture fraîche de l'utilisateur en D1, rôle admin|super_admin, non banni
+   ▶ McpServer (SDK officiel, instance par requête, mode stateless)
+   ▶ handler d'outil ──▶ lib/db/product-drafts.ts (Drizzle) ──▶ D1 / R2
+   ▶ audit_log (details.via = "mcp")
+```
+
+Mode stateless : un `McpServer` et un transport sont créés par requête, sans identifiant de session MCP. Rien à stocker entre deux requêtes, donc compatible avec plusieurs isolates Workers sans affinité.
+
+### Nouveaux fichiers
+
+| Fichier | Rôle |
+|---|---|
+| `app/api/mcp/route.ts` | `POST` = `withMcpAuth(auth, …)` puis transport Streamable HTTP « web standard » du SDK. `GET` et `DELETE` répondent 405. |
+| `app/.well-known/oauth-authorization-server/route.ts` | `oAuthDiscoveryMetadata(auth)` — exposé à la racine car certains clients cherchent là plutôt que sous `/api/auth`. |
+| `app/.well-known/oauth-protected-resource/route.ts` | `oAuthProtectedResourceMetadata(auth)`. |
+| `lib/mcp/server.ts` | Construit le `McpServer`, enregistre les outils depuis le registre. |
+| `lib/mcp/context.ts` | `McpContext { user: { id, name, role }, clientId, clientName }` et `assertAdminContext()`. |
+| `lib/mcp/result.ts` | Helpers `ok(data)` / `fail(code, message, fieldErrors?)` — format de réponse uniforme. |
+| `lib/mcp/tools/categories.ts` | `list_categories`. |
+| `lib/mcp/tools/products.ts` | Outils produits (section 4). |
+| `lib/validations/mcp-product.ts` | Schémas Zod d'entrée des outils, composés à partir de `product-story.ts` et `product-ai.ts`. Aucune règle métier dupliquée. |
+| `lib/db/product-drafts.ts` | Module Drizzle portant toute la logique brouillon : création, mise à jour partielle, slug unique, images, variantes, suppression. Chaque `UPDATE`/`DELETE` porte `is_draft = 1` dans son `WHERE`. |
+| `lib/db/audit.ts` | `recordAudit()` en Drizzle. |
+| `app/(admin-auth)/admin/mcp/consent/page.tsx` | Page de consentement OAuth (section 2). |
+
+### Fichiers modifiés
+
+| Fichier | Changement |
+|---|---|
+| `lib/auth/index.ts` | Ajout du plugin `mcp` de better-auth + hook `before` sur `/mcp/authorize` (force `prompt=consent`). |
+| `lib/db/schema.ts` | Trois tables OAuth (section 3). |
+| `lib/db/types.ts` + `lib/constants/audit.ts` | Trois actions d'audit `product.draft_created`, `product.draft_updated`, `product.draft_deleted` et leurs libellés. |
+| `app/(admin-auth)/admin/login/page.tsx` | Reprise du flux OAuth après connexion (section 2). |
+| `package.json` | `@modelcontextprotocol/sdk` ^1.30 (compatible zod 4). |
+
+Non modifiés, seulement réutilisés : `actions/admin/products-ai.ts`, le wizard, `lib/ai/image-fetch.ts`, `lib/utils/sanitize-html.ts`, `lib/utils` (`slugify`), `lib/db/categories.ts`, `lib/auth/ban.ts`, `lib/storage/images.ts`.
+
+`env.d.ts` et `wrangler.jsonc` ne changent pas : `SITE_URL` (déjà `baseURL` de better-auth) sert de base OAuth.
+
+## 2. Authentification OAuth 2.1
+
+### Flux standard (géré par le plugin `mcp` de better-auth 1.6.25)
+
+1. Le client appelle `POST /api/mcp` sans jeton → 401 + `WWW-Authenticate: Bearer resource_metadata="…/.well-known/oauth-protected-resource"`.
+2. Il lit les métadonnées, s'enregistre dynamiquement (`POST /api/auth/mcp/register`), ouvre `GET /api/auth/mcp/authorize` avec PKCE S256 dans le navigateur de l'admin.
+3. Sans session : le plugin redirige vers `/admin/login` avec les paramètres OAuth conservés. L'admin se connecte (email + mot de passe + Turnstile, inchangé).
+4. Consentement (voir ci-dessous) → code d'autorisation → `POST /api/auth/mcp/token` → jeton d'accès (1 h) + jeton de rafraîchissement (7 jours). Valeurs par défaut du plugin, non modifiées.
+5. Chaque appel MCP : `withMcpAuth` valide le jeton contre `oauthAccessToken` et fournit `{ userId, clientId, scopes }`.
+
+Configuration du plugin : `mcp({ loginPage: "/admin/login", resource: "<SITE_URL>/api/mcp", oidcConfig: { consentPage: "/admin/mcp/consent" } })`.
+
+### Consentement obligatoire (point de sécurité)
+
+En 1.6.25, `authorizeMCPOAuth` émet le code **sans écran de consentement** dès que l'admin a une session, sauf si la requête porte `prompt=consent`. L'enregistrement dynamique étant ouvert (obligatoire pour claude.ai et ChatGPT), un site malveillant pourrait enregistrer un client avec sa propre URL de redirection, faire cliquer un admin connecté sur l'URL d'autorisation, et récupérer un jeton admin. PKCE ne protège pas contre ce scénario, l'attaquant contrôlant le challenge.
+
+Mitigation :
+
+- Un hook `before` sur `/mcp/authorize` force `prompt=consent` sur toute requête, quelle que soit la valeur envoyée par le client.
+- `oidcConfig.consentPage = "/admin/mcp/consent"`. La page lit `client_id` et `scope` dans ses paramètres, charge le nom du client dans `oauthApplication` (nom fourni par le client, donc affiché échappé), et propose « Autoriser » / « Refuser ». Elle appelle l'endpoint de consentement du plugin (`/api/auth/oauth2/consent`, cookie signé `oidc_consent_prompt`), qui redirige vers le client avec le code et le `state`.
+- Résultat : aucun jeton n'est émis sans un clic humain explicite sur une page du domaine.
+
+La page de consentement vit dans `(admin-auth)` (layout sans sidebar) et exige une session : sans session elle redirige vers `/admin/login` en conservant ses paramètres.
+
+### Autorisation métier
+
+Un compte `customer` peut techniquement terminer le flux OAuth. La frontière de sécurité est `assertAdminContext()`, appelée dans `app/api/mcp/route.ts` avant toute instanciation du serveur MCP :
+
+- lecture fraîche de l'utilisateur en D1 à partir de `session.userId` (pas de cache cookie, même principe que `requireAdmin()`) ;
+- rôle `admin` ou `super_admin` ;
+- ban vérifié via `isActivelyBanned` ;
+- sinon réponse JSON-RPC 403, l'outil n'est jamais exécuté.
+
+Amélioration possible plus tard : refuser dès la page de consentement quand le rôle n'est pas admin.
+
+### Reprise après login
+
+La page `/admin/login` détecte `client_id` + `redirect_uri` dans ses paramètres de requête. Après connexion réussie, elle effectue une navigation complète (`window.location.assign`, pas `router.push`) vers `/api/auth/mcp/authorize?<mêmes paramètres>` au lieu de `/dashboard`. Le chemin de destination est codé en dur (même origine).
+
+Le plugin possède aussi son propre mécanisme de reprise (cookie signé `oidc_login_prompt` + hook `after` sur la connexion). Les deux sont compatibles : les codes sont à usage unique et expirent en 10 min. Le comportement exact du hook `after` sur un appel `fetch` de connexion (réponse 302 suivie par le navigateur) est à valider de bout en bout avec Claude Code comme premier client ; si le hook du plugin suffit, la modification de la page de login peut se réduire à ne pas rediriger vers `/dashboard`.
+
+### Rate limiting
+
+Les endpoints OAuth vivent sous `/api/auth/*` et héritent du rate limiting better-auth existant (30 req/min). `/api/mcp` n'a pas de rate limiting propre en phase 1 : chaque requête est liée à un jeton, lui-même lié à un compte admin.
+
+## 3. Données
+
+Trois tables ajoutées dans `lib/db/schema.ts`, colonnes conformes au schéma attendu par le plugin (noms camelCase, comme les tables better-auth `user`/`session`/`account`). Les clés étrangères pointent sur `user`, pas `users`.
+
+```
+oauthApplication
+  id, name, icon?, metadata?, clientId (unique), clientSecret?, redirectUrls,
+  type, disabled (default false), userId? → user.id (cascade), createdAt, updatedAt
+
+oauthAccessToken
+  id, accessToken (unique), refreshToken (unique), accessTokenExpiresAt,
+  refreshTokenExpiresAt, clientId → oauthApplication.clientId (cascade),
+  userId? → user.id (cascade), scopes, createdAt, updatedAt
+
+oauthConsent
+  id, clientId → oauthApplication.clientId (cascade), userId → user.id (cascade),
+  scopes, consentGiven, createdAt, updatedAt
+```
+
+Index sur `oauthApplication.userId`, `oauthAccessToken.clientId`, `oauthAccessToken.userId`, `oauthConsent.clientId`, `oauthConsent.userId`.
+
+Migration générée par `npm run db:generate`. Purement additive, donc conforme à expand/contract, aucun marqueur d'acquittement nécessaire.
+
+Aucun changement sur `products`, `product_images`, `product_variants`, `product_attributes`, `audit_log`.
+
+## 4. Contrat des outils
+
+Format commun :
+
+- Entrée validée par Zod via `inputSchema` ; le SDK renvoie une erreur JSON-RPC `-32602` si le schéma n'est pas respecté.
+- Sortie : `content: [{ type: "text", text: <JSON> }]`.
+- Erreur métier : `isError: true`, contenu `{ code, message, fieldErrors? }` (section 5).
+- Toutes les identités sont les `id` nanoid existants.
+
+### Lecture
+
+| Outil | Entrée | Sortie |
+|---|---|---|
+| `list_categories` | aucune | arbre `[{ id, name, slug, children[] }]` (2 niveaux max) |
+| `search_products` | `query` (3–100 car.), `limit` (1–50, défaut 20) | `[{ id, name, slug, brand, sku, base_price, is_draft, is_active }]`. Recherche sur nom, slug, SKU ; brouillons et publiés inclus : c'est l'outil anti-doublon. |
+| `get_product_draft` | `id` | fiche complète : champs produit, `attributes[]`, `images[]` (avec URL publique), `variants[]` |
+
+### Écriture
+
+Toutes refusent une cible qui n'est pas un brouillon (`not_found`).
+
+**`create_product_draft`** → `{ id, slug, edit_url }`
+
+- Obligatoires : `name` (1–150), `category_id` (doit exister).
+- Optionnels : `brand` (≤80), `short_description` (≤120), `description_html` (passé par `sanitizeDescriptionHtml`, stocké avec `description_type = "html"`), `story { tagline, highlights[3–6], feature_blocks[2–4], faq[≤5] }`, `seo { meta_title ≤60, meta_description ≤160 }`, `attributes { colors[≤12], dimensions { length_mm, height_mm, width_mm, weight_g }, specs[≤20] }`, `pricing { base_price, compare_price, sku, stock_quantity, low_stock_threshold, weight_grams }`.
+- Les schémas `story` et `attributes` sont ceux de `lib/validations/product-story.ts` et `lib/validations/product-ai.ts`, réutilisés tels quels.
+- Les couleurs s'écrivent en attributs `Couleur` = `nom|#hex`, les dimensions en `Longueur`, `Hauteur`, `Largeur`, `Poids` (convention du wizard et de `products-ai.ts`).
+- Slug généré depuis le nom via `slugify`, suffixe anti-collision (`-2`, `-3`, … jusqu'à 20 essais, puis slug placeholder `draft-<id>`), même logique que `products-ai.ts`.
+- `base_price` par défaut 0 si absent : le brouillon peut être créé avant la tarification et complété ensuite.
+- Écriture en un seul `db.batch` : insertion du produit + attributs.
+
+**`update_product_draft`** → `{ id, slug }`
+
+- `id` + les mêmes champs que la création, tous optionnels, plus `slug` (validé, unicité vérifiée).
+- Un champ absent est ignoré, `null` efface la valeur.
+- `attributes` fourni remplace l'ensemble des attributs (comportement de l'étape 2 du wizard).
+- `story` et `seo` : chaque sous-champ fourni remplace la valeur correspondante.
+
+**`add_product_images`** → `{ results: [{ url, ok, image_id?, reason? }], primary_image_id }`
+
+- `id`, `images: [{ url, alt? }]`, ≤8 par appel, ≤12 images au total par produit (`limit_exceeded` sinon, avant tout téléchargement).
+- Chaque URL passe par `fetchAndUploadImage` (garde SSRF, 5 Mo max, 10 s, types image seulement).
+- Succès partiel = résultat normal (pas `isError`), chaque échec porte sa raison (`ssrf`, `bad_status`, `bad_content_type`, `too_large`, `timeout`, `fetch_failed`, `upload_failed`).
+- La première image du produit devient `is_primary` ; `sort_order` continue après les images existantes.
+
+**`remove_product_image`** → `{ removed: true }`
+
+- `id`, `image_id`. Supprime la ligne et l'objet R2. Si l'image était primaire, la suivante par `sort_order` devient primaire.
+
+**`set_product_variants`** → `{ variants: [{ id, color_name, color_hex, price, stock }], stock_quantity }`
+
+- `id`, `variants: [{ color_name, color_hex, stock, price? }]`, `uniform_price` (défaut `true`).
+- Mêmes règles que `saveColorVariants` : `price` absent ou `uniform_price` → prix de base ; variantes existantes de même couleur mises à jour ; variantes retirées supprimées et leurs images désassociées (`variant_id = NULL`) ; `stock_quantity` du produit recalculé comme somme des stocks.
+- Les couleurs déclarées ici doivent correspondre aux attributs `Couleur` ; la documentation de l'outil le rappelle, aucune synchronisation automatique en phase 1.
+
+**`delete_product_draft`** → `{ deleted: true }`
+
+- Supprime la ligne (cascade sur attributs, images, variantes) puis les objets R2 des images.
+
+### Invariants
+
+- Aucun outil n'accepte ni n'écrit `is_draft`, `is_active`, `is_featured`.
+- Chaque `UPDATE`/`DELETE` porte `is_draft = 1` dans son `WHERE`.
+- Chaque outil d'écriture enregistre une ligne `audit_log` : `actor_id`/`actor_name` = admin porteur du jeton, `target_type = "product"`, `details = { via: "mcp", tool, client_id, client_name }`.
+
+## 5. Gestion d'erreurs
+
+- **Avant les outils** : 401 par `withMcpAuth` (jeton absent, invalide ou expiré), 403 par `assertAdminContext` (rôle insuffisant, ban, utilisateur supprimé). Réponses JSON-RPC ; le serveur MCP n'est jamais instancié.
+- **Codes d'erreur d'outil** : `validation_error` (avec `fieldErrors`), `not_found`, `conflict` (slug ou SKU déjà pris), `limit_exceeded`, `internal_error`. Messages en français, destinés à être relayés à l'admin par l'IA.
+- **Atomicité** : écritures multi-tables via `db.batch` (une transaction D1 implicite), comme `importCandidateImages`. Pour les images : upload R2 d'abord, puis batch d'insertion ; en cas d'échec du batch, suppression compensatoire des objets R2 uploadés, échecs de nettoyage journalisés mais non propagés.
+- **Journalisation** : `console.error("[mcp/<outil>] …")` avec l'id du produit et de l'utilisateur, jamais le jeton. Workers Logs retient 7 jours.
+- **Erreurs inattendues** : attrapées au niveau du registre d'outils, transformées en `internal_error` générique. Aucune stack trace ne sort vers le client.
+
+## 6. Tests
+
+### Unitaires (Vitest, `__tests__/unit/`)
+
+- `lib/validations/mcp-product.ts` : bornes, hex, tailles de listes, `null` vs absent.
+- `assertAdminContext` : `customer` → 403, banni → 403, `admin`/`super_admin` → ok, utilisateur inexistant → 403.
+- Hook `before` sur `/mcp/authorize` : `prompt=consent` forcé quelle que soit l'entrée (absent, `none`, `login`).
+- Handlers d'outils avec `product-drafts` mocké : mapping des erreurs, forme des résultats, succès partiel des images, refus d'un produit publié, audit enregistré.
+- `product-drafts.ts` : génération de slug avec collisions, calcul de `stock_quantity` des variantes, réattribution de l'image primaire, sur le pattern de mock DB des tests existants.
+- `scripts/check-migration-safety.mjs` valide la migration en pre-commit.
+
+### Bout en bout (checklist manuelle)
+
+1. Local : `npm run dev`, puis `claude mcp add --transport http netereka http://localhost:3000/api/mcp`, `/mcp` dans Claude Code → login admin → page de consentement → liste des outils visible.
+2. Créer un brouillon complet (fiche, story, SEO, attributs, prix, images, variantes), l'ouvrir dans le wizard admin (`/products/<id>/edit`), vérifier chaque étape, publier depuis le wizard.
+3. Vérifier qu'un compte `customer` obtient 403 sur `/api/mcp` après le flux OAuth.
+4. Vérifier qu'un produit publié est refusé par `update_product_draft` et `delete_product_draft`.
+5. Après déploiement : connecteur claude.ai sur `https://netereka.ci/api/mcp`.
+
+## Hors périmètre phase 1
+
+- Rate limiting propre à `/api/mcp`.
+- Ressources et prompts MCP (outils seulement).
+- Outils commandes, clients, catégories en écriture.
+- Interface de révocation des clients OAuth (les jetons de rafraîchissement expirent en 7 jours ; la suppression d'un compte cascade sur ses jetons).
+- Retrait de la fonctionnalité IA embarquée (`/products/ai-new`).
+- Refus des non-admins dès la page de consentement.

--- a/drizzle/0017_sticky_calypso.sql
+++ b/drizzle/0017_sticky_calypso.sql
@@ -1,0 +1,51 @@
+CREATE TABLE `oauthAccessToken` (
+	`id` text PRIMARY KEY NOT NULL,
+	`accessToken` text NOT NULL,
+	`refreshToken` text NOT NULL,
+	`accessTokenExpiresAt` text NOT NULL,
+	`refreshTokenExpiresAt` text NOT NULL,
+	`clientId` text NOT NULL,
+	`userId` text,
+	`scopes` text NOT NULL,
+	`createdAt` text DEFAULT (datetime('now')) NOT NULL,
+	`updatedAt` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`clientId`) REFERENCES `oauthApplication`(`clientId`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `oauthAccessToken_accessToken_unique` ON `oauthAccessToken` (`accessToken`);--> statement-breakpoint
+CREATE UNIQUE INDEX `oauthAccessToken_refreshToken_unique` ON `oauthAccessToken` (`refreshToken`);--> statement-breakpoint
+CREATE INDEX `idx_oauthAccessToken_clientId` ON `oauthAccessToken` (`clientId`);--> statement-breakpoint
+CREATE INDEX `idx_oauthAccessToken_userId` ON `oauthAccessToken` (`userId`);--> statement-breakpoint
+CREATE TABLE `oauthApplication` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`icon` text,
+	`metadata` text,
+	`clientId` text NOT NULL,
+	`clientSecret` text,
+	`redirectUrls` text NOT NULL,
+	`type` text NOT NULL,
+	`disabled` integer DEFAULT 0 NOT NULL,
+	`userId` text,
+	`createdAt` text DEFAULT (datetime('now')) NOT NULL,
+	`updatedAt` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `oauthApplication_clientId_unique` ON `oauthApplication` (`clientId`);--> statement-breakpoint
+CREATE INDEX `idx_oauthApplication_userId` ON `oauthApplication` (`userId`);--> statement-breakpoint
+CREATE TABLE `oauthConsent` (
+	`id` text PRIMARY KEY NOT NULL,
+	`clientId` text NOT NULL,
+	`userId` text NOT NULL,
+	`scopes` text NOT NULL,
+	`consentGiven` integer DEFAULT 0 NOT NULL,
+	`createdAt` text DEFAULT (datetime('now')) NOT NULL,
+	`updatedAt` text DEFAULT (datetime('now')) NOT NULL,
+	FOREIGN KEY (`clientId`) REFERENCES `oauthApplication`(`clientId`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`userId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_oauthConsent_clientId` ON `oauthConsent` (`clientId`);--> statement-breakpoint
+CREATE INDEX `idx_oauthConsent_userId` ON `oauthConsent` (`userId`);

--- a/drizzle/meta/0017_snapshot.json
+++ b/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,3470 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0461ae20-7a49-4e1a-8c77-9c491fbe006c",
+  "prevId": "aef9d25c-973c-4285-a54e-660cb16c8273",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_account_userId": {
+          "name": "idx_account_userId",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        },
+        "idx_account_provider": {
+          "name": "idx_account_provider",
+          "columns": [
+            "providerId",
+            "accountId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "addresses": {
+      "name": "addresses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Domicile'"
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "street": {
+          "name": "street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commune": {
+          "name": "commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Abidjan'"
+        },
+        "zone_id": {
+          "name": "zone_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_addresses_user": {
+          "name": "idx_addresses_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "addresses_user_id_user_id_fk": {
+          "name": "addresses_user_id_user_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "addresses_zone_id_delivery_zones_id_fk": {
+          "name": "addresses_zone_id_delivery_zones_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "delivery_zones",
+          "columnsFrom": [
+            "zone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_config": {
+      "name": "ai_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anthropic_api_key": {
+          "name": "anthropic_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "brave_api_key": {
+          "name": "brave_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "ai_config_singleton_id": {
+          "name": "ai_config_singleton_id",
+          "value": "\"ai_config\".\"id\" = 1"
+        },
+        "ai_config_enabled_bool": {
+          "name": "ai_config_enabled_bool",
+          "value": "\"ai_config\".\"enabled\" in (0, 1)"
+        }
+      }
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_audit_log_actor": {
+          "name": "idx_audit_log_actor",
+          "columns": [
+            "actor_id"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_log_action": {
+          "name": "idx_audit_log_action",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_log_created": {
+          "name": "idx_audit_log_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "banner_gradients": {
+      "name": "banner_gradients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_from": {
+          "name": "color_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color_to": {
+          "name": "color_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "banners": {
+      "name": "banners",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "badge_text": {
+          "name": "badge_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "badge_color": {
+          "name": "badge_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'mint'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cta_text": {
+          "name": "cta_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Découvrir'"
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bg_gradient_from": {
+          "name": "bg_gradient_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#183C78'"
+        },
+        "bg_gradient_to": {
+          "name": "bg_gradient_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#1E4A8F'"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_banners_active_order": {
+          "name": "idx_banners_active_order",
+          "columns": [
+            "is_active",
+            "display_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "idx_categories_slug": {
+          "name": "idx_categories_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "idx_categories_parent": {
+          "name": "idx_categories_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "categories_parent_id_categories_id_fk": {
+          "name": "categories_parent_id_categories_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "delivery_zones": {
+      "name": "delivery_zones",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commune": {
+          "name": "commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fee": {
+          "name": "fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimated_hours": {
+          "name": "estimated_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 24
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauthAccessToken": {
+      "name": "oauthAccessToken",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "oauthAccessToken_accessToken_unique": {
+          "name": "oauthAccessToken_accessToken_unique",
+          "columns": [
+            "accessToken"
+          ],
+          "isUnique": true
+        },
+        "oauthAccessToken_refreshToken_unique": {
+          "name": "oauthAccessToken_refreshToken_unique",
+          "columns": [
+            "refreshToken"
+          ],
+          "isUnique": true
+        },
+        "idx_oauthAccessToken_clientId": {
+          "name": "idx_oauthAccessToken_clientId",
+          "columns": [
+            "clientId"
+          ],
+          "isUnique": false
+        },
+        "idx_oauthAccessToken_userId": {
+          "name": "idx_oauthAccessToken_userId",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauthAccessToken_clientId_oauthApplication_clientId_fk": {
+          "name": "oauthAccessToken_clientId_oauthApplication_clientId_fk",
+          "tableFrom": "oauthAccessToken",
+          "tableTo": "oauthApplication",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "clientId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauthAccessToken_userId_user_id_fk": {
+          "name": "oauthAccessToken_userId_user_id_fk",
+          "tableFrom": "oauthAccessToken",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauthApplication": {
+      "name": "oauthApplication",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clientSecret": {
+          "name": "clientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redirectUrls": {
+          "name": "redirectUrls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "oauthApplication_clientId_unique": {
+          "name": "oauthApplication_clientId_unique",
+          "columns": [
+            "clientId"
+          ],
+          "isUnique": true
+        },
+        "idx_oauthApplication_userId": {
+          "name": "idx_oauthApplication_userId",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauthApplication_userId_user_id_fk": {
+          "name": "oauthApplication_userId_user_id_fk",
+          "tableFrom": "oauthApplication",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauthConsent": {
+      "name": "oauthConsent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consentGiven": {
+          "name": "consentGiven",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_oauthConsent_clientId": {
+          "name": "idx_oauthConsent_clientId",
+          "columns": [
+            "clientId"
+          ],
+          "isUnique": false
+        },
+        "idx_oauthConsent_userId": {
+          "name": "idx_oauthConsent_userId",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "oauthConsent_clientId_oauthApplication_clientId_fk": {
+          "name": "oauthConsent_clientId_oauthApplication_clientId_fk",
+          "tableFrom": "oauthConsent",
+          "tableTo": "oauthApplication",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "clientId"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauthConsent_userId_user_id_fk": {
+          "name": "oauthConsent_userId_user_id_fk",
+          "tableFrom": "oauthConsent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "order_items": {
+      "name": "order_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_name": {
+          "name": "variant_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_order_items_order": {
+          "name": "idx_order_items_order",
+          "columns": [
+            "order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "order_items_order_id_orders_id_fk": {
+          "name": "order_items_order_id_orders_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_items_product_id_products_id_fk": {
+          "name": "order_items_product_id_products_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "order_items_variant_id_product_variants_id_fk": {
+          "name": "order_items_variant_id_product_variants_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "order_status_history": {
+      "name": "order_status_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_order_status_history_order": {
+          "name": "idx_order_status_history_order",
+          "columns": [
+            "order_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "order_status_history_order_id_orders_id_fk": {
+          "name": "order_status_history_order_id_orders_id_fk",
+          "tableFrom": "order_status_history",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "orders": {
+      "name": "orders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_number": {
+          "name": "order_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_fee": {
+          "name": "delivery_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discount_amount": {
+          "name": "discount_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "promo_code_id": {
+          "name": "promo_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'web'"
+        },
+        "delivery_address": {
+          "name": "delivery_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_commune": {
+          "name": "delivery_commune",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_phone": {
+          "name": "delivery_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_instructions": {
+          "name": "delivery_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "estimated_delivery": {
+          "name": "estimated_delivery",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "internal_notes": {
+          "name": "internal_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivery_person_id": {
+          "name": "delivery_person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivery_person_name": {
+          "name": "delivery_person_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preparing_at": {
+          "name": "preparing_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shipping_at": {
+          "name": "shipping_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "returned_at": {
+          "name": "returned_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "return_reason": {
+          "name": "return_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "orders_order_number_unique": {
+          "name": "orders_order_number_unique",
+          "columns": [
+            "order_number"
+          ],
+          "isUnique": true
+        },
+        "idx_orders_user": {
+          "name": "idx_orders_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_orders_status": {
+          "name": "idx_orders_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_orders_number": {
+          "name": "idx_orders_number",
+          "columns": [
+            "order_number"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "orders_user_id_user_id_fk": {
+          "name": "orders_user_id_user_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "orders_promo_code_id_promo_codes_id_fk": {
+          "name": "orders_promo_code_id_promo_codes_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "promo_codes",
+          "columnsFrom": [
+            "promo_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product_attributes": {
+      "name": "product_attributes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_product_attributes_product": {
+          "name": "idx_product_attributes_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "product_attributes_product_id_products_id_fk": {
+          "name": "product_attributes_product_id_products_id_fk",
+          "tableFrom": "product_attributes",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product_images": {
+      "name": "product_images",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_product_images_product": {
+          "name": "idx_product_images_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "product_images_product_id_products_id_fk": {
+          "name": "product_images_product_id_products_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_images_variant_id_product_variants_id_fk": {
+          "name": "product_images_variant_id_product_variants_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "product_variants": {
+      "name": "product_variants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compare_price": {
+          "name": "compare_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "product_variants_sku_unique": {
+          "name": "product_variants_sku_unique",
+          "columns": [
+            "sku"
+          ],
+          "isUnique": true
+        },
+        "idx_product_variants_product": {
+          "name": "idx_product_variants_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "product_variants_product_id_products_id_fk": {
+          "name": "product_variants_product_id_products_id_fk",
+          "tableFrom": "product_variants",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "products": {
+      "name": "products",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description_type": {
+          "name": "description_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'richtext'"
+        },
+        "short_description": {
+          "name": "short_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_price": {
+          "name": "base_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "compare_price": {
+          "name": "compare_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sku": {
+          "name": "sku",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "low_stock_threshold": {
+          "name": "low_stock_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 5
+        },
+        "weight_grams": {
+          "name": "weight_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta_title": {
+          "name": "meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "highlights": {
+          "name": "highlights",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feature_blocks": {
+          "name": "feature_blocks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "faq": {
+          "name": "faq",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "products_slug_unique": {
+          "name": "products_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "products_sku_unique": {
+          "name": "products_sku_unique",
+          "columns": [
+            "sku"
+          ],
+          "isUnique": true
+        },
+        "idx_products_slug": {
+          "name": "idx_products_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "idx_products_category": {
+          "name": "idx_products_category",
+          "columns": [
+            "category_id"
+          ],
+          "isUnique": false
+        },
+        "idx_products_active": {
+          "name": "idx_products_active",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        },
+        "idx_products_featured": {
+          "name": "idx_products_featured",
+          "columns": [
+            "is_featured"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "products_category_id_categories_id_fk": {
+          "name": "products_category_id_categories_id_fk",
+          "tableFrom": "products",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "promo_codes": {
+      "name": "promo_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discount_value": {
+          "name": "discount_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "min_order_amount": {
+          "name": "min_order_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_count": {
+          "name": "used_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "promo_codes_code_unique": {
+          "name": "promo_codes_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rateLimit": {
+      "name": "rateLimit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lastRequest": {
+          "name": "lastRequest",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rateLimit_key_unique": {
+          "name": "rateLimit_key_unique",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reviews": {
+      "name": "reviews",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_verified_purchase": {
+          "name": "is_verified_purchase",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_reviews_product": {
+          "name": "idx_reviews_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        },
+        "idx_reviews_user": {
+          "name": "idx_reviews_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reviews_product_id_products_id_fk": {
+          "name": "reviews_product_id_products_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_user_id_user_id_fk": {
+          "name": "reviews_user_id_user_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "rating_range": {
+          "name": "rating_range",
+          "value": "\"reviews\".\"rating\" BETWEEN 1 AND 5"
+        }
+      }
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_session_userId": {
+          "name": "idx_session_userId",
+          "columns": [
+            "userId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stores": {
+      "name": "stores",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "google_maps_url": {
+          "name": "google_maps_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "opening_hours": {
+          "name": "opening_hours",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_stores_active_order": {
+          "name": "idx_stores_active_order",
+          "columns": [
+            "is_active",
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'customer'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "banReason": {
+          "name": "banReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banExpires": {
+          "name": "banExpires",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'customer'"
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'email'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_phone_unique": {
+          "name": "users_phone_unique",
+          "columns": [
+            "phone"
+          ],
+          "isUnique": true
+        },
+        "idx_users_email": {
+          "name": "idx_users_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "idx_users_phone": {
+          "name": "idx_users_phone",
+          "columns": [
+            "phone"
+          ],
+          "isUnique": false
+        },
+        "idx_users_is_active": {
+          "name": "idx_users_is_active",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "whatsapp_carts": {
+      "name": "whatsapp_carts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_wa_carts_session": {
+          "name": "idx_wa_carts_session",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "whatsapp_carts_session_id_whatsapp_sessions_id_fk": {
+          "name": "whatsapp_carts_session_id_whatsapp_sessions_id_fk",
+          "tableFrom": "whatsapp_carts",
+          "tableTo": "whatsapp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "whatsapp_carts_product_id_products_id_fk": {
+          "name": "whatsapp_carts_product_id_products_id_fk",
+          "tableFrom": "whatsapp_carts",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "whatsapp_carts_variant_id_product_variants_id_fk": {
+          "name": "whatsapp_carts_variant_id_product_variants_id_fk",
+          "tableFrom": "whatsapp_carts",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "whatsapp_config": {
+      "name": "whatsapp_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_number_id": {
+          "name": "phone_number_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_phone_number": {
+          "name": "display_phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verify_token": {
+          "name": "verify_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "business_account_id": {
+          "name": "business_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "admin_phones": {
+          "name": "admin_phones",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "whatsapp_messages": {
+      "name": "whatsapp_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "wa_message_id": {
+          "name": "wa_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_wa_messages_session": {
+          "name": "idx_wa_messages_session",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_wa_messages_created": {
+          "name": "idx_wa_messages_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_wa_messages_wa_id": {
+          "name": "idx_wa_messages_wa_id",
+          "columns": [
+            "wa_message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "whatsapp_messages_session_id_whatsapp_sessions_id_fk": {
+          "name": "whatsapp_messages_session_id_whatsapp_sessions_id_fk",
+          "tableFrom": "whatsapp_messages",
+          "tableTo": "whatsapp_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "whatsapp_sessions": {
+      "name": "whatsapp_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "wa_phone": {
+          "name": "wa_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_user_id": {
+          "name": "pending_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "otp_code": {
+          "name": "otp_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "otp_expires_at": {
+          "name": "otp_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "whatsapp_sessions_wa_phone_unique": {
+          "name": "whatsapp_sessions_wa_phone_unique",
+          "columns": [
+            "wa_phone"
+          ],
+          "isUnique": true
+        },
+        "idx_wa_sessions_phone": {
+          "name": "idx_wa_sessions_phone",
+          "columns": [
+            "wa_phone"
+          ],
+          "isUnique": false
+        },
+        "idx_wa_sessions_user": {
+          "name": "idx_wa_sessions_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "whatsapp_sessions_user_id_user_id_fk": {
+          "name": "whatsapp_sessions_user_id_user_id_fk",
+          "tableFrom": "whatsapp_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "whatsapp_sessions_pending_user_id_user_id_fk": {
+          "name": "whatsapp_sessions_pending_user_id_user_id_fk",
+          "tableFrom": "whatsapp_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "pending_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wishlist": {
+      "name": "wishlist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "wishlist_user_product_unique": {
+          "name": "wishlist_user_product_unique",
+          "columns": [
+            "user_id",
+            "product_id"
+          ],
+          "isUnique": true
+        },
+        "idx_wishlist_user": {
+          "name": "idx_wishlist_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_wishlist_product": {
+          "name": "idx_wishlist_product",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wishlist_user_id_user_id_fk": {
+          "name": "wishlist_user_id_user_id_fk",
+          "tableFrom": "wishlist",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wishlist_product_id_products_id_fk": {
+          "name": "wishlist_product_id_products_id_fk",
+          "tableFrom": "wishlist",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1784974150690,
       "tag": "0016_chief_revanche",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1788391162706,
+      "tag": "0017_sticky_calypso",
+      "breakpoints": true
     }
   ]
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,6 +16,10 @@ const eslintConfig = defineConfig([
     "next-env.d.ts",
     "NETEREKA_Homepage_Concept.jsx",
     "scripts/**",
+    // Nested git worktrees created by Claude Code agents. They carry a full
+    // copy of the repo, so linting the root would lint them too and the
+    // pre-commit hook fails on files that belong to another branch.
+    ".claude/worktrees/**",
   ]),
 ]);
 

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -256,9 +256,13 @@ export function buildAuthOptions(cfEnv: CloudflareEnv) {
         // their token request to it.
         resource: `${cfEnv.SITE_URL}/api/mcp`,
         oidcConfig: {
-          // OIDCOptions.loginPage is distinct from the top-level MCPOptions
-          // one above (used if a client requests the `login` prompt) and is
-          // required by the type — same admin login page in both places.
+          // OIDCOptions.loginPage is required by the type, but the plugin
+          // unconditionally overwrites it with the outer options.loginPage
+          // above (better-auth/dist/plugins/mcp/index.mjs: `{ ...defaults,
+          // ...options.oidcConfig, loginPage: options.loginPage, ... }` —
+          // the spread runs first, so this value is never read). Kept
+          // identical to the outer one purely so the two literals don't
+          // drift apart; it has no effect on runtime behaviour.
           loginPage: "/admin/login",
           consentPage: "/admin/mcp/consent",
           requirePKCE: true,

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -1,11 +1,13 @@
 import { betterAuth, type BetterAuthOptions } from "better-auth";
-import { captcha, emailOTP, admin } from "better-auth/plugins";
+import { captcha, emailOTP, admin, mcp } from "better-auth/plugins";
+import { createAuthMiddleware } from "better-auth/api";
 import { createAccessControl } from "better-auth/plugins/access";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { Kysely } from "kysely";
 import { D1Dialect } from "kysely-d1";
 import { sendEmail } from "@/lib/notifications/email";
 import { otpEmail } from "@/lib/notifications/templates";
+import { forceConsentQuery } from "@/lib/auth/mcp-consent-hook";
 
 // Statement universe for the better-auth admin plugin's ACL: every action
 // any role declared below may be granted. Scoped to what a role in this app
@@ -198,6 +200,16 @@ export function buildAuthOptions(cfEnv: CloudflareEnv) {
         maxAge: 5 * 60,
       },
     },
+    hooks: {
+      before: createAuthMiddleware(async (ctx) => {
+        // See lib/auth/mcp-consent-hook.ts — every /mcp/authorize must show
+        // the consent page. Returning { context } merges into the endpoint
+        // context (better-auth/dist/api/dispatch.mjs, defuReplaceArrays).
+        const query = forceConsentQuery(ctx.path, ctx.query as Record<string, unknown> | undefined);
+        if (!query) return;
+        return { context: { query } };
+      }),
+    },
     plugins: [
       admin({
         defaultRole: "customer",
@@ -237,6 +249,20 @@ export function buildAuthOptions(cfEnv: CloudflareEnv) {
         allowedAttempts: 3,
         sendVerificationOnSignUp: true,
         overrideDefaultEmailVerification: true,
+      }),
+      mcp({
+        loginPage: "/admin/login",
+        // Advertised in the protected-resource metadata; MCP clients bind
+        // their token request to it.
+        resource: `${cfEnv.SITE_URL}/api/mcp`,
+        oidcConfig: {
+          // OIDCOptions.loginPage is distinct from the top-level MCPOptions
+          // one above (used if a client requests the `login` prompt) and is
+          // required by the type — same admin login page in both places.
+          loginPage: "/admin/login",
+          consentPage: "/admin/mcp/consent",
+          requirePKCE: true,
+        },
       }),
     ],
     trustedOrigins: [

--- a/lib/auth/mcp-consent-client.ts
+++ b/lib/auth/mcp-consent-client.ts
@@ -1,0 +1,17 @@
+import { eq } from "drizzle-orm";
+import { getDrizzle } from "@/lib/db/drizzle";
+import { oauthApplication } from "@/lib/db/schema";
+
+/** Name a dynamically-registered MCP client gave itself. Untrusted: render escaped. */
+export async function findOAuthClientName(clientId: string): Promise<string | null> {
+  const db = await getDrizzle();
+  // No .limit(1): clientId is unique in the schema, so the filter already
+  // returns at most one row — and drizzle-orm/d1 binds LIMIT as a query
+  // parameter, which would break the ["client-1"] params assertion below.
+  const row = await db
+    .select({ name: oauthApplication.name })
+    .from(oauthApplication)
+    .where(eq(oauthApplication.clientId, clientId))
+    .get();
+  return row?.name ?? null;
+}

--- a/lib/auth/mcp-consent-client.ts
+++ b/lib/auth/mcp-consent-client.ts
@@ -1,6 +1,6 @@
 import { eq } from "drizzle-orm";
 import { getDrizzle } from "@/lib/db/drizzle";
-import { oauthApplication } from "@/lib/db/schema";
+import { oauthApplication, verification } from "@/lib/db/schema";
 
 /** Name a dynamically-registered MCP client gave itself. Untrusted: render escaped. */
 export async function findOAuthClientName(clientId: string): Promise<string | null> {
@@ -14,4 +14,64 @@ export async function findOAuthClientName(clientId: string): Promise<string | nu
     .where(eq(oauthApplication.clientId, clientId))
     .get();
   return row?.name ?? null;
+}
+
+export interface ConsentRequest {
+  clientId: string;
+  clientName: string | null;
+  redirectHost: string;
+  scopes: string[];
+}
+
+/** Shape of `verification.value` for a consent-flow row, per
+ * node_modules/better-auth/dist/plugins/mcp/authorize.mjs. Untrusted beyond
+ * `clientId`/`redirectURI`/`scope`/`requireConsent`, which is all we read. */
+interface StoredConsentValue {
+  clientId: string;
+  redirectURI: string;
+  scope: string[];
+  requireConsent: boolean;
+}
+
+/**
+ * Resolves the pending consent request identified by `consent_code` (the
+ * query param better-auth's oidc-provider redirects the admin with — see
+ * node_modules/better-auth/dist/plugins/mcp/authorize.mjs:130-136) directly
+ * from the `verification` table, rather than trusting the `client_id` in the
+ * query string. Returns null when the code is missing, expired, unparsable,
+ * or does not require consent — the caller must treat that as "unknown
+ * request" and never fall back to displaying the query string's client_id.
+ */
+export async function findConsentRequest(code: string): Promise<ConsentRequest | null> {
+  const db = await getDrizzle();
+  const row = await db
+    .select({ value: verification.value, expiresAt: verification.expiresAt })
+    .from(verification)
+    .where(eq(verification.identifier, code))
+    .get();
+  if (!row) return null;
+  if (new Date(row.expiresAt).getTime() < Date.now()) return null;
+
+  let value: StoredConsentValue;
+  try {
+    value = JSON.parse(row.value) as StoredConsentValue;
+  } catch {
+    return null;
+  }
+  if (value.requireConsent !== true) return null;
+
+  let redirectHost: string;
+  try {
+    redirectHost = new URL(value.redirectURI).host;
+  } catch {
+    return null;
+  }
+
+  const clientName = await findOAuthClientName(value.clientId);
+  return {
+    clientId: value.clientId,
+    clientName,
+    redirectHost,
+    scopes: Array.isArray(value.scope) ? value.scope : [],
+  };
 }

--- a/lib/auth/mcp-consent-hook.ts
+++ b/lib/auth/mcp-consent-hook.ts
@@ -1,0 +1,23 @@
+/**
+ * better-auth's `mcp` plugin (1.6.25) issues an authorization code without any
+ * consent screen as soon as the user has a session, unless the client sends
+ * `prompt=consent` (node_modules/better-auth/dist/plugins/mcp/authorize.mjs,
+ * `if (query.prompt !== "consent")`). Dynamic client registration is open — it
+ * has to be, claude.ai and ChatGPT register themselves — so without this hook a
+ * malicious site could register a client with its own redirect URI, send a
+ * signed-in admin to the authorize URL, and collect an admin token silently.
+ *
+ * Forcing `prompt=consent` on every /mcp/authorize request routes the flow
+ * through `oidcConfig.consentPage`, where a human must click "Autoriser".
+ *
+ * Pure function so the rule is unit-testable without a better-auth context.
+ */
+export const MCP_AUTHORIZE_PATH = "/mcp/authorize";
+
+export function forceConsentQuery(
+  path: string | undefined,
+  query: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (path !== MCP_AUTHORIZE_PATH) return undefined;
+  return { ...(query ?? {}), prompt: "consent" };
+}

--- a/lib/auth/oauth-resume.ts
+++ b/lib/auth/oauth-resume.ts
@@ -1,0 +1,14 @@
+const REQUIRED_PARAMS = ["client_id", "redirect_uri", "response_type"] as const;
+
+/**
+ * The better-auth `mcp` plugin sends an unauthenticated /mcp/authorize caller
+ * to `/admin/login?<original OAuth query>`. After sign-in the browser must go
+ * back to the authorize endpoint with that same query so the flow continues
+ * (and lands on the consent page). Same-origin path, hardcoded on purpose.
+ */
+export function getOAuthResumeUrl(params: URLSearchParams): string | null {
+  for (const key of REQUIRED_PARAMS) {
+    if (!params.get(key)) return null;
+  }
+  return `/api/auth/mcp/authorize?${params.toString()}`;
+}

--- a/lib/constants/audit.ts
+++ b/lib/constants/audit.ts
@@ -5,12 +5,12 @@ export const AUDIT_ACTION_LABELS: Record<AuditAction, string> = {
   "user.role_changed": "Changement de rôle",
   "user.banned": "Bannissement",
   "user.unbanned": "Débannissement",
+  "product.draft_created": "Brouillon produit créé",
+  "product.draft_updated": "Brouillon produit modifié",
+  "product.draft_deleted": "Brouillon produit supprimé",
 };
 
 export const AUDIT_ACTION_OPTIONS: { value: string; label: string }[] = [
   { value: "all", label: "Toutes les actions" },
-  { value: "user.created", label: "Création de compte" },
-  { value: "user.role_changed", label: "Changement de rôle" },
-  { value: "user.banned", label: "Bannissement" },
-  { value: "user.unbanned", label: "Débannissement" },
+  ...(Object.entries(AUDIT_ACTION_LABELS) as [AuditAction, string][]).map(([value, label]) => ({ value, label })),
 ];

--- a/lib/db/product-drafts.ts
+++ b/lib/db/product-drafts.ts
@@ -1,0 +1,353 @@
+import { and, asc, eq, ne, or, sql } from "drizzle-orm";
+import type { BatchItem } from "drizzle-orm/batch";
+import { nanoid } from "nanoid";
+import { getDrizzle, type DrizzleDB } from "@/lib/db/drizzle";
+import { categories, productAttributes, productImages, productVariants, products } from "@/lib/db/schema";
+import { slugify } from "@/lib/utils";
+import { sanitizeDescriptionHtml } from "@/lib/utils/sanitize-html";
+import { getImageUrl } from "@/lib/utils/images";
+import { deleteFromR2 } from "@/lib/storage/images";
+import { fetchAndUploadImage, type FetchImageResult } from "@/lib/ai/image-fetch";
+import type {
+  AddImagesInput,
+  CreateDraftInput,
+  DraftAttributesInput,
+  SetVariantsInput,
+  UpdateDraftInput,
+} from "@/lib/validations/mcp-product";
+
+/**
+ * Draft-only product persistence for the MCP tools (lib/mcp/tools/products.ts).
+ *
+ * Invariant: every UPDATE/DELETE on `products` filters on `is_draft = 1`. A
+ * published product is unreachable from here by construction — that is the
+ * mechanical form of the "drafts only" decision in the spec.
+ */
+
+export type DraftErrorCode = "not_found" | "conflict" | "limit_exceeded";
+
+export class DraftError extends Error {
+  constructor(public readonly code: DraftErrorCode, message: string) {
+    super(message);
+    this.name = "DraftError";
+  }
+}
+
+export const MAX_IMAGES_PER_PRODUCT = 12;
+
+type Statement = BatchItem<"sqlite">;
+type Batch = [Statement, ...Statement[]];
+
+// ─── Pure helpers ───
+
+const DIMENSION_LABELS: Array<[keyof DraftAttributesInput["dimensions"], string]> = [
+  ["length_mm", "Longueur"],
+  ["height_mm", "Hauteur"],
+  ["width_mm", "Largeur"],
+  ["weight_g", "Poids"],
+];
+
+/** Same encoding as the wizard's step 2 and products-ai.ts. */
+export function attributesToRows(attrs: DraftAttributesInput | undefined): { name: string; value: string }[] {
+  if (!attrs) return [];
+  const rows: { name: string; value: string }[] = [];
+  for (const c of attrs.colors) rows.push({ name: "Couleur", value: `${c.name}|${c.hex}` });
+  for (const [key, label] of DIMENSION_LABELS) {
+    const v = attrs.dimensions[key];
+    if (v != null) rows.push({ name: label, value: String(v) });
+  }
+  for (const s of attrs.specs) rows.push({ name: s.name, value: s.value });
+  return rows;
+}
+
+type ProductColumns = Partial<typeof products.$inferInsert>;
+
+/** Only keys the caller provided end up in the statement; `null` clears. */
+function buildProductColumns(input: UpdateDraftInput, productId: string): ProductColumns {
+  const cols: ProductColumns = {};
+  if (input.name !== undefined) cols.name = input.name;
+  if (input.category_id !== undefined) cols.category_id = input.category_id;
+  if (input.brand !== undefined) cols.brand = input.brand;
+  if (input.short_description !== undefined) cols.short_description = input.short_description;
+  if (input.description_html !== undefined) {
+    cols.description = input.description_html ? sanitizeDescriptionHtml(input.description_html, productId) : null;
+    cols.description_type = "html";
+  }
+  if (input.seo) {
+    if (input.seo.meta_title !== undefined) cols.meta_title = input.seo.meta_title;
+    if (input.seo.meta_description !== undefined) cols.meta_description = input.seo.meta_description;
+  }
+  if (input.story) {
+    const s = input.story;
+    if (s.tagline !== undefined) cols.tagline = s.tagline;
+    if (s.highlights !== undefined) cols.highlights = s.highlights ? JSON.stringify(s.highlights) : null;
+    if (s.feature_blocks !== undefined) cols.feature_blocks = s.feature_blocks ? JSON.stringify(s.feature_blocks) : null;
+    if (s.faq !== undefined) cols.faq = s.faq ? JSON.stringify(s.faq) : null;
+  }
+  if (input.pricing) {
+    const p = input.pricing;
+    if (p.base_price !== undefined) cols.base_price = p.base_price;
+    if (p.compare_price !== undefined) cols.compare_price = p.compare_price;
+    if (p.sku !== undefined) cols.sku = p.sku;
+    if (p.stock_quantity !== undefined) cols.stock_quantity = p.stock_quantity;
+    if (p.low_stock_threshold !== undefined) cols.low_stock_threshold = p.low_stock_threshold;
+    if (p.weight_grams !== undefined) cols.weight_grams = p.weight_grams;
+  }
+  return cols;
+}
+
+function escapeLike(q: string): string {
+  return q.replace(/[\\%_]/g, (m) => `\\${m}`);
+}
+
+function r2KeyFromImageUrl(url: string): string {
+  return url.replace(/^\/images\//, "");
+}
+
+// ─── DB probes ───
+
+async function requireDraft(db: DrizzleDB, id: string): Promise<{ id: string; slug: string }> {
+  const row = await db
+    .select({ id: products.id, slug: products.slug })
+    .from(products)
+    .where(and(eq(products.id, id), eq(products.is_draft, 1)))
+    .limit(1)
+    .get();
+  if (!row) throw new DraftError("not_found", "Brouillon introuvable (ou produit déjà publié)");
+  return row;
+}
+
+async function requireCategory(db: DrizzleDB, categoryId: string): Promise<void> {
+  const row = await db
+    .select({ id: categories.id })
+    .from(categories)
+    .where(and(eq(categories.id, categoryId), eq(categories.is_active, 1)))
+    .limit(1)
+    .get();
+  if (!row) throw new DraftError("not_found", "Catégorie introuvable");
+}
+
+async function requireSkuFree(db: DrizzleDB, sku: string, excludeId: string | null): Promise<void> {
+  const cond = excludeId ? and(eq(products.sku, sku), ne(products.id, excludeId)) : eq(products.sku, sku);
+  const row = await db.select({ id: products.id }).from(products).where(cond).limit(1).get();
+  if (row) throw new DraftError("conflict", `Le SKU "${sku}" est déjà utilisé`);
+}
+
+async function isSlugTaken(db: DrizzleDB, slug: string, excludeId: string): Promise<boolean> {
+  const row = await db
+    .select({ id: products.id })
+    .from(products)
+    .where(and(eq(products.slug, slug), ne(products.id, excludeId)))
+    .limit(1)
+    .get();
+  return Boolean(row);
+}
+
+/** `base`, then `base-2` … `base-20`; null when everything collides (caller uses a placeholder). */
+async function ensureUniqueSlug(db: DrizzleDB, base: string, excludeId: string): Promise<string | null> {
+  if (!base) return null;
+  let candidate = base;
+  for (let suffix = 1; suffix <= 20; suffix++) {
+    if (!(await isSlugTaken(db, candidate, excludeId))) return candidate;
+    candidate = `${base}-${suffix + 1}`;
+  }
+  return null;
+}
+
+// ─── Create / update / read / search / delete ───
+
+export async function createDraft(input: CreateDraftInput): Promise<{ id: string; slug: string }> {
+  const db = await getDrizzle();
+  await requireCategory(db, input.category_id);
+  if (input.pricing?.sku) await requireSkuFree(db, input.pricing.sku, null);
+
+  const id = nanoid();
+  const slug = (await ensureUniqueSlug(db, slugify(input.name), id)) ?? `draft-${id}`;
+  const cols = buildProductColumns(input, id);
+
+  const stmts: Batch = [
+    db.insert(products).values({
+      ...cols,
+      id,
+      name: input.name,
+      category_id: input.category_id,
+      slug,
+      base_price: cols.base_price ?? 0,
+      is_active: 0,
+      is_draft: 1,
+      created_at: sql`datetime('now')`,
+      updated_at: sql`datetime('now')`,
+    }),
+  ];
+  for (const row of attributesToRows(input.attributes)) {
+    stmts.push(db.insert(productAttributes).values({ id: nanoid(), product_id: id, ...row }));
+  }
+  await db.batch(stmts);
+  return { id, slug };
+}
+
+export async function updateDraft(id: string, patch: UpdateDraftInput): Promise<{ id: string; slug: string }> {
+  const db = await getDrizzle();
+  const current = await requireDraft(db, id);
+  if (patch.category_id !== undefined) await requireCategory(db, patch.category_id);
+  if (patch.pricing?.sku) await requireSkuFree(db, patch.pricing.sku, id);
+
+  let slug = current.slug;
+  if (patch.slug !== undefined) {
+    if (await isSlugTaken(db, patch.slug, id)) throw new DraftError("conflict", `Le slug "${patch.slug}" est déjà utilisé`);
+    slug = patch.slug;
+  }
+
+  const stmts: Batch = [
+    db
+      .update(products)
+      .set({ ...buildProductColumns(patch, id), slug, updated_at: sql`datetime('now')` })
+      .where(and(eq(products.id, id), eq(products.is_draft, 1))),
+  ];
+  if (patch.attributes !== undefined) {
+    stmts.push(db.delete(productAttributes).where(eq(productAttributes.product_id, id)));
+    for (const row of attributesToRows(patch.attributes)) {
+      stmts.push(db.insert(productAttributes).values({ id: nanoid(), product_id: id, ...row }));
+    }
+  }
+  await db.batch(stmts);
+  return { id, slug };
+}
+
+export interface DraftDetail {
+  id: string;
+  name: string;
+  slug: string;
+  edit_url: string;
+  category_id: string | null;
+  brand: string | null;
+  short_description: string | null;
+  description_html: string | null;
+  base_price: number;
+  compare_price: number | null;
+  sku: string | null;
+  stock_quantity: number;
+  low_stock_threshold: number;
+  weight_grams: number | null;
+  seo: { meta_title: string | null; meta_description: string | null };
+  story: { tagline: string | null; highlights: unknown; feature_blocks: unknown; faq: unknown };
+  attributes: { id: string; name: string; value: string }[];
+  images: { id: string; url: string; alt: string | null; is_primary: boolean; sort_order: number; variant_id: string | null }[];
+  variants: { id: string; name: string; price: number; compare_price: number | null; stock_quantity: number; attributes: unknown }[];
+  created_at: string;
+  updated_at: string;
+}
+
+function parseJson(v: string | null): unknown {
+  if (!v) return null;
+  try { return JSON.parse(v); } catch { return null; }
+}
+
+export async function getDraft(id: string): Promise<DraftDetail> {
+  const db = await getDrizzle();
+  const p = await db
+    .select()
+    .from(products)
+    .where(and(eq(products.id, id), eq(products.is_draft, 1)))
+    .limit(1)
+    .get();
+  if (!p) throw new DraftError("not_found", "Brouillon introuvable (ou produit déjà publié)");
+
+  const [attrs, imgs, vars] = await Promise.all([
+    db.select({ id: productAttributes.id, name: productAttributes.name, value: productAttributes.value })
+      .from(productAttributes).where(eq(productAttributes.product_id, id)).all(),
+    db.select({
+      id: productImages.id, url: productImages.url, alt: productImages.alt,
+      is_primary: productImages.is_primary, sort_order: productImages.sort_order, variant_id: productImages.variant_id,
+    }).from(productImages).where(eq(productImages.product_id, id)).orderBy(asc(productImages.sort_order)).all(),
+    db.select({
+      id: productVariants.id, name: productVariants.name, price: productVariants.price,
+      compare_price: productVariants.compare_price, stock_quantity: productVariants.stock_quantity, attributes: productVariants.attributes,
+    }).from(productVariants).where(eq(productVariants.product_id, id)).orderBy(asc(productVariants.sort_order)).all(),
+  ]);
+
+  return {
+    id: p.id,
+    name: p.name,
+    slug: p.slug,
+    edit_url: `/products/${p.id}/edit`,
+    category_id: p.category_id,
+    brand: p.brand,
+    short_description: p.short_description,
+    description_html: p.description,
+    base_price: p.base_price,
+    compare_price: p.compare_price,
+    sku: p.sku,
+    stock_quantity: p.stock_quantity,
+    low_stock_threshold: p.low_stock_threshold,
+    weight_grams: p.weight_grams,
+    seo: { meta_title: p.meta_title, meta_description: p.meta_description },
+    story: {
+      tagline: p.tagline,
+      highlights: parseJson(p.highlights),
+      feature_blocks: parseJson(p.feature_blocks),
+      faq: parseJson(p.faq),
+    },
+    attributes: attrs,
+    images: imgs.map((i) => ({ ...i, url: getImageUrl(i.url), is_primary: i.is_primary === 1 })),
+    variants: vars.map((v) => ({ ...v, attributes: parseJson(v.attributes) })),
+    created_at: p.created_at,
+    updated_at: p.updated_at,
+  };
+}
+
+export interface ProductSearchRow {
+  id: string;
+  name: string;
+  slug: string;
+  brand: string | null;
+  sku: string | null;
+  base_price: number;
+  is_draft: boolean;
+  is_active: boolean;
+}
+
+/** Drafts and published products alike: this is the duplicate detector. */
+export async function searchProducts(query: string, limit: number): Promise<ProductSearchRow[]> {
+  const db = await getDrizzle();
+  const pattern = `%${escapeLike(query)}%`;
+  const rows = await db
+    .select({
+      id: products.id, name: products.name, slug: products.slug, brand: products.brand,
+      sku: products.sku, base_price: products.base_price, is_draft: products.is_draft, is_active: products.is_active,
+    })
+    .from(products)
+    .where(or(
+      sql`${products.name} like ${pattern} escape '\\'`,
+      sql`${products.slug} like ${pattern} escape '\\'`,
+      sql`${products.sku} like ${pattern} escape '\\'`,
+    ))
+    .orderBy(asc(products.name))
+    .limit(limit)
+    .all();
+  return rows.map((r) => ({ ...r, is_draft: r.is_draft === 1, is_active: r.is_active === 1 }));
+}
+
+export async function deleteDraft(id: string): Promise<void> {
+  const db = await getDrizzle();
+  await requireDraft(db, id);
+  const imgs = await db.select({ url: productImages.url }).from(productImages).where(eq(productImages.product_id, id)).all();
+
+  // Children explicitly, like actions/admin/products.ts deleteProduct — do not
+  // rely on FK cascade being enabled on the D1 connection.
+  await db.batch([
+    db.delete(productImages).where(eq(productImages.product_id, id)),
+    db.delete(productVariants).where(eq(productVariants.product_id, id)),
+    db.delete(productAttributes).where(eq(productAttributes.product_id, id)),
+    db.delete(products).where(and(eq(products.id, id), eq(products.is_draft, 1))),
+  ]);
+
+  const cleanup = await Promise.allSettled(imgs.map((i) => deleteFromR2(r2KeyFromImageUrl(i.url))));
+  for (const c of cleanup) {
+    if (c.status === "rejected") console.warn("[product-drafts] orphan R2 object after deleteDraft", id, c.reason);
+  }
+}
+
+// ─── Images and variants: see Task 8 ───
+export { fetchAndUploadImage as _fetchAndUploadImage };
+export type { FetchImageResult as _FetchImageResult, AddImagesInput as _AddImagesInput, SetVariantsInput as _SetVariantsInput };

--- a/lib/db/product-drafts.ts
+++ b/lib/db/product-drafts.ts
@@ -412,7 +412,12 @@ export async function addImagesFromUrls(
       await db.batch(stmts as Batch);
     } catch (err) {
       console.error("[product-drafts] image batch failed, cleaning R2", { id }, err);
-      await Promise.allSettled(succeeded.map(({ r }) => deleteFromR2(r.key)));
+      const cleanup = await Promise.allSettled(succeeded.map(({ r }) => deleteFromR2(r.key)));
+      cleanup.forEach((c, i) => {
+        if (c.status === "rejected") {
+          console.warn("[product-drafts] orphan R2 object after failed image batch", succeeded[i].r.key, c.reason);
+        }
+      });
       throw err;
     }
   }

--- a/lib/db/product-drafts.ts
+++ b/lib/db/product-drafts.ts
@@ -348,6 +348,206 @@ export async function deleteDraft(id: string): Promise<void> {
   }
 }
 
-// ─── Images and variants: see Task 8 ───
-export { fetchAndUploadImage as _fetchAndUploadImage };
-export type { FetchImageResult as _FetchImageResult, AddImagesInput as _AddImagesInput, SetVariantsInput as _SetVariantsInput };
+// ─── Images ───
+
+export interface ImageImportResult {
+  url: string;
+  ok: boolean;
+  image_id?: string;
+  reason?: string;
+}
+
+type FetchSuccess = Extract<FetchImageResult, { ok: true }>;
+
+export async function addImagesFromUrls(
+  id: string,
+  images: AddImagesInput["images"],
+): Promise<{ results: ImageImportResult[]; primary_image_id: string | null }> {
+  const db = await getDrizzle();
+  await requireDraft(db, id);
+
+  const existing = await db
+    .select({ id: productImages.id, is_primary: productImages.is_primary, sort_order: productImages.sort_order })
+    .from(productImages)
+    .where(eq(productImages.product_id, id))
+    .all();
+
+  if (existing.length + images.length > MAX_IMAGES_PER_PRODUCT) {
+    throw new DraftError(
+      "limit_exceeded",
+      `Au plus ${MAX_IMAGES_PER_PRODUCT} images par produit (${existing.length} déjà présentes)`,
+    );
+  }
+
+  const fetched = await Promise.all(
+    images.map(async (img) => ({ img, r: await fetchAndUploadImage(id, img.url) })),
+  );
+  const succeeded = fetched.filter((x): x is { img: typeof x.img; r: FetchSuccess } => x.r.ok);
+
+  let primaryId: string | null = existing.find((e) => e.is_primary === 1)?.id ?? null;
+  let nextSort = existing.reduce((max, e) => Math.max(max, e.sort_order + 1), 0);
+
+  const idByUrl = new Map<string, string>();
+  const stmts: Statement[] = [];
+  for (const { img, r } of succeeded) {
+    const imageId = nanoid();
+    idByUrl.set(img.url, imageId);
+    const isPrimary = primaryId === null ? 1 : 0;
+    if (isPrimary) primaryId = imageId;
+    stmts.push(
+      db.insert(productImages).values({
+        id: imageId,
+        product_id: id,
+        url: r.key,
+        alt: img.alt ?? null,
+        is_primary: isPrimary,
+        sort_order: nextSort++,
+        created_at: sql`datetime('now')`,
+      }),
+    );
+  }
+
+  if (stmts.length > 0) {
+    try {
+      await db.batch(stmts as Batch);
+    } catch (err) {
+      console.error("[product-drafts] image batch failed, cleaning R2", { id }, err);
+      await Promise.allSettled(succeeded.map(({ r }) => deleteFromR2(r.key)));
+      throw err;
+    }
+  }
+
+  const results: ImageImportResult[] = fetched.map(({ img, r }) =>
+    r.ok ? { url: img.url, ok: true, image_id: idByUrl.get(img.url) } : { url: img.url, ok: false, reason: r.reason },
+  );
+  if (fetched.some((f) => !f.r.ok)) {
+    console.error("[product-drafts] image fetch failures", { id }, results.filter((x) => !x.ok));
+  }
+  return { results, primary_image_id: primaryId };
+}
+
+export async function removeImage(id: string, imageId: string): Promise<void> {
+  const db = await getDrizzle();
+  await requireDraft(db, id);
+
+  const img = await db
+    .select({ id: productImages.id, url: productImages.url, is_primary: productImages.is_primary })
+    .from(productImages)
+    .where(and(eq(productImages.id, imageId), eq(productImages.product_id, id)))
+    .limit(1)
+    .get();
+  if (!img) throw new DraftError("not_found", "Image introuvable sur ce brouillon");
+
+  const stmts: Batch = [db.delete(productImages).where(eq(productImages.id, imageId))];
+  if (img.is_primary === 1) {
+    const next = await db
+      .select({ id: productImages.id })
+      .from(productImages)
+      .where(and(eq(productImages.product_id, id), ne(productImages.id, imageId)))
+      .orderBy(asc(productImages.sort_order))
+      .limit(1)
+      .get();
+    if (next) stmts.push(db.update(productImages).set({ is_primary: 1 }).where(eq(productImages.id, next.id)));
+  }
+  await db.batch(stmts);
+
+  await deleteFromR2(r2KeyFromImageUrl(img.url)).catch((e) => {
+    console.warn("[product-drafts] orphan R2 object after removeImage", img.url, e);
+  });
+}
+
+// ─── Colour variants ───
+
+export interface VariantRow {
+  id: string;
+  color_name: string;
+  color_hex: string;
+  price: number;
+  stock: number;
+}
+
+/** Wizard convention (step-pricing.tsx): `{ color: "<name>:<#hex>" }`. */
+function colorKey(name: string, hex: string): string {
+  return `${name}:${hex}`;
+}
+
+/** Port of actions/admin/products.ts saveColorVariants, Drizzle + draft-only. */
+export async function setColorVariants(
+  id: string,
+  input: SetVariantsInput,
+): Promise<{ variants: VariantRow[]; stock_quantity: number }> {
+  const db = await getDrizzle();
+  const product = await db
+    .select({ id: products.id, slug: products.slug, base_price: products.base_price, compare_price: products.compare_price })
+    .from(products)
+    .where(and(eq(products.id, id), eq(products.is_draft, 1)))
+    .limit(1)
+    .get();
+  if (!product) throw new DraftError("not_found", "Brouillon introuvable (ou produit déjà publié)");
+
+  const existing = await db
+    .select({ id: productVariants.id, attributes: productVariants.attributes })
+    .from(productVariants)
+    .where(eq(productVariants.product_id, id))
+    .all();
+
+  // Only colour-only variants (single "color" key) are managed here.
+  const existingByColor = new Map<string, string>();
+  for (const v of existing) {
+    try {
+      const attrs = JSON.parse(v.attributes) as Record<string, unknown>;
+      const keys = Object.keys(attrs);
+      if (keys.length === 1 && keys[0] === "color" && typeof attrs.color === "string") existingByColor.set(attrs.color, v.id);
+    } catch (e) {
+      console.error("[product-drafts] malformed variant attributes", v.id, e);
+    }
+  }
+
+  const stmts: Statement[] = [];
+  const out: VariantRow[] = [];
+  const seen = new Set<string>();
+  let total = 0;
+
+  input.variants.forEach((entry, index) => {
+    const key = colorKey(entry.color_name, entry.color_hex);
+    seen.add(key);
+    const price = input.uniform_price || entry.price == null ? product.base_price : entry.price;
+    const comparePrice = input.uniform_price ? product.compare_price : null;
+    const attrs = JSON.stringify({ color: key });
+    total += entry.stock;
+
+    const existingId = existingByColor.get(key);
+    const variantId = existingId ?? nanoid();
+    if (existingId) {
+      stmts.push(
+        db.update(productVariants)
+          .set({ name: entry.color_name, price, compare_price: comparePrice, stock_quantity: entry.stock, attributes: attrs })
+          .where(eq(productVariants.id, existingId)),
+      );
+    } else {
+      stmts.push(
+        db.insert(productVariants).values({
+          id: variantId, product_id: id, name: entry.color_name, price, compare_price: comparePrice,
+          stock_quantity: entry.stock, attributes: attrs, is_active: 1, sort_order: index,
+          created_at: sql`datetime('now')`,
+        }),
+      );
+    }
+    out.push({ id: variantId, color_name: entry.color_name, color_hex: entry.color_hex, price, stock: entry.stock });
+  });
+
+  for (const [key, variantId] of existingByColor) {
+    if (seen.has(key)) continue;
+    stmts.push(db.update(productImages).set({ variant_id: null }).where(eq(productImages.variant_id, variantId)));
+    stmts.push(db.delete(productVariants).where(eq(productVariants.id, variantId)));
+  }
+
+  stmts.push(
+    db.update(products)
+      .set({ stock_quantity: total, updated_at: sql`datetime('now')` })
+      .where(and(eq(products.id, id), eq(products.is_draft, 1))),
+  );
+
+  await db.batch(stmts as Batch);
+  return { variants: out, stock_quantity: total };
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -96,6 +96,57 @@ export const rateLimit = sqliteTable("rateLimit", {
   lastRequest: integer("lastRequest").notNull(),
 });
 
+// better-auth `mcp` plugin (OAuth 2.1 provider for MCP clients). Column names
+// mirror node_modules/better-auth/dist/plugins/oidc-provider/schema.mjs exactly:
+// better-auth reaches these tables through its own Kysely adapter, so a
+// mismatch here fails at request time, not at compile time. Dates are ISO
+// strings (the adapter runs with supportsDates: false on sqlite), booleans 0/1.
+export const oauthApplication = sqliteTable("oauthApplication", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  icon: text("icon"),
+  metadata: text("metadata"),
+  clientId: text("clientId").unique().notNull(),
+  clientSecret: text("clientSecret"),
+  redirectUrls: text("redirectUrls").notNull(),
+  type: text("type").notNull(),
+  disabled: integer("disabled").notNull().default(0),
+  userId: text("userId").references(() => user.id, { onDelete: "cascade" }),
+  createdAt: text("createdAt").notNull().default(sql`(datetime('now'))`),
+  updatedAt: text("updatedAt").notNull().default(sql`(datetime('now'))`),
+}, (table) => [
+  index("idx_oauthApplication_userId").on(table.userId),
+]);
+
+export const oauthAccessToken = sqliteTable("oauthAccessToken", {
+  id: text("id").primaryKey(),
+  accessToken: text("accessToken").unique().notNull(),
+  refreshToken: text("refreshToken").unique().notNull(),
+  accessTokenExpiresAt: text("accessTokenExpiresAt").notNull(),
+  refreshTokenExpiresAt: text("refreshTokenExpiresAt").notNull(),
+  clientId: text("clientId").notNull().references(() => oauthApplication.clientId, { onDelete: "cascade" }),
+  userId: text("userId").references(() => user.id, { onDelete: "cascade" }),
+  scopes: text("scopes").notNull(),
+  createdAt: text("createdAt").notNull().default(sql`(datetime('now'))`),
+  updatedAt: text("updatedAt").notNull().default(sql`(datetime('now'))`),
+}, (table) => [
+  index("idx_oauthAccessToken_clientId").on(table.clientId),
+  index("idx_oauthAccessToken_userId").on(table.userId),
+]);
+
+export const oauthConsent = sqliteTable("oauthConsent", {
+  id: text("id").primaryKey(),
+  clientId: text("clientId").notNull().references(() => oauthApplication.clientId, { onDelete: "cascade" }),
+  userId: text("userId").notNull().references(() => user.id, { onDelete: "cascade" }),
+  scopes: text("scopes").notNull(),
+  consentGiven: integer("consentGiven").notNull().default(0),
+  createdAt: text("createdAt").notNull().default(sql`(datetime('now'))`),
+  updatedAt: text("updatedAt").notNull().default(sql`(datetime('now'))`),
+}, (table) => [
+  index("idx_oauthConsent_clientId").on(table.clientId),
+  index("idx_oauthConsent_userId").on(table.userId),
+]);
+
 // =============================================================================
 // Delivery Zones
 // =============================================================================

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -348,7 +348,10 @@ export type AuditAction =
   | "user.created"
   | "user.role_changed"
   | "user.banned"
-  | "user.unbanned";
+  | "user.unbanned"
+  | "product.draft_created"
+  | "product.draft_updated"
+  | "product.draft_deleted";
 
 export interface AuditLog {
   id: string;

--- a/lib/mcp/context.ts
+++ b/lib/mcp/context.ts
@@ -1,0 +1,38 @@
+import { eq } from "drizzle-orm";
+import { getDrizzle } from "@/lib/db/drizzle";
+import { user } from "@/lib/db/schema";
+import { isActivelyBanned } from "@/lib/auth/ban";
+
+export interface McpContext {
+  user: { id: string; name: string; role: "admin" | "super_admin" };
+  clientId: string;
+}
+
+/** Thrown before any tool runs; the route turns it into a JSON-RPC 403. */
+export class McpAuthError extends Error {
+  readonly status = 403;
+  constructor(message: string) {
+    super(message);
+    this.name = "McpAuthError";
+  }
+}
+
+/**
+ * The OAuth token proves "some user consented"; this is the authorization
+ * boundary. Fresh D1 read on every request (same spirit as requireAdmin's
+ * disableCookieCache) so a role change or ban applies immediately.
+ */
+export async function buildMcpContext(session: { userId?: string | null; clientId: string }): Promise<McpContext> {
+  if (!session.userId) throw new McpAuthError("Jeton sans utilisateur");
+  const db = await getDrizzle();
+  const row = await db
+    .select({ id: user.id, name: user.name, role: user.role, banned: user.banned, banExpires: user.banExpires })
+    .from(user)
+    .where(eq(user.id, session.userId))
+    .limit(1)
+    .get();
+  if (!row) throw new McpAuthError("Utilisateur introuvable");
+  if (isActivelyBanned(row)) throw new McpAuthError("Compte suspendu");
+  if (row.role !== "admin" && row.role !== "super_admin") throw new McpAuthError("Accès réservé aux administrateurs");
+  return { user: { id: row.id, name: row.name, role: row.role }, clientId: session.clientId };
+}

--- a/lib/mcp/result.ts
+++ b/lib/mcp/result.ts
@@ -1,0 +1,18 @@
+export type McpErrorCode = "validation_error" | "not_found" | "conflict" | "limit_exceeded" | "internal_error";
+
+/** Shape the MCP SDK expects back from a tool handler (text content only in phase 1). */
+export interface ToolResult {
+  content: { type: "text"; text: string }[];
+  isError?: boolean;
+  [key: string]: unknown;
+}
+
+export function ok(data: unknown): ToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(data) }] };
+}
+
+export function fail(code: McpErrorCode, message: string, fieldErrors?: Record<string, string[]>): ToolResult {
+  const body: Record<string, unknown> = { code, message };
+  if (fieldErrors) body.fieldErrors = fieldErrors;
+  return { content: [{ type: "text", text: JSON.stringify(body) }], isError: true };
+}

--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -1,0 +1,26 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpContext } from "@/lib/mcp/context";
+import { categoryTools } from "@/lib/mcp/tools/categories";
+import { productTools } from "@/lib/mcp/tools/products";
+import type { ToolDefinition } from "@/lib/mcp/tools/types";
+
+export const MCP_SERVER_NAME = "netereka-admin";
+export const MCP_SERVER_VERSION = "1.0.0";
+
+export const ALL_TOOLS: ToolDefinition[] = [...categoryTools, ...productTools];
+
+/**
+ * One server per request (stateless transport) bound to the admin who owns
+ * the OAuth token. Tools never see the token, only the resolved context.
+ */
+export function createMcpServer(ctx: McpContext): McpServer {
+  const server = new McpServer({ name: MCP_SERVER_NAME, version: MCP_SERVER_VERSION });
+  for (const tool of ALL_TOOLS) {
+    server.registerTool(
+      tool.name,
+      { description: tool.description, inputSchema: tool.inputSchema },
+      async (input) => tool.handler(ctx, input),
+    );
+  }
+  return server;
+}

--- a/lib/mcp/tools/categories.ts
+++ b/lib/mcp/tools/categories.ts
@@ -1,0 +1,27 @@
+import { getCategoryTree } from "@/lib/db/categories";
+import type { CategoryNode } from "@/lib/db/types";
+import { ok, fail } from "@/lib/mcp/result";
+import { defineTool, type ToolDefinition } from "./types";
+
+interface CategoryOut { id: string; name: string; slug: string; children: CategoryOut[] }
+
+function strip(nodes: readonly CategoryNode[]): CategoryOut[] {
+  return nodes.map((n) => ({ id: n.id, name: n.name, slug: n.slug, children: strip(n.children) }));
+}
+
+export const categoryTools: ToolDefinition[] = [
+  defineTool({
+    name: "list_categories",
+    description:
+      "Liste l'arbre des catégories actives de la boutique (2 niveaux max). Utilise l'id retourné comme category_id pour create_product_draft.",
+    inputSchema: {},
+    handler: async () => {
+      try {
+        return ok(strip(await getCategoryTree()));
+      } catch (err) {
+        console.error("[mcp/list_categories]", err);
+        return fail("internal_error", "Impossible de lire les catégories");
+      }
+    },
+  }),
+];

--- a/lib/mcp/tools/products.ts
+++ b/lib/mcp/tools/products.ts
@@ -1,0 +1,180 @@
+import { createAuditLog } from "@/lib/db/admin/audit-log";
+import type { AuditAction } from "@/lib/db/types";
+import {
+  DraftError,
+  addImagesFromUrls,
+  createDraft,
+  deleteDraft,
+  getDraft,
+  removeImage,
+  searchProducts,
+  setColorVariants,
+  updateDraft,
+} from "@/lib/db/product-drafts";
+import type { McpContext } from "@/lib/mcp/context";
+import { ok, fail, type ToolResult } from "@/lib/mcp/result";
+import {
+  addImagesSchema,
+  createDraftSchema,
+  idSchema,
+  searchProductsSchema,
+  setVariantsSchema,
+  updateDraftSchema,
+} from "@/lib/validations/mcp-product";
+import { defineTool, type ToolDefinition } from "./types";
+
+/**
+ * Product-draft tools. Every write goes through lib/db/product-drafts.ts,
+ * which refuses anything that is not `is_draft = 1`. Publishing stays in the
+ * admin wizard (/products/<id>/edit) — no tool here can flip is_draft/is_active.
+ */
+
+function toolError(toolName: string, err: unknown): ToolResult {
+  if (err instanceof DraftError) return fail(err.code, err.message);
+  console.error(`[mcp/${toolName}]`, err);
+  return fail("internal_error", "Erreur interne, réessayez ou contactez un administrateur");
+}
+
+async function audit(ctx: McpContext, tool: string, action: AuditAction, productId: string): Promise<void> {
+  try {
+    await createAuditLog({
+      actorId: ctx.user.id,
+      actorName: ctx.user.name,
+      action,
+      targetType: "product",
+      targetId: productId,
+      details: JSON.stringify({ via: "mcp", tool, client_id: ctx.clientId }),
+    });
+  } catch (err) {
+    // The write already succeeded; losing the audit row must not fail the tool.
+    console.error(`[mcp/${tool}] audit log failed`, { productId }, err);
+  }
+}
+
+const DESCRIPTION_RULES =
+  "Champs : name (requis), category_id (requis, voir list_categories), brand, short_description (≤120), description_html (HTML, assaini côté serveur), story {tagline, highlights[3-6] {icon,label}, feature_blocks[2-4] {title,body}, faq[≤5] {question,answer}}, seo {meta_title ≤60, meta_description ≤160}, attributes {colors[{name,hex}], dimensions {length_mm,height_mm,width_mm,weight_g}, specs[{name,value}]}, pricing {base_price, compare_price, sku, stock_quantity, low_stock_threshold, weight_grams} (prix en XOF entiers).";
+
+export const productTools: ToolDefinition[] = [
+  defineTool({
+    name: "search_products",
+    description:
+      "Recherche des produits (brouillons et publiés) par nom, slug ou SKU. À appeler avant create_product_draft pour éviter les doublons.",
+    inputSchema: searchProductsSchema.shape,
+    handler: async (_ctx, input) => {
+      try {
+        return ok(await searchProducts(input.query, input.limit));
+      } catch (err) {
+        return toolError("search_products", err);
+      }
+    },
+  }),
+
+  defineTool({
+    name: "get_product_draft",
+    description: "Relit un brouillon complet : champs, attributs, images (URL publiques), variantes. Échoue sur un produit publié.",
+    inputSchema: { id: idSchema },
+    handler: async (_ctx, input) => {
+      try {
+        return ok(await getDraft(input.id));
+      } catch (err) {
+        return toolError("get_product_draft", err);
+      }
+    },
+  }),
+
+  defineTool({
+    name: "create_product_draft",
+    description:
+      `Crée un brouillon produit (non publié, invisible en boutique). Retourne {id, slug, edit_url}. ${DESCRIPTION_RULES} Les couleurs déclarées ici doivent correspondre à celles de set_product_variants.`,
+    inputSchema: createDraftSchema.shape,
+    handler: async (ctx, input) => {
+      try {
+        const { id, slug } = await createDraft(input);
+        await audit(ctx, "create_product_draft", "product.draft_created", id);
+        return ok({ id, slug, edit_url: `/products/${id}/edit` });
+      } catch (err) {
+        return toolError("create_product_draft", err);
+      }
+    },
+  }),
+
+  defineTool({
+    name: "update_product_draft",
+    description:
+      `Met à jour un brouillon. Champs absents ignorés, null efface. attributes fourni remplace tous les attributs. slug optionnel (unique). ${DESCRIPTION_RULES}`,
+    inputSchema: { id: idSchema, ...updateDraftSchema.shape },
+    handler: async (ctx, input) => {
+      try {
+        const { id, ...patch } = input;
+        const result = await updateDraft(id, patch);
+        await audit(ctx, "update_product_draft", "product.draft_updated", id);
+        return ok(result);
+      } catch (err) {
+        return toolError("update_product_draft", err);
+      }
+    },
+  }),
+
+  defineTool({
+    name: "add_product_images",
+    description:
+      "Télécharge 1 à 8 images depuis des URL http(s) (≤5 Mo chacune, 12 max par produit) vers le stockage de la boutique et les attache au brouillon. Succès partiel possible : vérifier results[].ok. La première image du produit devient l'image principale.",
+    inputSchema: { id: idSchema, ...addImagesSchema.shape },
+    handler: async (ctx, input) => {
+      try {
+        const result = await addImagesFromUrls(input.id, input.images);
+        if (result.results.some((r) => r.ok)) await audit(ctx, "add_product_images", "product.draft_updated", input.id);
+        return ok(result);
+      } catch (err) {
+        return toolError("add_product_images", err);
+      }
+    },
+  }),
+
+  defineTool({
+    name: "remove_product_image",
+    description: "Retire une image d'un brouillon (ligne et fichier). Si elle était principale, la suivante le devient.",
+    inputSchema: { id: idSchema, image_id: idSchema },
+    handler: async (ctx, input) => {
+      try {
+        await removeImage(input.id, input.image_id);
+        await audit(ctx, "remove_product_image", "product.draft_updated", input.id);
+        return ok({ removed: true });
+      } catch (err) {
+        return toolError("remove_product_image", err);
+      }
+    },
+  }),
+
+  defineTool({
+    name: "set_product_variants",
+    description:
+      "Définit les variantes couleur d'un brouillon (remplace l'ensemble). price absent ou uniform_price=true → prix de base du produit. Les variantes retirées sont supprimées. Le stock du produit devient la somme des stocks. Déclarer les mêmes couleurs dans attributes.colors.",
+    inputSchema: { id: idSchema, ...setVariantsSchema.shape },
+    handler: async (ctx, input) => {
+      try {
+        const { id, ...rest } = input;
+        const result = await setColorVariants(id, rest);
+        await audit(ctx, "set_product_variants", "product.draft_updated", id);
+        return ok(result);
+      } catch (err) {
+        return toolError("set_product_variants", err);
+      }
+    },
+  }),
+
+  defineTool({
+    name: "delete_product_draft",
+    description: "Supprime définitivement un brouillon et ses images. Impossible sur un produit publié.",
+    inputSchema: { id: idSchema },
+    handler: async (ctx, input) => {
+      try {
+        await deleteDraft(input.id);
+        await audit(ctx, "delete_product_draft", "product.draft_deleted", input.id);
+        return ok({ deleted: true });
+      } catch (err) {
+        return toolError("delete_product_draft", err);
+      }
+    },
+  }),
+];

--- a/lib/mcp/tools/types.ts
+++ b/lib/mcp/tools/types.ts
@@ -1,0 +1,25 @@
+import type { z, ZodRawShape } from "zod";
+import type { McpContext } from "@/lib/mcp/context";
+import type { ToolResult } from "@/lib/mcp/result";
+
+/**
+ * One MCP tool. `inputSchema` is a raw Zod shape (what the SDK's registerTool
+ * takes); the SDK validates and rejects invalid params with JSON-RPC -32602
+ * before `handler` runs.
+ */
+export interface ToolDefinition<Shape extends ZodRawShape = ZodRawShape> {
+  name: string;
+  description: string;
+  inputSchema: Shape;
+  handler: (ctx: McpContext, input: z.infer<z.ZodObject<Shape>>) => Promise<ToolResult>;
+}
+
+/**
+ * Infers the handler's input type from the shape, then widens to the base
+ * ToolDefinition so heterogeneous tools can live in one array. The widening
+ * is a cast because handler parameters are contravariant under
+ * strictFunctionTypes; the SDK re-validates the input at runtime anyway.
+ */
+export function defineTool<Shape extends ZodRawShape>(def: ToolDefinition<Shape>): ToolDefinition {
+  return def as unknown as ToolDefinition;
+}

--- a/lib/validations/mcp-product.ts
+++ b/lib/validations/mcp-product.ts
@@ -1,0 +1,93 @@
+import { z } from "zod";
+import { colorSchema, dimensionsSchema, specSchema } from "@/lib/validations/product-ai";
+import { taglineSchema, highlightsSchema, featureBlocksSchema, faqSchema } from "@/lib/validations/product-story";
+
+/**
+ * Input contracts of the MCP product tools (lib/mcp/tools/products.ts).
+ * Story and attribute rules are the wizard's own schemas, reused so the MCP
+ * cannot write a product the admin UI would reject.
+ */
+
+export const idSchema = z.string().trim().min(1).max(64);
+
+const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/** Upper bound of sanitizeDescriptionHtml's input (lib/utils/sanitize-html.ts). */
+const DESCRIPTION_MAX_BYTES = 512_000;
+
+export const draftAttributesSchema = z.object({
+  colors: z.array(colorSchema).max(12).default([]),
+  dimensions: dimensionsSchema.default({}),
+  specs: z.array(specSchema).max(20).default([]),
+});
+
+const storyInputSchema = z.object({
+  tagline: taglineSchema.optional(),
+  highlights: highlightsSchema.optional(),
+  feature_blocks: featureBlocksSchema.optional(),
+  faq: faqSchema.optional(),
+});
+
+const seoSchema = z.object({
+  meta_title: z.string().trim().max(60).nullable().optional(),
+  meta_description: z.string().trim().max(160).nullable().optional(),
+});
+
+const pricingSchema = z.object({
+  base_price: z.number().int().min(0).optional(),
+  compare_price: z.number().int().min(0).nullable().optional(),
+  sku: z.string().trim().min(1).max(64).nullable().optional(),
+  stock_quantity: z.number().int().min(0).optional(),
+  low_stock_threshold: z.number().int().min(0).optional(),
+  weight_grams: z.number().int().positive().nullable().optional(),
+});
+
+export const createDraftSchema = z.object({
+  name: z.string().trim().min(1).max(150),
+  category_id: idSchema,
+  brand: z.string().trim().max(80).nullable().optional(),
+  short_description: z.string().trim().max(120).nullable().optional(),
+  description_html: z.string().max(DESCRIPTION_MAX_BYTES).nullable().optional(),
+  story: storyInputSchema.optional(),
+  seo: seoSchema.optional(),
+  attributes: draftAttributesSchema.optional(),
+  pricing: pricingSchema.optional(),
+});
+
+export const updateDraftSchema = createDraftSchema.partial().extend({
+  slug: z.string().trim().max(160).regex(SLUG_RE, "Slug invalide (minuscules, chiffres, tirets)").optional(),
+});
+
+export const addImagesSchema = z.object({
+  images: z
+    .array(z.object({
+      url: z.string().url().max(2048).refine((u) => /^https?:\/\//i.test(u), "URL http(s) requise"),
+      alt: z.string().trim().max(200).nullable().optional(),
+    }))
+    .min(1)
+    .max(8),
+});
+
+export const setVariantsSchema = z.object({
+  variants: z
+    .array(z.object({
+      color_name: z.string().trim().min(1).max(40),
+      color_hex: z.string().regex(/^#[0-9a-fA-F]{6}$/, "Couleur hex invalide (format #rrggbb)"),
+      stock: z.number().int().min(0),
+      price: z.number().int().min(0).nullable().optional(),
+    }))
+    .max(12),
+  uniform_price: z.boolean().default(true),
+});
+
+export const searchProductsSchema = z.object({
+  query: z.string().trim().min(3).max(100),
+  limit: z.number().int().min(1).max(50).default(20),
+});
+
+export type DraftAttributesInput = z.infer<typeof draftAttributesSchema>;
+export type CreateDraftInput = z.infer<typeof createDraftSchema>;
+export type UpdateDraftInput = z.infer<typeof updateDraftSchema>;
+export type AddImagesInput = z.infer<typeof addImagesSchema>;
+export type SetVariantsInput = z.infer<typeof setVariantsSchema>;
+export type SearchProductsInput = z.infer<typeof searchProductsSchema>;

--- a/lib/validations/product-ai.ts
+++ b/lib/validations/product-ai.ts
@@ -17,19 +17,19 @@ export const aiPromptSchema = z
 
 const hexColor = z.string().regex(/^#[0-9a-fA-F]{6}$/, "Couleur hex invalide (format #rrggbb)");
 
-const colorSchema = z.object({
+export const colorSchema = z.object({
   name: z.string().trim().min(1).max(40),
   hex: hexColor,
 });
 
-const dimensionsSchema = z.object({
+export const dimensionsSchema = z.object({
   length_mm: z.number().int().positive().optional(),
   height_mm: z.number().int().positive().optional(),
   width_mm:  z.number().int().positive().optional(),
   weight_g:  z.number().int().positive().optional(),
 });
 
-const specSchema = z.object({
+export const specSchema = z.object({
   name:  z.string().trim().min(1).max(60),
   value: z.string().trim().min(1).max(200),
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@lexical/rich-text": "^0.41.0",
         "@lexical/selection": "^0.41.0",
         "@lexical/utils": "^0.41.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@opennextjs/cloudflare": "^1.16.4",
         "@tailwindcss/typography": "^0.5.19",
         "better-auth": "^1.6.25",
@@ -3037,7 +3038,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3054,7 +3054,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3071,7 +3070,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3088,7 +3086,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3105,7 +3102,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3122,7 +3118,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3139,7 +3134,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3156,7 +3150,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3173,7 +3166,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3190,7 +3182,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3207,7 +3198,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3224,7 +3214,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3241,7 +3230,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3258,7 +3246,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3275,7 +3262,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3292,7 +3278,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3325,7 +3310,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3358,7 +3342,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3375,7 +3358,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3392,7 +3374,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3409,7 +3390,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3426,7 +3406,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3443,7 +3422,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3678,7 +3656,6 @@
       "version": "1.19.13",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
       "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -4235,7 +4212,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
       "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4245,7 +4222,7 @@
       "version": "5.1.21",
       "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
       "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -4267,7 +4244,7 @@
       "version": "10.3.2",
       "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
       "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^1.0.2",
@@ -4295,7 +4272,7 @@
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
       "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4305,7 +4282,7 @@
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
       "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4775,13 +4752,12 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
-      "dev": true,
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -4819,7 +4795,7 @@
       "version": "0.40.0",
       "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.40.0.tgz",
       "integrity": "sha512-EFd6cVbHsgLa6wa4RljGj6Wk75qoHxUSyc5asLyyPSyuhIcdS2Q3Phw6ImS1q+CkALthJRShiYfKANcQMuMqsQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@open-draft/deferred-promise": "^2.2.0",
@@ -5203,14 +5179,14 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
       "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@open-draft/logger": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
       "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-node-process": "^1.2.0",
@@ -5221,7 +5197,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@opennextjs/aws": {
@@ -7523,7 +7499,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7537,7 +7512,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7551,7 +7525,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7565,7 +7538,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7579,7 +7551,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7593,7 +7564,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7607,7 +7577,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7621,7 +7590,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7635,7 +7603,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7649,7 +7616,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7663,7 +7629,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7677,7 +7642,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7691,7 +7655,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7705,7 +7668,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7719,7 +7681,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7733,7 +7694,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7747,7 +7707,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7761,7 +7720,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7775,7 +7733,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7789,7 +7746,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7803,7 +7759,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7817,7 +7772,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7831,7 +7785,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7845,7 +7798,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7859,7 +7811,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9232,7 +9183,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/validate-npm-package-name": {
@@ -9964,7 +9915,6 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -9981,7 +9931,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -10869,7 +10818,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
       "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">= 12"
@@ -10885,7 +10834,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -10900,7 +10849,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10910,14 +10859,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -10932,7 +10881,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -10945,7 +10894,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -11205,7 +11154,6 @@
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
@@ -11649,7 +11597,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11666,7 +11613,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11683,7 +11629,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11700,7 +11645,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11717,7 +11661,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11734,7 +11677,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11751,7 +11693,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11768,7 +11709,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11785,7 +11725,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11802,7 +11741,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11819,7 +11757,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11836,7 +11773,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11853,7 +11789,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11870,7 +11805,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11887,7 +11821,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11904,7 +11837,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11921,7 +11853,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11938,7 +11869,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11955,7 +11885,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11972,7 +11901,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11989,7 +11917,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12006,7 +11933,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12023,7 +11949,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12040,7 +11965,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12057,7 +11981,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13168,7 +13091,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eventsource-parser": "^3.0.1"
@@ -13181,7 +13103,6 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
       "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -13281,7 +13202,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
       "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ip-address": "10.1.0"
@@ -13300,7 +13220,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -13357,7 +13276,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14094,7 +14012,7 @@
       "version": "16.12.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
       "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -14210,7 +14128,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
       "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/hermes-estree": {
@@ -14234,7 +14152,6 @@
       "version": "4.12.12",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -14425,7 +14342,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
       "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -14764,7 +14680,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
       "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-number": {
@@ -15087,7 +15003,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -15166,14 +15082,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -15328,7 +15242,7 @@
       "version": "1.30.2",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
       "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -15361,7 +15275,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15382,7 +15295,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15403,7 +15315,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15424,7 +15335,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15445,7 +15355,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15466,7 +15375,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15487,7 +15395,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15508,7 +15415,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15529,7 +15435,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15550,7 +15455,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15571,7 +15475,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15956,7 +15859,7 @@
       "version": "2.12.7",
       "resolved": "https://registry.npmjs.org/msw/-/msw-2.12.7.tgz",
       "integrity": "sha512-retd5i3xCZDVWMYjHEVuKTmhqY8lSsxujjVrZiGbbdoxxIBg5S7rCuYy/YQpfrTYIxpd/o0Kyb/3H+1udBMoYg==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16001,7 +15904,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
       "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -16015,7 +15918,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
       "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -16345,7 +16248,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -16606,7 +16508,7 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
       "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/own-keys": {
@@ -16834,7 +16736,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
@@ -17438,7 +17339,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -17448,7 +17349,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -17543,7 +17443,7 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.7.0.tgz",
       "integrity": "sha512-LPRKoHnLKd/r3dVxcwO7vhCW+orkOGj9ViueosEBK6ie89CijnfRlhaDhHq/3Hxu4CkWQtxwlBG0mzTQY6uQjw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/reusify": {
@@ -18307,7 +18207,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
       "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/string_decoder": {
@@ -18676,7 +18576,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
       "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -18855,7 +18755,7 @@
       "version": "7.0.21",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.21.tgz",
       "integrity": "sha512-Plu6V8fF/XU6d2k8jPtlQf5F4Xx2hAin4r2C2ca7wR8NK5MbRTo9huLUWRe28f3Uk8bYZfg74tit/dSjc18xnw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^7.0.21"
@@ -18868,7 +18768,7 @@
       "version": "7.0.21",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.21.tgz",
       "integrity": "sha512-oVOMdHvgjqyzUZH1rOESgJP1uNe2bVrfK0jUHHmiM2rpEiRbf3j4BrsIc6JigJRbHGanQwuZv/R+LTcHsw+bLA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/to-regex-range": {
@@ -18897,7 +18797,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
       "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
@@ -19007,7 +18907,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19024,7 +18923,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19041,7 +18939,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19058,7 +18955,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19075,7 +18971,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19092,7 +18987,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19109,7 +19003,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19126,7 +19019,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19143,7 +19035,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19160,7 +19051,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19177,7 +19067,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19194,7 +19083,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19211,7 +19099,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19228,7 +19115,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19245,7 +19131,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19262,7 +19147,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19279,7 +19163,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19296,7 +19179,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19313,7 +19195,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19330,7 +19211,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19347,7 +19227,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19364,7 +19243,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19381,7 +19259,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19398,7 +19275,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19415,7 +19291,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19432,7 +19307,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -19523,7 +19397,7 @@
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.3.tgz",
       "integrity": "sha512-AXSAQJu79WGc79/3e9/CR77I/KQgeY1AhNvcShIH4PTcGYyC4xv6H4R4AUOwkPS5799KlVDAu8zExeCrkGquiA==",
-      "dev": true,
+      "devOptional": true,
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"
@@ -19631,7 +19505,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -19779,7 +19653,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
       "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/kettanaito"
@@ -20004,7 +19878,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20021,7 +19894,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20038,7 +19910,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20055,7 +19926,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20072,7 +19942,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20089,7 +19958,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20106,7 +19974,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20123,7 +19990,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20140,7 +20006,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20157,7 +20022,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20174,7 +20038,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20191,7 +20054,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20208,7 +20070,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20225,7 +20086,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20242,7 +20102,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20259,7 +20118,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20276,7 +20134,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20293,7 +20150,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20310,7 +20166,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20327,7 +20182,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20344,7 +20198,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20361,7 +20214,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20378,7 +20230,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20395,7 +20246,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20412,7 +20262,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20429,7 +20278,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -21281,7 +21129,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -21355,7 +21203,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -21365,14 +21213,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -21387,7 +21235,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -21475,7 +21323,7 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -21494,7 +21342,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -21504,7 +21352,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -21514,14 +21362,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -21536,7 +21384,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -21593,7 +21441,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
       "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -21651,7 +21499,6 @@
       "version": "3.25.1",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
       "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
-      "dev": true,
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25 || ^4"

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@lexical/rich-text": "^0.41.0",
     "@lexical/selection": "^0.41.0",
     "@lexical/utils": "^0.41.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@opennextjs/cloudflare": "^1.16.4",
     "@tailwindcss/typography": "^0.5.19",
     "better-auth": "^1.6.25",


### PR DESCRIPTION
## Summary

- Remote MCP endpoint `POST /api/mcp` (Streamable HTTP, stateless) so any MCP client (claude.ai, Claude Desktop, Claude Code, ChatGPT, Cursor…) can administer product **drafts**. Publishing stays in the admin wizard.
- OAuth 2.1 provider via better-auth's `mcp` plugin (three additive tables, migration 0017). Dynamic client registration is open, so a `before` hook forces `prompt=consent` on every `/mcp/authorize`; the consent page `/admin/mcp/consent` shows the client name **and the redirect host** and approves exactly the code it displays (`no-referrer`). The admin login page resumes the authorize flow after sign-in.
- Authorization boundary `lib/mcp/context.ts`: fresh D1 read per request, only active `admin` / `super_admin`; customers can finish OAuth but every call gets a JSON-RPC 403.
- 9 tools: `list_categories`, `search_products`, `get_product_draft`, `create_product_draft`, `update_product_draft`, `add_product_images`, `remove_product_image`, `set_product_variants`, `delete_product_draft`. All writes go through `lib/db/product-drafts.ts`, whose every UPDATE/DELETE carries `is_draft = 1`; writes are audited with `details.via = "mcp"`.
- Zod contracts reuse the wizard's own story/attribute schemas. Existing in-app AI product creation is untouched.

Spec: `docs/superpowers/specs/2026-09-02-admin-mcp-server-design.md`
Plan: `docs/superpowers/plans/2026-09-02-admin-mcp-server.md`

## Test plan

- [x] `npm run test` green (96 files / 1482 tests): schemas, drafts module (SQL emitted through Drizzle's D1 driver), context guard, tools, route through the real `withMcpAuth` + transport, auth config, consent lookup
- [x] `npm run build:worker` passes; `/api/mcp`, `/admin/mcp/consent`, both `.well-known` documents listed as dynamic routes
- [x] Scripted e2e against `npm run dev` (21 steps): discovery → 401 → dynamic registration → admin sign-in → **forced consent** (redirect lands on the consent page, never on the client) → consent → PKCE token → 9 tools listed → create/images/variants/get/update → published product refused (`not_found`) → audit rows → customer token 403
- [x] Real-browser flow (agent-browser, 2026-09-03): authorize without session → `/admin/login` with the OAuth query → sign-in → resumed to `/admin/mcp/consent` showing client name **and** `localhost:9999` → Autoriser → callback with `code`+`state` → PKCE token → 9 tools listed → `search_products` OK. Still to do once with the real client: `claude mcp add --transport http netereka-local http://localhost:3000/api/mcp` → `/mcp` → admin login → consent page shows name + redirect host → tools available (exercises the login-resume branch only a real browser hits)
- [x] Opened the e2e draft in the wizard (step 5 shows the MCP-written summary, tagline, highlights, feature blocks, SEO) and published it; `is_draft` → 0, and `update_product_draft` / `delete_product_draft` / `get_product_draft` on it now return `not_found` while `search_products` still lists it
- [ ] After canary: connect a claude.ai custom connector to `https://netereka.ci/api/mcp`

## Follow-ups (deferred, non-blocking)

- Child-table deletes in `updateDraft`/`deleteDraft` are not themselves `is_draft`-guarded (race with a concurrent publish)
- Map SQLite `UNIQUE constraint failed` to `conflict` on slug/SKU races; refine duplicate colours in `set_product_variants`
- `lib/db/product-drafts.ts` (~550 lines) is a split candidate (images / variants)
- better-auth keeps every refreshed `oauthAccessToken` row; schedule pruning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015x8NA9A7Rc3sNLBSeUkC9g

